### PR TITLE
コンテンツ詳細画面の表示速度を改善

### DIFF
--- a/app/posts/[id]/page.tsx
+++ b/app/posts/[id]/page.tsx
@@ -11,6 +11,8 @@ import { CommentSectionSkeleton } from "@/features/posts/components/CommentSecti
 import { createClient } from "@/lib/supabase/server";
 import { getSiteUrl } from "@/lib/env";
 
+// Next.js 16では、動的ルートはデフォルトで動的レンダリングされる
+// キャッシュはfetchのrevalidateオプションまたはReact.cache()で制御
 interface PostDetailPageProps {
   params: Promise<{ id: string }>;
 }
@@ -144,9 +146,12 @@ export default async function PostDetailPage({ params }: PostDetailPageProps) {
 
   // 画像URLとアスペクト比を取得
   const imageUrl = getPostImageUrl(post);
-  const imageAspectRatio = imageUrl
-    ? await getImageAspectRatio(imageUrl)
-    : null;
+  // データベースからアスペクト比を取得（フォールバック: 存在しない場合は計算）
+  let imageAspectRatio: "portrait" | "landscape" | null = post.aspect_ratio as "portrait" | "landscape" | null;
+  if (!imageAspectRatio && imageUrl) {
+    // フォールバック: データベースに値がない場合は計算（初回表示時など）
+    imageAspectRatio = await getImageAspectRatio(imageUrl);
+  }
 
   return (
     <>

--- a/features/generation/lib/database.ts
+++ b/features/generation/lib/database.ts
@@ -16,11 +16,14 @@ export interface GeneratedImageRecord {
   caption?: string | null;
   posted_at?: string | null;
   created_at?: string;
+  view_count?: number;
   // Phase 1で追加されたカラム（optional）
   generation_type?: 'coordinate' | 'specified_coordinate' | 'full_body' | 'chibi' | null;
   input_images?: Record<string, unknown> | null;
   generation_metadata?: Record<string, unknown> | null;
   source_image_stock_id?: string | null;
+  // Phase 2で追加されたカラム（optional）
+  aspect_ratio?: 'portrait' | 'landscape' | null;
 }
 
 /**

--- a/features/posts/components/CommentSection.tsx
+++ b/features/posts/components/CommentSection.tsx
@@ -17,7 +17,7 @@ export function CommentSection({ postId, currentUserId }: CommentSectionProps) {
   const commentListRef = useRef<CommentListRef>(null);
 
   return (
-    <div className="border-t border-gray-200 bg-white px-4 py-3">
+    <div className="container mx-auto max-w-4xl border-t border-gray-200 bg-white px-4 py-3">
       <div className="mb-4">
         <CommentInput
           imageId={postId}

--- a/features/posts/components/PostCard.tsx
+++ b/features/posts/components/PostCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { Card, CardContent } from "@/components/ui/card";
@@ -27,10 +27,28 @@ export function PostCard({ post, currentUserId }: PostCardProps) {
   const [avatarUrl, setAvatarUrl] = useState<string | null>(
     post.user?.avatar_url ?? null
   );
+  const preloadLinkRef = useRef<HTMLLinkElement | null>(null);
+
+  // 画像のプリロード処理（onMouseEnter/onTouchStart）
+  const handlePreload = () => {
+    if (!imageUrl) return;
+    
+    // 既にプリロード済みの場合はスキップ
+    if (preloadLinkRef.current) return;
+
+    // Next.jsのImageコンポーネントは既に最適化されているため、
+    // 詳細ページへの遷移時に画像が再利用される
+    // ここでは、Linkのprefetchで詳細ページ自体をプリフェッチする
+  };
 
   return (
     <Card className="overflow-hidden pt-0 pb-0 gap-1">
-      <Link href={`/posts/${post.id}`}>
+      <Link 
+        href={`/posts/${post.id}`}
+        prefetch={true}
+        onMouseEnter={handlePreload}
+        onTouchStart={handlePreload}
+      >
         <div className="relative w-full overflow-hidden bg-gray-100">
           {imageUrl ? (
             <Image

--- a/features/posts/components/PostDetailStatic.tsx
+++ b/features/posts/components/PostDetailStatic.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, lazy, Suspense } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { User, MoreHorizontal, Edit, Trash2, Share2, Copy, Check } from "lucide-react";
@@ -11,7 +11,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { ImageFullscreen } from "./ImageFullscreen";
 import { CollapsibleText } from "./CollapsibleText";
 import { EditPostModal } from "./EditPostModal";
 import { DeletePostDialog } from "./DeletePostDialog";
@@ -19,6 +18,9 @@ import { PostModal } from "./PostModal";
 import { getPostImageUrl } from "../lib/utils";
 import { useToast } from "@/components/ui/use-toast";
 import type { Post } from "../types";
+
+// ImageFullscreenコンポーネントを動的インポート（SSR不要）
+const ImageFullscreen = lazy(() => import("./ImageFullscreen").then(module => ({ default: module.ImageFullscreen })));
 
 interface PostDetailStaticProps {
   post: Post;
@@ -75,7 +77,7 @@ export function PostDetailStatic({
 
   return (
     <div className="bg-white">
-      <div className="container mx-auto bg-white">
+      <div className="container mx-auto max-w-4xl bg-white">
         {/* 画像セクション */}
         <div className="relative w-full overflow-hidden bg-white">
           <div
@@ -83,7 +85,7 @@ export function PostDetailStatic({
               imageAspectRatio === "portrait"
                 ? "max-h-[50vh]"
                 : imageAspectRatio === "landscape"
-                ? "w-full"
+                ? "max-h-[50vh]"
                 : "aspect-square"
             }`}
             onClick={() => setIsFullscreenOpen(true)}
@@ -95,7 +97,9 @@ export function PostDetailStatic({
                 width={1200}
                 height={1200}
                 className={`w-full h-auto object-contain ${
-                  imageAspectRatio === "portrait" ? "max-h-[50vh]" : ""
+                  imageAspectRatio === "portrait" || imageAspectRatio === "landscape"
+                    ? "max-h-[50vh]"
+                    : ""
                 }`}
                 sizes="(max-width: 768px) 100vw, 80vw"
                 priority
@@ -257,12 +261,14 @@ export function PostDetailStatic({
 
       {/* 全画面表示 */}
       {imageUrl && (
-        <ImageFullscreen
-          imageUrl={imageUrl}
-          alt={post.caption || "投稿画像"}
-          isOpen={isFullscreenOpen}
-          onClose={() => setIsFullscreenOpen(false)}
-        />
+        <Suspense fallback={null}>
+          <ImageFullscreen
+            imageUrl={imageUrl}
+            alt={post.caption || "投稿画像"}
+            isOpen={isFullscreenOpen}
+            onClose={() => setIsFullscreenOpen(false)}
+          />
+        </Suspense>
       )}
 
       {/* 編集モーダル */}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Stores and uses image aspect ratio from DB (with fallback), caches post fetching, applies optimistic view counts, and lazy/prefetches UI for faster post detail rendering.
> 
> - **Data model**:
>   - Add `aspect_ratio` (and `view_count`) to `GeneratedImageRecord`.
> - **Generation**:
>   - Compute `aspect_ratio` after upload in `generateAndSaveImages` and save it with the record.
> - **Server/API**:
>   - Wrap `getPost` in `React.cache()` to avoid duplicate fetches per request.
>   - If `aspect_ratio` is missing, compute from image URL and persist.
>   - Switch `view_count` update to optimistic increment.
> - **Post detail page** (`app/posts/[id]/page.tsx`):
>   - Use DB `aspect_ratio` with fallback calculation when absent.
> - **UI/Components**:
>   - Lazy-load `ImageFullscreen` with `Suspense`; tweak image sizing and container to `max-w-4xl`.
>   - `PostCard`: enable `Link` prefetch and add hover/touch preload hook.
>   - `CommentSection`: wrap content in centered, constrained container.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fad66786b657bab0ed277360753af371b740429f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->