### PR TITLE
管理画面のワンタップスタイル期間指定の custom 選択挙動を修正

### DIFF
--- a/features/admin-dashboard/components/AdminOneTapStyleRangeControls.tsx
+++ b/features/admin-dashboard/components/AdminOneTapStyleRangeControls.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import Link from "next/link";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -46,12 +45,27 @@ export function AdminOneTapStyleRangeControls({
   currentStyleToLabel,
 }: AdminOneTapStyleRangeControlsProps) {
   const router = useRouter();
+  const [selectedRange, setSelectedRange] = useState<OneTapStyleDashboardRange>(
+    currentStyleRange
+  );
   const [fromValue, setFromValue] = useState(() =>
     toDateTimeLocalValue(currentStyleFrom)
   );
   const [toValue, setToValue] = useState(() =>
     toDateTimeLocalValue(currentStyleTo)
   );
+
+  useEffect(() => {
+    setSelectedRange(currentStyleRange);
+  }, [currentStyleRange]);
+
+  useEffect(() => {
+    setFromValue(toDateTimeLocalValue(currentStyleFrom));
+  }, [currentStyleFrom]);
+
+  useEffect(() => {
+    setToValue(toDateTimeLocalValue(currentStyleTo));
+  }, [currentStyleTo]);
 
   const hasValidCustomInputs = useMemo(() => {
     if (!fromValue || !toValue) {
@@ -81,6 +95,22 @@ export function AdminOneTapStyleRangeControls({
     );
   }
 
+  function handleRangeSelect(nextRange: OneTapStyleDashboardRange) {
+    if (nextRange === "custom") {
+      setSelectedRange("custom");
+      return;
+    }
+
+    setSelectedRange(nextRange);
+    router.push(
+      buildAdminDashboardHref({
+        range: currentRange,
+        tab: "one-tap-style",
+        styleRange: nextRange,
+      })
+    );
+  }
+
   return (
     <div className="space-y-4 rounded-2xl border border-violet-200/70 bg-white/95 p-4 shadow-sm">
       <div className="space-y-1">
@@ -92,21 +122,12 @@ export function AdminOneTapStyleRangeControls({
 
       <div className="flex flex-wrap gap-2">
         {ONE_TAP_STYLE_DASHBOARD_RANGE_OPTIONS.map((option) => {
-          const isActive = option.value === currentStyleRange;
+          const isActive = option.value === selectedRange;
           return (
-            <Link
+            <button
               key={option.value}
-              href={buildAdminDashboardHref({
-                range: currentRange,
-                tab: "one-tap-style",
-                styleRange: option.value,
-                ...(option.value === "custom"
-                  ? {
-                      styleFrom: currentStyleFrom,
-                      styleTo: currentStyleTo,
-                    }
-                  : {}),
-              })}
+              type="button"
+              onClick={() => handleRangeSelect(option.value)}
               className={cn(
                 "rounded-full border px-3 py-1.5 text-xs font-medium transition-colors",
                 isActive
@@ -115,7 +136,7 @@ export function AdminOneTapStyleRangeControls({
               )}
             >
               {option.label}
-            </Link>
+            </button>
           );
         })}
       </div>

--- a/tests/unit/features/admin-dashboard/admin-one-tap-style-range-controls.test.tsx
+++ b/tests/unit/features/admin-dashboard/admin-one-tap-style-range-controls.test.tsx
@@ -41,8 +41,20 @@ describe("AdminOneTapStyleRangeControls", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: "カスタム期間を適用" }));
 
-    expect(pushMock).toHaveBeenCalledWith(
-      "/admin?range=30d&tab=one-tap-style&styleRange=custom&styleFrom=2026-04-12T03%3A00%3A00.000Z&styleTo=2026-04-15T03%3A00%3A00.000Z"
+    expect(pushMock).toHaveBeenCalledTimes(1);
+
+    const pushedUrl = pushMock.mock.calls[0]?.[0];
+    expect(typeof pushedUrl).toBe("string");
+
+    const params = new URL(pushedUrl as string, "https://example.com").searchParams;
+    expect(params.get("range")).toBe("30d");
+    expect(params.get("tab")).toBe("one-tap-style");
+    expect(params.get("styleRange")).toBe("custom");
+    expect(params.get("styleFrom")).toBe(
+      new Date("2026-04-12T12:00").toISOString()
+    );
+    expect(params.get("styleTo")).toBe(
+      new Date("2026-04-15T12:00").toISOString()
     );
   });
 

--- a/tests/unit/features/admin-dashboard/admin-one-tap-style-range-controls.test.tsx
+++ b/tests/unit/features/admin-dashboard/admin-one-tap-style-range-controls.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useRouter } from "next/navigation";
+import { AdminOneTapStyleRangeControls } from "@/features/admin-dashboard/components/AdminOneTapStyleRangeControls";
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(),
+}));
+
+describe("AdminOneTapStyleRangeControls", () => {
+  const useRouterMock = useRouter as jest.MockedFunction<typeof useRouter>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("custom を押しただけでは遷移せず、適用時にだけ custom URL へ遷移する", () => {
+    const pushMock = jest.fn();
+    useRouterMock.mockReturnValue({
+      push: pushMock,
+    } as unknown as ReturnType<typeof useRouter>);
+
+    render(
+      <AdminOneTapStyleRangeControls
+        currentRange="30d"
+        currentStyleRange="30d"
+        currentStyleFrom={null}
+        currentStyleTo={null}
+        currentStyleFromLabel="-"
+        currentStyleToLabel="-"
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "custom" }));
+    expect(pushMock).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByLabelText("開始日時"), {
+      target: { value: "2026-04-12T12:00" },
+    });
+    fireEvent.change(screen.getByLabelText("終了日時"), {
+      target: { value: "2026-04-15T12:00" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "カスタム期間を適用" }));
+
+    expect(pushMock).toHaveBeenCalledWith(
+      "/admin?range=30d&tab=one-tap-style&styleRange=custom&styleFrom=2026-04-12T03%3A00%3A00.000Z&styleTo=2026-04-15T03%3A00%3A00.000Z"
+    );
+  });
+
+  test("通常 range は選択時に即座に遷移する", () => {
+    const pushMock = jest.fn();
+    useRouterMock.mockReturnValue({
+      push: pushMock,
+    } as unknown as ReturnType<typeof useRouter>);
+
+    render(
+      <AdminOneTapStyleRangeControls
+        currentRange="30d"
+        currentStyleRange="custom"
+        currentStyleFrom="2026-04-12T03:00:00.000Z"
+        currentStyleTo="2026-04-15T03:00:00.000Z"
+        currentStyleFromLabel="2026/04/12 12:00"
+        currentStyleToLabel="2026/04/15 12:00"
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "7d" }));
+
+    expect(pushMock).toHaveBeenCalledWith(
+      "/admin?range=30d&tab=one-tap-style&styleRange=7d"
+    );
+  });
+});


### PR DESCRIPTION
### 概要
管理画面のワンタップスタイル期間指定の custom 選択挙動を修正

### 変更内容
- `features/admin-dashboard/components/AdminOneTapStyleRangeControls.tsx` の `handleRangeSelect` を更新
- `features/admin-dashboard/components/AdminOneTapStyleRangeControls.tsx`
- `tests/unit/features/admin-dashboard/admin-one-tap-style-range-controls.test.tsx`

### 実機テスト
- [ ] ブラウザで主要導線を操作し、対象機能が期待どおり完了すること
- [ ] バリデーションエラー条件を操作し、ユーザー向けエラーメッセージが表示されること
- [ ] PC（Chrome）/ iOS Safari / Android Chrome で表示崩れがないこと

### テスト方法
- 自動テスト: `npm test -- tests/unit/features/admin-dashboard/admin-one-tap-style-range-controls.test.tsx`

### テスト結果
- [x] 実行コマンド: `npm test -- tests/unit/features/admin-dashboard/admin-one-tap-style-range-controls.test.tsx`
- [x] Test Suites: 1 passed, 1 total
- [x] Tests:       2 passed, 2 total
- [x] failed のテスト項目: なし
