### PR TITLE
fix(generation): apply Gemini safety block handling and user-facing message

### DIFF
--- a/app/api/generation-status/route.ts
+++ b/app/api/generation-status/route.ts
@@ -1,7 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getUser } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
-import { isMalformedGeminiPartsErrorMessage } from "@/shared/generation/errors";
+import {
+  isMalformedGeminiPartsErrorMessage,
+  isSafetyPolicyBlockedErrorMessage,
+} from "@/shared/generation/errors";
+
+const SAFETY_BLOCKED_USER_MESSAGE =
+  "安全性ポリシーにより生成できませんでした。\n内容を変更して再試行してください。";
 
 function normalizeUserFacingGenerationError(
   status: string,
@@ -11,6 +17,10 @@ function normalizeUserFacingGenerationError(
 
   if (errorMessage === "No images generated") {
     return "画像を生成できませんでした。";
+  }
+
+  if (isSafetyPolicyBlockedErrorMessage(errorMessage)) {
+    return SAFETY_BLOCKED_USER_MESSAGE;
   }
 
   if (isMalformedGeminiPartsErrorMessage(errorMessage)) {

--- a/features/generation/components/AsyncGenerationStatus.tsx
+++ b/features/generation/components/AsyncGenerationStatus.tsx
@@ -166,7 +166,9 @@ export function AsyncGenerationStatus({
           </div>
         )}
         {status.status === "failed" && status.errorMessage && (
-          <div className="text-sm text-destructive">{status.errorMessage}</div>
+          <div className="whitespace-pre-line text-sm text-destructive">
+            {status.errorMessage}
+          </div>
         )}
         {status.status === "processing" && (
           <div className="flex items-center justify-center py-8">

--- a/features/generation/components/GenerationFormContainer.tsx
+++ b/features/generation/components/GenerationFormContainer.tsx
@@ -317,7 +317,7 @@ export function GenerationFormContainer({}: GenerationFormContainerProps) {
       toast({
         variant: "destructive",
         title: "画像を生成できませんでした",
-        description: message,
+        description: <span className="whitespace-pre-line">{message}</span>,
       });
     };
 
@@ -563,7 +563,7 @@ export function GenerationFormContainer({}: GenerationFormContainerProps) {
       {/* エラー表示 */}
       {error ? (
         <div className="rounded-lg border border-red-200 bg-red-50 p-4">
-          <p className="text-sm text-red-900">{error}</p>
+          <p className="whitespace-pre-line text-sm text-red-900">{error}</p>
           {isPercoinInsufficientError(error) ? (
             <div className="mt-3 flex justify-center lg:justify-start">
               <Link

--- a/shared/generation/errors.ts
+++ b/shared/generation/errors.ts
@@ -5,9 +5,16 @@
 
 export const MALFORMED_GEMINI_PARTS_ERROR =
   "candidate.content.parts is not iterable";
+export const SAFETY_POLICY_BLOCKED_ERROR = "safety_policy_blocked";
 
 export function isMalformedGeminiPartsErrorMessage(
   errorMessage: string
 ): boolean {
   return errorMessage.toLowerCase().includes(MALFORMED_GEMINI_PARTS_ERROR);
+}
+
+export function isSafetyPolicyBlockedErrorMessage(
+  errorMessage: string
+): boolean {
+  return errorMessage.toLowerCase().includes(SAFETY_POLICY_BLOCKED_ERROR);
 }

--- a/supabase/functions/image-gen-worker/index.ts
+++ b/supabase/functions/image-gen-worker/index.ts
@@ -14,6 +14,8 @@ import type {
 import {
   MALFORMED_GEMINI_PARTS_ERROR,
   isMalformedGeminiPartsErrorMessage,
+  SAFETY_POLICY_BLOCKED_ERROR,
+  isSafetyPolicyBlockedErrorMessage,
 } from "../../../shared/generation/errors.ts";
 
 /**
@@ -200,7 +202,18 @@ interface GeminiResponse {
       }>;
     };
     finishReason?: string;
+    safetyRatings?: Array<{
+      category?: string;
+      probability?: string;
+    }>;
   }>;
+  promptFeedback?: {
+    blockReason?: string;
+    safetyRatings?: Array<{
+      category?: string;
+      probability?: string;
+    }>;
+  };
   error?: {
     code: number;
     message: string;
@@ -267,7 +280,39 @@ function getPercoinCost(model: string | null): number {
 function isNonRetriableGenerationError(errorMessage: string): boolean {
   return (
     errorMessage === "No images generated" ||
-    isMalformedGeminiPartsErrorMessage(errorMessage)
+    isMalformedGeminiPartsErrorMessage(errorMessage) ||
+    isSafetyPolicyBlockedErrorMessage(errorMessage)
+  );
+}
+
+function isSafetyBlockReason(blockReason: string | undefined): boolean {
+  if (!blockReason) return false;
+  const normalized = blockReason.toUpperCase();
+  return (
+    normalized === "SAFETY" ||
+    normalized === "IMAGE_SAFETY" ||
+    normalized === "PROHIBITED_CONTENT" ||
+    normalized === "BLOCKLIST"
+  );
+}
+
+function isSafetyFinishReason(finishReason: string | undefined): boolean {
+  if (!finishReason) return false;
+  const normalized = finishReason.toUpperCase();
+  return normalized === "SAFETY" || normalized === "IMAGE_SAFETY";
+}
+
+function isGeminiSafetyBlocked(response: GeminiResponse): boolean {
+  if (isSafetyBlockReason(response.promptFeedback?.blockReason)) {
+    return true;
+  }
+
+  if (!response.candidates || response.candidates.length === 0) {
+    return false;
+  }
+
+  return response.candidates.some((candidate) =>
+    isSafetyFinishReason(candidate?.finishReason)
   );
 }
 
@@ -866,6 +911,14 @@ Deno.serve(async () => {
             contents: Array<{
               parts: typeof parts;
             }>;
+            safetySettings: Array<{
+              category:
+                | "HARM_CATEGORY_HARASSMENT"
+                | "HARM_CATEGORY_HATE_SPEECH"
+                | "HARM_CATEGORY_SEXUALLY_EXPLICIT"
+                | "HARM_CATEGORY_DANGEROUS_CONTENT";
+              threshold: "BLOCK_ONLY_HIGH";
+            }>;
             generationConfig?: {
               candidateCount?: number;
               imageConfig?: {
@@ -877,6 +930,12 @@ Deno.serve(async () => {
               {
                 parts,
               },
+            ],
+            safetySettings: [
+              { category: "HARM_CATEGORY_HARASSMENT", threshold: "BLOCK_ONLY_HIGH" },
+              { category: "HARM_CATEGORY_HATE_SPEECH", threshold: "BLOCK_ONLY_HIGH" },
+              { category: "HARM_CATEGORY_SEXUALLY_EXPLICIT", threshold: "BLOCK_ONLY_HIGH" },
+              { category: "HARM_CATEGORY_DANGEROUS_CONTENT", threshold: "BLOCK_ONLY_HIGH" },
             ],
           };
 
@@ -919,6 +978,10 @@ Deno.serve(async () => {
 
             if (geminiData.error) {
               throw new Error(geminiData.error.message || "Gemini API error");
+            }
+
+            if (isGeminiSafetyBlocked(geminiData)) {
+              throw new Error(SAFETY_POLICY_BLOCKED_ERROR);
             }
 
             // 画像データを抽出


### PR DESCRIPTION
### 概要
apply Gemini safety block handling and user-facing message

### 変更内容
- `app/api/generation-status/route.ts`
- `features/generation/components/AsyncGenerationStatus.tsx`
- `features/generation/components/GenerationFormContainer.tsx`
- `shared/generation/errors.ts`
- `supabase/functions/image-gen-worker/index.ts`

### 実機テスト
- [ ] ブラウザで生成フォームに有効なプロンプトを入力して送信し、`queued/processing` の後に生成画像が表示されること
- [ ] ブラウザで空のプロンプトを送信し、入力必須のバリデーションエラーメッセージが表示されること
- [ ] 生成失敗ケースを再現し、`画像生成に失敗しました。しばらくしてから、もう一度お試しください。` が表示されること
- [ ] PC（Chrome）/ iOS Safari / Android Chrome で上記導線を操作し、表示崩れがないこと

### テスト方法
- 自動テスト: 実施なし（変更ファイルに tests/* は含まれていません）

### テスト結果
- [ ] 自動テスト: 実施なし（変更ファイルに tests/* は含まれていません）
- [ ] failed のテスト項目: 実施なしのため判定不可
