### PR TITLE
fix(auth): harden signup response and add AuthForm spec/tests

### DIFF
--- a/docs/specs/auth/auth_form_spec.yaml
+++ b/docs/specs/auth/auth_form_spec.yaml
@@ -1,0 +1,563 @@
+metadata:
+  class: AuthForm
+  source: features/auth/components/AuthForm.tsx
+  version: "1.1"
+  created_at: "2026-03-09"
+
+dependencies:
+  repositories: []
+  services:
+    - signUp / signIn / signInWithOAuth (features/auth/lib/auth-client.ts)
+    - useRouter (next/navigation)
+    - useSearchParams (next/navigation)
+    - useToast (components/ui/use-toast)
+    - isPasswordValid / PasswordRequirements (features/auth/components/PasswordRequirements.tsx)
+  external:
+    - None (external Auth/OAuth providers are accessed through auth-client boundary)
+
+state_properties:
+  - name: email
+    type: string
+    default: ""
+  - name: password
+    type: string
+    default: ""
+  - name: confirmPassword
+    type: string
+    default: ""
+  - name: isLoading
+    type: boolean
+    default: false
+  - name: error
+    type: string | null
+    default: null
+  - name: showPassword
+    type: boolean
+    default: false
+  - name: showConfirmPassword
+    type: boolean
+    default: false
+
+specifications:
+  - id: AUTH-001
+    method: handleSubmit
+    type: event-driven
+    ears: |
+      When handleSubmit is invoked in signup mode with valid input
+      and signUp resolves successfully,
+      the system shall show a generic confirmation toast
+      and navigate to /login.
+    ears_ja: |
+      signupモードで有効な入力値によりhandleSubmitが呼び出され、
+      signUpが成功した場合、
+      システムは汎用の確認トーストを表示し、
+      /loginへ遷移する。
+    preconditions:
+      - mode is signup
+      - email and password are provided
+      - password length is at least 8
+      - password satisfies isPasswordValid
+      - password matches confirmPassword
+      - signUp resolves
+    preconditions_ja:
+      - modeがsignupである
+      - emailとpasswordが入力されている
+      - passwordが8文字以上である
+      - passwordがisPasswordValidの要件を満たす
+      - passwordとconfirmPasswordが一致する
+      - signUpが成功する
+    postconditions:
+      success:
+        - error is cleared
+        - signUp is called with email, password, and referralCode (or undefined)
+        - confirmation toast is shown
+        - router.push is called with /login
+      error:
+        - None
+    postconditions_ja:
+      success:
+        - errorがクリアされる
+        - signUpがemail、password、referralCode（またはundefined）で呼ばれる
+        - 確認トーストが表示される
+        - router.push("/login") が呼ばれる
+      error:
+        - なし
+    edge_cases:
+      - description: When the ref query parameter is absent
+        expected: signUp receives undefined for referralCode
+      - description: When auth-client resolves signup for an already-registered email
+        expected: UI still shows the same generic confirmation toast and navigates to /login
+    edge_cases_ja:
+      - description: refクエリパラメータが存在しない場合
+        expected: signUpのreferralCodeにはundefinedが渡される
+      - description: 既存メールでもauth-clientがsignup成功として解決する場合
+        expected: 同じ確認トーストを表示し、/loginへ遷移する
+    test_cases:
+      - handleSubmit_GivenValidSignupInput_ShouldShowConfirmationToastAndNavigateLogin
+      - handleSubmit_GivenSignupWithReferralCode_ShouldPassReferralCodeToSignUp
+      - handleSubmit_GivenEnumerationSafeSignupResolution_ShouldKeepGenericSuccessResponse
+    test_cases_ja:
+      - handleSubmit_有効な新規登録入力の場合_確認トースト表示後にloginへ遷移する
+      - handleSubmit_ref付き新規登録の場合_signUpへ紹介コードを渡す
+      - handleSubmit_列挙対策でsignup成功解決される場合_汎用成功応答を維持する
+
+  - id: AUTH-002
+    method: handleSubmit
+    type: unwanted
+    ears: |
+      If email or password is missing,
+      or password length is less than 8,
+      then the system shall set a validation error
+      and shall not call signUp or signIn.
+    ears_ja: |
+      emailまたはpasswordが未入力、
+      もしくはpasswordが8文字未満の場合、
+      システムはバリデーションエラーを設定し、
+      signUpとsignInを呼び出さない。
+    preconditions:
+      - handleSubmit is invoked
+      - email is empty, or password is empty, or password length is less than 8
+    preconditions_ja:
+      - handleSubmitが呼び出される
+      - emailが空、またはpasswordが空、またはpasswordが8文字未満である
+    postconditions:
+      success:
+        - None
+      error:
+        - error is set with the corresponding validation message
+        - isLoading becomes false
+        - signUp and signIn are not called
+    postconditions_ja:
+      success:
+        - なし
+      error:
+        - 対応するバリデーションメッセージがerrorに設定される
+        - isLoadingがfalseになる
+        - signUpとsignInは呼び出されない
+    edge_cases:
+      - description: When both email and password are empty
+        expected: Missing credentials message is shown first
+    edge_cases_ja:
+      - description: emailとpasswordが両方空の場合
+        expected: 資格情報未入力メッセージが優先して表示される
+    test_cases:
+      - handleSubmit_GivenMissingCredentials_ShouldSetValidationErrorAndSkipAuthCalls
+      - handleSubmit_GivenTooShortPassword_ShouldSetMinLengthErrorAndSkipAuthCalls
+    test_cases_ja:
+      - handleSubmit_認証情報未入力の場合_バリデーションエラーを表示して認証呼び出しを行わない
+      - handleSubmit_パスワード8文字未満の場合_最小文字数エラーを表示して認証呼び出しを行わない
+
+  - id: AUTH-003
+    method: handleSubmit
+    type: state-driven
+    ears: |
+      While mode is signup,
+      the system shall enforce password complexity and confirmation match
+      before calling signUp.
+    ears_ja: |
+      modeがsignupの間、
+      システムはsignUp呼び出し前に
+      パスワード複雑性と確認一致を必須とする。
+    preconditions:
+      - mode is signup
+      - email and password are provided
+      - password length is at least 8
+    preconditions_ja:
+      - modeがsignupである
+      - emailとpasswordが入力されている
+      - passwordが8文字以上である
+    postconditions:
+      success:
+        - signUp is called only when complexity and confirmation are valid
+      error:
+        - error is set when complexity is invalid
+        - error is set when password and confirmPassword do not match
+        - isLoading becomes false
+    postconditions_ja:
+      success:
+        - 複雑性と確認一致が満たされた場合のみsignUpが呼ばれる
+      error:
+        - 複雑性不一致時にerrorが設定される
+        - password不一致時にerrorが設定される
+        - isLoadingがfalseになる
+    edge_cases:
+      - description: When password meets length requirement but fails complexity
+        expected: Complexity requirement message is shown
+    edge_cases_ja:
+      - description: 文字数要件は満たすが複雑性を満たさない場合
+        expected: 複雑性要件メッセージが表示される
+    test_cases:
+      - handleSubmit_GivenSignupPasswordWithoutRequiredComplexity_ShouldSetComplexityError
+      - handleSubmit_GivenSignupPasswordMismatch_ShouldSetMismatchError
+    test_cases_ja:
+      - handleSubmit_signupで複雑性不足のパスワードの場合_複雑性エラーを設定する
+      - handleSubmit_signupで確認パスワード不一致の場合_不一致エラーを設定する
+
+  - id: AUTH-004
+    method: handleSubmit
+    type: event-driven
+    ears: |
+      When handleSubmit is invoked in signin mode with valid input,
+      signIn succeeds, and onSuccess is provided,
+      the system shall wait approximately one second,
+      stop loading, and invoke onSuccess.
+    ears_ja: |
+      signinモードで有効入力によりhandleSubmitが呼ばれ、
+      signInが成功し、onSuccessが渡されている場合、
+      システムは約1秒待機後にローディングを解除し、
+      onSuccessを呼び出す。
+    preconditions:
+      - mode is signin
+      - email and password are valid
+      - signIn resolves
+      - onSuccess callback is provided
+    preconditions_ja:
+      - modeがsigninである
+      - emailとpasswordが有効である
+      - signInが成功する
+      - onSuccessコールバックが渡されている
+    postconditions:
+      success:
+        - signIn is called with email and password
+        - onSuccess is called after delay
+        - isLoading becomes false before callback completion path ends
+      error:
+        - None
+    postconditions_ja:
+      success:
+        - signInがemailとpasswordで呼ばれる
+        - 遅延後にonSuccessが呼ばれる
+        - コールバック経路ではisLoadingがfalseになる
+      error:
+        - なし
+    edge_cases:
+      - description: When redirectTo is provided together with onSuccess
+        expected: onSuccess branch is prioritized and router push is skipped
+    edge_cases_ja:
+      - description: onSuccessとredirectToが同時に指定された場合
+        expected: onSuccess分岐が優先され、router.pushは行われない
+    test_cases:
+      - handleSubmit_GivenValidSigninAndOnSuccess_ShouldCallOnSuccessAfterDelay
+    test_cases_ja:
+      - handleSubmit_有効signinかつonSuccessありの場合_遅延後にonSuccessを呼ぶ
+
+  - id: AUTH-005
+    method: handleSubmit
+    type: event-driven
+    ears: |
+      When handleSubmit is invoked in signin mode with valid input,
+      signIn succeeds, and onSuccess is not provided,
+      the system shall navigate to redirectTo or "/"
+      and refresh the route.
+    ears_ja: |
+      signinモードで有効入力によりhandleSubmitが呼ばれ、
+      signInが成功し、onSuccessが未指定の場合、
+      システムはredirectToまたは"/"へ遷移し、
+      ルートをrefreshする。
+    preconditions:
+      - mode is signin
+      - email and password are valid
+      - signIn resolves
+      - onSuccess callback is not provided
+    preconditions_ja:
+      - modeがsigninである
+      - emailとpasswordが有効である
+      - signInが成功する
+      - onSuccessコールバックが未指定である
+    postconditions:
+      success:
+        - after approximately one second delay, signin completion branch executes
+        - router.push is called with redirectTo or "/"
+        - router.refresh is called
+      error:
+        - None
+    postconditions_ja:
+      success:
+        - 約1秒の待機後にsignin完了後の分岐が実行される
+        - redirectToまたは"/"でrouter.pushが呼ばれる
+        - router.refreshが呼ばれる
+      error:
+        - なし
+    edge_cases:
+      - description: When redirectTo is undefined
+        expected: Root path / is used as fallback target
+    edge_cases_ja:
+      - description: redirectToが未指定の場合
+        expected: フォールバック先としてルートパス / が使われる
+    test_cases:
+      - handleSubmit_GivenValidSigninWithoutOnSuccess_ShouldNavigateAndRefresh
+      - handleSubmit_GivenValidSigninWithoutRedirectTo_ShouldNavigateToRoot
+    test_cases_ja:
+      - handleSubmit_有効signinでonSuccessなしの場合_遷移してrefreshする
+      - handleSubmit_有効signinでredirectTo未指定の場合_rootへ遷移する
+
+  - id: AUTH-006
+    method: handleSubmit
+    type: unwanted
+    ears: |
+      If signUp or signIn throws an error during handleSubmit,
+      then the system shall set a user-visible error message
+      and stop loading.
+    ears_ja: |
+      handleSubmit中にsignUpまたはsignInが例外を投げた場合、
+      システムはユーザー向けエラーメッセージを設定し、
+      ローディングを停止する。
+    preconditions:
+      - handleSubmit is invoked after passing local validation
+      - signUp or signIn rejects with an error
+    preconditions_ja:
+      - ローカルバリデーション通過後にhandleSubmitが呼び出される
+      - signUpまたはsignInがエラーで失敗する
+    postconditions:
+      success:
+        - None
+      error:
+        - error is set to thrown error message or fallback text
+        - isLoading becomes false
+    postconditions_ja:
+      success:
+        - なし
+      error:
+        - 例外メッセージまたはフォールバック文言がerrorに設定される
+        - isLoadingがfalseになる
+    edge_cases:
+      - description: When thrown value is not an Error instance
+        expected: Fallback text "エラーが発生しました" is set
+    edge_cases_ja:
+      - description: throwされた値がErrorインスタンスではない場合
+        expected: フォールバック文言「エラーが発生しました」が設定される
+    test_cases:
+      - handleSubmit_GivenAuthClientError_ShouldSetErrorAndStopLoading
+      - handleSubmit_GivenNonErrorThrow_ShouldSetFallbackErrorAndStopLoading
+    test_cases_ja:
+      - handleSubmit_認証クライアントエラーの場合_errorを設定してローディング停止する
+      - handleSubmit_Error以外がthrowされた場合_フォールバックエラーを設定してローディング停止する
+
+  - id: AUTH-007
+    method: handleOAuthSignIn
+    type: event-driven
+    ears: |
+      When handleOAuthSignIn is invoked with a provider
+      and signInWithOAuth resolves,
+      the system shall delegate OAuth sign-in with redirect target and referral code
+      while keeping the user in loading state for provider redirect.
+    ears_ja: |
+      handleOAuthSignInがprovider付きで呼び出され、
+      signInWithOAuthが成功した場合、
+      システムはredirect先と紹介コードを使ってOAuth認証を委譲し、
+      プロバイダー遷移のためローディング状態を維持する。
+    preconditions:
+      - provider is selected
+      - signInWithOAuth resolves
+    preconditions_ja:
+      - providerが選択されている
+      - signInWithOAuthが成功する
+    postconditions:
+      success:
+        - error is cleared
+        - isLoading becomes true
+        - signInWithOAuth is called with provider, redirect target, and referral code (or undefined)
+      error:
+        - None
+    postconditions_ja:
+      success:
+        - errorがクリアされる
+        - isLoadingがtrueになる
+        - provider・redirect先・紹介コード（またはundefined）でsignInWithOAuthが呼ばれる
+      error:
+        - なし
+    edge_cases:
+      - description: When redirectTo is not provided
+        expected: Root path / is passed as OAuth redirect target
+    edge_cases_ja:
+      - description: redirectToが未指定の場合
+        expected: OAuthのredirect先としてルートパス / が渡される
+    test_cases:
+      - handleOAuthSignIn_GivenGoogleProvider_ShouldCallOAuthWithResolvedRedirectAndReferral
+    test_cases_ja:
+      - handleOAuthSignIn_Google選択時_解決済みredirectと紹介コードでOAuthを呼ぶ
+
+  - id: AUTH-008
+    method: handleOAuthSignIn
+    type: unwanted
+    ears: |
+      If signInWithOAuth throws,
+      then the system shall set an OAuth error message
+      and stop loading.
+    ears_ja: |
+      signInWithOAuthが例外を投げた場合、
+      システムはOAuthエラーメッセージを設定し、
+      ローディングを停止する。
+    preconditions:
+      - handleOAuthSignIn is invoked
+      - signInWithOAuth rejects
+    preconditions_ja:
+      - handleOAuthSignInが呼び出される
+      - signInWithOAuthが失敗する
+    postconditions:
+      success:
+        - None
+      error:
+        - error is set to thrown error message or OAuth fallback text
+        - isLoading becomes false
+    postconditions_ja:
+      success:
+        - なし
+      error:
+        - 例外メッセージまたはOAuth失敗フォールバックがerrorに設定される
+        - isLoadingがfalseになる
+    edge_cases:
+      - description: When thrown value is not an Error instance
+        expected: Fallback text "OAuth認証に失敗しました" is set
+    edge_cases_ja:
+      - description: throwされた値がErrorインスタンスではない場合
+        expected: フォールバック文言「OAuth認証に失敗しました」が設定される
+    test_cases:
+      - handleOAuthSignIn_GivenOAuthError_ShouldSetErrorAndStopLoading
+      - handleOAuthSignIn_GivenNonErrorThrow_ShouldSetOAuthFallbackError
+    test_cases_ja:
+      - handleOAuthSignIn_OAuthエラー時_errorを設定してローディング停止する
+      - handleOAuthSignIn_Error以外がthrowされた場合_OAuthフォールバックエラーを設定する
+
+  - id: AUTH-009
+    method: modeResetEffect
+    type: event-driven
+    ears: |
+      When AuthForm is mounted or mode changes,
+      the system shall reset loading state and clear error state.
+    ears_ja: |
+      AuthFormの初回マウント時またはmodeが変化した場合、
+      システムはローディング状態をリセットし、
+      エラー状態をクリアする。
+    preconditions:
+      - Component is mounted, or mode prop changes between signin and signup
+    preconditions_ja:
+      - コンポーネントが初回マウントされる、またはmodeプロパティがsigninとsignupの間で変化する
+    postconditions:
+      success:
+        - isLoading becomes false
+        - error becomes null
+      error:
+        - None
+    postconditions_ja:
+      success:
+        - isLoadingがfalseになる
+        - errorがnullになる
+      error:
+        - なし
+    edge_cases:
+      - description: When mounted with default state values
+        expected: Reset effect is idempotent and visible state remains unchanged
+      - description: When mode changes while loading overlay is visible
+        expected: Overlay is hidden after state reset
+    edge_cases_ja:
+      - description: デフォルトstateのまま初回マウントされる場合
+        expected: リセット処理はべき等で、表示状態は実質的に変化しない
+      - description: ローディングオーバーレイ表示中にmodeが変化した場合
+        expected: 状態リセット後にオーバーレイが非表示になる
+    test_cases:
+      - modeResetEffect_GivenInitialMount_ShouldKeepCleanState
+      - modeResetEffect_GivenModeChange_ShouldResetLoadingAndError
+    test_cases_ja:
+      - modeResetEffect_初回マウント時_クリーンな状態を維持する
+      - modeResetEffect_mode変更時_ローディングとエラーをリセットする
+
+  - id: AUTH-010
+    method: renderAuthForm
+    type: state-driven
+    ears: |
+      While rendering AuthForm,
+      the system shall present mode-specific inputs and guidance,
+      and shall disable submission when loading or signup validation errors exist.
+    ears_ja: |
+      AuthFormの描画中、
+      システムはmodeに応じた入力UIと案内を表示し、
+      ローディング中またはsignup検証エラー時には送信を無効化する。
+    preconditions:
+      - AuthForm is rendered with mode signin or signup
+    preconditions_ja:
+      - AuthFormがsigninまたはsignupモードで描画される
+    postconditions:
+      success:
+        - Signup mode shows confirmPassword input and PasswordRequirements
+        - Signin mode shows reset-password helper link instead of signup-only fields
+        - Submit button is disabled when isLoading or validation errors are present
+      error:
+        - None
+    postconditions_ja:
+      success:
+        - signupモードではconfirmPassword入力とPasswordRequirementsを表示する
+        - signinモードではsignup専用項目の代わりにパスワード再設定リンクを表示する
+        - isLoadingまたは検証エラー時は送信ボタンが無効化される
+      error:
+        - なし
+    edge_cases:
+      - description: When isLoading is true
+        expected: Submit and OAuth buttons are disabled and loading overlay is shown
+      - description: When password requirements are unmet in signup mode
+        expected: Requirement warning is shown and submit is disabled
+    edge_cases_ja:
+      - description: isLoadingがtrueの場合
+        expected: 送信ボタンとOAuthボタンが無効化され、ローディングオーバーレイが表示される
+      - description: signupモードでパスワード要件未達の場合
+        expected: 要件警告が表示され、送信が無効化される
+    test_cases:
+      - renderAuthForm_GivenSignupMode_ShouldRenderSignupSpecificFields
+      - renderAuthForm_GivenSigninMode_ShouldRenderResetPasswordGuidance
+      - renderAuthForm_GivenLoadingOrValidationError_ShouldDisableSubmit
+      - renderAuthForm_GivenLoadingState_ShouldDisableOAuthActionsAndShowOverlay
+    test_cases_ja:
+      - renderAuthForm_signupモードの場合_signup専用項目を描画する
+      - renderAuthForm_signinモードの場合_パスワード再設定案内を描画する
+      - renderAuthForm_ローディングまたは検証エラー時_送信を無効化する
+      - renderAuthForm_ローディング状態の場合_OAuth操作を無効化してオーバーレイを表示する
+
+  - id: AUTH-011
+    method: togglePasswordVisibility
+    type: event-driven
+    ears: |
+      When the password visibility toggle button is clicked,
+      the system shall invert the corresponding visibility state
+      and switch the related input type between password and text.
+    ears_ja: |
+      パスワード表示切替ボタンがクリックされた場合、
+      システムは対応する可視状態を反転し、
+      関連入力のtypeをpasswordとtextで切り替える。
+    preconditions:
+      - AuthForm is rendered
+      - Target toggle button is enabled
+    preconditions_ja:
+      - AuthFormが描画されている
+      - 対象の切替ボタンが有効である
+    postconditions:
+      success:
+        - showPassword toggles for the password field toggle button
+        - showConfirmPassword toggles for the confirm password field toggle button in signup mode
+        - aria-label switches to match the next expected action
+      error:
+        - None
+    postconditions_ja:
+      success:
+        - パスワード欄の切替ボタンではshowPasswordが反転する
+        - signupモードの確認パスワード切替ボタンではshowConfirmPasswordが反転する
+        - aria-labelが次の操作内容に応じて切り替わる
+      error:
+        - なし
+    edge_cases:
+      - description: When isLoading is true
+        expected: Toggle button is disabled and visibility state does not change
+      - description: When mode is signin
+        expected: Confirm password toggle is not rendered
+    edge_cases_ja:
+      - description: isLoadingがtrueの場合
+        expected: 切替ボタンは無効で、可視状態は変化しない
+      - description: modeがsigninの場合
+        expected: 確認パスワードの切替ボタンは描画されない
+    test_cases:
+      - togglePasswordVisibility_GivenPasswordToggleClick_ShouldSwitchPasswordInputType
+      - togglePasswordVisibility_GivenSignupConfirmToggleClick_ShouldSwitchConfirmPasswordInputType
+      - togglePasswordVisibility_GivenLoadingState_ShouldNotChangeVisibilityState
+    test_cases_ja:
+      - togglePasswordVisibility_パスワード切替クリック時_password入力typeを切り替える
+      - togglePasswordVisibility_signupで確認パスワード切替クリック時_confirm入力typeを切り替える
+      - togglePasswordVisibility_ローディング時_可視状態を変更しない

