### PR TITLE
生成結果通知の修正

### DIFF
--- a/components/GeneratedImageNotificationChecker.tsx
+++ b/components/GeneratedImageNotificationChecker.tsx
@@ -7,24 +7,94 @@ import { getGeneratedImages } from "@/features/generation/lib/database";
 
 const GENERATED_IMAGE_TOAST_HISTORY_STORAGE_KEY =
   "notified-generated-image-ids:v2";
+const GENERATED_IMAGE_TOAST_SESSION_KEY =
+  "notified-generated-image-ids-session:v2";
 const GENERATED_IMAGE_TOAST_HISTORY_LIMIT = 200;
+
+// js-cache-storage: Storage API の同期的な読み取りをメモリキャッシュで軽減
+const localStorageCache = new Map<string, string | null>();
+const sessionStorageCache = new Map<string, string | null>();
 
 function getGeneratedImageToastStorageKey(userId: string): string {
   return `${GENERATED_IMAGE_TOAST_HISTORY_STORAGE_KEY}:${userId}`;
 }
 
+function getSessionShownStorageKey(userId: string): string {
+  return `${GENERATED_IMAGE_TOAST_SESSION_KEY}:${userId}`;
+}
+
+function readSessionShownIds(userId: string): Set<string> {
+  if (typeof window === "undefined") return new Set();
+  const key = getSessionShownStorageKey(userId);
+  let raw: string | null = null;
+  if (sessionStorageCache.has(key)) {
+    raw = sessionStorageCache.get(key) ?? null;
+  } else {
+    try {
+      raw = sessionStorage.getItem(key);
+      sessionStorageCache.set(key, raw);
+    } catch {
+      return new Set();
+    }
+  }
+  if (!raw) return new Set();
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(
+      parsed.filter(
+        (item): item is string => typeof item === "string" && item.length > 0
+      )
+    );
+  } catch {
+    return new Set();
+  }
+}
+
+/**
+ * 既存の sessionShownIds を渡すことで二重読み取りを回避（js-cache-storage, 二重読み取り削減）
+ */
+function addToSessionShownIds(
+  userId: string,
+  newIds: Iterable<string>,
+  existingSessionShownIds: Set<string>
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    const union = new Set([...existingSessionShownIds, ...newIds]);
+    const normalized = Array.from(union).slice(
+      -GENERATED_IMAGE_TOAST_HISTORY_LIMIT
+    );
+    const key = getSessionShownStorageKey(userId);
+    sessionStorage.setItem(key, JSON.stringify(normalized));
+    sessionStorageCache.set(key, JSON.stringify(normalized));
+  } catch {
+    // セッション記録失敗時は静かに無視（localStorageの永続化に依存）
+  }
+}
+
 function readGeneratedImageToastHistory(storageKey: string): string[] {
   if (typeof window === "undefined") return [];
-
+  let raw: string | null = null;
+  if (localStorageCache.has(storageKey)) {
+    raw = localStorageCache.get(storageKey) ?? null;
+  } else {
+    try {
+      raw = localStorage.getItem(storageKey);
+      localStorageCache.set(storageKey, raw);
+    } catch {
+      return [];
+    }
+  }
+  if (!raw) return [];
   try {
-    const raw = localStorage.getItem(storageKey);
-    if (!raw) return [];
-
     const parsed: unknown = JSON.parse(raw);
     if (!Array.isArray(parsed)) return [];
 
     return parsed
-      .filter((item): item is string => typeof item === "string" && item.length > 0)
+      .filter(
+        (item): item is string => typeof item === "string" && item.length > 0
+      )
       .slice(-GENERATED_IMAGE_TOAST_HISTORY_LIMIT);
   } catch {
     return [];
@@ -43,6 +113,7 @@ function writeGeneratedImageToastHistory(
 
   try {
     localStorage.setItem(storageKey, JSON.stringify(normalized));
+    localStorageCache.set(storageKey, JSON.stringify(normalized));
   } catch (error) {
     if (process.env.NODE_ENV === "development") {
       console.error(
@@ -53,6 +124,23 @@ function writeGeneratedImageToastHistory(
   }
 
   return normalized;
+}
+
+function invalidateStorageCache(): void {
+  localStorageCache.clear();
+  sessionStorageCache.clear();
+}
+
+// 外部変更時のキャッシュ無効化（他タブのlocalStorage変更、タブ復帰時）
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (e) => {
+    if (e.key) localStorageCache.delete(e.key);
+  });
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible") {
+      invalidateStorageCache();
+    }
+  });
 }
 
 /**
@@ -119,13 +207,17 @@ export function GeneratedImageNotificationChecker() {
           return;
         }
 
-        // 通知済みでない画像IDを抽出
-        const newImageIds = recentImageIds.filter((id) => !notifiedIds.has(id));
+        // 通知済みでない画像IDを抽出（localStorage + sessionStorageの両方で除外し、1回表示したら二度と表示しない）
+        const sessionShownIds = readSessionShownIds(userId);
+        const newImageIds = recentImageIds.filter(
+          (id) => !notifiedIds.has(id) && !sessionShownIds.has(id)
+        );
 
-        // 新規画像があればトースト通知
+        // 新規画像があればトースト通知（1回のみ）
         if (newImageIds.length > 0) {
           newImageIds.forEach((id) => notifiedIds.add(id));
           persistNotifiedIds();
+          addToSessionShownIds(userId, newImageIds, sessionShownIds);
 
           toast({
             title: "新しい画像が生成されました",


### PR DESCRIPTION
同一タブ内: sessionStorage に記録するため、localStorage の永続化に失敗しても、同じセッションでは二度表示されません。
タブを閉じて再度開いた場合: sessionStorage はクリアされるため、localStorage の通知履歴のみで判定します。
ログイン直後の誤表示: 同じセッション内では、一度表示したトーストは再表示されません。