### PR TITLE
確認のために実装

### DIFF
--- a/features/credits/components/StripePricingTable.tsx
+++ b/features/credits/components/StripePricingTable.tsx
@@ -10,11 +10,16 @@ interface StripePricingTableProps {
 export function StripePricingTable({ userId }: StripePricingTableProps) {
   // 環境変数から取得、なければデフォルト値（テスト環境のID）を使用
   // クライアントコンポーネントでは NEXT_PUBLIC_ プレフィックスを持つ環境変数のみ使用可能
+  // 直接process.envにアクセス（Next.jsではクライアント側でもNEXT_PUBLIC_*は利用可能）
+  const publishableKey =
+    process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ||
+    env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ||
+    "";
+
   const pricingTableId =
+    process.env.NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID ||
     env.NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID ||
     "prctbl_1So3YGEtgRYjQynQvtDbE755"; // テスト環境のデフォルト値
-
-  const publishableKey = env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY;
 
   // 公開キーが設定されていない場合はエラーを表示
   if (!publishableKey) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves client-side Stripe config resolution in `StripePricingTable`.
> 
> - `publishableKey` and `pricingTableId` now read from `process.env.NEXT_PUBLIC_*` first, falling back to `env.NEXT_PUBLIC_*` and a test default for `pricingTableId`
> - Retains existing error UI when the publishable key is missing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51993fe2cdc541c662e75778ac9abe0be76b73d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->