### PR TITLE
詳細ページに遷移した時のみ閲覧数がカウントされるように修正

### DIFF
--- a/features/my-page/components/MyImageCard.tsx
+++ b/features/my-page/components/MyImageCard.tsx
@@ -23,7 +23,7 @@ export function MyImageCard({ image, currentUserId }: MyImageCardProps) {
 
   return (
     <Card className="overflow-hidden p-0">
-      <Link href={detailUrl}>
+      <Link href={detailUrl} prefetch={false}>
         <div className="relative w-full overflow-hidden bg-gray-100">
           {imageUrl ? (
             <Image

--- a/features/posts/components/PostCard.tsx
+++ b/features/posts/components/PostCard.tsx
@@ -45,7 +45,7 @@ export function PostCard({ post, currentUserId }: PostCardProps) {
     <Card className="overflow-hidden pt-0 pb-0 gap-1">
       <Link 
         href={`/posts/${post.id}`}
-        prefetch={true}
+        prefetch={false}
         onMouseEnter={handlePreload}
         onTouchStart={handlePreload}
       >


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> - Set `prefetch={false}` on post detail `Link` components in `PostCard.tsx` and `MyImageCard.tsx` to prevent automatic page prefetching.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c740acecbf7f814d7585f7ae6b7ede1e9c6638d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->