### PR TITLE
トランザクションロジックの修正

### DIFF
--- a/app/api/generation-status/route.ts
+++ b/app/api/generation-status/route.ts
@@ -1,9 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getUser } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
-import { createAdminClient } from "@/lib/supabase/admin";
-
-const JOB_PROCESSING_TIMEOUT_MS = 6 * 60 * 1000;
 
 /**
  * 画像生成ステータス取得API
@@ -52,39 +49,6 @@ export async function GET(request: NextRequest) {
         { error: "ステータスの取得に失敗しました" },
         { status: 500 }
       );
-    }
-
-    // Edge Function異常終了などでprocessingが長時間継続するケースを救済
-    if (job.status === "processing") {
-      const startedAt = job.started_at ? new Date(job.started_at).getTime() : 0;
-      const now = Date.now();
-      const elapsed = now - startedAt;
-
-      if (!startedAt || elapsed >= JOB_PROCESSING_TIMEOUT_MS) {
-        const timeoutMessage = "処理がタイムアウトしました。入力画像サイズを下げて再試行してください。";
-        try {
-          const admin = createAdminClient();
-          const { error: timeoutUpdateError } = await admin
-            .from("image_jobs")
-            .update({
-              status: "failed",
-              error_message: timeoutMessage,
-              completed_at: new Date().toISOString(),
-            })
-            .eq("id", job.id)
-            .eq("user_id", user.id)
-            .eq("status", "processing");
-
-          if (timeoutUpdateError) {
-            console.error("Failed to mark stale job as failed:", timeoutUpdateError);
-          } else {
-            job.status = "failed";
-            job.error_message = timeoutMessage;
-          }
-        } catch (timeoutError) {
-          console.error("Stale job rescue failed:", timeoutError);
-        }
-      }
     }
 
     const normalizedErrorMessage =

--- a/docs/billing-consistency-runbook.md
+++ b/docs/billing-consistency-runbook.md
@@ -1,0 +1,105 @@
+# Billing Consistency Runbook
+
+## Purpose
+画像生成課金の整合性を維持し、以下の異常を検知するための運用手順です。
+
+- `refund` があるのに `image_jobs.status = succeeded`
+- `consumption` があるのに最終 `failed` で `refund` がない
+- `succeeded` なのに `consumption` がない
+
+この運用は **検知のみ** です。自動金額是正は行いません。
+
+## Pre-Deploy Checklist
+
+1. 事前重複確認（部分一意インデックス追加前）
+
+```sql
+with tx as (
+  select
+    transaction_type,
+    user_id,
+    metadata->>'job_id' as job_id,
+    count(*) as cnt,
+    array_agg(id order by created_at) as tx_ids
+  from public.credit_transactions
+  where transaction_type in ('consumption', 'refund')
+    and metadata ? 'job_id'
+  group by transaction_type, user_id, metadata->>'job_id'
+)
+select *
+from tx
+where cnt > 1
+order by cnt desc, transaction_type, user_id;
+```
+
+2. 本番バックアップ（スナップショット）取得
+- 推奨タイミング: マイグレーション適用の直前（5分以内）
+- 取得対象: DB schema + data
+
+## Monitoring
+
+1. 異常検知関数（2時間窓）
+
+```sql
+select *
+from public.detect_generation_billing_anomalies(now() - interval '2 hours')
+order by observed_at desc;
+```
+
+2. 監視実行関数（異常がある場合のみ `admin_audit_log` 記録）
+
+```sql
+select public.monitor_generation_billing_anomalies(now() - interval '2 hours');
+```
+
+3. 定期実行
+- pg_cron job name: `generation_billing_anomaly_monitor_hourly`
+- schedule: `7 * * * *`
+
+## Test Checklist
+
+詳細な検証手順は `docs/billing-consistency-test-checklist.md` を参照してください。
+
+## Triage Procedure
+
+1. 対象 `job_id` のジョブ状態確認
+
+```sql
+select id, user_id, status, attempts, error_message, created_at, started_at, completed_at, updated_at
+from public.image_jobs
+where id = :job_id;
+```
+
+2. 対象 `job_id` の課金履歴確認
+
+```sql
+select id, user_id, amount, transaction_type, related_generation_id, metadata, created_at
+from public.credit_transactions
+where metadata->>'job_id' = :job_id
+order by created_at;
+```
+
+3. 生成結果確認
+
+```sql
+select id, user_id, image_url, storage_path, created_at
+from public.generated_images
+where id = :related_generation_id;
+```
+
+4. Storageログ/Edge Functionログを時系列で照合
+- 失敗→再試行→成功の流れを確認
+- 返金発生時刻と `job.status` 変遷を確認
+
+## Operational Policy
+
+1. 自動是正は行わない（検知のみ）。
+2. 是正が必要な場合は、運用承認後に手動で調整取引を実施する。
+3. 手動調整時は `admin_audit_log` に根拠（job_id, tx_id, reason）を残す。
+
+## Post-Deploy Validation
+
+1. `succeeded + refund` の同時成立が新規データで 0 件。
+2. `failed` 最終確定ジョブで `consumption` がある場合、`refund` が 1 件。
+3. retry途中で返金ログが発生しない。
+4. 監視ジョブが1時間ごとに実行され、異常時のみ監査ログに記録される。

--- a/docs/billing-consistency-test-checklist.md
+++ b/docs/billing-consistency-test-checklist.md
@@ -1,0 +1,127 @@
+# Billing Consistency Test Checklist
+
+## Scope
+課金整合性改善の受け入れ確認を、`TEST-01` から `TEST-06` までの観点で実施するためのチェックリストです。
+
+## Common Setup
+1. 対象環境は `staging` を使用する。
+2. 画像生成ジョブは検証用ユーザーを固定して実行する。
+3. すべての検証で `job_id` を控え、`image_jobs` / `credit_transactions` / Edge Functionログを同一時系列で照合する。
+
+## TEST-01 Retry可能失敗→再試行成功で返金なし
+1. 一時的に失敗しやすい入力でジョブを実行し、1回以上の再試行を発生させる。
+2. 最終状態が `image_jobs.status = 'succeeded'` であることを確認する。
+3. 以下SQLで `refund` が 0 件であることを確認する。
+
+```sql
+select count(*) as refund_count
+from public.credit_transactions
+where transaction_type = 'refund'
+  and metadata->>'job_id' = :job_id;
+```
+
+期待結果: `refund_count = 0`
+
+## TEST-02 Retry可能失敗×上限到達で返金あり
+1. 再試行可能エラーを連続で発生させ、`attempts >= 3` まで到達させる。
+2. `image_jobs.status = 'failed'` を確認する。
+3. 以下SQLで `consumption = 1` かつ `refund = 1` を確認する。
+
+```sql
+select
+  count(*) filter (where transaction_type = 'consumption') as consumption_count,
+  count(*) filter (where transaction_type = 'refund') as refund_count
+from public.credit_transactions
+where metadata->>'job_id' = :job_id;
+```
+
+期待結果: `consumption_count = 1` かつ `refund_count = 1`
+
+## TEST-03 Non-retryable失敗で即最終失敗＋返金あり
+1. `No images generated` を再現する入力でジョブを実行する。
+2. 初回失敗で `image_jobs.status = 'failed'` になることを確認する。
+3. 以下SQLで `refund = 1` を確認する。
+
+```sql
+select count(*) as refund_count
+from public.credit_transactions
+where transaction_type = 'refund'
+  and metadata->>'job_id' = :job_id;
+```
+
+期待結果: `refund_count = 1`
+
+## TEST-04 stale未到達は再キュー、到達は最終失敗＋返金
+1. `processing` 状態ジョブを作り、stale閾値未満で worker を実行する。
+2. メッセージ削除されず再処理対象として残ることを確認する。
+3. stale閾値超過後に worker を実行し、`attempts` で分岐することを確認する。
+4. 最終失敗確定時のみ `refund` が 1 件作成されることを確認する。
+
+期待結果: stale未到達時は返金なし、最終失敗確定時のみ返金あり
+
+## TEST-05 同一jobの二重消費/二重返金がDB制約で防止
+以下SQLを実行して重複挿入が失敗することを確認する。
+
+```sql
+-- consumption重複検証（2回目は unique violation）
+insert into public.credit_transactions (user_id, amount, transaction_type, metadata)
+values (:user_id, -20, 'consumption', jsonb_build_object('job_id', :job_id));
+
+insert into public.credit_transactions (user_id, amount, transaction_type, metadata)
+values (:user_id, -20, 'consumption', jsonb_build_object('job_id', :job_id));
+
+-- refund重複検証（2回目は unique violation）
+insert into public.credit_transactions (user_id, amount, transaction_type, metadata)
+values (:user_id, 20, 'refund', jsonb_build_object('job_id', :job_id));
+
+insert into public.credit_transactions (user_id, amount, transaction_type, metadata)
+values (:user_id, 20, 'refund', jsonb_build_object('job_id', :job_id));
+```
+
+期待結果: 2回目の insert が失敗する
+
+## TEST-06 異常検知関数が anomaly を検出
+1. 検証用に anomaly データ（例: `succeeded + refund`）を投入する。
+2. 以下SQLで anomaly を検出できることを確認する。
+
+```sql
+select *
+from public.detect_generation_billing_anomalies(now() - interval '24 hours')
+order by observed_at desc;
+```
+
+3. 以下SQLで監視関数実行時に異常件数が返ることを確認する。
+
+```sql
+select public.monitor_generation_billing_anomalies(now() - interval '24 hours');
+```
+
+期待結果: anomaly 件数が 1 件以上で返る
+
+## Acceptance Queries
+受け入れ基準の最終確認に使用するクエリ:
+
+```sql
+-- 1) succeeded + refund が 0 件
+select count(*) as succeeded_with_refund
+from public.image_jobs j
+join public.credit_transactions r
+  on r.user_id = j.user_id
+ and r.transaction_type = 'refund'
+ and r.metadata->>'job_id' = j.id::text
+where j.status = 'succeeded';
+
+-- 2) failed + consumption なのに refund がない件数
+select count(*) as failed_missing_refund
+from public.image_jobs j
+join public.credit_transactions c
+  on c.user_id = j.user_id
+ and c.transaction_type = 'consumption'
+ and c.metadata->>'job_id' = j.id::text
+left join public.credit_transactions r
+  on r.user_id = j.user_id
+ and r.transaction_type = 'refund'
+ and r.metadata->>'job_id' = j.id::text
+where j.status = 'failed'
+  and r.id is null;
+```

--- a/supabase/migrations/20260222090000_add_generation_billing_uniqueness_indexes.sql
+++ b/supabase/migrations/20260222090000_add_generation_billing_uniqueness_indexes.sql
@@ -1,0 +1,16 @@
+-- 課金整合性: ジョブ単位の重複消費・重複返金を防止
+-- 事前確認:
+--   transaction_type in ('consumption', 'refund') かつ metadata->>'job_id' 単位で
+--   重複レコードがないことを確認してから適用すること
+
+-- consumption: 1 user + 1 job_id につき 1 レコードのみ許可
+CREATE UNIQUE INDEX IF NOT EXISTS idx_credit_transactions_one_consumption_per_job
+  ON public.credit_transactions (user_id, (metadata->>'job_id'))
+  WHERE transaction_type = 'consumption'
+    AND metadata ? 'job_id';
+
+-- refund: 1 user + 1 job_id につき 1 レコードのみ許可
+CREATE UNIQUE INDEX IF NOT EXISTS idx_credit_transactions_one_refund_per_job
+  ON public.credit_transactions (user_id, (metadata->>'job_id'))
+  WHERE transaction_type = 'refund'
+    AND metadata ? 'job_id';

--- a/supabase/migrations/20260222091000_add_generation_billing_anomaly_monitoring.sql
+++ b/supabase/migrations/20260222091000_add_generation_billing_anomaly_monitoring.sql
@@ -1,0 +1,227 @@
+-- 課金整合性の異常検知（検知のみ・自動是正なし）
+-- 1) 異常検知関数
+-- 2) 監視実行関数（admin_audit_logへ要約記録）
+-- 3) pg_cron による1時間ごとの定期実行
+
+CREATE OR REPLACE FUNCTION public.detect_generation_billing_anomalies(
+  p_since timestamptz DEFAULT (now() - interval '2 hours')
+)
+RETURNS TABLE (
+  anomaly_type text,
+  job_id uuid,
+  user_id uuid,
+  job_status text,
+  consumption_tx_id uuid,
+  refund_tx_id uuid,
+  observed_at timestamptz,
+  details jsonb
+)
+LANGUAGE sql
+STABLE
+SET search_path = public
+AS $function$
+WITH consumption AS (
+  SELECT
+    ct.id,
+    ct.user_id,
+    ct.created_at,
+    ct.metadata,
+    CASE
+      WHEN (ct.metadata->>'job_id') ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+        THEN (ct.metadata->>'job_id')::uuid
+      ELSE NULL
+    END AS job_id
+  FROM public.credit_transactions ct
+  WHERE ct.transaction_type = 'consumption'
+    AND ct.metadata ? 'job_id'
+),
+refund AS (
+  SELECT
+    ct.id,
+    ct.user_id,
+    ct.created_at,
+    ct.metadata,
+    CASE
+      WHEN (ct.metadata->>'job_id') ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+        THEN (ct.metadata->>'job_id')::uuid
+      ELSE NULL
+    END AS job_id
+  FROM public.credit_transactions ct
+  WHERE ct.transaction_type = 'refund'
+    AND ct.metadata ? 'job_id'
+),
+refund_for_succeeded_job AS (
+  SELECT
+    'refund_for_succeeded_job'::text AS anomaly_type,
+    r.job_id,
+    r.user_id,
+    j.status::text AS job_status,
+    c.id AS consumption_tx_id,
+    r.id AS refund_tx_id,
+    GREATEST(r.created_at, j.updated_at) AS observed_at,
+    jsonb_build_object(
+      'refund_created_at', r.created_at,
+      'job_updated_at', j.updated_at,
+      'job_attempts', j.attempts,
+      'job_error_message', j.error_message
+    ) AS details
+  FROM refund r
+  JOIN public.image_jobs j
+    ON j.id = r.job_id
+   AND j.user_id = r.user_id
+  LEFT JOIN consumption c
+    ON c.job_id = r.job_id
+   AND c.user_id = r.user_id
+  WHERE r.job_id IS NOT NULL
+    AND j.status = 'succeeded'
+    AND GREATEST(r.created_at, j.updated_at) >= p_since
+),
+consumption_missing_refund_for_failed_job AS (
+  SELECT
+    'consumption_without_refund_for_failed_job'::text AS anomaly_type,
+    c.job_id,
+    c.user_id,
+    j.status::text AS job_status,
+    c.id AS consumption_tx_id,
+    NULL::uuid AS refund_tx_id,
+    GREATEST(c.created_at, j.updated_at) AS observed_at,
+    jsonb_build_object(
+      'consumption_created_at', c.created_at,
+      'job_updated_at', j.updated_at,
+      'job_attempts', j.attempts,
+      'job_error_message', j.error_message
+    ) AS details
+  FROM consumption c
+  JOIN public.image_jobs j
+    ON j.id = c.job_id
+   AND j.user_id = c.user_id
+  LEFT JOIN refund r
+    ON r.job_id = c.job_id
+   AND r.user_id = c.user_id
+  WHERE c.job_id IS NOT NULL
+    AND j.status = 'failed'
+    AND r.id IS NULL
+    AND GREATEST(c.created_at, j.updated_at) >= p_since
+),
+succeeded_job_without_consumption AS (
+  SELECT
+    'succeeded_job_without_consumption'::text AS anomaly_type,
+    j.id AS job_id,
+    j.user_id,
+    j.status::text AS job_status,
+    NULL::uuid AS consumption_tx_id,
+    r.id AS refund_tx_id,
+    j.updated_at AS observed_at,
+    jsonb_build_object(
+      'job_created_at', j.created_at,
+      'job_updated_at', j.updated_at,
+      'job_attempts', j.attempts,
+      'job_error_message', j.error_message
+    ) AS details
+  FROM public.image_jobs j
+  LEFT JOIN consumption c
+    ON c.job_id = j.id
+   AND c.user_id = j.user_id
+  LEFT JOIN refund r
+    ON r.job_id = j.id
+   AND r.user_id = j.user_id
+  WHERE j.status = 'succeeded'
+    AND c.id IS NULL
+    AND j.updated_at >= p_since
+)
+SELECT *
+FROM refund_for_succeeded_job
+UNION ALL
+SELECT *
+FROM consumption_missing_refund_for_failed_job
+UNION ALL
+SELECT *
+FROM succeeded_job_without_consumption
+ORDER BY observed_at DESC, anomaly_type;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.monitor_generation_billing_anomalies(
+  p_since timestamptz DEFAULT (now() - interval '2 hours')
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+DECLARE
+  v_count integer := 0;
+  v_sample jsonb := '[]'::jsonb;
+BEGIN
+  WITH anomalies AS (
+    SELECT *
+    FROM public.detect_generation_billing_anomalies(p_since)
+  ),
+  counted AS (
+    SELECT count(*)::integer AS cnt
+    FROM anomalies
+  ),
+  sampled AS (
+    SELECT
+      COALESCE(jsonb_agg(to_jsonb(x) ORDER BY x.observed_at DESC), '[]'::jsonb) AS sample
+    FROM (
+      SELECT *
+      FROM anomalies
+      ORDER BY observed_at DESC
+      LIMIT 20
+    ) x
+  )
+  SELECT counted.cnt, sampled.sample
+  INTO v_count, v_sample
+  FROM counted, sampled;
+
+  IF v_count > 0 THEN
+    INSERT INTO public.admin_audit_log (
+      admin_user_id,
+      action_type,
+      target_type,
+      target_id,
+      metadata
+    ) VALUES (
+      NULL,
+      'generation_billing_anomaly_detected',
+      'credit_transactions',
+      NULL,
+      jsonb_build_object(
+        'count', v_count,
+        'since', p_since,
+        'sample', v_sample,
+        'auto_remediation', false,
+        'source', 'cron'
+      )
+    );
+  END IF;
+
+  RETURN jsonb_build_object(
+    'count', v_count,
+    'since', p_since,
+    'logged', (v_count > 0)
+  );
+END;
+$function$;
+
+DO $do$
+DECLARE
+  v_existing_job_id bigint;
+BEGIN
+  SELECT jobid
+  INTO v_existing_job_id
+  FROM cron.job
+  WHERE jobname = 'generation_billing_anomaly_monitor_hourly'
+  LIMIT 1;
+
+  IF v_existing_job_id IS NOT NULL THEN
+    PERFORM cron.unschedule(v_existing_job_id);
+  END IF;
+
+  PERFORM cron.schedule(
+    'generation_billing_anomaly_monitor_hourly',
+    '7 * * * *',
+    $cron$SELECT public.monitor_generation_billing_anomalies();$cron$
+  );
+END;
+$do$;


### PR DESCRIPTION
## 概要
画像生成課金の整合性改善として、返金タイミングを「失敗時即時」から「最終失敗確定時のみ」に変更しました。  
あわせて、DB制約・監視関数・定期監視（pg_cron）・運用ドキュメントを追加し、`succeeded` と `refund` の同時成立を防止する実装を行いました。

## 背景 / 課題
- 画像生成が最終的に成功しているにもかかわらず、途中失敗で返金が先行する可能性があった
- API側で状態更新を持っており、worker責務と競合しうる構造だった
- DBレベルでの二重消費/二重返金ガードが不足していた
- 異常発生時の定期検知・運用手順が不足していた

## 変更内容

### 1. Workerロジック変更
対象: `supabase/functions/image-gen-worker/index.ts`

- 失敗catch直後の即時返金を削除
- 最終失敗確定時（non-retriable または attempts上限到達）のみ返金
- retry可能失敗時は `queued` に戻し、返金しない
- stale処理も同一ルールに統一（未確定は再キュー、確定時のみ返金）
- `refundPercoinsFromGeneration` で `consumption` 存在確認を必須化
- 成功時に `image_jobs.error_message = null` を明示更新
- `status` 更新時に `.eq("status","processing") + maybeSingle()` を導入し、0件更新の誤進行を防止
- 返金重複はDB一意制約エラー（`23505`）を冪等として扱いスキップ

### 2. API責務分離
対象: `app/api/generation-status/route.ts`

- stale救済のDB更新処理を削除
- 読み取り専用API化（状態は返すが更新しない）
- `failed` + `"No images generated"` のメッセージ正規化は維持

### 3. DBマイグレーション（課金一意制約）
対象: `supabase/migrations/20260222090000_add_generation_billing_uniqueness_indexes.sql`

- `consumption` 用 部分一意インデックス追加  
  `idx_credit_transactions_one_consumption_per_job`
- `refund` 用 部分一意インデックス追加  
  `idx_credit_transactions_one_refund_per_job`

### 4. 監視・検知（検知のみ）
対象: `supabase/migrations/20260222091000_add_generation_billing_anomaly_monitoring.sql`

- `public.detect_generation_billing_anomalies()` 追加
- `public.monitor_generation_billing_anomalies()` 追加（異常時のみ `admin_audit_log` 記録）
- pg_cron 1時間毎ジョブ追加  
  `generation_billing_anomaly_monitor_hourly`（`7 * * * *`）

### 5. ドキュメント追加
- `docs/billing-consistency-runbook.md`
- `docs/billing-consistency-test-checklist.md`

## 互換性 / 影響範囲
- 公開APIレスポンス形式の変更なし
- 課金整合性ロジックのみ変更（UI大規模変更なし）
- `failed` 判定は worker 一元化

## 本番適用結果
- migration適用順:
  1. `add_generation_billing_uniqueness_indexes`
  2. `add_generation_billing_anomaly_monitoring`
- 適用後確認:
  - 2つの一意インデックス作成済み
  - 2つの監視関数作成済み
  - cronジョブ登録済み
  - 監視関数手動実行結果: `count=0, logged=false`
- migration履歴:
  - `20260222003044 add_generation_billing_uniqueness_indexes`
  - `20260222003124 add_generation_billing_anomaly_monitoring`

## 動作確認
- `npm run lint -- app/api/generation-status/route.ts` 実行
- `npm run lint -- supabase/functions/image-gen-worker/index.ts` 実行
- 実ジョブ確認:
  - `5b96f4ed-81c2-4a37-8ef8-4db92d87b22c` -> `succeeded` / `consumption=1` / `refund=0` / anomalyなし
  - `c81769ff-b8d6-4442-a543-cc351cb3e6ec` -> `succeeded` / `consumption=1` / `refund=0` / anomalyなし

## 受け入れ観点（対応）
- `succeeded + refund` 同時成立の防止
- 最終失敗時のみ返金
- retry途中返金の抑止
- 二重消費/二重返金のDB制約防止
- 定期監視による異常検知（自動是正なし）

## チェックリスト
- [x] Worker返金タイミング修正
- [x] API読み取り専用化
- [x] DB部分一意インデックス追加
- [x] 異常検知関数追加
- [x] pg_cron定期監視追加
- [x] Runbook追加
- [x] テストチェックリスト追加
- [x] 本番適用・適用後確認完了
