### PR TITLE
fix(image-gen-worker): abort input image fetch on stall

### DIFF
--- a/supabase/functions/image-gen-worker/index.ts
+++ b/supabase/functions/image-gen-worker/index.ts
@@ -188,6 +188,7 @@ async function downloadInputImageFromUrlWithRetry(inputImageUrl: string): Promis
         break;
       }
     } catch (error) {
+      lastStatus = null;
       lastError =
         error instanceof Error && error.name === "AbortError"
           ? new Error(

--- a/supabase/functions/image-gen-worker/index.ts
+++ b/supabase/functions/image-gen-worker/index.ts
@@ -38,6 +38,7 @@ const PROCESSING_STALE_TIMEOUT_SECONDS = 360; // processing状態がこの秒数
 
 const INPUT_IMAGE_FETCH_MAX_ATTEMPTS = 3;
 const INPUT_IMAGE_FETCH_RETRYABLE_STATUS = new Set([408, 429, 500, 502, 503, 504]);
+const INPUT_IMAGE_FETCH_TIMEOUT_MS = 15_000;
 
 const GEMINI_REQUEST_TIMEOUT_MS = 35_000;
 
@@ -162,8 +163,15 @@ async function downloadInputImageFromUrlWithRetry(inputImageUrl: string): Promis
   let lastError: unknown = null;
 
   for (let attempt = 1; attempt <= INPUT_IMAGE_FETCH_MAX_ATTEMPTS; attempt++) {
+    const abortController = new AbortController();
+    const timeoutId = setTimeout(
+      () => abortController.abort(),
+      INPUT_IMAGE_FETCH_TIMEOUT_MS
+    );
     try {
-      const response = await fetch(inputImageUrl);
+      const response = await fetch(inputImageUrl, {
+        signal: abortController.signal,
+      });
       if (response.ok) {
         const imageBlob = await response.blob();
         const mimeType = imageBlob.type || "image/png";
@@ -180,7 +188,14 @@ async function downloadInputImageFromUrlWithRetry(inputImageUrl: string): Promis
         break;
       }
     } catch (error) {
-      lastError = error;
+      lastError =
+        error instanceof Error && error.name === "AbortError"
+          ? new Error(
+              `URL download timed out after ${INPUT_IMAGE_FETCH_TIMEOUT_MS}ms`
+            )
+          : error;
+    } finally {
+      clearTimeout(timeoutId);
     }
 
     if (attempt < INPUT_IMAGE_FETCH_MAX_ATTEMPTS) {
@@ -196,6 +211,38 @@ async function downloadInputImageFromUrlWithRetry(inputImageUrl: string): Promis
   throw new Error(`URL download failed: ${lastErrorMessage}`);
 }
 
+async function withInputImageFetchTimeout<T>(
+  operation: PromiseLike<T>,
+  label: string
+): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race<T>([
+      Promise.resolve(operation),
+      new Promise<T>((_, reject) => {
+        timeoutId = setTimeout(
+          () =>
+            reject(
+              new Error(
+                `${label} timed out after ${INPUT_IMAGE_FETCH_TIMEOUT_MS}ms`
+              )
+            ),
+          INPUT_IMAGE_FETCH_TIMEOUT_MS
+        );
+      }),
+    ]);
+  } finally {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
+type StorageDownloadResult = {
+  data: Blob | null;
+  error: { message: string } | null;
+};
+
 async function downloadInputImageViaStorageFallback(
   supabase: ReturnType<typeof createClient>,
   inputImageUrl: string
@@ -205,9 +252,10 @@ async function downloadInputImageViaStorageFallback(
     throw new Error("Storage path could not be parsed from input_image_url");
   }
 
-  const { data, error } = await supabase.storage
-    .from(location.bucket)
-    .download(location.objectPath);
+  const { data, error } = await withInputImageFetchTimeout<StorageDownloadResult>(
+    supabase.storage.from(location.bucket).download(location.objectPath),
+    "Storage fallback download"
+  );
 
   if (error || !data) {
     throw new Error(`Storage fallback download failed: ${error?.message ?? "Unknown error"}`);
@@ -240,9 +288,10 @@ async function downloadInputImageViaStockFallback(
 
   let storagePathError = "";
   if (stock.storage_path) {
-    const { data, error } = await supabase.storage
-      .from(STORAGE_BUCKET)
-      .download(stock.storage_path);
+    const { data, error } = await withInputImageFetchTimeout<StorageDownloadResult>(
+      supabase.storage.from(STORAGE_BUCKET).download(stock.storage_path),
+      "Stock fallback download"
+    );
 
     if (!error && data) {
       const mimeType = data.type || "image/png";


### PR DESCRIPTION
## Summary

- 入力画像 fetch の 3 経路（URL 直接 fetch / Storage フォールバック / Stock フォールバック）すべてに **15 秒のタイムアウト**を追加
- URL fetch は `AbortController.signal`、Storage/Stock フォールバックは `Promise.race` ベースの `withInputImageFetchTimeout` ヘルパーで包んだ
- タイムアウト時は既存のリトライループ（3 回）に乗り、全消費後は `image_jobs.error_message` にラベル付きメッセージ（例: `"URL download timed out after 15000ms"`）を残す

## Motivation

ジョブ `32c78f69-69b8-4425-a6b1-ec25b89d7fd9` でリトライ発生の挙動を確認した際、1 回目の worker invocation が **40 秒ハング** → `started_at` / `generation_metadata` 無記入のまま 200 を返し、pgmq の 60 秒 visibility timeout で黙って再キューされる、というパターンが判明した。

40 秒停滞の原因究明のために worker コードを精査したところ、`downloadInputImageFromUrlWithRetry` の `fetch()` を含む全ての入力画像 fetch 系に `AbortController` やタイムアウトが一切付いておらず、Supabase Storage / CDN 側が TCP/TLS レベルで stall した場合に throw されず永久待機してしまう状態だった。`AbortController` は Gemini API 呼び出し（L1479）にだけ存在していた。

本 PR により今後は:
- 15 秒経過で fetch が中断され、既存のリトライが走る
- 3 回消費で `image_jobs.error_message` にラベル付き timeout メッセージが残る
- どの fetch パスで stall したか判別可能（`"URL download"` / `"Storage fallback download"` / `"Stock fallback download"`）
- worker の attempts カウントと返金ロジックが正常動作

## Test plan

- [x] 既存 `prompt-core.test.ts` 11 件すべて pass
- [x] `deno check` で新規エラー 0 件（ベースラインの JSR 型解決エラーのみ）
- [ ] Edge Function デプロイ後、通常ケース（正常な入力画像）で coordinate / one_tap_style が生成できることを動作確認
- [ ] 必要に応じて、意図的に遅い URL / 存在しない Storage パスで timeout の error_message が残ることを手動検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)