### PR TITLE
fix(generation): reinforce outfit/framing prompts and harden worker retries

### DIFF
--- a/.claude/skills/resolve-gemini-review
+++ b/.claude/skills/resolve-gemini-review
@@ -1,0 +1,1 @@
+../../.agents/skills/resolve-gemini-review

--- a/app/(app)/style/generate-async/handler.ts
+++ b/app/(app)/style/generate-async/handler.ts
@@ -32,21 +32,8 @@ import {
 import { getPercoinCost } from "@/features/generation/lib/model-config";
 import { buildOneTapStyleGenerationMetadata } from "@/shared/generation/one-tap-style-metadata";
 import type { SourceImageType } from "@/shared/generation/prompt-core";
+import { buildStyleGenerationPrompt } from "@/shared/generation/style-prompts";
 import type { StyleUsageAuthState } from "@/features/style/lib/style-usage-events";
-
-const STYLE_PROMPT_BASE_PREFIX = `CRITICAL INSTRUCTION: This is an Image-to-Image task based on \`image_0.png\`. Strictly follow these steps:
-
-1. Strict Filtering: DO NOT describe or generate any body parts, clothing, or items that are not visible in \`image_0.png\`. If a part is not in the original frame, omit its description entirely.
-
-2. Pose Preservation: Maintain the exact facial features, hair style, and pose of the person in \`image_0.png\`.`;
-const STYLE_PROMPT_ILLUSTRATION_SUFFIX =
-  "Maintain the exact artistic style, brushwork, and original composition.";
-const STYLE_PROMPT_REAL_SUFFIX =
-  "Generate a photorealistic result based on the uploaded photo. Preserve the original camera angle, framing, realistic lighting, and composition. Do not introduce painterly or illustrated rendering.";
-const STYLE_PROMPT_KEEP_BACKGROUND_SUFFIX =
-  "Keep the entire original background unchanged as much as possible. Do not replace, redesign, or restyle the background.";
-const STYLE_PROMPT_CHANGE_BACKGROUND_SUFFIX =
-  "You may restyle the background within the existing framing so it complements the selected outfit. Preserve the camera angle, crop, composition, pose, facial features, and character identity.";
 
 interface StyleGenerateAsyncRouteDependencies {
   getUserFn?: typeof getUser;
@@ -129,33 +116,6 @@ function resolveSourceImageType(entry: FormDataEntryValue | null): SourceImageTy
 
 function resolveBackgroundChange(entry: FormDataEntryValue | null): boolean {
   return entry === "true";
-}
-
-function buildGenerationPrompt(params: {
-  stylingPrompt: string;
-  backgroundPrompt: string | null;
-  backgroundChange: boolean;
-  sourceImageType: SourceImageType;
-}): string {
-  const promptSuffix =
-    params.sourceImageType === "real"
-      ? STYLE_PROMPT_REAL_SUFFIX
-      : STYLE_PROMPT_ILLUSTRATION_SUFFIX;
-  const backgroundInstruction = params.backgroundChange
-    ? STYLE_PROMPT_CHANGE_BACKGROUND_SUFFIX
-    : STYLE_PROMPT_KEEP_BACKGROUND_SUFFIX;
-  const promptSections = [
-    STYLE_PROMPT_BASE_PREFIX,
-    promptSuffix,
-    backgroundInstruction,
-    `Styling Direction:\n${params.stylingPrompt}`,
-  ];
-
-  if (params.backgroundChange && params.backgroundPrompt) {
-    promptSections.push(`Background Direction:\n${params.backgroundPrompt}`);
-  }
-
-  return promptSections.join("\n\n");
 }
 
 async function recordStyleRateLimitedEvent(params: {
@@ -341,7 +301,7 @@ export async function postStyleGenerateAsyncRoute(
       }
     }
 
-    const prompt = buildGenerationPrompt({
+    const prompt = buildStyleGenerationPrompt({
       stylingPrompt: preset.stylingPrompt,
       backgroundPrompt: preset.backgroundPrompt,
       backgroundChange,

--- a/app/(app)/style/generate/handler.ts
+++ b/app/(app)/style/generate/handler.ts
@@ -9,6 +9,10 @@ import {
 } from "@/features/i2i-poc/shared/image-constraints";
 import { getPublishedStylePresetForGeneration } from "@/features/style-presets/lib/style-preset-repository";
 import { STYLE_GENERATION_IMAGE_SIZE, STYLE_GENERATION_MODEL } from "@/features/style/lib/constants";
+import {
+  buildStyleAttemptReinforcementPrefix,
+  buildStyleGenerationPrompt,
+} from "@/shared/generation/style-prompts";
 import { recordStyleUsageEvent } from "@/features/style/lib/style-usage-events";
 import {
   checkAndConsumeStyleGenerateRateLimit,
@@ -30,19 +34,6 @@ const MAX_RETRYABLE_ATTEMPTS = 2;
 const RETRYABLE_NO_IMAGE_FINISH_REASONS = new Set([
   "MALFORMED_FUNCTION_CALL",
 ]);
-const STYLE_PROMPT_BASE_PREFIX = `CRITICAL INSTRUCTION: This is an Image-to-Image task based on \`image_0.png\`. Strictly follow these steps:
-
-1. Strict Filtering: DO NOT describe or generate any body parts, clothing, or items that are not visible in \`image_0.png\`. If a part is not in the original frame, omit its description entirely.
-
-2. Pose Preservation: Maintain the exact facial features, hair style, and pose of the person in \`image_0.png\`.`;
-const STYLE_PROMPT_ILLUSTRATION_SUFFIX =
-  "Maintain the exact artistic style, brushwork, and original composition.";
-const STYLE_PROMPT_REAL_SUFFIX =
-  "Generate a photorealistic result based on the uploaded photo. Preserve the original camera angle, framing, realistic lighting, and composition. Do not introduce painterly or illustrated rendering.";
-const STYLE_PROMPT_KEEP_BACKGROUND_SUFFIX =
-  "Keep the entire original background unchanged as much as possible. Do not replace, redesign, or restyle the background.";
-const STYLE_PROMPT_CHANGE_BACKGROUND_SUFFIX =
-  "You may restyle the background within the existing framing so it complements the selected outfit. Preserve the camera angle, crop, composition, pose, facial features, and character identity.";
 
 type FetchFn = typeof fetch;
 
@@ -160,35 +151,6 @@ function resolveSourceImageType(entry: FormDataEntryValue | null): SourceImageTy
 
 function resolveBackgroundChange(entry: FormDataEntryValue | null): boolean {
   return entry === "true";
-}
-
-function buildGenerationPrompt(
-  params: {
-    stylingPrompt: string;
-    backgroundPrompt: string | null;
-    backgroundChange: boolean;
-    sourceImageType: SourceImageType;
-  }
-): string {
-  const promptSuffix =
-    params.sourceImageType === "real"
-      ? STYLE_PROMPT_REAL_SUFFIX
-      : STYLE_PROMPT_ILLUSTRATION_SUFFIX;
-  const backgroundInstruction = params.backgroundChange
-    ? STYLE_PROMPT_CHANGE_BACKGROUND_SUFFIX
-    : STYLE_PROMPT_KEEP_BACKGROUND_SUFFIX;
-  const promptSections = [
-    STYLE_PROMPT_BASE_PREFIX,
-    promptSuffix,
-    backgroundInstruction,
-    `Styling Direction:\n${params.stylingPrompt}`,
-  ];
-
-  if (params.backgroundChange && params.backgroundPrompt) {
-    promptSections.push(`Background Direction:\n${params.backgroundPrompt}`);
-  }
-
-  return promptSections.join("\n\n");
 }
 
 async function recordStyleRateLimitedEvent(params: {
@@ -419,19 +381,21 @@ export async function postStyleGenerateRoute(
       });
     }
 
-    const parts: GeminiContentPart[] = [
-      {
-        text: buildGenerationPrompt({
-          stylingPrompt: preset.stylingPrompt,
-          backgroundPrompt: preset.backgroundPrompt,
-          backgroundChange,
-          sourceImageType,
-        }),
-      },
-      await toInlineData(uploadImage),
-    ];
+    const basePromptText = buildStyleGenerationPrompt({
+      stylingPrompt: preset.stylingPrompt,
+      backgroundPrompt: preset.backgroundPrompt,
+      backgroundChange,
+      sourceImageType,
+    });
+    const imagePart = await toInlineData(uploadImage);
 
     for (let attempt = 1; attempt <= MAX_RETRYABLE_ATTEMPTS; attempt += 1) {
+      const reinforcementPrefix = buildStyleAttemptReinforcementPrefix(attempt);
+      const parts: GeminiContentPart[] = [
+        { text: `${reinforcementPrefix}${basePromptText}` },
+        imagePart,
+      ];
+
       const abortController = new AbortController();
       const timeoutId = setTimeout(() => abortController.abort(), GEMINI_TIMEOUT_MS);
 

--- a/shared/generation/prompt-core.ts
+++ b/shared/generation/prompt-core.ts
@@ -108,66 +108,43 @@ export function buildPrompt(options: BuildPromptOptions): string {
   }
 
   if (generationType === "coordinate") {
-    if (sourceImageType === "real") {
-      if (backgroundMode === "keep") {
-        return `A photorealistic image based on the uploaded photo.
-Captured with an 85mm portrait lens.
-Do not change the camera angle or framing.
-Edit only the outfit.
+    const coordinateBasePrefix = `CRITICAL INSTRUCTION: This is an Image-to-Image task based on \`image_0.png\`. You MUST follow these steps exactly:
 
-New Outfit:
+1. Outfit Transformation within the Existing Frame (REQUIRED): You MUST replace the person's current clothing with the outfit described under "New Outfit" below. The replacement MUST appear only on body parts that are already visible in \`image_0.png\`. DO NOT extend the crop, widen the framing, or reveal additional body parts (legs, feet, lower body, etc.) that are not visible in the original image. The output image MUST visibly show the new outfit on the parts of the body that were already in frame. Returning the original outfit unchanged is a failure; extending the frame or adding body parts not in the original image is also a failure.
 
-${sanitizedDescription}`;
-      }
+2. Pose & Identity Preservation: Maintain the exact facial features, hair style, and pose of the person in \`image_0.png\`. Do not alter the person's identity.
 
-      if (backgroundMode === "ai_auto") {
-        return `A photorealistic image based on the uploaded photo.
-Captured with an 85mm portrait lens.
-Do not change the camera angle or framing.
-Adjust the background to match the new outfit’s style.
+3. Strict Framing: DO NOT describe or generate any body parts, clothing, or items that are not visible in \`image_0.png\`. If a body part is not in the original frame, do not add it. Preserve the exact crop, camera angle, and composition of \`image_0.png\`.`;
 
-New Outfit:
+    const coordinateRealStyleSuffix =
+      "Generate a photorealistic result based on the uploaded photo. Captured with an 85mm portrait lens. Preserve the original camera angle, framing, realistic lighting, and composition. Do not introduce painterly or illustrated rendering.";
 
-${sanitizedDescription}`;
-      }
+    const coordinateIllustrationStyleSuffix =
+      "Maintain the exact illustration touch and artistic style of the uploaded image. Preserve the original camera angle, framing, pose, and composition.";
 
-      // include_in_prompt: 背景についてはシステム指示を追加せず、ユーザー記述に委ねる
-      return `A photorealistic image based on the uploaded photo.
-Captured with an 85mm portrait lens.
-Do not change the camera angle or framing.
+    const coordinateKeepBackgroundSuffix =
+      "Keep the entire original background unchanged as much as possible. Do not replace, redesign, or restyle the background.";
 
-New Outfit:
+    const coordinateChangeBackgroundSuffix =
+      "You MUST restyle the background within the existing framing so that it complements the new outfit's style and color palette. Replace or redesign the original background accordingly. Preserve the camera angle, crop, composition, pose, facial features, and character identity.";
 
-${sanitizedDescription}`;
-    }
+    const styleSuffix =
+      sourceImageType === "real"
+        ? coordinateRealStyleSuffix
+        : coordinateIllustrationStyleSuffix;
+
+    const sections: string[] = [coordinateBasePrefix, styleSuffix];
 
     if (backgroundMode === "keep") {
-      return `Maintain the exact illustration touch and artistic style of the uploaded image, and preserve its pose and composition exactly.
-Do not change the camera angle or framing from the original image.
-Edit only the outfit.
-
-New Outfit:
-
-${sanitizedDescription}`;
+      sections.push(coordinateKeepBackgroundSuffix);
+    } else if (backgroundMode === "ai_auto") {
+      sections.push(coordinateChangeBackgroundSuffix);
     }
+    // include_in_prompt: ユーザー記述に背景指示を委ねるため、システム側の背景指示は追加しない
 
-    if (backgroundMode === "ai_auto") {
-      return `Maintain the exact illustration touch and artistic style of the uploaded image, and preserve its pose and composition exactly.
-Do not change the camera angle or framing from the original image.
-Adjust the background to match the new outfit’s style and color palette.
+    sections.push(`New Outfit:\n\n${sanitizedDescription}`);
 
-New Outfit:
-
-${sanitizedDescription}`;
-    }
-
-    // include_in_prompt: 背景についてはシステム指示を追加せず、ユーザー記述に委ねる
-    return `Maintain the exact illustration touch and artistic style of the uploaded image, and preserve its pose and composition exactly.
-Do not change the camera angle or framing from the original image.
-
-New Outfit:
-
-${sanitizedDescription}`;
+    return sections.join("\n\n");
   }
 
   if (generationType === "specified_coordinate") {
@@ -270,4 +247,15 @@ Keep everything else consistent: face features, hair, pose, expression, lighting
   throw new Error(
     `API Error - Configuration '${generationType}' not found. Available types: coordinate, specified_coordinate, full_body, chibi, one_tap_style`
   );
+}
+
+/**
+ * coordinate 生成タイプ向けのリトライ強化 prefix。
+ * attempt=1 は空文字、attempt>=2 で「前回は衣装置換が反映されなかった」旨を Gemini に強く伝える。
+ */
+export function buildCoordinateAttemptReinforcementPrefix(attempt: number): string {
+  if (attempt <= 1) {
+    return "";
+  }
+  return `RETRY NOTICE (attempt ${attempt}): The previous generation failed to apply the requested transformation — the output was either unchanged, only partially modified, or did not reflect the New Outfit described below. You MUST strictly apply the outfit replacement on the body parts already visible in \`image_0.png\`, within the existing frame, and any background instruction below. Do not return the original image unchanged. Do not extend the crop, widen the framing, or add body parts (legs, feet, lower body) that were not visible in \`image_0.png\`.\n\n`;
 }

--- a/shared/generation/style-prompts.ts
+++ b/shared/generation/style-prompts.ts
@@ -1,0 +1,75 @@
+/**
+ * /style (One-Tap Style) 用のプロンプト生成・リトライ強化ヘルパー。
+ * Next.js API route (sync) と Supabase Edge Function worker (async) の両方から利用する。
+ *
+ * 同期 path はリクエストごとにフルプロンプトを組み立てて Gemini に投げる。
+ * 非同期 path は生成時にフルプロンプトを組み立てて image_jobs.prompt_text に保存し、
+ * worker はそれをそのまま使うため、本モジュールは worker 側でもそのまま import できるよう
+ * Deno と Node の両方で動く pure TypeScript で書く。
+ */
+
+import type { SourceImageType } from "./prompt-core.ts";
+
+export const STYLE_PROMPT_BASE_PREFIX = `CRITICAL INSTRUCTION: This is an Image-to-Image task based on \`image_0.png\`. You MUST follow these steps exactly:
+
+1. Outfit Transformation within the Existing Frame (REQUIRED): You MUST replace the person's current clothing with the outfit described in the "Styling Direction" below. The replacement MUST appear only on body parts that are already visible in \`image_0.png\`. DO NOT extend the crop, widen the framing, or reveal additional body parts (legs, feet, lower body, etc.) that are not visible in the original image. The output image MUST visibly show the new outfit on the parts of the body that were already in frame. Returning the original outfit unchanged is a failure; extending the frame or adding body parts not in the original image is also a failure.
+
+2. Pose & Identity Preservation: Maintain the exact facial features, hair style, and pose of the person in \`image_0.png\`. Do not alter the person's identity.
+
+3. Strict Framing: DO NOT describe or generate any body parts, clothing, or items that are not visible in \`image_0.png\`. If a body part is not in the original frame, do not add it. Preserve the exact crop, camera angle, and composition of \`image_0.png\`.`;
+
+export const STYLE_PROMPT_ILLUSTRATION_SUFFIX =
+  "Maintain the exact artistic style, brushwork, and original composition.";
+
+export const STYLE_PROMPT_REAL_SUFFIX =
+  "Generate a photorealistic result based on the uploaded photo. Preserve the original camera angle, framing, realistic lighting, and composition. Do not introduce painterly or illustrated rendering.";
+
+export const STYLE_PROMPT_KEEP_BACKGROUND_SUFFIX =
+  "Keep the entire original background unchanged as much as possible. Do not replace, redesign, or restyle the background.";
+
+export const STYLE_PROMPT_CHANGE_BACKGROUND_SUFFIX =
+  "You MUST restyle the background within the existing framing so that it matches the \"Background Direction\" below and complements the selected outfit. Replace or redesign the original background accordingly. Preserve the camera angle, crop, composition, pose, facial features, and character identity.";
+
+export interface BuildStyleGenerationPromptParams {
+  stylingPrompt: string;
+  backgroundPrompt: string | null;
+  backgroundChange: boolean;
+  sourceImageType: SourceImageType;
+}
+
+export function buildStyleGenerationPrompt(
+  params: BuildStyleGenerationPromptParams
+): string {
+  const promptSuffix =
+    params.sourceImageType === "real"
+      ? STYLE_PROMPT_REAL_SUFFIX
+      : STYLE_PROMPT_ILLUSTRATION_SUFFIX;
+  const backgroundInstruction = params.backgroundChange
+    ? STYLE_PROMPT_CHANGE_BACKGROUND_SUFFIX
+    : STYLE_PROMPT_KEEP_BACKGROUND_SUFFIX;
+
+  const promptSections = [
+    STYLE_PROMPT_BASE_PREFIX,
+    promptSuffix,
+    backgroundInstruction,
+    `Styling Direction:\n${params.stylingPrompt}`,
+  ];
+
+  if (params.backgroundChange && params.backgroundPrompt) {
+    promptSections.push(`Background Direction:\n${params.backgroundPrompt}`);
+  }
+
+  return promptSections.join("\n\n");
+}
+
+/**
+ * リトライ時に先頭へ差し込む強化プロンプト。
+ * attempt=1 は空文字を返し、attempt>=2 で Gemini に「前回は変化しなかった／不十分だった」旨を
+ * 明示する文言を返す。呼び出し側はこの戻り値を既存プロンプトの先頭に結合する想定。
+ */
+export function buildStyleAttemptReinforcementPrefix(attempt: number): string {
+  if (attempt <= 1) {
+    return "";
+  }
+  return `RETRY NOTICE (attempt ${attempt}): The previous generation failed to apply the requested transformation — the output was either unchanged, only partially modified, or did not reflect the Styling Direction. You MUST strictly apply the outfit replacement on the body parts already visible in \`image_0.png\`, within the existing frame, and any background instruction below. Do not return the original image unchanged. Do not extend the crop, widen the framing, or add body parts (legs, feet, lower body) that were not visible in \`image_0.png\`.\n\n`;
+}

--- a/supabase/functions/image-gen-worker/index.ts
+++ b/supabase/functions/image-gen-worker/index.ts
@@ -1545,15 +1545,19 @@ Deno.serve(async () => {
                   "responseProcessing",
                   generatingSubstepDurationsMs,
                   async () => {
-                    if (geminiData!.error) {
-                      throw new Error(geminiData!.error!.message || "Gemini API error");
+                    if (!geminiData) {
+                      throw new Error("Internal error: Gemini response data is missing.");
                     }
 
-                    if (isGeminiSafetyBlocked(geminiData!)) {
+                    if (geminiData.error) {
+                      throw new Error(geminiData.error.message || "Gemini API error");
+                    }
+
+                    if (isGeminiSafetyBlocked(geminiData)) {
                       throw new Error(SAFETY_POLICY_BLOCKED_ERROR);
                     }
 
-                    const images = extractImagesFromGeminiResponse(geminiData!);
+                    const images = extractImagesFromGeminiResponse(geminiData);
                     return images.length > 0 ? images[0] : null;
                   },
                   { attempt }

--- a/supabase/functions/image-gen-worker/index.ts
+++ b/supabase/functions/image-gen-worker/index.ts
@@ -6,11 +6,13 @@ import { decodeBase64, encodeBase64 } from "jsr:@std/encoding@1/base64";
 import {
   buildPrompt as buildSharedPrompt,
   backgroundModeToBackgroundChange,
+  buildCoordinateAttemptReinforcementPrefix,
   resolveBackgroundMode,
 } from "../../../shared/generation/prompt-core.ts";
 import type {
   GenerationType,
 } from "../../../shared/generation/prompt-core.ts";
+import { buildStyleAttemptReinforcementPrefix } from "../../../shared/generation/style-prompts.ts";
 import {
   MALFORMED_GEMINI_PARTS_ERROR,
   isInvalidGeminiArgumentErrorMessage,
@@ -36,6 +38,31 @@ const PROCESSING_STALE_TIMEOUT_SECONDS = 360; // processing状態がこの秒数
 
 const INPUT_IMAGE_FETCH_MAX_ATTEMPTS = 3;
 const INPUT_IMAGE_FETCH_RETRYABLE_STATUS = new Set([408, 429, 500, 502, 503, 504]);
+
+const GEMINI_REQUEST_TIMEOUT_MS = 35_000;
+
+type GeminiAttemptMetadata = {
+  attempt: number;
+  startedAt: string;
+  durationMs: number;
+  httpStatus: number | null;
+  httpOk: boolean;
+  finishReasons: string[];
+  hasImage: boolean;
+  timedOut: boolean;
+  errorMessage: string | null;
+  reinforcementApplied: boolean;
+};
+
+function extractGeminiFinishReasons(payload: GeminiResponse | null | undefined): string[] {
+  if (!payload?.candidates || payload.candidates.length === 0) {
+    return [];
+  }
+  const reasons = payload.candidates
+    .map((candidate) => candidate?.finishReason?.trim())
+    .filter((reason): reason is string => Boolean(reason));
+  return Array.from(new Set(reasons));
+}
 
 type InputImageData = {
   base64: string;
@@ -1214,6 +1241,7 @@ Deno.serve(async () => {
         }
 
         // ===== フェーズ4-1: Gemini API呼び出しの実装 =====
+        const geminiAttempts: GeminiAttemptMetadata[] = [];
         try {
           let generatedImage: { mimeType: string; data: string } | null = null;
           currentStage = "generating";
@@ -1399,52 +1427,151 @@ Deno.serve(async () => {
 
               const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/${apiModel}:generateContent`;
               const maxAttempts = 2;
+              const isOneTapStyle = job.generation_type === "one_tap_style";
+              const isCoordinate = job.generation_type === "coordinate";
+              const basePromptText =
+                requestBody.contents[0]?.parts.find((part) => typeof part.text === "string")
+                  ?.text ?? "";
 
               for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-                const geminiData = await measureGeneratingSubstep(
-                  jobId,
-                  "geminiRequest",
-                  generatingSubstepDurationsMs,
-                  async () => {
-                    const geminiResponse = await fetch(apiUrl, {
-                      method: "POST",
-                      headers: {
-                        "Content-Type": "application/json",
-                        "x-goog-api-key": geminiApiKey,
-                      },
-                      body: JSON.stringify(requestBody),
-                    });
+                const reinforcementPrefix = isOneTapStyle
+                  ? buildStyleAttemptReinforcementPrefix(attempt)
+                  : isCoordinate
+                    ? buildCoordinateAttemptReinforcementPrefix(attempt)
+                    : "";
+                const reinforcementApplied = reinforcementPrefix.length > 0;
 
-                    if (!geminiResponse.ok) {
-                      const errorData = await geminiResponse.json();
-                      throw new Error(
-                        errorData.error?.message || `Gemini API error: ${geminiResponse.status}`
+                const attemptParts = requestBody.contents[0].parts.map((part) => {
+                  if (typeof part.text === "string") {
+                    return {
+                      ...part,
+                      text: reinforcementApplied
+                        ? `${reinforcementPrefix}${basePromptText}`
+                        : part.text,
+                    };
+                  }
+                  return part;
+                });
+
+                const attemptRequestBody = {
+                  ...requestBody,
+                  contents: [
+                    {
+                      ...requestBody.contents[0],
+                      parts: attemptParts,
+                    },
+                  ],
+                };
+
+                const attemptStartedAtMs = Date.now();
+                let attemptHttpStatus: number | null = null;
+                let attemptHttpOk = false;
+                let attemptTimedOut = false;
+                let attemptErrorMessage: string | null = null;
+                let geminiData: GeminiResponse | null = null;
+
+                try {
+                  geminiData = await measureGeneratingSubstep(
+                    jobId,
+                    "geminiRequest",
+                    generatingSubstepDurationsMs,
+                    async () => {
+                      const abortController = new AbortController();
+                      const timeoutId = setTimeout(
+                        () => abortController.abort(),
+                        GEMINI_REQUEST_TIMEOUT_MS
                       );
-                    }
+                      try {
+                        const geminiResponse = await fetch(apiUrl, {
+                          method: "POST",
+                          headers: {
+                            "Content-Type": "application/json",
+                            "x-goog-api-key": geminiApiKey,
+                          },
+                          body: JSON.stringify(attemptRequestBody),
+                          signal: abortController.signal,
+                        });
 
-                    return (await geminiResponse.json()) as GeminiResponse;
-                  },
-                  { attempt }
-                );
+                        attemptHttpStatus = geminiResponse.status;
+                        attemptHttpOk = geminiResponse.ok;
+
+                        if (!geminiResponse.ok) {
+                          const errorData = await geminiResponse
+                            .json()
+                            .catch(() => null);
+                          throw new Error(
+                            errorData?.error?.message ||
+                              `Gemini API error: ${geminiResponse.status}`
+                          );
+                        }
+
+                        return (await geminiResponse.json()) as GeminiResponse;
+                      } finally {
+                        clearTimeout(timeoutId);
+                      }
+                    },
+                    { attempt }
+                  );
+                } catch (attemptError) {
+                  attemptErrorMessage =
+                    attemptError instanceof Error
+                      ? attemptError.message
+                      : String(attemptError);
+                  if (
+                    attemptError instanceof Error &&
+                    (attemptError.name === "AbortError" ||
+                      /aborted/i.test(attemptErrorMessage))
+                  ) {
+                    attemptTimedOut = true;
+                    attemptErrorMessage = `Gemini request timed out after ${GEMINI_REQUEST_TIMEOUT_MS}ms`;
+                  }
+                  geminiAttempts.push({
+                    attempt,
+                    startedAt: new Date(attemptStartedAtMs).toISOString(),
+                    durationMs: Date.now() - attemptStartedAtMs,
+                    httpStatus: attemptHttpStatus,
+                    httpOk: attemptHttpOk,
+                    finishReasons: [],
+                    hasImage: false,
+                    timedOut: attemptTimedOut,
+                    errorMessage: attemptErrorMessage,
+                    reinforcementApplied,
+                  });
+                  throw attemptError;
+                }
 
                 const nextGeneratedImage = await measureGeneratingSubstep(
                   jobId,
                   "responseProcessing",
                   generatingSubstepDurationsMs,
                   async () => {
-                    if (geminiData.error) {
-                      throw new Error(geminiData.error.message || "Gemini API error");
+                    if (geminiData!.error) {
+                      throw new Error(geminiData!.error!.message || "Gemini API error");
                     }
 
-                    if (isGeminiSafetyBlocked(geminiData)) {
+                    if (isGeminiSafetyBlocked(geminiData!)) {
                       throw new Error(SAFETY_POLICY_BLOCKED_ERROR);
                     }
 
-                    const images = extractImagesFromGeminiResponse(geminiData);
+                    const images = extractImagesFromGeminiResponse(geminiData!);
                     return images.length > 0 ? images[0] : null;
                   },
                   { attempt }
                 );
+
+                const finishReasons = extractGeminiFinishReasons(geminiData);
+                geminiAttempts.push({
+                  attempt,
+                  startedAt: new Date(attemptStartedAtMs).toISOString(),
+                  durationMs: Date.now() - attemptStartedAtMs,
+                  httpStatus: attemptHttpStatus,
+                  httpOk: attemptHttpOk,
+                  finishReasons,
+                  hasImage: Boolean(nextGeneratedImage),
+                  timedOut: false,
+                  errorMessage: null,
+                  reinforcementApplied,
+                });
 
                 if (nextGeneratedImage) {
                   generatedImage = nextGeneratedImage;
@@ -1453,7 +1580,8 @@ Deno.serve(async () => {
 
                 if (attempt < maxAttempts) {
                   console.log(
-                    `[Job Processing] No images generated (attempt ${attempt}/${maxAttempts}), retrying...`
+                    `[Job Processing] No images generated (attempt ${attempt}/${maxAttempts}), retrying...`,
+                    { finishReasons }
                   );
                 } else {
                   throw new Error("No images generated");
@@ -1576,6 +1704,10 @@ Deno.serve(async () => {
 
               // ===== フェーズ4-4: 成功時の処理 =====
               // image_jobsテーブルを更新（成功時）
+              const successGenerationMetadata = {
+                ...(job.generation_metadata as Record<string, unknown> | null ?? {}),
+                geminiAttempts,
+              };
               const { data: succeededJob, error: successUpdateError } = await supabase
                 .from("image_jobs")
                 .update({
@@ -1584,6 +1716,7 @@ Deno.serve(async () => {
                   result_image_url: publicUrl,
                   error_message: null,
                   completed_at: new Date().toISOString(),
+                  generation_metadata: successGenerationMetadata,
                 })
                 .eq("id", jobId)
                 .eq("status", "processing")
@@ -1718,6 +1851,10 @@ Deno.serve(async () => {
           const shouldMarkAsFailed = isNonRetriable || newAttempts >= 3;
 
           // image_jobsテーブルを更新（失敗時）
+          const failureGenerationMetadata = {
+            ...(job.generation_metadata as Record<string, unknown> | null ?? {}),
+            geminiAttempts,
+          };
           const { data: failUpdatedJob, error: failUpdateError } = await supabase
             .from("image_jobs")
             .update({
@@ -1728,6 +1865,7 @@ Deno.serve(async () => {
               attempts: newAttempts,
               started_at: shouldMarkAsFailed ? currentJob?.started_at ?? job.started_at : null,
               completed_at: shouldMarkAsFailed ? new Date().toISOString() : null,
+              generation_metadata: failureGenerationMetadata,
             })
             .eq("id", jobId)
             .eq("status", "processing")

--- a/tests/integration/app/style-generate-async-route.test.ts
+++ b/tests/integration/app/style-generate-async-route.test.ts
@@ -7,14 +7,15 @@ import type {
   StyleGenerateAttemptReservation,
   StyleGenerateRateLimitResult,
 } from "@/features/style/lib/style-rate-limit";
+import {
+  STYLE_PROMPT_BASE_PREFIX,
+  STYLE_PROMPT_ILLUSTRATION_SUFFIX,
+  STYLE_PROMPT_KEEP_BACKGROUND_SUFFIX,
+  STYLE_PROMPT_REAL_SUFFIX,
+} from "@/shared/generation/style-prompts";
 
 type JsonRecord = Record<string, unknown>;
 const STYLE_ID = "c3f48c0b-54d2-4c4d-a18c-bd358b58d3b1";
-const STYLE_PROMPT_BASE_PREFIX = `CRITICAL INSTRUCTION: This is an Image-to-Image task based on \`image_0.png\`. Strictly follow these steps:
-
-1. Strict Filtering: DO NOT describe or generate any body parts, clothing, or items that are not visible in \`image_0.png\`. If a part is not in the original frame, omit its description entirely.
-
-2. Pose Preservation: Maintain the exact facial features, hair style, and pose of the person in \`image_0.png\`.`;
 
 function buildExpectedPrompt(params: {
   sourceImageType?: "illustration" | "real";
@@ -23,8 +24,8 @@ function buildExpectedPrompt(params: {
 }): string {
   const promptSuffix =
     params.sourceImageType === "real"
-      ? "Generate a photorealistic result based on the uploaded photo. Preserve the original camera angle, framing, realistic lighting, and composition. Do not introduce painterly or illustrated rendering."
-      : "Maintain the exact artistic style, brushwork, and original composition.";
+      ? STYLE_PROMPT_REAL_SUFFIX
+      : STYLE_PROMPT_ILLUSTRATION_SUFFIX;
 
   const promptSections = [
     STYLE_PROMPT_BASE_PREFIX,
@@ -198,7 +199,7 @@ describe("StyleGenerateAsyncRoute integration tests", () => {
       user_id: "user-123",
       prompt_text: buildExpectedPrompt({
         backgroundInstruction:
-          "Keep the entire original background unchanged as much as possible. Do not replace, redesign, or restyle the background.",
+          STYLE_PROMPT_KEEP_BACKGROUND_SUFFIX,
       }),
       input_image_url: "https://cdn.example.com/temp/user-123/upload-image.png",
       source_image_stock_id: null,

--- a/tests/integration/app/style-generate-route.test.ts
+++ b/tests/integration/app/style-generate-route.test.ts
@@ -6,14 +6,17 @@ import type {
   StyleGenerateAttemptReservation,
   StyleGenerateRateLimitResult,
 } from "@/features/style/lib/style-rate-limit";
+import {
+  STYLE_PROMPT_BASE_PREFIX,
+  STYLE_PROMPT_CHANGE_BACKGROUND_SUFFIX,
+  STYLE_PROMPT_ILLUSTRATION_SUFFIX,
+  STYLE_PROMPT_KEEP_BACKGROUND_SUFFIX,
+  STYLE_PROMPT_REAL_SUFFIX,
+  buildStyleAttemptReinforcementPrefix,
+} from "@/shared/generation/style-prompts";
 
 type JsonRecord = Record<string, unknown>;
 const STYLE_ID = "c3f48c0b-54d2-4c4d-a18c-bd358b58d3b1";
-const STYLE_PROMPT_BASE_PREFIX = `CRITICAL INSTRUCTION: This is an Image-to-Image task based on \`image_0.png\`. Strictly follow these steps:
-
-1. Strict Filtering: DO NOT describe or generate any body parts, clothing, or items that are not visible in \`image_0.png\`. If a part is not in the original frame, omit its description entirely.
-
-2. Pose Preservation: Maintain the exact facial features, hair style, and pose of the person in \`image_0.png\`.`;
 
 function buildExpectedPrompt(params: {
   sourceImageType?: "illustration" | "real";
@@ -22,8 +25,8 @@ function buildExpectedPrompt(params: {
 }): string {
   const promptSuffix =
     params.sourceImageType === "real"
-      ? "Generate a photorealistic result based on the uploaded photo. Preserve the original camera angle, framing, realistic lighting, and composition. Do not introduce painterly or illustrated rendering."
-      : "Maintain the exact artistic style, brushwork, and original composition.";
+      ? STYLE_PROMPT_REAL_SUFFIX
+      : STYLE_PROMPT_ILLUSTRATION_SUFFIX;
 
   const promptSections = [
     STYLE_PROMPT_BASE_PREFIX,
@@ -310,7 +313,7 @@ describe("StyleGenerateRoute integration tests", () => {
     expect(requestBody.contents[0].parts[0]).toEqual({
       text: buildExpectedPrompt({
         backgroundInstruction:
-          "Keep the entire original background unchanged as much as possible. Do not replace, redesign, or restyle the background.",
+          STYLE_PROMPT_KEEP_BACKGROUND_SUFFIX,
       }),
     });
     expect(requestBody.contents[0].parts).toHaveLength(2);
@@ -484,7 +487,7 @@ describe("StyleGenerateRoute integration tests", () => {
       text: buildExpectedPrompt({
         sourceImageType: "real",
         backgroundInstruction:
-          "Keep the entire original background unchanged as much as possible. Do not replace, redesign, or restyle the background.",
+          STYLE_PROMPT_KEEP_BACKGROUND_SUFFIX,
       }),
     });
   });
@@ -525,8 +528,7 @@ describe("StyleGenerateRoute integration tests", () => {
 
     expect(requestBody.contents[0].parts[0]).toEqual({
       text: buildExpectedPrompt({
-        backgroundInstruction:
-          "You may restyle the background within the existing framing so it complements the selected outfit. Preserve the camera angle, crop, composition, pose, facial features, and character identity.",
+        backgroundInstruction: STYLE_PROMPT_CHANGE_BACKGROUND_SUFFIX,
         backgroundPrompt: "Soft spring city street with blossoms",
       }),
     });
@@ -744,5 +746,62 @@ describe("StyleGenerateRoute integration tests", () => {
       },
       reason: "upstream_error",
     });
+  });
+
+  test("postStyleGenerateRoute_MALFORMED_FUNCTION_CALLリトライ時_2回目にreinforcementPrefix付きで送信する", async () => {
+    checkAndConsumeRateLimitFn.mockResolvedValueOnce({
+      allowed: true,
+      reservation: {
+        authState: "authenticated",
+        attemptId: "attempt-auth-001",
+      },
+    });
+    fetchFn.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          candidates: [
+            {
+              content: { parts: [{ text: "" }] },
+              finishReason: "MALFORMED_FUNCTION_CALL",
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+    fetchFn.mockResolvedValueOnce(createSuccessResponse());
+
+    const formData = new FormData();
+    formData.set("styleId", STYLE_ID);
+    formData.set("uploadImage", createUploadImage());
+
+    const response = await postStyleGenerateRoute(createRequest(formData), {
+      fetchFn,
+      geminiApiKey: "test-api-key",
+      getUserFn,
+      getPublishedStylePresetForGenerationFn,
+      recordStyleUsageEventFn,
+      checkAndConsumeRateLimitFn,
+      releaseRateLimitAttemptFn,
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+
+    const firstBody = JSON.parse(
+      String(fetchFn.mock.calls[0][1]?.body)
+    ) as { contents: Array<{ parts: Array<{ text?: string }> }> };
+    const secondBody = JSON.parse(
+      String(fetchFn.mock.calls[1][1]?.body)
+    ) as { contents: Array<{ parts: Array<{ text?: string }> }> };
+
+    const firstText = firstBody.contents[0].parts[0].text ?? "";
+    const secondText = secondBody.contents[0].parts[0].text ?? "";
+    expect(firstText.startsWith("RETRY NOTICE")).toBe(false);
+    expect(secondText.startsWith("RETRY NOTICE (attempt 2)")).toBe(true);
+    expect(secondText).toBe(
+      `${buildStyleAttemptReinforcementPrefix(2)}${firstText}`
+    );
+    expect(releaseRateLimitAttemptFn).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/shared/generation/prompt-core.test.ts
+++ b/tests/unit/shared/generation/prompt-core.test.ts
@@ -1,4 +1,7 @@
-import { buildPrompt } from "@/shared/generation/prompt-core";
+import {
+  buildCoordinateAttemptReinforcementPrefix,
+  buildPrompt,
+} from "@/shared/generation/prompt-core";
 
 describe("shared/generation/prompt-core", () => {
   test("buildPrompt_one_tap_styleは組み立て済みプロンプトをそのまま返す", () => {
@@ -15,5 +18,151 @@ Minimal monochrome look`;
         sourceImageType: "illustration",
       })
     ).toBe(prebuiltPrompt);
+  });
+
+  describe("buildPrompt_coordinate", () => {
+    const outfitDescription = "オーバーサイズの白シャツとワイドデニム";
+
+    test("real_keepはphotorealistic指示と背景維持suffixを含む", () => {
+      const result = buildPrompt({
+        generationType: "coordinate",
+        outfitDescription,
+        backgroundMode: "keep",
+        sourceImageType: "real",
+      });
+
+      expect(result).toContain("CRITICAL INSTRUCTION");
+      expect(result).toContain(
+        "Outfit Transformation within the Existing Frame (REQUIRED)"
+      );
+      expect(result).toContain(
+        "DO NOT extend the crop, widen the framing, or reveal additional body parts"
+      );
+      expect(result).toContain("Strict Framing");
+      expect(result).toContain("photorealistic result");
+      expect(result).toContain("85mm portrait lens");
+      expect(result).toContain("Keep the entire original background unchanged");
+      expect(result).not.toContain("You MUST restyle the background");
+      expect(result).toContain(`New Outfit:\n\n${outfitDescription}`);
+    });
+
+    test("real_ai_autoはMUST背景変更suffixを含む", () => {
+      const result = buildPrompt({
+        generationType: "coordinate",
+        outfitDescription,
+        backgroundMode: "ai_auto",
+        sourceImageType: "real",
+      });
+
+      expect(result).toContain("photorealistic result");
+      expect(result).toContain("You MUST restyle the background");
+      expect(result).not.toContain(
+        "Keep the entire original background unchanged"
+      );
+    });
+
+    test("real_include_in_promptは背景suffixを含まない", () => {
+      const result = buildPrompt({
+        generationType: "coordinate",
+        outfitDescription,
+        backgroundMode: "include_in_prompt",
+        sourceImageType: "real",
+      });
+
+      expect(result).toContain("photorealistic result");
+      expect(result).not.toContain(
+        "Keep the entire original background unchanged"
+      );
+      expect(result).not.toContain("You MUST restyle the background");
+    });
+
+    test("illustration_keepはillustration指示と背景維持suffixを含む", () => {
+      const result = buildPrompt({
+        generationType: "coordinate",
+        outfitDescription,
+        backgroundMode: "keep",
+        sourceImageType: "illustration",
+      });
+
+      expect(result).toContain(
+        "Maintain the exact illustration touch and artistic style"
+      );
+      expect(result).not.toContain("photorealistic result");
+      expect(result).toContain("Keep the entire original background unchanged");
+    });
+
+    test("illustration_ai_autoはMUST背景変更suffixを含む", () => {
+      const result = buildPrompt({
+        generationType: "coordinate",
+        outfitDescription,
+        backgroundMode: "ai_auto",
+        sourceImageType: "illustration",
+      });
+
+      expect(result).toContain(
+        "Maintain the exact illustration touch and artistic style"
+      );
+      expect(result).toContain("You MUST restyle the background");
+    });
+
+    test("illustration_include_in_promptは背景suffixを含まない", () => {
+      const result = buildPrompt({
+        generationType: "coordinate",
+        outfitDescription,
+        backgroundMode: "include_in_prompt",
+        sourceImageType: "illustration",
+      });
+
+      expect(result).toContain(
+        "Maintain the exact illustration touch and artistic style"
+      );
+      expect(result).not.toContain(
+        "Keep the entire original background unchanged"
+      );
+      expect(result).not.toContain("You MUST restyle the background");
+    });
+
+    test("セクション順序はbase_styleSuffix_backgroundSuffix_newOutfit", () => {
+      const result = buildPrompt({
+        generationType: "coordinate",
+        outfitDescription,
+        backgroundMode: "keep",
+        sourceImageType: "real",
+      });
+
+      const baseIdx = result.indexOf("CRITICAL INSTRUCTION");
+      const styleIdx = result.indexOf("photorealistic result");
+      const bgIdx = result.indexOf(
+        "Keep the entire original background unchanged"
+      );
+      const outfitIdx = result.indexOf("New Outfit:");
+
+      expect(baseIdx).toBeGreaterThanOrEqual(0);
+      expect(styleIdx).toBeGreaterThan(baseIdx);
+      expect(bgIdx).toBeGreaterThan(styleIdx);
+      expect(outfitIdx).toBeGreaterThan(bgIdx);
+    });
+  });
+
+  describe("buildCoordinateAttemptReinforcementPrefix", () => {
+    test("attempt1は空文字を返す", () => {
+      expect(buildCoordinateAttemptReinforcementPrefix(1)).toBe("");
+    });
+
+    test("attempt2以降はRETRY_NOTICEと枠維持制約を含む", () => {
+      const prefix = buildCoordinateAttemptReinforcementPrefix(2);
+
+      expect(prefix).toContain("RETRY NOTICE (attempt 2)");
+      expect(prefix).toContain("body parts already visible in `image_0.png`");
+      expect(prefix).toContain("Do not extend the crop");
+      expect(prefix).toContain("New Outfit");
+      expect(prefix.endsWith("\n\n")).toBe(true);
+    });
+
+    test("attempt番号がメッセージに埋め込まれる", () => {
+      expect(buildCoordinateAttemptReinforcementPrefix(3)).toContain(
+        "RETRY NOTICE (attempt 3)"
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Embed framing constraint into step 1 of the `/style` and coordinate base prompts so upper-body uploads stop being expanded into full-body outputs.
- Add MUST-wording and a retry-attempt RETRY NOTICE prefix that reminds Gemini to apply the outfit change inside the existing frame without revealing new body parts.
- Extract the `/style` prompt pieces into `shared/generation/style-prompts.ts` so the Next.js sync route and the Supabase `image-gen-worker` build identical text.
- Add a 35s `AbortController` timeout around the Gemini fetch in the worker and persist `finishReason` / per-attempt history under `generation_metadata` for post-hoc debugging.

## Test plan
- [x] `npx jest --testPathPattern="style-generate|prompt-core"` — 3 suites / 22 tests pass locally
- [x] Manual guest run on `/style` (sync path) with an upper-body source image — output stays in-frame and outfit transformation is applied
- [ ] After merge: redeploy `image-gen-worker` so the async path (authenticated users) picks up the shared prompt module
- [ ] Spot-check `/coordinate` generation with an upper-body source to confirm the same A+C framing fix behaves as expected