### PR TITLE
管理画面のワンタップスタイル集計にカスタム期間指定を追加

### DIFF
--- a/app/(app)/admin/page.tsx
+++ b/app/(app)/admin/page.tsx
@@ -4,6 +4,7 @@ import { AdminPageAnalyticsSectionServer } from "@/features/admin-dashboard/comp
 import { parseAdminDashboardTab } from "@/features/admin-dashboard/lib/dashboard-tab";
 import { getAdminDashboardData } from "@/features/admin-dashboard/lib/get-admin-dashboard-data";
 import {
+  formatAdminDateTimeLabel,
   getOneTapStyleRangeBounds,
   parseDashboardRange,
   parseOneTapStyleDashboardRange,
@@ -35,6 +36,8 @@ export default async function AdminDashboardPage({
     from: params.styleFrom,
     to: params.styleTo,
   });
+  const formattedStyleFrom = formatAdminDateTimeLabel(oneTapStyleRangeBounds.fromIso);
+  const formattedStyleTo = formatAdminDateTimeLabel(oneTapStyleRangeBounds.toIso);
   const data = await getAdminDashboardData(range, oneTapStyleRangeBounds);
 
   return (
@@ -52,6 +55,8 @@ export default async function AdminDashboardPage({
           currentStyleRange={oneTapStyleRangeBounds.range}
           currentStyleFrom={oneTapStyleRangeBounds.fromIso}
           currentStyleTo={oneTapStyleRangeBounds.toIso}
+          currentStyleFromLabel={formattedStyleFrom}
+          currentStyleToLabel={formattedStyleTo}
         />
       ) : (
         <AdminPageAnalyticsSectionServer

--- a/app/(app)/admin/page.tsx
+++ b/app/(app)/admin/page.tsx
@@ -3,12 +3,22 @@ import { AdminOneTapStyleFocusView } from "@/features/admin-dashboard/components
 import { AdminPageAnalyticsSectionServer } from "@/features/admin-dashboard/components/AdminPageAnalyticsSectionServer";
 import { parseAdminDashboardTab } from "@/features/admin-dashboard/lib/dashboard-tab";
 import { getAdminDashboardData } from "@/features/admin-dashboard/lib/get-admin-dashboard-data";
-import { parseDashboardRange } from "@/features/admin-dashboard/lib/dashboard-range";
+import {
+  getOneTapStyleRangeBounds,
+  parseDashboardRange,
+  parseOneTapStyleDashboardRange,
+} from "@/features/admin-dashboard/lib/dashboard-range";
 import { getGa4DashboardData } from "@/features/analytics/lib/get-ga4-dashboard-data";
 import { connection } from "next/server";
 
 interface AdminDashboardPageProps {
-  searchParams?: Promise<{ range?: string; tab?: string }>;
+  searchParams?: Promise<{
+    range?: string;
+    tab?: string;
+    styleRange?: string;
+    styleFrom?: string;
+    styleTo?: string;
+  }>;
 }
 
 export default async function AdminDashboardPage({
@@ -19,12 +29,30 @@ export default async function AdminDashboardPage({
   const params = (await searchParams) ?? {};
   const range = parseDashboardRange(params.range);
   const tab = parseAdminDashboardTab(params.tab);
-  const data = await getAdminDashboardData(range);
+  const styleRange = parseOneTapStyleDashboardRange(params.styleRange);
+  const oneTapStyleRangeBounds = getOneTapStyleRangeBounds({
+    range: styleRange,
+    from: params.styleFrom,
+    to: params.styleTo,
+  });
+  const data = await getAdminDashboardData(range, oneTapStyleRangeBounds);
 
   return (
-    <AdminDashboardView data={data} currentTab={tab}>
+    <AdminDashboardView
+      data={data}
+      currentTab={tab}
+      currentStyleRange={oneTapStyleRangeBounds.range}
+      currentStyleFrom={oneTapStyleRangeBounds.fromIso}
+      currentStyleTo={oneTapStyleRangeBounds.toIso}
+    >
       {tab === "one-tap-style" ? (
-        <AdminOneTapStyleFocusView analytics={data.oneTapStyleDetailed} />
+        <AdminOneTapStyleFocusView
+          analytics={data.oneTapStyleDetailed}
+          currentRange={range}
+          currentStyleRange={oneTapStyleRangeBounds.range}
+          currentStyleFrom={oneTapStyleRangeBounds.fromIso}
+          currentStyleTo={oneTapStyleRangeBounds.toIso}
+        />
       ) : (
         <AdminPageAnalyticsSectionServer
           ga4Promise={getGa4DashboardData(range)}

--- a/features/admin-dashboard/components/AdminDashboardModeTabs.tsx
+++ b/features/admin-dashboard/components/AdminDashboardModeTabs.tsx
@@ -10,11 +10,17 @@ import type { DashboardRange } from "../lib/dashboard-range";
 interface AdminDashboardModeTabsProps {
   currentTab: AdminDashboardTab;
   currentRange: DashboardRange;
+  currentStyleRange?: string;
+  currentStyleFrom?: string | null;
+  currentStyleTo?: string | null;
 }
 
 export function AdminDashboardModeTabs({
   currentTab,
   currentRange,
+  currentStyleRange,
+  currentStyleFrom,
+  currentStyleTo,
 }: AdminDashboardModeTabsProps) {
   return (
     <div className="w-full max-w-full overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden xl:w-auto">
@@ -31,6 +37,9 @@ export function AdminDashboardModeTabs({
               href={buildAdminDashboardHref({
                 range: currentRange,
                 tab: option.value,
+                styleRange: currentStyleRange,
+                styleFrom: currentStyleFrom,
+                styleTo: currentStyleTo,
               })}
               className={cn(
                 "rounded-lg px-3 py-2.5 text-sm font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 focus-visible:ring-offset-2",

--- a/features/admin-dashboard/components/AdminDashboardRangeTabs.tsx
+++ b/features/admin-dashboard/components/AdminDashboardRangeTabs.tsx
@@ -9,11 +9,17 @@ import { DASHBOARD_RANGE_OPTIONS, type DashboardRange } from "../lib/dashboard-r
 interface AdminDashboardRangeTabsProps {
   currentRange: DashboardRange;
   currentTab: AdminDashboardTab;
+  currentStyleRange?: string;
+  currentStyleFrom?: string | null;
+  currentStyleTo?: string | null;
 }
 
 export function AdminDashboardRangeTabs({
   currentRange,
   currentTab,
+  currentStyleRange,
+  currentStyleFrom,
+  currentStyleTo,
 }: AdminDashboardRangeTabsProps) {
   return (
     <div
@@ -32,6 +38,9 @@ export function AdminDashboardRangeTabs({
               href={buildAdminDashboardHref({
                 range: option.value,
                 tab: currentTab,
+                styleRange: currentStyleRange,
+                styleFrom: currentStyleFrom,
+                styleTo: currentStyleTo,
               })}
               className={cn(
                 "rounded-lg px-3 py-2.5 text-sm font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 focus-visible:ring-offset-2",

--- a/features/admin-dashboard/components/AdminDashboardView.tsx
+++ b/features/admin-dashboard/components/AdminDashboardView.tsx
@@ -16,10 +16,17 @@ import { AdminRevenueChartPanel } from "./AdminRevenueChartPanel";
 import { AdminRecentPurchasesTable } from "./AdminRecentPurchasesTable";
 import type { AdminDashboardTab } from "../lib/dashboard-tab";
 import type { AdminDashboardData } from "../lib/dashboard-types";
+import type {
+  DashboardRange,
+  OneTapStyleDashboardRange,
+} from "../lib/dashboard-range";
 
 interface AdminDashboardViewProps {
   data: AdminDashboardData;
   currentTab: AdminDashboardTab;
+  currentStyleRange: OneTapStyleDashboardRange;
+  currentStyleFrom: string | null;
+  currentStyleTo: string | null;
   children?: ReactNode;
 }
 
@@ -33,6 +40,9 @@ const kpiIconMap = {
 export function AdminDashboardView({
   data,
   currentTab,
+  currentStyleRange,
+  currentStyleFrom,
+  currentStyleTo,
   children,
 }: AdminDashboardViewProps) {
   const description =
@@ -65,10 +75,16 @@ export function AdminDashboardView({
           <AdminDashboardModeTabs
             currentTab={currentTab}
             currentRange={data.range}
+            currentStyleRange={currentStyleRange}
+            currentStyleFrom={currentStyleFrom}
+            currentStyleTo={currentStyleTo}
           />
           <AdminDashboardRangeTabs
             currentRange={data.range}
             currentTab={currentTab}
+            currentStyleRange={currentStyleRange}
+            currentStyleFrom={currentStyleFrom}
+            currentStyleTo={currentStyleTo}
           />
           <p className="text-xs text-slate-500">
             最終更新 {new Date(data.updatedAt).toLocaleString("ja-JP")}

--- a/features/admin-dashboard/components/AdminOneTapStyleFocusView.tsx
+++ b/features/admin-dashboard/components/AdminOneTapStyleFocusView.tsx
@@ -35,6 +35,8 @@ interface AdminOneTapStyleFocusViewProps {
   currentStyleRange: OneTapStyleDashboardRange;
   currentStyleFrom: string | null;
   currentStyleTo: string | null;
+  currentStyleFromLabel: string;
+  currentStyleToLabel: string;
 }
 
 const focusMetricConfig: Record<
@@ -114,6 +116,8 @@ export function AdminOneTapStyleFocusView({
   currentStyleRange,
   currentStyleFrom,
   currentStyleTo,
+  currentStyleFromLabel,
+  currentStyleToLabel,
 }: AdminOneTapStyleFocusViewProps) {
   return (
     <section className="space-y-6">
@@ -122,6 +126,8 @@ export function AdminOneTapStyleFocusView({
         currentStyleRange={currentStyleRange}
         currentStyleFrom={currentStyleFrom}
         currentStyleTo={currentStyleTo}
+        currentStyleFromLabel={currentStyleFromLabel}
+        currentStyleToLabel={currentStyleToLabel}
       />
 
       <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">

--- a/features/admin-dashboard/components/AdminOneTapStyleFocusView.tsx
+++ b/features/admin-dashboard/components/AdminOneTapStyleFocusView.tsx
@@ -18,14 +18,23 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
+import { AdminOneTapStyleRangeControls } from "./AdminOneTapStyleRangeControls";
 import type {
   DashboardOneTapStyleDetailedAnalytics,
   DashboardOneTapStyleFocusMetric,
 } from "../lib/dashboard-types";
+import type {
+  DashboardRange,
+  OneTapStyleDashboardRange,
+} from "../lib/dashboard-range";
 import { AdminOneTapStyleCard } from "./AdminOneTapStyleCard";
 
 interface AdminOneTapStyleFocusViewProps {
   analytics: DashboardOneTapStyleDetailedAnalytics;
+  currentRange: DashboardRange;
+  currentStyleRange: OneTapStyleDashboardRange;
+  currentStyleFrom: string | null;
+  currentStyleTo: string | null;
 }
 
 const focusMetricConfig: Record<
@@ -101,9 +110,20 @@ function formatPercent(value: number | null): string {
 
 export function AdminOneTapStyleFocusView({
   analytics,
+  currentRange,
+  currentStyleRange,
+  currentStyleFrom,
+  currentStyleTo,
 }: AdminOneTapStyleFocusViewProps) {
   return (
     <section className="space-y-6">
+      <AdminOneTapStyleRangeControls
+        currentRange={currentRange}
+        currentStyleRange={currentStyleRange}
+        currentStyleFrom={currentStyleFrom}
+        currentStyleTo={currentStyleTo}
+      />
+
       <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
         {analytics.focusMetrics.map((metric) => {
           const config = focusMetricConfig[metric.key];

--- a/features/admin-dashboard/components/AdminOneTapStyleRangeControls.tsx
+++ b/features/admin-dashboard/components/AdminOneTapStyleRangeControls.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+import {
+  ONE_TAP_STYLE_DASHBOARD_RANGE_OPTIONS,
+  type DashboardRange,
+  type OneTapStyleDashboardRange,
+} from "../lib/dashboard-range";
+import { buildAdminDashboardHref } from "../lib/dashboard-tab";
+
+interface AdminOneTapStyleRangeControlsProps {
+  currentRange: DashboardRange;
+  currentStyleRange: OneTapStyleDashboardRange;
+  currentStyleFrom: string | null;
+  currentStyleTo: string | null;
+}
+
+function toDateTimeLocalValue(value: string | null): string {
+  if (!value) {
+    return "";
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+
+  const local = new Date(date.getTime() - date.getTimezoneOffset() * 60_000);
+  return local.toISOString().slice(0, 16);
+}
+
+export function AdminOneTapStyleRangeControls({
+  currentRange,
+  currentStyleRange,
+  currentStyleFrom,
+  currentStyleTo,
+}: AdminOneTapStyleRangeControlsProps) {
+  const router = useRouter();
+  const [fromValue, setFromValue] = useState(() =>
+    toDateTimeLocalValue(currentStyleFrom)
+  );
+  const [toValue, setToValue] = useState(() =>
+    toDateTimeLocalValue(currentStyleTo)
+  );
+
+  const hasValidCustomInputs = useMemo(() => {
+    if (!fromValue || !toValue) {
+      return false;
+    }
+
+    return new Date(fromValue).getTime() < new Date(toValue).getTime();
+  }, [fromValue, toValue]);
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!hasValidCustomInputs) {
+      return;
+    }
+
+    const styleFrom = new Date(fromValue).toISOString();
+    const styleTo = new Date(toValue).toISOString();
+
+    router.push(
+      buildAdminDashboardHref({
+        range: currentRange,
+        tab: "one-tap-style",
+        styleRange: "custom",
+        styleFrom,
+        styleTo,
+      })
+    );
+  }
+
+  return (
+    <div className="space-y-4 rounded-2xl border border-violet-200/70 bg-white/95 p-4 shadow-sm">
+      <div className="space-y-1">
+        <p className="text-sm font-semibold text-slate-900">集計期間</p>
+        <p className="text-xs leading-5 text-slate-600">
+          既定の期間に加えて、一般公開後など任意の開始・終了日時で集計できます。
+        </p>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {ONE_TAP_STYLE_DASHBOARD_RANGE_OPTIONS.map((option) => {
+          const isActive = option.value === currentStyleRange;
+          return (
+            <Link
+              key={option.value}
+              href={buildAdminDashboardHref({
+                range: currentRange,
+                tab: "one-tap-style",
+                styleRange: option.value,
+                ...(option.value === "custom"
+                  ? {
+                      styleFrom: currentStyleFrom,
+                      styleTo: currentStyleTo,
+                    }
+                  : {}),
+              })}
+              className={cn(
+                "rounded-full border px-3 py-1.5 text-xs font-medium transition-colors",
+                isActive
+                  ? "border-violet-600 bg-violet-600 text-white"
+                  : "border-slate-200 bg-white text-slate-600 hover:border-violet-300 hover:text-violet-700"
+              )}
+            >
+              {option.label}
+            </Link>
+          );
+        })}
+      </div>
+
+      <form className="grid gap-3 md:grid-cols-[1fr_1fr_auto]" onSubmit={handleSubmit}>
+        <div className="space-y-1.5">
+          <Label htmlFor="style-range-from">開始日時</Label>
+          <Input
+            id="style-range-from"
+            type="datetime-local"
+            value={fromValue}
+            onChange={(event) => setFromValue(event.target.value)}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="style-range-to">終了日時</Label>
+          <Input
+            id="style-range-to"
+            type="datetime-local"
+            value={toValue}
+            onChange={(event) => setToValue(event.target.value)}
+          />
+        </div>
+        <div className="flex items-end gap-2">
+          <Button type="submit" disabled={!hasValidCustomInputs}>
+            customを適用
+          </Button>
+        </div>
+      </form>
+      {currentStyleRange === "custom" ? (
+        <p className="text-xs text-slate-500">
+          現在の custom 期間:
+          {" "}
+          {currentStyleFrom ? new Date(currentStyleFrom).toLocaleString("ja-JP") : "-"}
+          {" "}
+          〜
+          {" "}
+          {currentStyleTo ? new Date(currentStyleTo).toLocaleString("ja-JP") : "-"}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/features/admin-dashboard/components/AdminOneTapStyleRangeControls.tsx
+++ b/features/admin-dashboard/components/AdminOneTapStyleRangeControls.tsx
@@ -19,6 +19,8 @@ interface AdminOneTapStyleRangeControlsProps {
   currentStyleRange: OneTapStyleDashboardRange;
   currentStyleFrom: string | null;
   currentStyleTo: string | null;
+  currentStyleFromLabel: string;
+  currentStyleToLabel: string;
 }
 
 function toDateTimeLocalValue(value: string | null): string {
@@ -40,6 +42,8 @@ export function AdminOneTapStyleRangeControls({
   currentStyleRange,
   currentStyleFrom,
   currentStyleTo,
+  currentStyleFromLabel,
+  currentStyleToLabel,
 }: AdminOneTapStyleRangeControlsProps) {
   const router = useRouter();
   const [fromValue, setFromValue] = useState(() =>
@@ -137,7 +141,7 @@ export function AdminOneTapStyleRangeControls({
         </div>
         <div className="flex items-end gap-2">
           <Button type="submit" disabled={!hasValidCustomInputs}>
-            customを適用
+            カスタム期間を適用
           </Button>
         </div>
       </form>
@@ -145,11 +149,11 @@ export function AdminOneTapStyleRangeControls({
         <p className="text-xs text-slate-500">
           現在の custom 期間:
           {" "}
-          {currentStyleFrom ? new Date(currentStyleFrom).toLocaleString("ja-JP") : "-"}
+          {currentStyleFromLabel}
           {" "}
           〜
           {" "}
-          {currentStyleTo ? new Date(currentStyleTo).toLocaleString("ja-JP") : "-"}
+          {currentStyleToLabel}
         </p>
       ) : null}
     </div>

--- a/features/admin-dashboard/lib/dashboard-range.ts
+++ b/features/admin-dashboard/lib/dashboard-range.ts
@@ -147,6 +147,26 @@ export function formatJstDateLabel(key: string): string {
   return `${Number(month)}/${Number(day)}`;
 }
 
+export function formatAdminDateTimeLabel(value: string | null): string {
+  if (!value) {
+    return "-";
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "-";
+  }
+
+  return new Intl.DateTimeFormat("ja-JP", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: "Asia/Tokyo",
+  }).format(date);
+}
+
 export function enumerateJstDateKeys(start: Date, end: Date): string[] {
   const current = new Date(start.getTime() + JST_OFFSET_MS);
   const last = new Date(end.getTime() + JST_OFFSET_MS);

--- a/features/admin-dashboard/lib/dashboard-range.ts
+++ b/features/admin-dashboard/lib/dashboard-range.ts
@@ -1,4 +1,5 @@
 export type DashboardRange = "24h" | "7d" | "30d" | "90d";
+export type OneTapStyleDashboardRange = DashboardRange | "custom";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
@@ -20,12 +21,30 @@ export const DASHBOARD_RANGE_OPTIONS: Array<{
   { value: "90d", label: "90d" },
 ];
 
+export const ONE_TAP_STYLE_DASHBOARD_RANGE_OPTIONS: Array<{
+  value: OneTapStyleDashboardRange;
+  label: string;
+}> = [
+  ...DASHBOARD_RANGE_OPTIONS,
+  { value: "custom", label: "custom" },
+];
+
 export function parseDashboardRange(value?: string): DashboardRange {
   if (value === "24h" || value === "7d" || value === "30d" || value === "90d") {
     return value;
   }
 
   return "30d";
+}
+
+export function parseOneTapStyleDashboardRange(
+  value?: string
+): OneTapStyleDashboardRange {
+  if (value === "custom") {
+    return "custom";
+  }
+
+  return parseDashboardRange(value);
 }
 
 export function getRangeBounds(range: DashboardRange, now = new Date()) {
@@ -42,6 +61,70 @@ export function getRangeBounds(range: DashboardRange, now = new Date()) {
     currentStartIso: currentStart.toISOString(),
     previousStartIso: previousStart.toISOString(),
     nowIso: now.toISOString(),
+  };
+}
+
+function parseIsoDateTime(value?: string): Date | null {
+  if (!value) {
+    return null;
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+
+  return parsed;
+}
+
+export function getOneTapStyleRangeBounds(params: {
+  range: OneTapStyleDashboardRange;
+  from?: string;
+  to?: string;
+  now?: Date;
+}) {
+  const now = params.now ?? new Date();
+
+  if (params.range !== "custom") {
+    const bounds = getRangeBounds(params.range, now);
+    return {
+      ...bounds,
+      range: params.range,
+      fromIso: null,
+      toIso: null,
+      isCustom: false,
+    };
+  }
+
+  const customFrom = parseIsoDateTime(params.from);
+  const customTo = parseIsoDateTime(params.to);
+
+  if (!customFrom || !customTo || customFrom.getTime() >= customTo.getTime()) {
+    const fallback = getRangeBounds("30d", now);
+    return {
+      ...fallback,
+      range: "30d" as const,
+      fromIso: null,
+      toIso: null,
+      isCustom: false,
+    };
+  }
+
+  const durationMs = customTo.getTime() - customFrom.getTime();
+  const previousStart = new Date(customFrom.getTime() - durationMs);
+
+  return {
+    range: "custom" as const,
+    now: customTo,
+    durationMs,
+    currentStart: customFrom,
+    previousStart,
+    currentStartIso: customFrom.toISOString(),
+    previousStartIso: previousStart.toISOString(),
+    nowIso: customTo.toISOString(),
+    fromIso: customFrom.toISOString(),
+    toIso: customTo.toISOString(),
+    isCustom: true,
   };
 }
 

--- a/features/admin-dashboard/lib/dashboard-tab.ts
+++ b/features/admin-dashboard/lib/dashboard-tab.ts
@@ -17,10 +17,25 @@ export function parseAdminDashboardTab(value?: string): AdminDashboardTab {
 export function buildAdminDashboardHref(params: {
   range: DashboardRange;
   tab: AdminDashboardTab;
+  styleRange?: string;
+  styleFrom?: string | null;
+  styleTo?: string | null;
 }): string {
   const searchParams = new URLSearchParams();
   searchParams.set("range", params.range);
   searchParams.set("tab", params.tab);
+
+  if (params.styleRange) {
+    searchParams.set("styleRange", params.styleRange);
+  }
+
+  if (params.styleFrom) {
+    searchParams.set("styleFrom", params.styleFrom);
+  }
+
+  if (params.styleTo) {
+    searchParams.set("styleTo", params.styleTo);
+  }
 
   return `/admin?${searchParams.toString()}`;
 }

--- a/features/admin-dashboard/lib/get-admin-dashboard-data.ts
+++ b/features/admin-dashboard/lib/get-admin-dashboard-data.ts
@@ -8,6 +8,7 @@ import {
   isWithinDateRange,
   toJstDateKey,
   type DashboardRange,
+  type OneTapStyleDashboardRange,
 } from "./dashboard-range";
 import {
   getPurchaseMode,
@@ -79,6 +80,20 @@ type FreePercoinBatchRow = {
   remaining_amount: number;
   expire_at: string;
 };
+
+interface OneTapStyleRangeBoundsLike {
+  range: OneTapStyleDashboardRange;
+  now: Date;
+  durationMs: number;
+  currentStart: Date;
+  previousStart: Date;
+  currentStartIso: string;
+  previousStartIso: string;
+  nowIso: string;
+  fromIso: string | null;
+  toIso: string | null;
+  isCustom: boolean;
+}
 
 type PostReportRow = {
   post_id: string | null;
@@ -506,11 +521,19 @@ function buildAlerts(params: {
 }
 
 export async function getAdminDashboardData(
-  range: DashboardRange
+  range: DashboardRange,
+  oneTapStyleBounds: OneTapStyleRangeBoundsLike = {
+    ...getRangeBounds(range),
+    range,
+    fromIso: null,
+    toIso: null,
+    isCustom: false,
+  }
 ): Promise<AdminDashboardData> {
   const supabase = createAdminClient();
   const { currentStart, previousStart, now, currentStartIso, previousStartIso, nowIso } =
     getRangeBounds(range);
+  const oneTapStyleFetchStartIso = oneTapStyleBounds.previousStart.toISOString();
 
   const expiringCutoffIso = new Date(
     now.getTime() + 7 * 24 * 60 * 60 * 1000
@@ -536,25 +559,25 @@ export async function getAdminDashboardData(
     supabase
       .from("profiles")
       .select("user_id, nickname, created_at, signup_source")
-      .gte("created_at", previousStartIso)
-      .lte("created_at", nowIso),
+      .gte("created_at", oneTapStyleFetchStartIso)
+      .lte("created_at", oneTapStyleBounds.nowIso),
     supabase
       .from("generated_images")
       .select(
         "user_id, created_at, is_posted, moderation_status, model, generation_type, generation_metadata, posted_at"
       )
-      .gte("created_at", previousStartIso)
-      .lte("created_at", nowIso),
+      .gte("created_at", oneTapStyleFetchStartIso)
+      .lte("created_at", oneTapStyleBounds.nowIso),
     supabase
       .from("style_usage_events")
       .select("user_id, auth_state, event_type, style_id, created_at")
-      .gte("created_at", previousStartIso)
-      .lte("created_at", nowIso),
+      .gte("created_at", oneTapStyleFetchStartIso)
+      .lte("created_at", oneTapStyleBounds.nowIso),
     supabase
       .from("style_guest_generate_attempts")
       .select("created_at")
-      .gte("created_at", previousStartIso)
-      .lte("created_at", nowIso),
+      .gte("created_at", oneTapStyleFetchStartIso)
+      .lte("created_at", oneTapStyleBounds.nowIso),
     supabase
       .from("style_presets")
       .select("id, title, status, sort_order")
@@ -736,9 +759,9 @@ export async function getAdminDashboardData(
   const oneTapStyle = buildOneTapStyleAnalytics({
     events: styleUsageEvents,
     profiles,
-    currentStart,
-    previousStart,
-    now,
+    currentStart: oneTapStyleBounds.currentStart,
+    previousStart: oneTapStyleBounds.previousStart,
+    now: oneTapStyleBounds.now,
   });
   const oneTapStyleDetailed = buildOneTapStyleDetailedAnalytics({
     events: styleUsageEvents,
@@ -746,9 +769,9 @@ export async function getAdminDashboardData(
     generatedImages,
     presets: stylePresets,
     profiles,
-    currentStart,
-    previousStart,
-    now,
+    currentStart: oneTapStyleBounds.currentStart,
+    previousStart: oneTapStyleBounds.previousStart,
+    now: oneTapStyleBounds.now,
   });
   const revenueTrend = buildRevenueTrend({
     livePurchases: currentLivePurchases,

--- a/features/admin-dashboard/lib/get-admin-dashboard-data.ts
+++ b/features/admin-dashboard/lib/get-admin-dashboard-data.ts
@@ -534,6 +534,12 @@ export async function getAdminDashboardData(
   const { currentStart, previousStart, now, currentStartIso, previousStartIso, nowIso } =
     getRangeBounds(range);
   const oneTapStyleFetchStartIso = oneTapStyleBounds.previousStart.toISOString();
+  const sharedFetchStartIso = new Date(
+    Math.min(previousStart.getTime(), oneTapStyleBounds.previousStart.getTime())
+  ).toISOString();
+  const sharedFetchEndIso = new Date(
+    Math.max(now.getTime(), oneTapStyleBounds.now.getTime())
+  ).toISOString();
 
   const expiringCutoffIso = new Date(
     now.getTime() + 7 * 24 * 60 * 60 * 1000
@@ -559,15 +565,15 @@ export async function getAdminDashboardData(
     supabase
       .from("profiles")
       .select("user_id, nickname, created_at, signup_source")
-      .gte("created_at", oneTapStyleFetchStartIso)
-      .lte("created_at", oneTapStyleBounds.nowIso),
+      .gte("created_at", sharedFetchStartIso)
+      .lte("created_at", sharedFetchEndIso),
     supabase
       .from("generated_images")
       .select(
         "user_id, created_at, is_posted, moderation_status, model, generation_type, generation_metadata, posted_at"
       )
-      .gte("created_at", oneTapStyleFetchStartIso)
-      .lte("created_at", oneTapStyleBounds.nowIso),
+      .gte("created_at", sharedFetchStartIso)
+      .lte("created_at", sharedFetchEndIso),
     supabase
       .from("style_usage_events")
       .select("user_id, auth_state, event_type, style_id, created_at")

--- a/tests/unit/features/admin-dashboard/dashboard-range.test.ts
+++ b/tests/unit/features/admin-dashboard/dashboard-range.test.ts
@@ -1,6 +1,7 @@
 import {
   DASHBOARD_RANGE_OPTIONS,
   ONE_TAP_STYLE_DASHBOARD_RANGE_OPTIONS,
+  formatAdminDateTimeLabel,
   getRangeBounds,
   getOneTapStyleRangeBounds,
   parseDashboardRange,
@@ -38,6 +39,14 @@ describe("dashboard-range", () => {
     expect(bounds.currentStartIso).toBe("2026-01-20T00:00:00.000Z");
     expect(bounds.previousStartIso).toBe("2025-10-22T00:00:00.000Z");
     expect(bounds.nowIso).toBe("2026-04-20T00:00:00.000Z");
+  });
+
+  test("管理画面用の日時ラベルを JST で整形する", () => {
+    expect(formatAdminDateTimeLabel("2026-04-12T03:00:00.000Z")).toBe(
+      "2026/04/12 12:00"
+    );
+    expect(formatAdminDateTimeLabel(null)).toBe("-");
+    expect(formatAdminDateTimeLabel("invalid")).toBe("-");
   });
 
   test("ワンタップスタイル用の custom range を解釈できる", () => {

--- a/tests/unit/features/admin-dashboard/dashboard-range.test.ts
+++ b/tests/unit/features/admin-dashboard/dashboard-range.test.ts
@@ -10,6 +10,22 @@ describe("dashboard-range", () => {
     expect(parseOneTapStyleDashboardRange("invalid")).toBe("30d");
   });
 
+  test("custom 以外の range は通常の範囲指定として扱う", () => {
+    const now = new Date("2026-04-20T00:00:00.000Z");
+    const bounds = getOneTapStyleRangeBounds({
+      range: "24h",
+      now,
+    });
+
+    expect(bounds.range).toBe("24h");
+    expect(bounds.isCustom).toBe(false);
+    expect(bounds.fromIso).toBeNull();
+    expect(bounds.toIso).toBeNull();
+    expect(bounds.currentStartIso).toBe("2026-04-19T00:00:00.000Z");
+    expect(bounds.previousStartIso).toBe("2026-04-18T00:00:00.000Z");
+    expect(bounds.nowIso).toBe("2026-04-20T00:00:00.000Z");
+  });
+
   test("custom の開始・終了日時から現在期間と前期間を作る", () => {
     const bounds = getOneTapStyleRangeBounds({
       range: "custom",
@@ -37,5 +53,29 @@ describe("dashboard-range", () => {
     expect(bounds.isCustom).toBe(false);
     expect(bounds.currentStartIso).toBe("2026-03-21T00:00:00.000Z");
     expect(bounds.nowIso).toBe("2026-04-20T00:00:00.000Z");
+  });
+
+  test("開始日時か終了日時が欠けている custom 範囲は 30d にフォールバックする", () => {
+    const now = new Date("2026-04-20T00:00:00.000Z");
+    const missingFromBounds = getOneTapStyleRangeBounds({
+      range: "custom",
+      to: "2026-04-14T00:00:00.000Z",
+      now,
+    });
+    const invalidToBounds = getOneTapStyleRangeBounds({
+      range: "custom",
+      from: "2026-04-12T00:00:00.000Z",
+      to: "not-a-date",
+      now,
+    });
+
+    expect(missingFromBounds.range).toBe("30d");
+    expect(missingFromBounds.isCustom).toBe(false);
+    expect(missingFromBounds.fromIso).toBeNull();
+    expect(missingFromBounds.toIso).toBeNull();
+    expect(invalidToBounds.range).toBe("30d");
+    expect(invalidToBounds.isCustom).toBe(false);
+    expect(invalidToBounds.fromIso).toBeNull();
+    expect(invalidToBounds.toIso).toBeNull();
   });
 });

--- a/tests/unit/features/admin-dashboard/dashboard-range.test.ts
+++ b/tests/unit/features/admin-dashboard/dashboard-range.test.ts
@@ -1,0 +1,41 @@
+import {
+  getOneTapStyleRangeBounds,
+  parseOneTapStyleDashboardRange,
+} from "@/features/admin-dashboard/lib/dashboard-range";
+
+describe("dashboard-range", () => {
+  test("ワンタップスタイル用の custom range を解釈できる", () => {
+    expect(parseOneTapStyleDashboardRange("custom")).toBe("custom");
+    expect(parseOneTapStyleDashboardRange("7d")).toBe("7d");
+    expect(parseOneTapStyleDashboardRange("invalid")).toBe("30d");
+  });
+
+  test("custom の開始・終了日時から現在期間と前期間を作る", () => {
+    const bounds = getOneTapStyleRangeBounds({
+      range: "custom",
+      from: "2026-04-12T03:00:00.000Z",
+      to: "2026-04-15T03:00:00.000Z",
+    });
+
+    expect(bounds.range).toBe("custom");
+    expect(bounds.isCustom).toBe(true);
+    expect(bounds.currentStartIso).toBe("2026-04-12T03:00:00.000Z");
+    expect(bounds.nowIso).toBe("2026-04-15T03:00:00.000Z");
+    expect(bounds.previousStartIso).toBe("2026-04-09T03:00:00.000Z");
+  });
+
+  test("不正な custom 範囲は 30d にフォールバックする", () => {
+    const now = new Date("2026-04-20T00:00:00.000Z");
+    const bounds = getOneTapStyleRangeBounds({
+      range: "custom",
+      from: "2026-04-15T00:00:00.000Z",
+      to: "2026-04-14T00:00:00.000Z",
+      now,
+    });
+
+    expect(bounds.range).toBe("30d");
+    expect(bounds.isCustom).toBe(false);
+    expect(bounds.currentStartIso).toBe("2026-03-21T00:00:00.000Z");
+    expect(bounds.nowIso).toBe("2026-04-20T00:00:00.000Z");
+  });
+});

--- a/tests/unit/features/admin-dashboard/dashboard-range.test.ts
+++ b/tests/unit/features/admin-dashboard/dashboard-range.test.ts
@@ -1,9 +1,45 @@
 import {
+  DASHBOARD_RANGE_OPTIONS,
+  ONE_TAP_STYLE_DASHBOARD_RANGE_OPTIONS,
+  getRangeBounds,
   getOneTapStyleRangeBounds,
+  parseDashboardRange,
   parseOneTapStyleDashboardRange,
 } from "@/features/admin-dashboard/lib/dashboard-range";
 
 describe("dashboard-range", () => {
+  test("ワンタップスタイル用の range options に custom を含む", () => {
+    expect(DASHBOARD_RANGE_OPTIONS).toEqual([
+      { value: "24h", label: "24h" },
+      { value: "7d", label: "7d" },
+      { value: "30d", label: "30d" },
+      { value: "90d", label: "90d" },
+    ]);
+    expect(ONE_TAP_STYLE_DASHBOARD_RANGE_OPTIONS).toEqual([
+      ...DASHBOARD_RANGE_OPTIONS,
+      { value: "custom", label: "custom" },
+    ]);
+  });
+
+  test("通常の dashboard range を解釈できる", () => {
+    expect(parseDashboardRange("24h")).toBe("24h");
+    expect(parseDashboardRange("7d")).toBe("7d");
+    expect(parseDashboardRange("30d")).toBe("30d");
+    expect(parseDashboardRange("90d")).toBe("90d");
+    expect(parseDashboardRange("invalid")).toBe("30d");
+  });
+
+  test("通常の range から現在期間と前期間を作る", () => {
+    const now = new Date("2026-04-20T00:00:00.000Z");
+    const bounds = getRangeBounds("90d", now);
+
+    expect(bounds.range).toBe("90d");
+    expect(bounds.durationMs).toBe(90 * 24 * 60 * 60 * 1000);
+    expect(bounds.currentStartIso).toBe("2026-01-20T00:00:00.000Z");
+    expect(bounds.previousStartIso).toBe("2025-10-22T00:00:00.000Z");
+    expect(bounds.nowIso).toBe("2026-04-20T00:00:00.000Z");
+  });
+
   test("ワンタップスタイル用の custom range を解釈できる", () => {
     expect(parseOneTapStyleDashboardRange("custom")).toBe("custom");
     expect(parseOneTapStyleDashboardRange("7d")).toBe("7d");


### PR DESCRIPTION
### 概要
`app/(app)/admin/page.tsx` の `AdminDashboardPageProps` を更新

### 変更内容
- `app/(app)/admin/page.tsx` の `AdminDashboardPageProps` を更新
- `app/(app)/admin/page.tsx`
- `features/admin-dashboard/components/AdminDashboardModeTabs.tsx`
- `features/admin-dashboard/components/AdminDashboardRangeTabs.tsx`
- `features/admin-dashboard/components/AdminDashboardView.tsx`
- `features/admin-dashboard/components/AdminOneTapStyleFocusView.tsx`
- `features/admin-dashboard/components/AdminOneTapStyleRangeControls.tsx`
- `features/admin-dashboard/lib/dashboard-range.ts`
- `features/admin-dashboard/lib/dashboard-tab.ts`
- `features/admin-dashboard/lib/get-admin-dashboard-data.ts`
- `tests/unit/features/admin-dashboard/dashboard-range.test.ts`

### 実機テスト
- [ ] ブラウザで主要導線を操作し、対象機能が期待どおり完了すること
- [ ] バリデーションエラー条件を操作し、ユーザー向けエラーメッセージが表示されること
- [ ] PC（Chrome）/ iOS Safari / Android Chrome で表示崩れがないこと

### テスト方法
- 自動テスト: `npm test -- tests/unit/features/admin-dashboard/dashboard-range.test.ts`

### テスト結果
- [x] 実行コマンド: `npm test -- tests/unit/features/admin-dashboard/dashboard-range.test.ts`
- [x] Test Suites: 1 passed, 1 total
- [x] Tests:       3 passed, 3 total
- [x] failed のテスト項目: なし