--- a/docs/test-progress.yaml
+++ b/docs/test-progress.yaml
@@ -2,7 +2,7 @@
 # Updated by /test-checklist and read by /test-flow.
 
 version: "2.0"
-last_updated: "2026-03-08"
+last_updated: "2026-03-09"
 
 # Status values:
 # - pending
@@ -71,7 +71,7 @@ tier2:
     test_file: tests/integration/api/notifications-route.test.ts
 
   AuthForm:
-    status: pending
+    status: completed
     score: 84
     file: features/auth/components/AuthForm.tsx
     prerequisites:
@@ -239,8 +239,8 @@ summary:
     percentage: 50
   tier2:
     total: 6
-    completed: 0
-    percentage: 0
+    completed: 1
+    percentage: 17
   tier3:
     total: 7
     completed: 0
@@ -251,5 +251,5 @@ summary:
     percentage: 0
   overall:
     total: 25
-    completed: 1
-    percentage: 4
+    completed: 2
+    percentage: 8

--- a/features/auth/components/AuthForm.tsx
+++ b/features/auth/components/AuthForm.tsx
@@ -86,7 +86,12 @@ export function AuthForm({ mode, onSuccess, redirectTo }: AuthFormProps) {
         setError(null);
         toast({
           title: "確認メールを送信しました。",
-          description: "新規登録を受け付けました。メールをご確認ください。",
+          description: (
+            <>
+              <span className="block">新規登録を受け付けました。メールをご確認ください。</span>
+              <span className="block">届かない場合は、迷惑メールフォルダもあわせてご確認ください。</span>
+            </>
+          ),
         });
         router.push("/login");
       } else {

--- a/features/auth/lib/auth-client.ts
+++ b/features/auth/lib/auth-client.ts
@@ -12,6 +12,27 @@ import { checkReferralBonusOnFirstLogin } from "@/features/referral/lib/api";
 /**
  * Supabaseのエラーメッセージを日本語に変換
  */
+function isAlreadyRegisteredSignUpError(error: {
+  message?: string | null;
+  code?: string | null;
+}): boolean {
+  const message = (error.message ?? "").toLowerCase();
+  const code = (error.code ?? "").toLowerCase();
+
+  // Supabaseの設定によっては既存メールに対して明示エラーが返るため、
+  // その場合も同一レスポンスに寄せてアカウント列挙を防ぐ。
+  return (
+    code === "user_already_exists" ||
+    message.includes("user already registered") ||
+    message.includes("already been registered") ||
+    (message.includes("email") &&
+      (message.includes("already in use") ||
+        message.includes("already exists") ||
+        message.includes("already taken") ||
+        message.includes("already registered")))
+  );
+}
+
 function translateAuthError(errorMessage: string): string {
   const errorLower = errorMessage.toLowerCase();
 
@@ -128,6 +149,11 @@ export async function signUp(
   });
 
   if (error) {
+    if (isAlreadyRegisteredSignUpError(error)) {
+      console.info("Sign up attempted with an existing email. Returning generic success response.");
+      return data;
+    }
+
     // より詳細なエラー情報を提供
     console.error("Sign up error:", {
       message: error.message,

--- a/tests/unit/components/auth-form.test.tsx
+++ b/tests/unit/components/auth-form.test.tsx
@@ -1,0 +1,714 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { AuthForm } from "@/features/auth/components/AuthForm";
+import { signIn, signInWithOAuth, signUp } from "@/features/auth/lib/auth-client";
+import { useToast } from "@/components/ui/use-toast";
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(),
+  useSearchParams: jest.fn(),
+}));
+
+jest.mock("@/features/auth/lib/auth-client", () => ({
+  signIn: jest.fn(),
+  signUp: jest.fn(),
+  signInWithOAuth: jest.fn(),
+}));
+
+jest.mock("@/components/ui/use-toast", () => ({
+  useToast: jest.fn(),
+}));
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+};
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function submitForm(container: HTMLElement) {
+  const form = container.querySelector("form");
+  if (!form) {
+    throw new Error("form element not found");
+  }
+  fireEvent.submit(form);
+}
+
+function fillSignUpInputs(params: {
+  email: string;
+  password: string;
+  confirmPassword?: string;
+}) {
+  fireEvent.change(screen.getByLabelText("メールアドレス"), {
+    target: { value: params.email },
+  });
+  fireEvent.change(screen.getByLabelText("パスワード"), {
+    target: { value: params.password },
+  });
+  fireEvent.change(screen.getByLabelText("パスワード（確認）"), {
+    target: { value: params.confirmPassword ?? params.password },
+  });
+}
+
+function fillSignInInputs(params: { email: string; password: string }) {
+  fireEvent.change(screen.getByLabelText("メールアドレス"), {
+    target: { value: params.email },
+  });
+  fireEvent.change(screen.getByLabelText("パスワード"), {
+    target: { value: params.password },
+  });
+}
+
+describe("AuthForm unit tests from EARS specs", () => {
+  const validEmail = "user@example.com";
+  const validPassword = "Aa1!aaaa";
+
+  const useRouterMock = useRouter as jest.MockedFunction<typeof useRouter>;
+  const useSearchParamsMock = useSearchParams as jest.MockedFunction<
+    typeof useSearchParams
+  >;
+  const signUpMock = signUp as jest.MockedFunction<typeof signUp>;
+  const signInMock = signIn as jest.MockedFunction<typeof signIn>;
+  const signInWithOAuthMock = signInWithOAuth as jest.MockedFunction<
+    typeof signInWithOAuth
+  >;
+  const useToastMock = useToast as jest.MockedFunction<typeof useToast>;
+
+  let pushMock: jest.Mock;
+  let refreshMock: jest.Mock;
+  let toastMock: jest.Mock;
+  let referralCode: string | null;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    pushMock = jest.fn();
+    refreshMock = jest.fn();
+    toastMock = jest.fn();
+    referralCode = null;
+
+    useRouterMock.mockReturnValue({
+      push: pushMock,
+      refresh: refreshMock,
+    } as unknown as ReturnType<typeof useRouter>);
+    useSearchParamsMock.mockReturnValue({
+      get: (key: string) => (key === "ref" ? referralCode : null),
+    } as unknown as ReturnType<typeof useSearchParams>);
+    useToastMock.mockReturnValue({
+      toast: toastMock,
+    });
+
+    signUpMock.mockResolvedValue({} as Awaited<ReturnType<typeof signUp>>);
+    signInMock.mockResolvedValue({} as Awaited<ReturnType<typeof signIn>>);
+    signInWithOAuthMock.mockResolvedValue(
+      {} as Awaited<ReturnType<typeof signInWithOAuth>>
+    );
+  });
+
+  describe("AUTH-001 handleSubmit", () => {
+    test("handleSubmit_有効な新規登録入力の場合_確認トースト表示後にloginへ遷移する", async () => {
+      // ============================================================
+      // Arrange
+      // ============================================================
+      const { container } = render(<AuthForm mode="signup" />);
+      fillSignUpInputs({ email: validEmail, password: validPassword });
+
+      // ============================================================
+      // Act
+      // ============================================================
+      submitForm(container);
+
+      // ============================================================
+      // Assert
+      // ============================================================
+      await waitFor(() => {
+        expect(signUpMock).toHaveBeenCalledWith(validEmail, validPassword, undefined);
+      });
+      expect(toastMock).toHaveBeenCalledTimes(1);
+      expect(toastMock.mock.calls[0]?.[0]).toEqual(
+        expect.objectContaining({
+          title: "確認メールを送信しました。",
+        })
+      );
+      expect(pushMock).toHaveBeenCalledWith("/login");
+    });
+
+    test("handleSubmit_ref付き新規登録の場合_signUpへ紹介コードを渡す", async () => {
+      // ============================================================
+      // Arrange
+      // ============================================================
+      referralCode = "REF-CODE-001";
+      const { container } = render(<AuthForm mode="signup" />);
+      fillSignUpInputs({ email: validEmail, password: validPassword });
+
+      // ============================================================
+      // Act
+      // ============================================================
+      submitForm(container);
+
+      // ============================================================
+      // Assert
+      // ============================================================
+      await waitFor(() => {
+        expect(signUpMock).toHaveBeenCalledWith(
+          validEmail,
+          validPassword,
+          "REF-CODE-001"
+        );
+      });
+      expect(pushMock).toHaveBeenCalledWith("/login");
+    });
+
+    test("handleSubmit_列挙対策でsignup成功解決される場合_汎用成功応答を維持する", async () => {
+      // ============================================================
+      // Arrange
+      // ============================================================
+      signUpMock.mockResolvedValueOnce(undefined as Awaited<ReturnType<typeof signUp>>);
+      const { container } = render(<AuthForm mode="signup" />);
+      fillSignUpInputs({ email: validEmail, password: validPassword });
+
+      // ============================================================
+      // Act
+      // ============================================================
+      submitForm(container);
+
+      // ============================================================
+      // Assert
+      // ============================================================
+      await waitFor(() => {
+        expect(signUpMock).toHaveBeenCalledTimes(1);
+      });
+      expect(toastMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "確認メールを送信しました。",
+        })
+      );
+      expect(pushMock).toHaveBeenCalledWith("/login");
+    });
+  });
+
+  describe("AUTH-002 handleSubmit", () => {
+    test("handleSubmit_認証情報未入力の場合_バリデーションエラーを表示して認証呼び出しを行わない", async () => {
+      // ============================================================
+      // Arrange
+      // ============================================================
+      const { container } = render(<AuthForm mode="signup" />);
+
+      // ============================================================
+      // Act
+      // ============================================================
+      submitForm(container);
+
+      // ============================================================
+      // Assert
+      // ============================================================
+      expect(await screen.findByText("メールアドレスとパスワードを入力してください")).toBeInTheDocument();
+      expect(signUpMock).not.toHaveBeenCalled();
+      expect(signInMock).not.toHaveBeenCalled();
+    });
+
+    test("handleSubmit_パスワード8文字未満の場合_最小文字数エラーを表示して認証呼び出しを行わない", async () => {
+      // ============================================================
+      // Arrange
+      // ============================================================
+      const { container } = render(<AuthForm mode="signup" />);
+      fillSignUpInputs({
+        email: validEmail,
+        password: "Aa1!a",
+      });
+
+      // ============================================================
+      // Act
+      // ============================================================
+      submitForm(container);
+
+      // ============================================================
+      // Assert
+      // ============================================================
+      expect(
+        await screen.findAllByText("パスワードは8文字以上で入力してください")
+      ).toHaveLength(2);
+      expect(signUpMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("AUTH-003 handleSubmit", () => {
+    test("handleSubmit_signupで複雑性不足のパスワードの場合_複雑性エラーを設定する", async () => {
+      // ============================================================
+      // Arrange
+      // ============================================================
+      const { container } = render(<AuthForm mode="signup" />);
+      fillSignUpInputs({
+        email: validEmail,
+        password: "aaaaaaaa",
+      });
+
+      // ============================================================
+      // Act
+      // ============================================================
+      submitForm(container);
+
+      // ============================================================
+      // Assert
+      // ============================================================
+      expect(
+        await screen.findByText(
+          "パスワードは英大文字・英小文字・数字・記号をそれぞれ1文字以上含めてください"
+        )
+      ).toBeInTheDocument();
+      expect(signUpMock).not.toHaveBeenCalled();
+    });
+
+    test("handleSubmit_signupで確認パスワード不一致の場合_不一致エラーを設定する", async () => {
+      // ============================================================
+      // Arrange
+      // ============================================================
+      const { container } = render(<AuthForm mode="signup" />);
+      fillSignUpInputs({
+        email: validEmail,
+        password: validPassword,
+        confirmPassword: "Aa1!aaab",
+      });
+
+      // ============================================================
+      // Act
+      // ============================================================
+      submitForm(container);
+
+      // ============================================================
+      // Assert
+      // ============================================================
+      expect(await screen.findAllByText("パスワードが一致しません")).toHaveLength(2);
+      expect(signUpMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("AUTH-004 handleSubmit", () => {
+    test("handleSubmit_有効signinかつonSuccessありの場合_遅延後にonSuccessを呼ぶ", async () => {
+      jest.useFakeTimers();
+      try {
+        // ============================================================
+        // Arrange
+        // ============================================================
+        const onSuccess = jest.fn();
+        const { container } = render(<AuthForm mode="signin" onSuccess={onSuccess} />);
+        fillSignInInputs({ email: validEmail, password: validPassword });
+
+        // ============================================================
+        // Act
+        // ============================================================
+        submitForm(container);
+        await waitFor(() => {
+          expect(signInMock).toHaveBeenCalledWith(validEmail, validPassword);
+        });
+        await act(async () => {
+          jest.advanceTimersByTime(1000);
+        });
+
+        // ============================================================
+        // Assert
+        // ============================================================
+        await waitFor(() => {
+          expect(onSuccess).toHaveBeenCalledTimes(1);
+        });
+        expect(pushMock).not.toHaveBeenCalled();
+        expect(refreshMock).not.toHaveBeenCalled();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+  });
+
+  describe("AUTH-005 handleSubmit", () => {
+    test("handleSubmit_有効signinでonSuccessなしの場合_遷移してrefreshする", async () => {
+      jest.useFakeTimers();
+      try {
+        // ============================================================
+        // Arrange
+        // ============================================================
+        const { container } = render(
+          <AuthForm mode="signin" redirectTo="/dashboard" />
+        );
+        fillSignInInputs({ email: validEmail, password: validPassword });
+
+        // ============================================================
+        // Act
+        // ============================================================
+        submitForm(container);
+        await waitFor(() => {
+          expect(signInMock).toHaveBeenCalledWith(validEmail, validPassword);
+        });
+        await act(async () => {
+          jest.advanceTimersByTime(1000);
+        });
+
+        // ============================================================
+        // Assert
+        // ============================================================
+        await waitFor(() => {
+          expect(pushMock).toHaveBeenCalledWith("/dashboard");
+        });
+        expect(refreshMock).toHaveBeenCalledTimes(1);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    test("handleSubmit_有効signinでredirectTo未指定の場合_rootへ遷移する", async () => {
+      jest.useFakeTimers();
+      try {
+        // ============================================================
+        // Arrange
+        // ============================================================
+        const { container } = render(<AuthForm mode="signin" />);
+        fillSignInInputs({ email: validEmail, password: validPassword });
+
+        // ============================================================
+        // Act
+        // ============================================================
+        submitForm(container);
+        await waitFor(() => {
+          expect(signInMock).toHaveBeenCalledWith(validEmail, validPassword);
+        });
+        await act(async () => {
+          jest.advanceTimersByTime(1000);
+        });
+
+        // ============================================================
+        // Assert
+        // ============================================================
+        await waitFor(() => {
+          expect(pushMock).toHaveBeenCalledWith("/");
+        });
+        expect(refreshMock).toHaveBeenCalledTimes(1);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+  });
+
+  describe("AUTH-006 handleSubmit", () => {
+    test("handleSubmit_認証クライアントエラーの場合_errorを設定してローディング停止する", async () => {
+      // ============================================================
+      // Arrange
+      // ============================================================
+      signInMock.mockRejectedValueOnce(new Error("ログイン失敗"));
+      const { container } = render(<AuthForm mode="signin" />);
+      fillSignInInputs({ email: validEmail, password: validPassword });
+
+      // ============================================================
+      // Act
+      // ============================================================
+      submitForm(container);
+
+      // ============================================================
+      // Assert
+      // ============================================================
+      expect(await screen.findByText("ログイン失敗")).toBeInTheDocument();
+      expect(screen.queryByText("ログイン中...")).not.toBeInTheDocument();
+    });
+
+    test("handleSubmit_Error以外がthrowされた場合_フォールバックエラーを設定してローディング停止する", async () => {
+      // ============================================================
+      // Arrange
+      // ============================================================
+      signUpMock.mockRejectedValueOnce("boom");
+      const { container } = render(<AuthForm mode="signup" />);
+      fillSignUpInputs({ email: validEmail, password: validPassword });
+
+      // ============================================================
+      // Act
+      // ============================================================
+      submitForm(container);
+
+      // ============================================================
+      // Assert
+      // ============================================================
+      expect(await screen.findByText("エラーが発生しました")).toBeInTheDocument();
+      expect(screen.queryByText("アカウントを作成中...")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("AUTH-007 handleOAuthSignIn", () => {
+    test("handleOAuthSignIn_Google選択時_解決済みredirectと紹介コードでOAuthを呼ぶ", async () => {
+      // ============================================================
+      // Arrange
+      // ============================================================
+      referralCode = "REF-OAUTH-001";
+      render(<AuthForm mode="signin" redirectTo="/my-page" />);
+
+      // ============================================================
+      // Act
+      // ============================================================
+      fireEvent.click(screen.getByRole("button", { name: "Googleで続ける" }));
+
+      // ============================================================
+      // Assert
+      // ============================================================
+      await waitFor(() => {
+        expect(signInWithOAuthMock).toHaveBeenCalledWith(
+          "google",
+          "/my-page",
+          "REF-OAUTH-001"
+        );
+      });
+      expect(screen.getByRole("button", { name: "Googleで続ける" })).toBeDisabled();
+      expect(screen.getByText("ログイン中...")).toBeInTheDocument();
+    });
+  });
+
+  describe("AUTH-008 handleOAuthSignIn", () => {
+    test("handleOAuthSignIn_OAuthエラー時_errorを設定してローディング停止する", async () => {
+      // ============================================================
+      // Arrange
+      // ============================================================
+      signInWithOAuthMock.mockRejectedValueOnce(new Error("OAuthエラー"));
+      render(<AuthForm mode="signin" />);
+
+      // ============================================================
+      // Act
+      // ============================================================
+      fireEvent.click(screen.getByRole("button", { name: "Googleで続ける" }));
+
+      // ============================================================
+      // Assert
+      // ============================================================
+      expect(await screen.findByText("OAuthエラー")).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "Googleで続ける" })).not.toBeDisabled();
+      });
+    });
+
+    test("handleOAuthSignIn_Error以外がthrowされた場合_OAuthフォールバックエラーを設定する", async () => {
+      // ============================================================
+      // Arrange
+      // ============================================================
+      signInWithOAuthMock.mockRejectedValueOnce("oauth-failed");
+      render(<AuthForm mode="signin" />);
+
+      // ============================================================
+      // Act
+      // ============================================================
+      fireEvent.click(screen.getByRole("button", { name: "Googleで続ける" }));
+
+      // ============================================================
+      // Assert
+      // ============================================================
+      expect(await screen.findByText("OAuth認証に失敗しました")).toBeInTheDocument();
+    });
+  });
+
+  describe("AUTH-009 modeResetEffect", () => {
+    test("modeResetEffect_初回マウント時_クリーンな状態を維持する", () => {
+      // ============================================================
+      // Arrange / Act
+      // ============================================================
+      render(<AuthForm mode="signin" />);
+
+      // ============================================================
+      // Assert
+      // ============================================================
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+      expect(screen.queryByText("ログイン中...")).not.toBeInTheDocument();
+    });
+
+    test("modeResetEffect_mode変更時_ローディングとエラーをリセットする", async () => {
+      // ============================================================
+      // Arrange
+      // ============================================================
+      signInMock.mockRejectedValueOnce(new Error("ログイン失敗"));
+      const { container, rerender } = render(<AuthForm mode="signin" />);
+      fillSignInInputs({ email: validEmail, password: validPassword });
+      submitForm(container);
+      expect(await screen.findByText("ログイン失敗")).toBeInTheDocument();
+
+      const signInDeferred = createDeferred<Awaited<ReturnType<typeof signIn>>>();
+      signInMock.mockImplementationOnce(() => signInDeferred.promise);
+      submitForm(container);
+      expect(screen.getByText("ログイン中...")).toBeInTheDocument();
+
+      // ============================================================
+      // Act
+      // ============================================================
+      rerender(<AuthForm mode="signup" />);
+
+      // ============================================================
+      // Assert
+      // ============================================================
+      await waitFor(() => {
+        expect(screen.queryByText("ログイン失敗")).not.toBeInTheDocument();
+      });
+      expect(screen.queryByText("ログイン中...")).not.toBeInTheDocument();
+
+      signInDeferred.resolve({} as Awaited<ReturnType<typeof signIn>>);
+    });
+  });
+
+  describe("AUTH-010 renderAuthForm", () => {
+    test("renderAuthForm_signupモードの場合_signup専用項目を描画する", () => {
+      // ============================================================
+      // Arrange / Act
+      // ============================================================
+      render(<AuthForm mode="signup" />);
+      fireEvent.change(screen.getByLabelText("パスワード"), {
+        target: { value: "a" },
+      });
+
+      // ============================================================
+      // Assert
+      // ============================================================
+      expect(screen.getByLabelText("パスワード（確認）")).toBeInTheDocument();
+      expect(screen.getByText("8文字以上")).toBeInTheDocument();
+    });
+
+    test("renderAuthForm_signinモードの場合_パスワード再設定案内を描画する", () => {
+      // ============================================================
+      // Arrange / Act
+      // ============================================================
+      render(<AuthForm mode="signin" />);
+
+      // ============================================================
+      // Assert
+      // ============================================================
+      expect(screen.queryByLabelText("パスワード（確認）")).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: "こちら", hidden: false })
+      ).toHaveAttribute("href", "/reset-password");
+    });
+
+    test("renderAuthForm_ローディングまたは検証エラー時_送信を無効化する", () => {
+      // ============================================================
+      // Arrange
+      // ============================================================
+      render(<AuthForm mode="signup" />);
+      const submitButton = screen.getByRole("button", { name: "アカウントを作成" });
+
+      // ============================================================
+      // Act
+      // ============================================================
+      fillSignUpInputs({
+        email: validEmail,
+        password: "aaaaaaaa",
+      });
+
+      // ============================================================
+      // Assert
+      // ============================================================
+      expect(submitButton).toBeDisabled();
+    });
+
+    test("renderAuthForm_ローディング状態の場合_OAuth操作を無効化してオーバーレイを表示する", async () => {
+      // ============================================================
+      // Arrange
+      // ============================================================
+      const oauthDeferred = createDeferred<Awaited<ReturnType<typeof signInWithOAuth>>>();
+      signInWithOAuthMock.mockImplementationOnce(() => oauthDeferred.promise);
+      render(<AuthForm mode="signin" />);
+
+      // ============================================================
+      // Act
+      // ============================================================
+      fireEvent.click(screen.getByRole("button", { name: "Googleで続ける" }));
+
+      // ============================================================
+      // Assert
+      // ============================================================
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "Googleで続ける" })).toBeDisabled();
+      });
+      expect(screen.getByText("ログイン中...")).toBeInTheDocument();
+
+      oauthDeferred.resolve({} as Awaited<ReturnType<typeof signInWithOAuth>>);
+    });
+  });
+
+  describe("AUTH-011 togglePasswordVisibility", () => {
+    test("togglePasswordVisibility_パスワード切替クリック時_password入力typeを切り替える", () => {
+      // ============================================================
+      // Arrange
+      // ============================================================
+      render(<AuthForm mode="signup" />);
+      const passwordInput = screen.getByLabelText("パスワード") as HTMLInputElement;
+      const toggleButtons = screen.getAllByRole("button", {
+        name: "パスワードを表示",
+      });
+
+      // ============================================================
+      // Act
+      // ============================================================
+      fireEvent.click(toggleButtons[0]);
+
+      // ============================================================
+      // Assert
+      // ============================================================
+      expect(passwordInput.type).toBe("text");
+      expect(
+        screen.getByRole("button", { name: "パスワードを非表示" })
+      ).toBeInTheDocument();
+    });
+
+    test("togglePasswordVisibility_signupで確認パスワード切替クリック時_confirm入力typeを切り替える", () => {
+      // ============================================================
+      // Arrange
+      // ============================================================
+      render(<AuthForm mode="signup" />);
+      const confirmPasswordInput = screen.getByLabelText(
+        "パスワード（確認）"
+      ) as HTMLInputElement;
+      const toggleButtons = screen.getAllByRole("button", {
+        name: "パスワードを表示",
+      });
+
+      // ============================================================
+      // Act
+      // ============================================================
+      fireEvent.click(toggleButtons[1]);
+
+      // ============================================================
+      // Assert
+      // ============================================================
+      expect(confirmPasswordInput.type).toBe("text");
+      expect(
+        screen.getByRole("button", { name: "パスワードを非表示" })
+      ).toBeInTheDocument();
+    });
+
+    test("togglePasswordVisibility_ローディング時_可視状態を変更しない", async () => {
+      // ============================================================
+      // Arrange
+      // ============================================================
+      const signInDeferred = createDeferred<Awaited<ReturnType<typeof signIn>>>();
+      signInMock.mockImplementationOnce(() => signInDeferred.promise);
+      const { container } = render(<AuthForm mode="signin" />);
+      fillSignInInputs({ email: validEmail, password: validPassword });
+      submitForm(container);
+
+      const passwordInput = screen.getByLabelText("パスワード") as HTMLInputElement;
+      const toggleButton = screen.getByRole("button", {
+        name: "パスワードを表示",
+      });
+
+      // ============================================================
+      // Act
+      // ============================================================
+      fireEvent.click(toggleButton);
+
+      // ============================================================
+      // Assert
+      // ============================================================
+      expect(toggleButton).toBeDisabled();
+      expect(passwordInput.type).toBe("password");
+
+      signInDeferred.resolve({} as Awaited<ReturnType<typeof signIn>>);
+    });
+  });
+});


### PR DESCRIPTION
### 概要
harden signup response and add AuthForm spec/tests

### 変更内容
- `docs/specs/auth/auth_form_spec.yaml`
- `docs/test-progress.yaml`
- `features/auth/components/AuthForm.tsx`
- `features/auth/lib/auth-client.ts`
- `tests/unit/components/auth-form.test.tsx`

### 実機テスト
- [ ] ブラウザで主要導線を操作し、対象機能が期待どおり完了すること
- [ ] バリデーションエラー条件を操作し、ユーザー向けエラーメッセージが表示されること
- [ ] PC（Chrome）/ iOS Safari / Android Chrome で表示崩れがないこと

### テスト方法
- 自動テスト: `npm test -- tests/unit/components/auth-form.test.tsx`

### テスト結果
- [x] 実行コマンド: `npm test -- tests/unit/components/auth-form.test.tsx`
- [x] Test Suites: 1 passed, 1 total
- [x] Tests:       24 passed, 24 total
- [x] failed のテスト項目: なし
