### PR TITLE
feat(marketing): move thanks page to /thanks-sample and add bronze supporters

### DIFF
--- a/app/(marketing)/thanks-sample/page.tsx
+++ b/app/(marketing)/thanks-sample/page.tsx
@@ -8,14 +8,14 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { Button } from "@/components/ui/button";
-import { ChevronDown, Crown, Star, Medal, Heart, Shield, Users } from "lucide-react";
+import { ChevronDown, Crown, Star, Medal, Award, Shield, Users } from "lucide-react";
 import { SUPPORTERS, type Supporter } from "@/constants/supporters";
 import { createMarketingPageMetadata } from "@/lib/metadata";
 
 export const metadata: Metadata = createMarketingPageMetadata({
   title: "Special Thanks",
   description: "Persta.AIを支えてくださった皆様への感謝を込めて",
-  path: "/thanks",
+  path: "/thanks-sample",
 });
 
 export default function ThanksPage() {
@@ -23,16 +23,15 @@ export default function ThanksPage() {
   const platinumSupporters = SUPPORTERS.filter((s) => s.tier === "platinum");
   const goldSupporters = SUPPORTERS.filter((s) => s.tier === "gold");
   const silverSupporters = SUPPORTERS.filter((s) => s.tier === "silver");
+  const bronzeSupporters = SUPPORTERS.filter((s) => s.tier === "bronze");
   
   // Supporter Sub-tiers
   const coreSupporters = SUPPORTERS.filter((s) => s.tier === "core-supporter");
   const standardSupporters = SUPPORTERS.filter((s) => s.tier === "supporter");
-  const friendSupporters = SUPPORTERS.filter((s) => s.tier === "friend-supporter");
 
   const hasAnySupporters = 
     coreSupporters.length > 0 || 
-    standardSupporters.length > 0 || 
-    friendSupporters.length > 0;
+    standardSupporters.length > 0;
 
   return (
     <main className="mx-auto w-full max-w-screen-md px-4 py-8 md:py-12">
@@ -148,6 +147,29 @@ export default function ThanksPage() {
           </section>
         )}
 
+        {/* Bronze Supporters */}
+        {bronzeSupporters.length > 0 && (
+          <section className="space-y-6">
+            <div className="flex items-center justify-center gap-2 text-xl font-bold text-slate-800 md:text-2xl">
+              <Award className="h-6 w-6 fill-[#CD7F32]/40 text-[#A1622B]" />
+              <h2>Bronze Supporters</h2>
+            </div>
+
+            <Card className="relative overflow-hidden border border-[#8C6239] bg-[linear-gradient(135deg,#F8E5D2_0%,#D7A979_35%,#B87333_65%,#8C6239_100%)] shadow-sm">
+              <div className="absolute inset-0 bg-[linear-gradient(110deg,transparent,45%,#FFE9D2,55%,transparent)] bg-[length:220%_100%] animate-shine opacity-45 mix-blend-overlay pointer-events-none" />
+              <CardContent className="relative z-10 p-6">
+                <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
+                  {bronzeSupporters.map((supporter) => (
+                    <div key={supporter.id} className="flex items-baseline gap-2">
+                      <span className="text-base font-medium text-amber-950/90">{supporter.name}</span>
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          </section>
+        )}
+
         {/* Supporters Section */}
         {hasAnySupporters && (
           <section className="space-y-8">
@@ -177,7 +199,7 @@ export default function ThanksPage() {
             {/* Standard Supporters (5,000円) - Visible & Normal */}
             {standardSupporters.length > 0 && (
               <div className="space-y-3">
-                <div className="flex items-center justify-center gap-2 text-sm font-medium text-slate-500">
+                <div className="flex items-center justify-center gap-2 text-base font-semibold text-black">
                   <Users className="h-4 w-4 text-emerald-400" />
                   <span>Supporters</span>
                 </div>
@@ -185,7 +207,7 @@ export default function ThanksPage() {
                   <CardContent className="p-6">
                     <div className="grid grid-cols-3 gap-4 md:grid-cols-4 lg:grid-cols-4">
                       {standardSupporters.map((supporter) => (
-                        <div key={supporter.id} className="text-sm text-slate-600">
+                        <div key={supporter.id} className="text-sm font-medium text-black">
                           {supporter.name}
                         </div>
                       ))}
@@ -195,26 +217,6 @@ export default function ThanksPage() {
               </div>
             )}
 
-            {/* Friend Supporters (1,000円) - Visible & Small */}
-            {friendSupporters.length > 0 && (
-              <div className="space-y-1">
-                <div className="flex items-center justify-center gap-2 text-xs font-medium text-slate-500">
-                  <Heart className="h-3 w-3 text-pink-300" />
-                  <span>Friend Supporters</span>
-                </div>
-                <Card>
-                  <CardContent className="p-2">
-                    <div className="grid grid-cols-4 gap-2 text-center md:grid-cols-5 lg:grid-cols-5 text-xs text-slate-600">
-                      {friendSupporters.map((supporter) => (
-                        <div key={supporter.id} className="truncate px-1">
-                          {supporter.name}
-                        </div>
-                      ))}
-                    </div>
-                  </CardContent>
-                </Card>
-              </div>
-            )}
           </section>
         )}
       </div>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -50,7 +50,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.4,
     },
     {
-      url: `${baseUrl}/thanks`,
+      url: `${baseUrl}/thanks-sample`,
       changeFrequency: "monthly",
       priority: 0.4,
     },

--- a/constants/supporters.ts
+++ b/constants/supporters.ts
@@ -1,4 +1,4 @@
-export type SupporterTier = 'platinum' | 'gold' | 'silver' | 'core-supporter' | 'supporter' | 'friend-supporter';
+export type SupporterTier = 'platinum' | 'gold' | 'silver' | 'bronze' | 'core-supporter' | 'supporter' | 'friend-supporter';
 
 export interface Supporter {
   id: string;
@@ -115,6 +115,18 @@ export const SUPPORTERS: Supporter[] = [
   { id: 's-8', name: 'Silver User 8', tier: 'silver', amount: 50000, date: '2025-01-09' },
   { id: 's-9', name: 'Silver User 9', tier: 'silver', amount: 50000, date: '2025-01-09' },
   { id: 's-10', name: 'Silver User 10', tier: 'silver', amount: 50000, date: '2025-01-09' },
+
+  // Bronze (20,000円)
+  { id: 'b-1', name: 'Bronze Supporter 1', tier: 'bronze', amount: 20000, date: '2025-01-09' },
+  { id: 'b-2', name: 'Bronze Supporter 2', tier: 'bronze', amount: 20000, date: '2025-01-10' },
+  { id: 'b-3', name: 'Bronze Supporter 3', tier: 'bronze', amount: 20000, date: '2025-01-10' },
+  { id: 'b-4', name: 'Bronze Supporter 4', tier: 'bronze', amount: 20000, date: '2025-01-10' },
+  { id: 'b-5', name: 'Bronze Supporter 5', tier: 'bronze', amount: 20000, date: '2025-01-10' },
+  { id: 'b-6', name: 'Bronze Supporter 6', tier: 'bronze', amount: 20000, date: '2025-01-10' },
+  { id: 'b-7', name: 'Bronze Supporter 7', tier: 'bronze', amount: 20000, date: '2025-01-10' },
+  { id: 'b-8', name: 'Bronze Supporter 8', tier: 'bronze', amount: 20000, date: '2025-01-10' },
+  { id: 'b-9', name: 'Bronze Supporter 9', tier: 'bronze', amount: 20000, date: '2025-01-10' },
+  { id: 'b-10', name: 'Bronze Supporter 10', tier: 'bronze', amount: 20000, date: '2025-01-10' },
 
   // Core Supporter (10,000円)
   { id: 'cs-1', name: 'Core Supporter 1', tier: 'core-supporter', amount: 10000, date: '2025-01-10' },

--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,11 @@ const nextConfig: NextConfig = {
         destination: "/free-materials",
         permanent: true,
       },
+      {
+        source: "/thanks",
+        destination: "/thanks-sample",
+        permanent: true,
+      },
     ];
   },
   experimental: {


### PR DESCRIPTION
### 概要
move thanks page to /thanks-sample and add bronze supporters

### 変更内容
- `app/(marketing)/thanks-sample/page.tsx`
- `app/sitemap.ts`
- `constants/supporters.ts`
- `next.config.ts`

### 実機テスト
- [ ] ブラウザで主要導線を操作し、対象機能が期待どおり完了すること
- [ ] バリデーションエラー条件を操作し、ユーザー向けエラーメッセージが表示されること
- [ ] PC（Chrome）/ iOS Safari / Android Chrome で表示崩れがないこと

### テスト方法
- 自動テスト: 実施なし（変更ファイルに tests/* は含まれていません）

### テスト結果
- [ ] 自動テスト: 実施なし（変更ファイルに tests/* は含まれていません）
- [ ] failed のテスト項目: 実施なしのため判定不可
