### PR TITLE
修正

### DIFF
--- a/app/(app)/my-page/credits/purchase/page.tsx
+++ b/app/(app)/my-page/credits/purchase/page.tsx
@@ -3,9 +3,21 @@ import { requireAuth } from "@/lib/auth";
 import { StripePricingTable } from "@/features/credits/components/StripePricingTable";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { CheckCircle2, XCircle, ShoppingCart } from "lucide-react";
+import { env } from "@/lib/env";
 
 async function PurchasePageContent() {
   const user = await requireAuth();
+
+  // サーバーサイドで環境変数を取得してクライアントコンポーネントに渡す
+  const publishableKey =
+    env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ||
+    process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ||
+    "";
+
+  const pricingTableId =
+    env.NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID ||
+    process.env.NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID ||
+    "prctbl_1So3YGEtgRYjQynQvtDbE755"; // テスト環境のデフォルト値
 
   return (
     <Card>
@@ -20,7 +32,11 @@ async function PurchasePageContent() {
       </CardHeader>
       <CardContent>
         <div className="mt-6">
-          <StripePricingTable userId={user.id} />
+          <StripePricingTable
+            userId={user.id}
+            publishableKey={publishableKey}
+            pricingTableId={pricingTableId}
+          />
         </div>
       </CardContent>
     </Card>

--- a/features/credits/components/StripePricingTable.tsx
+++ b/features/credits/components/StripePricingTable.tsx
@@ -1,26 +1,18 @@
 "use client";
 
 import Script from "next/script";
-import { env } from "@/lib/env";
 
 interface StripePricingTableProps {
   userId?: string;
+  publishableKey: string;
+  pricingTableId: string;
 }
 
-export function StripePricingTable({ userId }: StripePricingTableProps) {
-  // 環境変数から取得、なければデフォルト値（テスト環境のID）を使用
-  // クライアントコンポーネントでは NEXT_PUBLIC_ プレフィックスを持つ環境変数のみ使用可能
-  // 直接process.envにアクセス（Next.jsではクライアント側でもNEXT_PUBLIC_*は利用可能）
-  const publishableKey =
-    process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ||
-    env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ||
-    "";
-
-  const pricingTableId =
-    process.env.NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID ||
-    env.NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID ||
-    "prctbl_1So3YGEtgRYjQynQvtDbE755"; // テスト環境のデフォルト値
-
+export function StripePricingTable({
+  userId,
+  publishableKey,
+  pricingTableId,
+}: StripePricingTableProps) {
   // 公開キーが設定されていない場合はエラーを表示
   if (!publishableKey) {
     return (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors Stripe pricing integration to source environment variables on the server and pass them to the client component.
> 
> - `PurchasePageContent` now reads `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` and `NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID` (with a test default) via `env`/`process.env`, and passes them to `StripePricingTable`
> - `StripePricingTable` is updated to accept `publishableKey` and `pricingTableId` props and no longer accesses env vars directly; renders an inline error if `publishableKey` is missing
> - Updated usage of `StripePricingTable` to include `userId` plus the new props
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 275eb43bff6580119054d7a3c56c556de4db332a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->