### PR TITLE
モバイル返信パネルの導線と表示体験を改善

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -132,7 +132,7 @@ html[lang="en"]:not(.ppr-locale-ready) .main-content {
   * {
     @apply border-border;
   }
-  
+
   html {
     /* モバイル向けスクロール最適化 */
     scroll-behavior: smooth;
@@ -155,33 +155,34 @@ html[lang="en"]:not(.ppr-locale-ready) .main-content {
       scroll-padding-bottom: 0;
     }
   }
-  
+
   body {
     @apply bg-background text-foreground;
     font-family: var(--font-geist-sans);
     /* モバイル向けのタップハイライト最適化 */
     -webkit-tap-highlight-color: transparent;
     /* iOSセーフエリア対応（必要に応じて使用） */
-    padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+    padding: env(safe-area-inset-top) env(safe-area-inset-right)
+      env(safe-area-inset-bottom) env(safe-area-inset-left);
     /* モバイル向けフォントレンダリング */
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
-  
+
   button:not(:disabled),
   [role="button"]:not(:disabled) {
     cursor: pointer;
     /* モバイル向けタップ感度向上 */
     touch-action: manipulation;
   }
-  
+
   /* 入力フィールドのモバイル最適化 */
   input,
   textarea,
   select {
     font-size: 16px; /* iOSのズームを防ぐ */
   }
-  
+
   @media (min-width: 640px) {
     input,
     textarea,
@@ -196,12 +197,12 @@ html[lang="en"]:not(.ppr-locale-ready) .main-content {
       transition: padding-left 200ms ease;
     }
   }
-  
+
   /* モバイルナビゲーションバーのセーフエリア対応 */
   .safe-area-inset-bottom {
     padding-bottom: env(safe-area-inset-bottom);
   }
-  
+
   /* 管理画面表示時: 下部ナビゲーションバー用の余白を無効化 */
   body.admin-active {
     padding-bottom: 0;
@@ -219,7 +220,7 @@ html[lang="en"]:not(.ppr-locale-ready) .main-content {
       width: 2rem; /* w-8 = 2rem */
     }
   }
-  
+
   .nav-indicator-expand {
     animation: expandFromCenter 0.2s ease-out;
   }
@@ -254,14 +255,45 @@ html[lang="en"]:not(.ppr-locale-ready) .main-content {
   }
 
   .popup-banner-panel-enter {
-    animation: popupBannerPanelFadeIn 1000ms cubic-bezier(0.2, 0.8, 0.2, 1)
-      both;
+    animation: popupBannerPanelFadeIn 1000ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
     will-change: opacity, transform;
+  }
+
+  @keyframes replyPanelSlideIn {
+    from {
+      opacity: 0.96;
+      transform: translate3d(40px, 0, 0);
+    }
+    to {
+      opacity: 1;
+      transform: translate3d(0, 0, 0);
+    }
+  }
+
+  @keyframes replyPanelOverlayIn {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+
+  .reply-panel-mobile-content[data-state="open"] {
+    animation: replyPanelSlideIn 280ms cubic-bezier(0.22, 1, 0.36, 1) both;
+    will-change: transform, opacity;
+  }
+
+  .reply-panel-mobile-overlay[data-state="open"] {
+    animation: replyPanelOverlayIn 220ms ease-out both;
+    will-change: opacity;
   }
 
   @media (prefers-reduced-motion: reduce) {
     .popup-banner-card-enter,
-    .popup-banner-panel-enter {
+    .popup-banner-panel-enter,
+    .reply-panel-mobile-content[data-state="open"],
+    .reply-panel-mobile-overlay[data-state="open"] {
       animation: none;
     }
   }

--- a/features/posts/components/CommentItem.tsx
+++ b/features/posts/components/CommentItem.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import dynamic from "next/dynamic";
-import { useState } from "react";
 import { ChevronRight } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
@@ -9,19 +7,13 @@ import type { ParentComment } from "../types";
 import { EditableComment } from "./EditableComment";
 import { ReplyThread } from "./ReplyThread";
 
-const ReplyPanel = dynamic(
-  () => import("./ReplyPanel").then((mod) => mod.ReplyPanel),
-  {
-    ssr: false,
-  }
-);
-
 interface CommentItemProps {
   comment: ParentComment;
   currentUserId?: string | null;
   onCommentUpdated: () => void;
   onCommentDeleted: () => void;
   onThreadChanged: () => void;
+  onOpenReplyPanel?: () => void;
 }
 
 /**
@@ -34,16 +26,10 @@ export function CommentItem({
   onCommentUpdated,
   onCommentDeleted,
   onThreadChanged,
+  onOpenReplyPanel,
 }: CommentItemProps) {
   const t = useTranslations("posts");
-  const [isReplyPanelOpen, setIsReplyPanelOpen] = useState(false);
-  const [hasLoadedReplyPanel, setHasLoadedReplyPanel] = useState(false);
-  const hasReplyEntryPoint = comment.reply_count > 0 || !comment.deleted_at;
-
-  const handleOpenReplyPanel = () => {
-    setHasLoadedReplyPanel(true);
-    setIsReplyPanelOpen(true);
-  };
+  const hasReplies = comment.reply_count > 0;
 
   return (
     <div>
@@ -52,21 +38,18 @@ export function CommentItem({
         currentUserId={currentUserId}
         onCommentUpdated={onCommentUpdated}
         onCommentDeleted={onCommentDeleted}
+        onCommentSelected={!comment.deleted_at ? onOpenReplyPanel : undefined}
       />
-      {hasReplyEntryPoint && (
+      {hasReplies && (
         <div className="pb-3 pl-11 md:hidden">
           <Button
             type="button"
             variant="ghost"
             size="sm"
             className="h-8 px-2 text-xs text-gray-600"
-            onClick={handleOpenReplyPanel}
+            onClick={onOpenReplyPanel}
           >
-            <span>
-              {comment.reply_count > 0
-                ? t("repliesCount", { count: comment.reply_count })
-                : t("replyAction")}
-            </span>
+            <span>{t("repliesCount", { count: comment.reply_count })}</span>
             <ChevronRight className="h-4 w-4" />
           </Button>
         </div>
@@ -78,15 +61,6 @@ export function CommentItem({
           onThreadChanged={onThreadChanged}
         />
       </div>
-      {hasLoadedReplyPanel && (
-        <ReplyPanel
-          open={isReplyPanelOpen}
-          onOpenChange={setIsReplyPanelOpen}
-          parentComment={comment}
-          currentUserId={currentUserId}
-          onThreadChanged={onThreadChanged}
-        />
-      )}
     </div>
   );
 }

--- a/features/posts/components/CommentList.tsx
+++ b/features/posts/components/CommentList.tsx
@@ -1,10 +1,19 @@
 "use client";
 
-import { useState, useEffect, useCallback, useImperativeHandle, forwardRef, useRef } from "react";
+import type { CSSProperties } from "react";
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
 import { useInView } from "react-intersection-observer";
 import { useTranslations } from "next-intl";
 import { CommentItem } from "./CommentItem";
 import { CommentLoadMoreSkeleton } from "./CommentLoadMoreSkeleton";
+import { ReplyPanel } from "./ReplyPanel";
 import { getCommentsAPI } from "../lib/api";
 import type { ParentComment } from "../types";
 import { createClient } from "@/lib/supabase/client";
@@ -30,6 +39,10 @@ interface CommentListProps {
   imageId: string;
   currentUserId?: string | null;
   onCommentAdded?: () => void;
+  activeReplyCommentId?: string | null;
+  replyPanelStyle?: CSSProperties | null;
+  onReplyPanelOpen?: (commentId: string) => void;
+  onReplyPanelOpenChange?: (open: boolean) => void;
 }
 
 export interface CommentListRef {
@@ -48,227 +61,271 @@ export const CommentList = forwardRef<CommentListRef, CommentListProps>(
       imageId,
       currentUserId,
       onCommentAdded,
+      activeReplyCommentId,
+      replyPanelStyle,
+      onReplyPanelOpen,
+      onReplyPanelOpenChange,
     },
-    ref
+    ref,
   ) {
-  const t = useTranslations("posts");
-  const [comments, setComments] = useState<ParentComment[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const [hasMore, setHasMore] = useState(true);
-  const [offset, setOffset] = useState(0);
-  const requestSequenceRef = useRef(0);
-  const inFlightKeysRef = useRef<Set<string>>(new Set());
-  const pendingRequestsRef = useRef(0);
-  const { ref: inViewRef, inView } = useInView({
-    threshold: 0,
-    rootMargin: "200px",
-  });
+    const t = useTranslations("posts");
+    const [comments, setComments] = useState<ParentComment[]>([]);
+    const [isLoading, setIsLoading] = useState(false);
+    const [hasMore, setHasMore] = useState(true);
+    const [offset, setOffset] = useState(0);
+    const requestSequenceRef = useRef(0);
+    const inFlightKeysRef = useRef<Set<string>>(new Set());
+    const pendingRequestsRef = useRef(0);
+    const { ref: inViewRef, inView } = useInView({
+      threshold: 0,
+      rootMargin: "200px",
+    });
 
-  const loadComments = useCallback(
-    async (newOffset: number, reset: boolean = false) => {
-      const requestKey = `${newOffset}:${reset ? "reset" : "append"}`;
-      if (inFlightKeysRef.current.has(requestKey)) {
-        return;
-      }
-
-      inFlightKeysRef.current.add(requestKey);
-      pendingRequestsRef.current += 1;
-      setIsLoading(true);
-      const requestId = ++requestSequenceRef.current;
-
-      try {
-        const newComments = await getCommentsAPI(
-          imageId,
-          COMMENTS_PER_PAGE,
-          newOffset,
-          {
-            commentsFetchFailed: t("commentsFetchFailed"),
-          }
-        );
-
-        if (requestId !== requestSequenceRef.current) {
+    const loadComments = useCallback(
+      async (newOffset: number, reset: boolean = false) => {
+        const requestKey = `${newOffset}:${reset ? "reset" : "append"}`;
+        if (inFlightKeysRef.current.has(requestKey)) {
           return;
         }
 
-        if (reset) {
-          setComments(newComments);
-          setOffset(newComments.length);
-        } else {
-          setComments((prev) => [...prev, ...newComments]);
-          setOffset((prev) => prev + newComments.length);
+        inFlightKeysRef.current.add(requestKey);
+        pendingRequestsRef.current += 1;
+        setIsLoading(true);
+        const requestId = ++requestSequenceRef.current;
+
+        try {
+          const newComments = await getCommentsAPI(
+            imageId,
+            COMMENTS_PER_PAGE,
+            newOffset,
+            {
+              commentsFetchFailed: t("commentsFetchFailed"),
+            },
+          );
+
+          if (requestId !== requestSequenceRef.current) {
+            return;
+          }
+
+          if (reset) {
+            setComments(newComments);
+            setOffset(newComments.length);
+          } else {
+            setComments((prev) => [...prev, ...newComments]);
+            setOffset((prev) => prev + newComments.length);
+          }
+
+          setHasMore(newComments.length === COMMENTS_PER_PAGE);
+        } catch (error) {
+          console.error("Failed to load comments:", error);
+        } finally {
+          inFlightKeysRef.current.delete(requestKey);
+          pendingRequestsRef.current = Math.max(
+            0,
+            pendingRequestsRef.current - 1,
+          );
+
+          if (pendingRequestsRef.current === 0) {
+            setIsLoading(false);
+          }
         }
+      },
+      [imageId, t],
+    );
 
-        setHasMore(newComments.length === COMMENTS_PER_PAGE);
-      } catch (error) {
-        console.error("Failed to load comments:", error);
-      } finally {
-        inFlightKeysRef.current.delete(requestKey);
-        pendingRequestsRef.current = Math.max(0, pendingRequestsRef.current - 1);
-
-        if (pendingRequestsRef.current === 0) {
-          setIsLoading(false);
-        }
-      }
-    },
-    [imageId, t]
-  );
-
-  const handleThreadChanged = useCallback(() => {
-    loadComments(0, true);
-  }, [loadComments]);
-
-  // 親コンポーネントから呼び出せるrefresh関数を公開
-  useImperativeHandle(ref, () => ({
-    refresh: () => {
+    const handleThreadChanged = useCallback(() => {
       loadComments(0, true);
-    },
-  }));
+    }, [loadComments]);
 
-  // 初期読み込み
-  useEffect(() => {
-    loadComments(0, true);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [imageId]);
+    // 親コンポーネントから呼び出せるrefresh関数を公開
+    useImperativeHandle(ref, () => ({
+      refresh: () => {
+        loadComments(0, true);
+      },
+    }));
 
-  // 無限スクロール
-  useEffect(() => {
-    if (inView && hasMore && !isLoading) {
-      loadComments(offset, false);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [inView, hasMore, isLoading, offset]);
+    // 初期読み込み
+    useEffect(() => {
+      loadComments(0, true);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [imageId]);
 
-  // リアルタイム更新の購読
-  useEffect(() => {
-    const supabase = createClient();
-    const channel = supabase
-      .channel(`comments:${imageId}`)
-      .on(
-        "postgres_changes",
-        {
-          event: "*",
-          schema: "public",
-          table: "comments",
-          filter: `image_id=eq.${imageId}`,
-        },
-        (payload) => {
-          const nextComment = payload.new as CommentRealtimeRow | null;
-          const previousComment = payload.old as CommentRealtimeRow | null;
+    // 無限スクロール
+    useEffect(() => {
+      if (inView && hasMore && !isLoading) {
+        loadComments(offset, false);
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [inView, hasMore, isLoading, offset]);
 
-          if (nextComment?.parent_comment_id) {
-            return;
-          }
+    // リアルタイム更新の購読
+    useEffect(() => {
+      const supabase = createClient();
+      const channel = supabase
+        .channel(`comments:${imageId}`)
+        .on(
+          "postgres_changes",
+          {
+            event: "*",
+            schema: "public",
+            table: "comments",
+            filter: `image_id=eq.${imageId}`,
+          },
+          (payload) => {
+            const nextComment = payload.new as CommentRealtimeRow | null;
+            const previousComment = payload.old as CommentRealtimeRow | null;
 
-          if (previousComment?.parent_comment_id) {
-            return;
-          }
+            if (nextComment?.parent_comment_id) {
+              return;
+            }
 
-          // 自分の操作はオプティミスティックUIで既に反映済みなので、Realtimeイベントでは追加しない
-          if (
-            nextComment?.user_id === currentUserId ||
-            previousComment?.user_id === currentUserId
-          ) {
-            return;
-          }
+            if (previousComment?.parent_comment_id) {
+              return;
+            }
 
-          if (payload.eventType === "INSERT" && nextComment) {
-            loadComments(0, true);
-            return;
-          }
+            // 自分の操作はオプティミスティックUIで既に反映済みなので、Realtimeイベントでは追加しない
+            if (
+              nextComment?.user_id === currentUserId ||
+              previousComment?.user_id === currentUserId
+            ) {
+              return;
+            }
 
-          if (
-            payload.eventType === "UPDATE" &&
-            nextComment &&
-            !previousComment?.deleted_at &&
-            nextComment.deleted_at
-          ) {
-            setComments((prev) =>
-              prev.map((comment) =>
-                comment.id === nextComment.id
-                  ? {
-                      ...comment,
-                      content: t("commentDeletedPlaceholder"),
-                      deleted_at: nextComment.deleted_at ?? comment.deleted_at,
-                      updated_at: nextComment.updated_at ?? comment.updated_at,
-                    }
-                  : comment
-              )
-            );
-            return;
-          }
+            if (payload.eventType === "INSERT" && nextComment) {
+              loadComments(0, true);
+              return;
+            }
 
-          if (payload.eventType === "UPDATE" || payload.eventType === "DELETE") {
-            loadComments(0, true);
-          }
-        }
-      )
-      .on(
-        "broadcast",
-        { event: "reply_lifecycle" },
-        ({ payload }: { payload: ReplyLifecyclePayload }) => {
-          if (payload.user_id && payload.user_id === currentUserId) {
-            return;
-          }
+            if (
+              payload.eventType === "UPDATE" &&
+              nextComment &&
+              !previousComment?.deleted_at &&
+              nextComment.deleted_at
+            ) {
+              setComments((prev) =>
+                prev.map((comment) =>
+                  comment.id === nextComment.id
+                    ? {
+                        ...comment,
+                        content: t("commentDeletedPlaceholder"),
+                        deleted_at:
+                          nextComment.deleted_at ?? comment.deleted_at,
+                        updated_at:
+                          nextComment.updated_at ?? comment.updated_at,
+                      }
+                    : comment,
+                ),
+              );
+              return;
+            }
 
-          if (payload.parent_comment_id) {
-            loadComments(0, true);
-          }
-        }
-      )
-      .subscribe();
+            if (
+              payload.eventType === "UPDATE" ||
+              payload.eventType === "DELETE"
+            ) {
+              loadComments(0, true);
+            }
+          },
+        )
+        .on(
+          "broadcast",
+          { event: "reply_lifecycle" },
+          ({ payload }: { payload: ReplyLifecyclePayload }) => {
+            if (payload.user_id && payload.user_id === currentUserId) {
+              return;
+            }
 
-    return () => {
-      supabase.removeChannel(channel);
+            if (payload.parent_comment_id) {
+              loadComments(0, true);
+            }
+          },
+        )
+        .subscribe();
+
+      return () => {
+        supabase.removeChannel(channel);
+      };
+    }, [imageId, currentUserId, loadComments, t]);
+
+    const handleCommentUpdated = () => {
+      // コメントが更新されたら再読み込み
+      loadComments(0, true);
     };
-  }, [imageId, currentUserId, loadComments, t]);
 
-  const handleCommentUpdated = () => {
-    // コメントが更新されたら再読み込み
-    loadComments(0, true);
-  };
+    const handleCommentDeleted = () => {
+      // コメントが削除されたら再読み込み
+      loadComments(0, true);
+      // コメントが削除されたことを親コンポーネントに通知
+      onCommentAdded?.();
+    };
 
-  const handleCommentDeleted = () => {
-    // コメントが削除されたら再読み込み
-    loadComments(0, true);
-    // コメントが削除されたことを親コンポーネントに通知
-    onCommentAdded?.();
-  };
+    const activeReplyComment = activeReplyCommentId
+      ? (comments.find((comment) => comment.id === activeReplyCommentId) ??
+        null)
+      : null;
 
-  if (comments.length === 0 && !isLoading) {
+    useEffect(() => {
+      if (!activeReplyCommentId || isLoading) {
+        return;
+      }
+
+      if (!activeReplyComment) {
+        onReplyPanelOpenChange?.(false);
+      }
+    }, [
+      activeReplyComment,
+      activeReplyCommentId,
+      isLoading,
+      onReplyPanelOpenChange,
+    ]);
+
+    if (comments.length === 0 && !isLoading) {
+      return (
+        <div className="py-8 text-center text-sm text-gray-500">
+          {t("noComments")}
+        </div>
+      );
+    }
+
     return (
-      <div className="py-8 text-center text-sm text-gray-500">
-        {t("noComments")}
+      <div className="divide-y divide-gray-200">
+        {comments.map((comment) => (
+          <CommentItem
+            key={comment.id}
+            comment={comment}
+            currentUserId={currentUserId}
+            onCommentUpdated={handleCommentUpdated}
+            onCommentDeleted={handleCommentDeleted}
+            onThreadChanged={handleThreadChanged}
+            onOpenReplyPanel={
+              onReplyPanelOpen ? () => onReplyPanelOpen(comment.id) : undefined
+            }
+          />
+        ))}
+
+        {/* 無限スクロール用のトリガー要素 */}
+        {hasMore && (
+          <div ref={inViewRef}>{isLoading && <CommentLoadMoreSkeleton />}</div>
+        )}
+
+        {/* 全て読み込み完了時のメッセージ */}
+        {!hasMore && comments.length > 0 && (
+          <div className="py-4 text-center text-sm text-gray-500">
+            {t("allCommentsShown")}
+          </div>
+        )}
+
+        {activeReplyComment && replyPanelStyle && (
+          <ReplyPanel
+            open
+            onOpenChange={(nextOpen) => onReplyPanelOpenChange?.(nextOpen)}
+            parentComment={activeReplyComment}
+            currentUserId={currentUserId}
+            onThreadChanged={handleThreadChanged}
+            panelStyle={replyPanelStyle}
+          />
+        )}
       </div>
     );
-  }
-
-  return (
-    <div className="divide-y divide-gray-200">
-      {comments.map((comment) => (
-        <CommentItem
-          key={comment.id}
-          comment={comment}
-          currentUserId={currentUserId}
-          onCommentUpdated={handleCommentUpdated}
-          onCommentDeleted={handleCommentDeleted}
-          onThreadChanged={handleThreadChanged}
-        />
-      ))}
-
-      {/* 無限スクロール用のトリガー要素 */}
-      {hasMore && (
-        <div ref={inViewRef}>
-          {isLoading && <CommentLoadMoreSkeleton />}
-        </div>
-      )}
-
-      {/* 全て読み込み完了時のメッセージ */}
-      {!hasMore && comments.length > 0 && (
-        <div className="py-4 text-center text-sm text-gray-500">
-          {t("allCommentsShown")}
-        </div>
-      )}
-    </div>
-  );
-  }
+  },
 );

--- a/features/posts/components/CommentSection.tsx
+++ b/features/posts/components/CommentSection.tsx
@@ -1,8 +1,11 @@
 "use client";
 
-import { useRef } from "react";
+import type { CSSProperties } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { CommentInput } from "./CommentInput";
 import { CommentList, type CommentListRef } from "./CommentList";
+
+const REPLY_PANEL_MOBILE_BREAKPOINT = 768;
 
 interface CommentSectionProps {
   postId: string;
@@ -15,9 +18,101 @@ interface CommentSectionProps {
  */
 export function CommentSection({ postId, currentUserId }: CommentSectionProps) {
   const commentListRef = useRef<CommentListRef>(null);
+  const sectionRef = useRef<HTMLDivElement>(null);
+  const [activeReplyCommentId, setActiveReplyCommentId] = useState<
+    string | null
+  >(null);
+  const [replyPanelStyle, setReplyPanelStyle] = useState<CSSProperties | null>(
+    null,
+  );
+
+  const measureReplyPanelStyle = useCallback((): CSSProperties | null => {
+    const section = sectionRef.current;
+
+    if (!section || window.innerWidth >= REPLY_PANEL_MOBILE_BREAKPOINT) {
+      return null;
+    }
+
+    const rect = section.getBoundingClientRect();
+    const visualViewport = window.visualViewport;
+    const viewportHeight = visualViewport?.height ?? window.innerHeight;
+    const top = Math.max(rect.top, 0);
+    const height = Math.max(viewportHeight - top, 0);
+
+    if (rect.width <= 0 || height <= 0) {
+      return null;
+    }
+
+    return {
+      top,
+      left: rect.left,
+      width: rect.width,
+      height,
+    };
+  }, []);
+
+  const updateReplyPanelStyle = useCallback(() => {
+    setReplyPanelStyle(measureReplyPanelStyle());
+  }, [measureReplyPanelStyle]);
+
+  const handleOpenReplyPanel = useCallback(
+    (commentId: string) => {
+      setActiveReplyCommentId(commentId);
+      setReplyPanelStyle(measureReplyPanelStyle());
+    },
+    [measureReplyPanelStyle],
+  );
+
+  const handleReplyPanelOpenChange = useCallback((open: boolean) => {
+    if (!open) {
+      setActiveReplyCommentId(null);
+      setReplyPanelStyle(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!activeReplyCommentId) {
+      setReplyPanelStyle(null);
+      return;
+    }
+
+    updateReplyPanelStyle();
+    const section = sectionRef.current;
+
+    const handleViewportChange = () => {
+      updateReplyPanelStyle();
+    };
+
+    window.addEventListener("resize", handleViewportChange);
+    window.addEventListener("scroll", handleViewportChange);
+
+    const visualViewport = window.visualViewport;
+    visualViewport?.addEventListener("resize", handleViewportChange);
+    visualViewport?.addEventListener("scroll", handleViewportChange);
+
+    const resizeObserver =
+      typeof ResizeObserver === "undefined" || !section
+        ? null
+        : new ResizeObserver(handleViewportChange);
+
+    if (resizeObserver && section) {
+      resizeObserver.observe(section);
+    }
+
+    return () => {
+      window.removeEventListener("resize", handleViewportChange);
+      window.removeEventListener("scroll", handleViewportChange);
+      visualViewport?.removeEventListener("resize", handleViewportChange);
+      visualViewport?.removeEventListener("scroll", handleViewportChange);
+      resizeObserver?.disconnect();
+    };
+  }, [activeReplyCommentId, updateReplyPanelStyle]);
 
   return (
-    <div className="container mx-auto max-w-4xl border-t border-gray-200 bg-white px-4 py-3">
+    <div
+      ref={sectionRef}
+      className="container mx-auto max-w-4xl border-t border-gray-200 bg-white px-4 py-3"
+    >
       <div className="mb-4">
         <CommentInput
           imageId={postId}
@@ -32,8 +127,11 @@ export function CommentSection({ postId, currentUserId }: CommentSectionProps) {
         ref={commentListRef}
         imageId={postId}
         currentUserId={currentUserId}
+        activeReplyCommentId={activeReplyCommentId}
+        replyPanelStyle={replyPanelStyle}
+        onReplyPanelOpen={handleOpenReplyPanel}
+        onReplyPanelOpenChange={handleReplyPanelOpenChange}
       />
     </div>
   );
 }
-

--- a/features/posts/components/CommentSection.tsx
+++ b/features/posts/components/CommentSection.tsx
@@ -2,10 +2,9 @@
 
 import type { CSSProperties } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { REPLY_PANEL_MOBILE_BREAKPOINT } from "../lib/constants";
 import { CommentInput } from "./CommentInput";
 import { CommentList, type CommentListRef } from "./CommentList";
-
-const REPLY_PANEL_MOBILE_BREAKPOINT = 768;
 
 interface CommentSectionProps {
   postId: string;

--- a/features/posts/components/EditableComment.tsx
+++ b/features/posts/components/EditableComment.tsx
@@ -26,7 +26,7 @@ import { deleteCommentAPI, updateCommentAPI } from "../lib/api";
 import type { ParentComment, ReplyComment } from "../types";
 import { useToast } from "@/components/ui/use-toast";
 import { CollapsibleText } from "./CollapsibleText";
-import { sanitizeProfileText, validateProfileText } from "@/lib/utils";
+import { cn, sanitizeProfileText, validateProfileText } from "@/lib/utils";
 import { COMMENT_MAX_LENGTH } from "@/constants";
 
 type DisplayComment = ParentComment | ReplyComment;
@@ -36,6 +36,7 @@ interface EditableCommentProps {
   currentUserId?: string | null;
   onCommentUpdated: () => void;
   onCommentDeleted: () => void;
+  onCommentSelected?: () => void;
 }
 
 export function EditableComment({
@@ -43,6 +44,7 @@ export function EditableComment({
   currentUserId,
   onCommentUpdated,
   onCommentDeleted,
+  onCommentSelected,
 }: EditableCommentProps) {
   const t = useTranslations("posts");
   const locale = useLocale();
@@ -57,8 +59,11 @@ export function EditableComment({
   const isOwner = !isDeleted && currentUserId === comment.user_id;
   const displayName = isDeleted
     ? ""
-    : comment.user_nickname || comment.user_id?.slice(0, 8) || t("anonymousUser");
+    : comment.user_nickname ||
+      comment.user_id?.slice(0, 8) ||
+      t("anonymousUser");
   const remainingChars = COMMENT_MAX_LENGTH - editContent.length;
+  const isSelectable = Boolean(onCommentSelected) && !isEditing && !isDeleted;
 
   useEffect(() => {
     setEditContent(comment.content);
@@ -85,7 +90,7 @@ export function EditableComment({
         required: t("commentRequired"),
         invalidCharacters: t("commentInvalidCharacters"),
         maxLength: t("commentTooLong", { max: COMMENT_MAX_LENGTH }),
-      }
+      },
     );
 
     if (!validation.valid) {
@@ -136,9 +141,28 @@ export function EditableComment({
     }
   };
 
+  const handleSelect = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (!isSelectable || window.innerWidth >= 768) {
+      return;
+    }
+
+    const target = event.target as HTMLElement | null;
+    if (target?.closest("button, a, input, textarea, [role='menuitem']")) {
+      return;
+    }
+
+    onCommentSelected?.();
+  };
+
   return (
     <>
-      <div className="flex gap-3 py-3">
+      <div
+        className={cn(
+          "flex gap-3 py-3",
+          isSelectable && "cursor-pointer md:cursor-default",
+        )}
+        onClick={handleSelect}
+      >
         {!isDeleted &&
           (comment.user_avatar_url ? (
             <div className="relative h-8 w-8 shrink-0 overflow-hidden rounded-full">
@@ -214,7 +238,9 @@ export function EditableComment({
             <CollapsibleText
               text={comment.content}
               maxLines={2}
-              textClassName={isDeleted ? "italic text-gray-500" : "text-gray-900"}
+              textClassName={
+                isDeleted ? "italic text-gray-500" : "text-gray-900"
+              }
             />
           )}
         </div>

--- a/features/posts/components/EditableComment.tsx
+++ b/features/posts/components/EditableComment.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import {
+  useEffect,
+  useState,
+  type KeyboardEvent,
+  type MouseEvent,
+} from "react";
 import Image from "next/image";
 import { useLocale, useTranslations } from "next-intl";
 import { User, MoreVertical, Edit, Trash2, Check, X } from "lucide-react";
@@ -26,6 +31,7 @@ import { deleteCommentAPI, updateCommentAPI } from "../lib/api";
 import type { ParentComment, ReplyComment } from "../types";
 import { useToast } from "@/components/ui/use-toast";
 import { CollapsibleText } from "./CollapsibleText";
+import { REPLY_PANEL_MOBILE_BREAKPOINT } from "../lib/constants";
 import { cn, sanitizeProfileText, validateProfileText } from "@/lib/utils";
 import { COMMENT_MAX_LENGTH } from "@/constants";
 
@@ -141,108 +147,131 @@ export function EditableComment({
     }
   };
 
-  const handleSelect = (event: React.MouseEvent<HTMLDivElement>) => {
-    if (!isSelectable || window.innerWidth >= 768) {
+  const handleSelect = (target: EventTarget | null) => {
+    if (
+      !isSelectable ||
+      window.innerWidth >= REPLY_PANEL_MOBILE_BREAKPOINT
+    ) {
       return;
     }
 
-    const target = event.target as HTMLElement | null;
-    if (target?.closest("button, a, input, textarea, [role='menuitem']")) {
+    if (
+      target instanceof HTMLElement &&
+      target.closest("button, a, input, textarea, [role='menuitem']")
+    ) {
       return;
     }
 
     onCommentSelected?.();
   };
 
+  const handleSelectClick = (event: MouseEvent<HTMLDivElement>) => {
+    handleSelect(event.target);
+  };
+
+  const handleSelectKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "Enter" && event.key !== " ") {
+      return;
+    }
+
+    event.preventDefault();
+    handleSelect(event.target);
+  };
+
   return (
     <>
-      <div
-        className={cn(
-          "flex gap-3 py-3",
-          isSelectable && "cursor-pointer md:cursor-default",
-        )}
-        onClick={handleSelect}
-      >
-        {!isDeleted &&
-          (comment.user_avatar_url ? (
-            <div className="relative h-8 w-8 shrink-0 overflow-hidden rounded-full">
-              <Image
-                src={comment.user_avatar_url}
-                alt={displayName}
-                fill
-                className="object-cover"
-                sizes="32px"
-              />
-            </div>
-          ) : (
-            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-200">
-              <User className="h-4 w-4 text-gray-500" />
-            </div>
-          ))}
+      <div className="flex gap-3 py-3">
+        <div
+          role={isSelectable ? "button" : undefined}
+          tabIndex={isSelectable ? 0 : -1}
+          className={cn(
+            "flex min-w-0 flex-1 gap-3 rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            isSelectable && "cursor-pointer md:cursor-default",
+          )}
+          onClick={handleSelectClick}
+          onKeyDown={handleSelectKeyDown}
+        >
+          {!isDeleted &&
+            (comment.user_avatar_url ? (
+              <div className="relative h-8 w-8 shrink-0 overflow-hidden rounded-full">
+                <Image
+                  src={comment.user_avatar_url}
+                  alt={displayName}
+                  fill
+                  className="object-cover"
+                  sizes="32px"
+                />
+              </div>
+            ) : (
+              <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-200">
+                <User className="h-4 w-4 text-gray-500" />
+              </div>
+            ))}
 
-        <div className="min-w-0 flex-1">
-          <div className="mb-1 flex items-center gap-2">
-            {!isDeleted && (
-              <span className="text-sm font-medium text-gray-900">
-                {displayName}
-              </span>
-            )}
-            <span className="text-xs text-gray-500">
-              {new Intl.DateTimeFormat(locale === "ja" ? "ja-JP" : "en-US", {
-                month: "short",
-                day: "numeric",
-                hour: "2-digit",
-                minute: "2-digit",
-              }).format(new Date(comment.created_at))}
-            </span>
-          </div>
-
-          {isEditing ? (
-            <div className="space-y-2">
-              <Textarea
-                value={editContent}
-                onChange={(e) => setEditContent(e.target.value)}
-                maxLength={COMMENT_MAX_LENGTH}
-                rows={3}
-                className="resize-none text-sm"
-                disabled={isLoading}
-              />
-              <div className="flex items-center justify-between">
-                <span
-                  className={`text-xs ${
-                    remainingChars < 20 ? "text-red-500" : "text-gray-500"
-                  }`}
-                >
-                  {t("commentRemaining", { count: remainingChars })}
+          <div className="min-w-0 flex-1">
+            <div className="mb-1 flex items-center gap-2">
+              {!isDeleted && (
+                <span className="text-sm font-medium text-gray-900">
+                  {displayName}
                 </span>
-                <div className="flex gap-2">
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={handleCancelEdit}
-                    disabled={isLoading}
+              )}
+              <span className="text-xs text-gray-500">
+                {new Intl.DateTimeFormat(locale === "ja" ? "ja-JP" : "en-US", {
+                  month: "short",
+                  day: "numeric",
+                  hour: "2-digit",
+                  minute: "2-digit",
+                }).format(new Date(comment.created_at))}
+              </span>
+            </div>
+
+            {isEditing ? (
+              <div className="space-y-2">
+                <Textarea
+                  value={editContent}
+                  onChange={(e) => setEditContent(e.target.value)}
+                  maxLength={COMMENT_MAX_LENGTH}
+                  rows={3}
+                  className="resize-none text-sm"
+                  disabled={isLoading}
+                />
+                <div className="flex items-center justify-between">
+                  <span
+                    className={`text-xs ${
+                      remainingChars < 20 ? "text-red-500" : "text-gray-500"
+                    }`}
                   >
-                    <X className="h-4 w-4" />
-                  </Button>
-                  <Button
-                    size="sm"
-                    onClick={handleSaveEdit}
-                    disabled={isLoading || editContent.trim().length === 0}
-                  >
-                    <Check className="h-4 w-4" />
-                  </Button>
+                    {t("commentRemaining", { count: remainingChars })}
+                  </span>
+                  <div className="flex gap-2">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={handleCancelEdit}
+                      disabled={isLoading}
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      size="sm"
+                      onClick={handleSaveEdit}
+                      disabled={isLoading || editContent.trim().length === 0}
+                    >
+                      <Check className="h-4 w-4" />
+                    </Button>
+                  </div>
                 </div>
               </div>
-            </div>
-          ) : (
-            <CollapsibleText
-              text={comment.content}
-              maxLines={2}
-              textClassName={
-                isDeleted ? "italic text-gray-500" : "text-gray-900"
-              }
-            />
-          )}
+            ) : (
+              <CollapsibleText
+                text={comment.content}
+                maxLines={2}
+                textClassName={
+                  isDeleted ? "italic text-gray-500" : "text-gray-900"
+                }
+              />
+            )}
+          </div>
         </div>
 
         {isOwner && !isEditing && (

--- a/features/posts/components/ReplyPanel.tsx
+++ b/features/posts/components/ReplyPanel.tsx
@@ -1,19 +1,15 @@
 "use client";
 
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import type { CSSProperties } from "react";
 import { useTransition } from "react";
 import { ChevronLeft, X } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
-import {
-  Sheet,
-  SheetClose,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
 import { CommentInput } from "./CommentInput";
 import { EditableComment } from "./EditableComment";
 import { ReplyItem } from "./ReplyItem";
+import { ReplyPanelSkeleton } from "./ReplyPanelSkeleton";
 import type { ParentComment } from "../types";
 import { useReplies } from "../hooks/useReplies";
 
@@ -23,6 +19,7 @@ interface ReplyPanelProps {
   parentComment: ParentComment;
   currentUserId?: string | null;
   onThreadChanged: () => void;
+  panelStyle: CSSProperties;
 }
 
 export function ReplyPanel({
@@ -31,6 +28,7 @@ export function ReplyPanel({
   parentComment,
   currentUserId,
   onThreadChanged,
+  panelStyle,
 }: ReplyPanelProps) {
   const t = useTranslations("posts");
   const commonT = useTranslations("common");
@@ -40,6 +38,7 @@ export function ReplyPanel({
     isLoading,
     hasMore,
     offset,
+    hasResolvedInitialLoad,
     loadReplies,
     refreshReplies,
   } = useReplies({
@@ -75,104 +74,112 @@ export function ReplyPanel({
   };
 
   const hasReplies = parentComment.reply_count > 0 || replies.length > 0;
+  const showRepliesSkeleton =
+    parentComment.reply_count > 0 && !hasResolvedInitialLoad;
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent
-        side="right"
-        className="w-full max-w-none gap-0 p-0"
-        showCloseButton={false}
-      >
-        <div className="flex h-full flex-col bg-gray-50">
-          <SheetHeader className="border-b border-gray-200 bg-white px-4 py-3">
-            <div className="flex items-center justify-between gap-3">
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-sm"
-                onClick={() => onOpenChange(false)}
-              >
-                <ChevronLeft className="h-5 w-5" />
-                <span className="sr-only">{commonT("back")}</span>
-              </Button>
-              <SheetTitle className="text-base">{t("repliesTitle")}</SheetTitle>
-              <SheetClose asChild>
-                <Button type="button" variant="ghost" size="icon-sm">
-                  <X className="h-5 w-5" />
-                  <span className="sr-only">{t("cancel")}</span>
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal forceMount>
+        <DialogPrimitive.Overlay
+          className="reply-panel-mobile-overlay fixed z-40 bg-black/5 md:hidden"
+          style={panelStyle}
+        />
+        <DialogPrimitive.Content
+          aria-describedby={undefined}
+          className="reply-panel-mobile-content fixed z-50 flex flex-col overflow-hidden border border-gray-200 bg-gray-50 shadow-xl outline-none md:hidden"
+          style={panelStyle}
+        >
+          <div className="flex h-full flex-col bg-gray-50">
+            <div className="border-b border-gray-200 bg-white px-4 py-3">
+              <div className="flex items-center justify-between gap-3">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={() => onOpenChange(false)}
+                >
+                  <ChevronLeft className="h-5 w-5" />
+                  <span className="sr-only">{commonT("back")}</span>
                 </Button>
-              </SheetClose>
+                <DialogPrimitive.Title className="text-base font-semibold">
+                  {t("repliesTitle")}
+                </DialogPrimitive.Title>
+                <DialogPrimitive.Close asChild>
+                  <Button type="button" variant="ghost" size="icon-sm">
+                    <X className="h-5 w-5" />
+                    <span className="sr-only">{t("cancel")}</span>
+                  </Button>
+                </DialogPrimitive.Close>
+              </div>
             </div>
-          </SheetHeader>
 
-          <div className="flex-1 overflow-y-auto">
-            <div className="border-b border-gray-200 bg-white px-4">
-              <EditableComment
-                comment={parentComment}
-                onCommentUpdated={() => undefined}
-                onCommentDeleted={() => undefined}
+            <div className="flex-1 overflow-y-auto">
+              <div className="border-b border-gray-200 bg-white px-4">
+                <EditableComment
+                  comment={parentComment}
+                  onCommentUpdated={() => undefined}
+                  onCommentDeleted={() => undefined}
+                />
+              </div>
+
+              <div className="px-4 py-4">
+                {showRepliesSkeleton ? (
+                  <ReplyPanelSkeleton />
+                ) : replies.length === 0 ? (
+                  <div className="rounded-xl border border-dashed border-gray-200 bg-white px-4 py-6 text-center text-sm text-gray-500">
+                    {t("noReplies")}
+                  </div>
+                ) : (
+                  <div className="rounded-xl border border-gray-200 bg-white px-3">
+                    {replies.map((reply) => (
+                      <ReplyItem
+                        key={reply.id}
+                        reply={reply}
+                        currentUserId={currentUserId}
+                        onReplyUpdated={handleReplyUpdated}
+                        onReplyDeleted={handleReplyDeleted}
+                      />
+                    ))}
+                  </div>
+                )}
+
+                {hasReplies && hasMore && (
+                  <div className="pt-3">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="h-9 w-full text-sm text-gray-600"
+                      onClick={() => loadReplies(offset, false)}
+                      disabled={isLoading}
+                    >
+                      {isLoading ? t("repliesLoading") : t("loadMoreReplies")}
+                    </Button>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="safe-area-inset-bottom border-t border-gray-200 bg-white p-4">
+              <CommentInput
+                parentCommentId={parentComment.id}
+                currentUserId={currentUserId}
+                onCommentAdded={handleReplyAdded}
+                placeholder={t("replyPlaceholder")}
+                submitLabel={t("replySubmit")}
+                submittingLabel={t("replySubmitting")}
+                compact
+                disabled={Boolean(parentComment.deleted_at)}
+                disabledMessage={
+                  parentComment.deleted_at
+                    ? t("cannotReplyToDeletedComment")
+                    : undefined
+                }
               />
             </div>
-
-            <div className="px-4 py-4">
-              {isLoading && replies.length === 0 ? (
-                <div className="py-6 text-center text-sm text-gray-500">
-                  {t("repliesLoading")}
-                </div>
-              ) : replies.length === 0 ? (
-                <div className="rounded-xl border border-dashed border-gray-200 bg-white px-4 py-6 text-center text-sm text-gray-500">
-                  {t("noReplies")}
-                </div>
-              ) : (
-                <div className="rounded-xl border border-gray-200 bg-white px-3">
-                  {replies.map((reply) => (
-                    <ReplyItem
-                      key={reply.id}
-                      reply={reply}
-                      currentUserId={currentUserId}
-                      onReplyUpdated={handleReplyUpdated}
-                      onReplyDeleted={handleReplyDeleted}
-                    />
-                  ))}
-                </div>
-              )}
-
-              {hasReplies && hasMore && (
-                <div className="pt-3">
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="h-9 w-full text-sm text-gray-600"
-                    onClick={() => loadReplies(offset, false)}
-                    disabled={isLoading}
-                  >
-                    {isLoading ? t("repliesLoading") : t("loadMoreReplies")}
-                  </Button>
-                </div>
-              )}
-            </div>
           </div>
-
-          <div className="safe-area-inset-bottom border-t border-gray-200 bg-white p-4">
-            <CommentInput
-              parentCommentId={parentComment.id}
-              currentUserId={currentUserId}
-              onCommentAdded={handleReplyAdded}
-              placeholder={t("replyPlaceholder")}
-              submitLabel={t("replySubmit")}
-              submittingLabel={t("replySubmitting")}
-              compact
-              disabled={Boolean(parentComment.deleted_at)}
-              disabledMessage={
-                parentComment.deleted_at
-                  ? t("cannotReplyToDeletedComment")
-                  : undefined
-              }
-            />
-          </div>
-        </div>
-      </SheetContent>
-    </Sheet>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
   );
 }

--- a/features/posts/components/ReplyPanelSkeleton.tsx
+++ b/features/posts/components/ReplyPanelSkeleton.tsx
@@ -1,0 +1,19 @@
+export function ReplyPanelSkeleton() {
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white px-3 py-1">
+      {Array.from({ length: 3 }).map((_, index) => (
+        <div
+          key={index}
+          className="flex animate-pulse gap-3 border-b border-gray-100 py-3 last:border-b-0"
+        >
+          <div className="h-8 w-8 shrink-0 rounded-full bg-gray-200" />
+          <div className="flex-1 space-y-2">
+            <div className="h-4 w-24 rounded bg-gray-200" />
+            <div className="h-4 w-full rounded bg-gray-200" />
+            <div className="h-4 w-2/3 rounded bg-gray-100" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/features/posts/hooks/useReplies.ts
+++ b/features/posts/hooks/useReplies.ts
@@ -44,6 +44,9 @@ export function useReplies({
   const [isLoading, setIsLoading] = useState(false);
   const [hasMore, setHasMore] = useState(false);
   const [offset, setOffset] = useState(0);
+  const [hasResolvedInitialLoad, setHasResolvedInitialLoad] = useState(
+    parentReplyCount === 0,
+  );
   const requestSequenceRef = useRef(0);
   const inFlightKeysRef = useRef<Set<string>>(new Set());
   const pendingRequestsRef = useRef(0);
@@ -67,7 +70,7 @@ export function useReplies({
           nextOffset,
           {
             repliesFetchFailed: t("repliesFetchFailed"),
-          }
+          },
         );
 
         if (requestId !== requestSequenceRef.current) {
@@ -87,14 +90,18 @@ export function useReplies({
         console.error("Failed to load replies:", error);
       } finally {
         inFlightKeysRef.current.delete(requestKey);
-        pendingRequestsRef.current = Math.max(0, pendingRequestsRef.current - 1);
+        pendingRequestsRef.current = Math.max(
+          0,
+          pendingRequestsRef.current - 1,
+        );
+        setHasResolvedInitialLoad(true);
 
         if (pendingRequestsRef.current === 0) {
           setIsLoading(false);
         }
       }
     },
-    [parentCommentId, t]
+    [parentCommentId, t],
   );
 
   const refreshReplies = useCallback(async () => {
@@ -105,18 +112,25 @@ export function useReplies({
     setReplies([]);
     setHasMore(false);
     setOffset(0);
+    setHasResolvedInitialLoad(parentReplyCount === 0);
     requestSequenceRef.current = 0;
     inFlightKeysRef.current.clear();
     pendingRequestsRef.current = 0;
     setIsLoading(false);
-  }, [parentCommentId]);
+  }, [parentCommentId, parentReplyCount]);
 
   useEffect(() => {
-    if (!enabled || parentReplyCount === 0) {
+    if (!enabled) {
+      return;
+    }
+
+    if (parentReplyCount === 0) {
+      setHasResolvedInitialLoad(true);
       return;
     }
 
     if (replies.length > 0 && replies.length === parentReplyCount && !hasMore) {
+      setHasResolvedInitialLoad(true);
       return;
     }
 
@@ -139,11 +153,14 @@ export function useReplies({
             return;
           }
 
-          if (payload.event_type === "INSERT" || payload.event_type === "DELETE") {
+          if (
+            payload.event_type === "INSERT" ||
+            payload.event_type === "DELETE"
+          ) {
             void refreshReplies();
             onReplyCountChanged?.();
           }
-        }
+        },
       )
       .on(
         "postgres_changes",
@@ -170,14 +187,14 @@ export function useReplies({
                     ...reply,
                     content: updatedReply.deleted_at
                       ? t("commentDeletedPlaceholder")
-                      : updatedReply.content ?? reply.content,
+                      : (updatedReply.content ?? reply.content),
                     deleted_at: updatedReply.deleted_at ?? reply.deleted_at,
                     updated_at: updatedReply.updated_at ?? reply.updated_at,
                   }
-                : reply
-            )
+                : reply,
+            ),
           );
-        }
+        },
       )
       .subscribe();
 
@@ -198,6 +215,7 @@ export function useReplies({
     isLoading,
     hasMore,
     offset,
+    hasResolvedInitialLoad,
     loadReplies,
     refreshReplies,
   };

--- a/features/posts/lib/constants.ts
+++ b/features/posts/lib/constants.ts
@@ -1,0 +1,1 @@
+export const REPLY_PANEL_MOBILE_BREAKPOINT = 768;

--- a/tests/unit/features/posts/comment-item.test.tsx
+++ b/tests/unit/features/posts/comment-item.test.tsx
@@ -1,0 +1,124 @@
+/** @jest-environment jsdom */
+
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useTranslations } from "next-intl";
+import { CommentItem } from "@/features/posts/components/CommentItem";
+import type { ParentComment } from "@/features/posts/types";
+
+jest.mock("next-intl", () => ({
+  useTranslations: jest.fn(),
+}));
+
+jest.mock("@/features/posts/components/EditableComment", () => ({
+  EditableComment: ({
+    onCommentSelected,
+  }: {
+    onCommentSelected?: () => void;
+  }) => (
+    <button type="button" onClick={onCommentSelected}>
+      select-comment
+    </button>
+  ),
+}));
+
+jest.mock("@/features/posts/components/ReplyThread", () => ({
+  ReplyThread: () => <div data-testid="reply-thread" />,
+}));
+
+const useTranslationsMock = useTranslations as jest.MockedFunction<
+  typeof useTranslations
+>;
+
+function createComment(overrides: Partial<ParentComment> = {}): ParentComment {
+  return {
+    id: "comment-1",
+    user_id: "user-1",
+    image_id: "post-1",
+    parent_comment_id: null,
+    content: "comment body",
+    created_at: "2026-04-17T00:00:00.000Z",
+    updated_at: "2026-04-17T00:00:00.000Z",
+    deleted_at: null,
+    user_nickname: "User",
+    user_avatar_url: null,
+    reply_count: 0,
+    last_activity_at: "2026-04-17T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("CommentItem", () => {
+  beforeEach(() => {
+    useTranslationsMock.mockImplementation((namespace?: string) => {
+      return ((key: string, values?: Record<string, string | number>) => {
+        if (namespace !== "posts") {
+          return key;
+        }
+
+        if (key === "repliesCount") {
+          return `${values?.count}件の返信`;
+        }
+
+        return key;
+      }) as ReturnType<typeof useTranslations>;
+    });
+  });
+
+  test("返信がない場合は返信数ボタンを表示しない", () => {
+    render(
+      <CommentItem
+        comment={createComment({ reply_count: 0 })}
+        currentUserId="viewer-1"
+        onCommentUpdated={() => undefined}
+        onCommentDeleted={() => undefined}
+        onThreadChanged={() => undefined}
+        onOpenReplyPanel={() => undefined}
+      />,
+    );
+
+    expect(screen.queryByText("0件の返信")).not.toBeInTheDocument();
+  });
+
+  test("コメント本体の選択で返信画面を開ける", () => {
+    const onOpenReplyPanel = jest.fn();
+
+    render(
+      <CommentItem
+        comment={createComment({ reply_count: 0 })}
+        currentUserId="viewer-1"
+        onCommentUpdated={() => undefined}
+        onCommentDeleted={() => undefined}
+        onThreadChanged={() => undefined}
+        onOpenReplyPanel={onOpenReplyPanel}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "select-comment" }));
+
+    expect(onOpenReplyPanel).toHaveBeenCalledTimes(1);
+  });
+
+  test("削除済みコメントは本体選択で返信画面を開かない", () => {
+    const onOpenReplyPanel = jest.fn();
+
+    render(
+      <CommentItem
+        comment={createComment({
+          deleted_at: "2026-04-17T00:10:00.000Z",
+          reply_count: 2,
+        })}
+        currentUserId="viewer-1"
+        onCommentUpdated={() => undefined}
+        onCommentDeleted={() => undefined}
+        onThreadChanged={() => undefined}
+        onOpenReplyPanel={onOpenReplyPanel}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "select-comment" }));
+
+    expect(onOpenReplyPanel).not.toHaveBeenCalled();
+    expect(screen.getByText("2件の返信")).toBeInTheDocument();
+  });
+});

--- a/tests/unit/features/posts/comment-section.test.tsx
+++ b/tests/unit/features/posts/comment-section.test.tsx
@@ -1,0 +1,135 @@
+/** @jest-environment jsdom */
+
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { CommentSection } from "@/features/posts/components/CommentSection";
+
+const refreshMock = jest.fn();
+
+jest.mock("@/features/posts/components/CommentInput", () => ({
+  CommentInput: () => <div data-testid="comment-input" />,
+}));
+
+jest.mock("@/features/posts/components/CommentList", () => {
+  const { forwardRef, useImperativeHandle } = jest.requireActual("react");
+
+  return {
+    CommentList: forwardRef(
+      (
+        {
+          activeReplyCommentId,
+          onReplyPanelOpen,
+          replyPanelStyle,
+        }: {
+          activeReplyCommentId?: string | null;
+          onReplyPanelOpen?: (commentId: string) => void;
+          replyPanelStyle?: React.CSSProperties | null;
+        },
+        ref: React.Ref<{ refresh: () => void }>,
+      ) => {
+        useImperativeHandle(ref, () => ({
+          refresh: refreshMock,
+        }));
+
+        return (
+          <div>
+            <div data-testid="active-reply-comment-id">
+              {activeReplyCommentId ?? "none"}
+            </div>
+            <div data-testid="reply-panel-style">
+              {replyPanelStyle ? JSON.stringify(replyPanelStyle) : "none"}
+            </div>
+            <button
+              type="button"
+              onClick={() => onReplyPanelOpen?.("parent-comment-1")}
+            >
+              open-reply-panel
+            </button>
+          </div>
+        );
+      },
+    ),
+  };
+});
+
+describe("CommentSection", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 390,
+      writable: true,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 844,
+      writable: true,
+    });
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: {
+        height: 844,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      },
+      writable: true,
+    });
+
+    class ResizeObserverMock {
+      observe = jest.fn();
+      disconnect = jest.fn();
+    }
+
+    Object.defineProperty(window, "ResizeObserver", {
+      configurable: true,
+      value: ResizeObserverMock,
+      writable: true,
+    });
+    Object.defineProperty(global, "ResizeObserver", {
+      configurable: true,
+      value: ResizeObserverMock,
+      writable: true,
+    });
+  });
+
+  test("モバイルで返信を開くとコメント領域の矩形だけをオーバーレイに使う", async () => {
+    const { container } = render(
+      <CommentSection postId="post-1" currentUserId="user-1" />,
+    );
+
+    const section = container.querySelector(".container") as HTMLDivElement;
+    expect(section).not.toBeNull();
+
+    Object.defineProperty(section, "getBoundingClientRect", {
+      configurable: true,
+      value: () => ({
+        top: 240,
+        left: 0,
+        width: 390,
+        height: 900,
+        bottom: 1140,
+        right: 390,
+        x: 0,
+        y: 240,
+        toJSON: () => ({}),
+      }),
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "open-reply-panel" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("active-reply-comment-id")).toHaveTextContent(
+        "parent-comment-1",
+      );
+      expect(screen.getByTestId("reply-panel-style")).toHaveTextContent(
+        JSON.stringify({
+          top: 240,
+          left: 0,
+          width: 390,
+          height: 604,
+        }),
+      );
+    });
+  });
+});

--- a/tests/unit/features/posts/comment-section.test.tsx
+++ b/tests/unit/features/posts/comment-section.test.tsx
@@ -5,6 +5,10 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { CommentSection } from "@/features/posts/components/CommentSection";
 
 const refreshMock = jest.fn();
+const visualViewportAddEventListenerMock = jest.fn();
+const visualViewportRemoveEventListenerMock = jest.fn();
+const resizeObserverObserveMock = jest.fn();
+const resizeObserverDisconnectMock = jest.fn();
 
 jest.mock("@/features/posts/components/CommentInput", () => ({
   CommentInput: () => <div data-testid="comment-input" />,
@@ -19,10 +23,12 @@ jest.mock("@/features/posts/components/CommentList", () => {
         {
           activeReplyCommentId,
           onReplyPanelOpen,
+          onReplyPanelOpenChange,
           replyPanelStyle,
         }: {
           activeReplyCommentId?: string | null;
           onReplyPanelOpen?: (commentId: string) => void;
+          onReplyPanelOpenChange?: (open: boolean) => void;
           replyPanelStyle?: React.CSSProperties | null;
         },
         ref: React.Ref<{ refresh: () => void }>,
@@ -45,12 +51,44 @@ jest.mock("@/features/posts/components/CommentList", () => {
             >
               open-reply-panel
             </button>
+            <button
+              type="button"
+              onClick={() => onReplyPanelOpenChange?.(false)}
+            >
+              close-reply-panel
+            </button>
           </div>
         );
       },
     ),
   };
 });
+
+function setSectionRect(
+  container: HTMLElement,
+  overrides: Partial<DOMRect> = {},
+): HTMLDivElement {
+  const section = container.querySelector(".container") as HTMLDivElement;
+  expect(section).not.toBeNull();
+
+  Object.defineProperty(section, "getBoundingClientRect", {
+    configurable: true,
+    value: () => ({
+      top: 240,
+      left: 0,
+      width: 390,
+      height: 900,
+      bottom: 1140,
+      right: 390,
+      x: 0,
+      y: 240,
+      toJSON: () => ({}),
+      ...overrides,
+    }),
+  });
+
+  return section;
+}
 
 describe("CommentSection", () => {
   beforeEach(() => {
@@ -70,15 +108,15 @@ describe("CommentSection", () => {
       configurable: true,
       value: {
         height: 844,
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
+        addEventListener: visualViewportAddEventListenerMock,
+        removeEventListener: visualViewportRemoveEventListenerMock,
       },
       writable: true,
     });
 
     class ResizeObserverMock {
-      observe = jest.fn();
-      disconnect = jest.fn();
+      observe = resizeObserverObserveMock;
+      disconnect = resizeObserverDisconnectMock;
     }
 
     Object.defineProperty(window, "ResizeObserver", {
@@ -98,23 +136,7 @@ describe("CommentSection", () => {
       <CommentSection postId="post-1" currentUserId="user-1" />,
     );
 
-    const section = container.querySelector(".container") as HTMLDivElement;
-    expect(section).not.toBeNull();
-
-    Object.defineProperty(section, "getBoundingClientRect", {
-      configurable: true,
-      value: () => ({
-        top: 240,
-        left: 0,
-        width: 390,
-        height: 900,
-        bottom: 1140,
-        right: 390,
-        x: 0,
-        y: 240,
-        toJSON: () => ({}),
-      }),
-    });
+    setSectionRect(container);
 
     fireEvent.click(screen.getByRole("button", { name: "open-reply-panel" }));
 
@@ -131,5 +153,135 @@ describe("CommentSection", () => {
         }),
       );
     });
+
+    expect(visualViewportAddEventListenerMock).toHaveBeenCalledWith(
+      "resize",
+      expect.any(Function),
+    );
+    expect(visualViewportAddEventListenerMock).toHaveBeenCalledWith(
+      "scroll",
+      expect.any(Function),
+    );
+    expect(resizeObserverObserveMock).toHaveBeenCalled();
+  });
+
+  test("デスクトップ幅では返信パネルのスタイルを計算しない", async () => {
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 1024,
+      writable: true,
+    });
+
+    const { container } = render(
+      <CommentSection postId="post-1" currentUserId="user-1" />,
+    );
+
+    setSectionRect(container, { width: 960, right: 960 });
+
+    fireEvent.click(screen.getByRole("button", { name: "open-reply-panel" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("active-reply-comment-id")).toHaveTextContent(
+        "parent-comment-1",
+      );
+      expect(screen.getByTestId("reply-panel-style")).toHaveTextContent("none");
+    });
+  });
+
+  test("計測結果が無効な場合は返信パネルのスタイルを設定しない", async () => {
+    const { container } = render(
+      <CommentSection postId="post-1" currentUserId="user-1" />,
+    );
+
+    setSectionRect(container, {
+      width: 0,
+      right: 0,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "open-reply-panel" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("active-reply-comment-id")).toHaveTextContent(
+        "parent-comment-1",
+      );
+      expect(screen.getByTestId("reply-panel-style")).toHaveTextContent("none");
+    });
+  });
+
+  test("visualViewport や ResizeObserver がなくても innerHeight でスタイルを計算できる", async () => {
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: undefined,
+      writable: true,
+    });
+    Object.defineProperty(window, "ResizeObserver", {
+      configurable: true,
+      value: undefined,
+      writable: true,
+    });
+    Object.defineProperty(global, "ResizeObserver", {
+      configurable: true,
+      value: undefined,
+      writable: true,
+    });
+
+    const { container } = render(
+      <CommentSection postId="post-1" currentUserId="user-1" />,
+    );
+
+    setSectionRect(container, {
+      top: 100,
+      y: 100,
+      height: 600,
+      bottom: 700,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "open-reply-panel" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("reply-panel-style")).toHaveTextContent(
+        JSON.stringify({
+          top: 100,
+          left: 0,
+          width: 390,
+          height: 744,
+        }),
+      );
+    });
+  });
+
+  test("返信パネルを閉じるとアクティブ状態とスタイルをクリアして cleanup する", async () => {
+    const { container } = render(
+      <CommentSection postId="post-1" currentUserId="user-1" />,
+    );
+
+    setSectionRect(container);
+
+    fireEvent.click(screen.getByRole("button", { name: "open-reply-panel" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("active-reply-comment-id")).toHaveTextContent(
+        "parent-comment-1",
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "close-reply-panel" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("active-reply-comment-id")).toHaveTextContent(
+        "none",
+      );
+      expect(screen.getByTestId("reply-panel-style")).toHaveTextContent("none");
+    });
+
+    expect(visualViewportRemoveEventListenerMock).toHaveBeenCalledWith(
+      "resize",
+      expect.any(Function),
+    );
+    expect(visualViewportRemoveEventListenerMock).toHaveBeenCalledWith(
+      "scroll",
+      expect.any(Function),
+    );
+    expect(resizeObserverDisconnectMock).toHaveBeenCalled();
   });
 });

--- a/tests/unit/features/posts/comment-section.test.tsx
+++ b/tests/unit/features/posts/comment-section.test.tsx
@@ -11,7 +11,11 @@ const resizeObserverObserveMock = jest.fn();
 const resizeObserverDisconnectMock = jest.fn();
 
 jest.mock("@/features/posts/components/CommentInput", () => ({
-  CommentInput: () => <div data-testid="comment-input" />,
+  CommentInput: ({ onCommentAdded }: { onCommentAdded?: () => void }) => (
+    <button type="button" onClick={() => onCommentAdded?.()}>
+      add-comment
+    </button>
+  ),
 }));
 
 jest.mock("@/features/posts/components/CommentList", () => {
@@ -283,5 +287,61 @@ describe("CommentSection", () => {
       expect.any(Function),
     );
     expect(resizeObserverDisconnectMock).toHaveBeenCalled();
+  });
+
+  test("ビューポート変更時に返信パネルのスタイルを再計算する", async () => {
+    const { container } = render(
+      <CommentSection postId="post-1" currentUserId="user-1" />,
+    );
+
+    const section = setSectionRect(container);
+    fireEvent.click(screen.getByRole("button", { name: "open-reply-panel" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("reply-panel-style")).toHaveTextContent(
+        JSON.stringify({
+          top: 240,
+          left: 0,
+          width: 390,
+          height: 604,
+        }),
+      );
+    });
+
+    Object.defineProperty(section, "getBoundingClientRect", {
+      configurable: true,
+      value: () => ({
+        top: 180,
+        left: 12,
+        width: 360,
+        height: 900,
+        bottom: 1080,
+        right: 372,
+        x: 12,
+        y: 180,
+        toJSON: () => ({}),
+      }),
+    });
+
+    fireEvent(window, new Event("resize"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("reply-panel-style")).toHaveTextContent(
+        JSON.stringify({
+          top: 180,
+          left: 12,
+          width: 360,
+          height: 664,
+        }),
+      );
+    });
+  });
+
+  test("コメント追加後に一覧を refresh する", () => {
+    render(<CommentSection postId="post-1" currentUserId="user-1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "add-comment" }));
+
+    expect(refreshMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/features/posts/editable-comment.test.tsx
+++ b/tests/unit/features/posts/editable-comment.test.tsx
@@ -1,14 +1,16 @@
 /** @jest-environment jsdom */
 
 import React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { useLocale, useTranslations } from "next-intl";
 import { EditableComment } from "@/features/posts/components/EditableComment";
 import type { ParentComment } from "@/features/posts/types";
 
 const updateCommentAPIMock = jest.fn();
 const deleteCommentAPIMock = jest.fn();
+const sanitizeProfileTextMock = jest.fn();
 const toastMock = jest.fn();
+const validateProfileTextMock = jest.fn();
 
 jest.mock("next/image", () => ({
   __esModule: true,
@@ -30,6 +32,13 @@ jest.mock("@/components/ui/use-toast", () => ({
 jest.mock("@/features/posts/lib/api", () => ({
   updateCommentAPI: (...args: unknown[]) => updateCommentAPIMock(...args),
   deleteCommentAPI: (...args: unknown[]) => deleteCommentAPIMock(...args),
+}));
+
+jest.mock("@/lib/utils", () => ({
+  cn: (...classes: Array<string | false | null | undefined>) =>
+    classes.filter(Boolean).join(" "),
+  sanitizeProfileText: (...args: unknown[]) => sanitizeProfileTextMock(...args),
+  validateProfileText: (...args: unknown[]) => validateProfileTextMock(...args),
 }));
 
 jest.mock("@/features/posts/components/CollapsibleText", () => ({
@@ -69,11 +78,31 @@ jest.mock("@/components/ui/alert-dialog", () => ({
   }) => (
     <div>{open ? children : null}</div>
   ),
-  AlertDialogAction: ({ children }: { children: React.ReactNode }) => (
-    <button type="button">{children}</button>
+  AlertDialogAction: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
   ),
-  AlertDialogCancel: ({ children }: { children: React.ReactNode }) => (
-    <button type="button">{children}</button>
+  AlertDialogCancel: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
   ),
   AlertDialogContent: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
@@ -115,6 +144,12 @@ function createComment(overrides: Partial<ParentComment> = {}): ParentComment {
   };
 }
 
+function getSelectionTrigger() {
+  const trigger = screen.getByText("comment body").closest("[role='button']");
+  expect(trigger).not.toBeNull();
+  return trigger as HTMLElement;
+}
+
 describe("EditableComment", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -127,8 +162,18 @@ describe("EditableComment", () => {
 
     useLocaleMock.mockReturnValue("ja");
     useTranslationsMock.mockImplementation(() => {
-      return ((key: string) => key) as ReturnType<typeof useTranslations>;
+      return ((key: string, values?: Record<string, string | number>) => {
+        if (key === "commentRemaining") {
+          return `remaining-${values?.count}`;
+        }
+
+        return key;
+      }) as ReturnType<typeof useTranslations>;
     });
+    sanitizeProfileTextMock.mockImplementation((value: string) => ({
+      value,
+    }));
+    validateProfileTextMock.mockReturnValue({ valid: true });
   });
 
   test("選択可能なコメント領域に button semantics を付与する", () => {
@@ -142,9 +187,27 @@ describe("EditableComment", () => {
       />,
     );
 
-    const trigger = screen.getByRole("button");
+    const trigger = getSelectionTrigger();
 
     expect(trigger).toHaveAttribute("tabindex", "0");
+  });
+
+  test("クリックで返信画面を開く", () => {
+    const onCommentSelected = jest.fn();
+
+    render(
+      <EditableComment
+        comment={createComment()}
+        currentUserId="viewer-1"
+        onCommentUpdated={() => undefined}
+        onCommentDeleted={() => undefined}
+        onCommentSelected={onCommentSelected}
+      />,
+    );
+
+    fireEvent.click(getSelectionTrigger());
+
+    expect(onCommentSelected).toHaveBeenCalledTimes(1);
   });
 
   test("Enter キーで返信画面を開く", () => {
@@ -160,7 +223,7 @@ describe("EditableComment", () => {
       />,
     );
 
-    fireEvent.keyDown(screen.getByRole("button"), { key: "Enter" });
+    fireEvent.keyDown(getSelectionTrigger(), { key: "Enter" });
 
     expect(onCommentSelected).toHaveBeenCalledTimes(1);
   });
@@ -178,9 +241,72 @@ describe("EditableComment", () => {
       />,
     );
 
-    fireEvent.keyDown(screen.getByRole("button"), { key: " " });
+    fireEvent.keyDown(getSelectionTrigger(), { key: " " });
 
     expect(onCommentSelected).toHaveBeenCalledTimes(1);
+  });
+
+  test("Enter と Space 以外のキーでは返信画面を開かない", () => {
+    const onCommentSelected = jest.fn();
+
+    render(
+      <EditableComment
+        comment={createComment()}
+        currentUserId="viewer-1"
+        onCommentUpdated={() => undefined}
+        onCommentDeleted={() => undefined}
+        onCommentSelected={onCommentSelected}
+      />,
+    );
+
+    fireEvent.keyDown(getSelectionTrigger(), { key: "Escape" });
+
+    expect(onCommentSelected).not.toHaveBeenCalled();
+  });
+
+  test("デスクトップ幅ではコメント選択で返信画面を開かない", () => {
+    const onCommentSelected = jest.fn();
+
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 1024,
+      writable: true,
+    });
+
+    render(
+      <EditableComment
+        comment={createComment()}
+        currentUserId="viewer-1"
+        onCommentUpdated={() => undefined}
+        onCommentDeleted={() => undefined}
+        onCommentSelected={onCommentSelected}
+      />,
+    );
+
+    fireEvent.click(getSelectionTrigger());
+
+    expect(onCommentSelected).not.toHaveBeenCalled();
+  });
+
+  test("コメント領域内のインタラクティブ要素クリックでは返信画面を開かない", () => {
+    const onCommentSelected = jest.fn();
+
+    render(
+      <EditableComment
+        comment={createComment()}
+        currentUserId="viewer-1"
+        onCommentUpdated={() => undefined}
+        onCommentDeleted={() => undefined}
+        onCommentSelected={onCommentSelected}
+      />,
+    );
+
+    const nestedButton = document.createElement("button");
+    getSelectionTrigger().appendChild(nestedButton);
+
+    fireEvent.click(nestedButton);
+
+    expect(onCommentSelected).not.toHaveBeenCalled();
   });
 
   test("選択不可のコメント領域は button semantics を持たない", () => {
@@ -193,6 +319,282 @@ describe("EditableComment", () => {
       />,
     );
 
-    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.queryByText("comment body")?.closest("[role='button']")).toBeNull();
+  });
+
+  test("編集開始とキャンセルで入力内容を元に戻す", () => {
+    render(
+      <EditableComment
+        comment={createComment()}
+        currentUserId="user-1"
+        onCommentUpdated={() => undefined}
+        onCommentDeleted={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "edit" }));
+
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: "updated body" } });
+    fireEvent.click(screen.getAllByRole("button")[0]);
+
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(screen.getByText("comment body")).toBeInTheDocument();
+  });
+
+  test("編集保存成功時に API を呼んで更新通知する", async () => {
+    const onCommentUpdated = jest.fn();
+    updateCommentAPIMock.mockResolvedValue(undefined);
+
+    render(
+      <EditableComment
+        comment={createComment()}
+        currentUserId="user-1"
+        onCommentUpdated={onCommentUpdated}
+        onCommentDeleted={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "edit" }));
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "updated body" },
+    });
+    fireEvent.click(screen.getAllByRole("button")[1]);
+
+    await waitFor(() => {
+      expect(updateCommentAPIMock).toHaveBeenCalledWith(
+        "comment-1",
+        "updated body",
+        {
+          commentUpdateFailed: "commentUpdateFailed",
+        },
+      );
+      expect(onCommentUpdated).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test("編集保存のバリデーションエラー時は toast を表示する", () => {
+    validateProfileTextMock.mockReturnValue({
+      valid: false,
+      error: "validation failed",
+    });
+
+    render(
+      <EditableComment
+        comment={createComment()}
+        currentUserId="user-1"
+        onCommentUpdated={() => undefined}
+        onCommentDeleted={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "edit" }));
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "updated body" },
+    });
+    fireEvent.click(screen.getAllByRole("button")[1]);
+
+    expect(updateCommentAPIMock).not.toHaveBeenCalled();
+    expect(toastMock).toHaveBeenCalledWith({
+      title: "errorTitle",
+      description: "validation failed",
+      variant: "destructive",
+    });
+  });
+
+  test("編集保存のバリデーションエラーで詳細がない場合は既定文言を表示する", () => {
+    validateProfileTextMock.mockReturnValue({
+      valid: false,
+    });
+
+    render(
+      <EditableComment
+        comment={createComment()}
+        currentUserId="user-1"
+        onCommentUpdated={() => undefined}
+        onCommentDeleted={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "edit" }));
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "updated body" },
+    });
+    fireEvent.click(screen.getAllByRole("button")[1]);
+
+    expect(toastMock).toHaveBeenCalledWith({
+      title: "errorTitle",
+      description: "commentCreateFailed",
+      variant: "destructive",
+    });
+  });
+
+  test("編集保存 API 失敗時は toast を表示する", async () => {
+    updateCommentAPIMock.mockRejectedValue(new Error("update failed"));
+
+    render(
+      <EditableComment
+        comment={createComment()}
+        currentUserId="user-1"
+        onCommentUpdated={() => undefined}
+        onCommentDeleted={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "edit" }));
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "updated body" },
+    });
+    fireEvent.click(screen.getAllByRole("button")[1]);
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith({
+        title: "errorTitle",
+        description: "update failed",
+        variant: "destructive",
+      });
+    });
+  });
+
+  test("編集保存 API が Error 以外で失敗した場合は既定文言を表示する", async () => {
+    updateCommentAPIMock.mockRejectedValue("unexpected");
+
+    render(
+      <EditableComment
+        comment={createComment()}
+        currentUserId="user-1"
+        onCommentUpdated={() => undefined}
+        onCommentDeleted={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "edit" }));
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "updated body" },
+    });
+    fireEvent.click(screen.getAllByRole("button")[1]);
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith({
+        title: "errorTitle",
+        description: "commentUpdateFailed",
+        variant: "destructive",
+      });
+    });
+  });
+
+  test("削除成功時に API を呼んで削除通知する", async () => {
+    const onCommentDeleted = jest.fn();
+    deleteCommentAPIMock.mockResolvedValue(undefined);
+
+    render(
+      <EditableComment
+        comment={createComment()}
+        currentUserId="user-1"
+        onCommentUpdated={() => undefined}
+        onCommentDeleted={onCommentDeleted}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "delete" }));
+    const deleteButtons = screen.getAllByRole("button", { name: "delete" });
+    fireEvent.click(deleteButtons[deleteButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(deleteCommentAPIMock).toHaveBeenCalledWith("comment-1", {
+        commentDeleteFailed: "commentDeleteFailed",
+      });
+      expect(onCommentDeleted).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test("削除 API 失敗時は toast を表示する", async () => {
+    deleteCommentAPIMock.mockRejectedValue(new Error("delete failed"));
+
+    render(
+      <EditableComment
+        comment={createComment()}
+        currentUserId="user-1"
+        onCommentUpdated={() => undefined}
+        onCommentDeleted={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "delete" }));
+    const deleteButtons = screen.getAllByRole("button", { name: "delete" });
+    fireEvent.click(deleteButtons[deleteButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith({
+        title: "errorTitle",
+        description: "delete failed",
+        variant: "destructive",
+      });
+    });
+  });
+
+  test("削除 API が Error 以外で失敗した場合は既定文言を表示する", async () => {
+    deleteCommentAPIMock.mockRejectedValue("unexpected");
+
+    render(
+      <EditableComment
+        comment={createComment()}
+        currentUserId="user-1"
+        onCommentUpdated={() => undefined}
+        onCommentDeleted={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "delete" }));
+    const deleteButtons = screen.getAllByRole("button", { name: "delete" });
+    fireEvent.click(deleteButtons[deleteButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith({
+        title: "errorTitle",
+        description: "commentDeleteFailed",
+        variant: "destructive",
+      });
+    });
+  });
+
+  test("英語ロケールでは匿名名のアバター付きコメントを表示する", () => {
+    useLocaleMock.mockReturnValue("en");
+
+    render(
+      <EditableComment
+        comment={createComment({
+          user_id: null,
+          user_nickname: "",
+          user_avatar_url: "https://cdn.example/avatar.png",
+        })}
+        currentUserId="viewer-1"
+        onCommentUpdated={() => undefined}
+        onCommentDeleted={() => undefined}
+      />,
+    );
+
+    expect(screen.getByRole("img", { name: "anonymousUser" })).toHaveAttribute(
+      "src",
+      "https://cdn.example/avatar.png",
+    );
+  });
+
+  test("残り文字数が 20 未満になると警告色で表示する", () => {
+    render(
+      <EditableComment
+        comment={createComment()}
+        currentUserId="user-1"
+        onCommentUpdated={() => undefined}
+        onCommentDeleted={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "edit" }));
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "x".repeat(181) },
+    });
+
+    expect(screen.getByText("remaining-19")).toHaveClass("text-red-500");
   });
 });

--- a/tests/unit/features/posts/editable-comment.test.tsx
+++ b/tests/unit/features/posts/editable-comment.test.tsx
@@ -1,0 +1,198 @@
+/** @jest-environment jsdom */
+
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useLocale, useTranslations } from "next-intl";
+import { EditableComment } from "@/features/posts/components/EditableComment";
+import type { ParentComment } from "@/features/posts/types";
+
+const updateCommentAPIMock = jest.fn();
+const deleteCommentAPIMock = jest.fn();
+const toastMock = jest.fn();
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: { src: string; alt: string }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img src={props.src} alt={props.alt} />
+  ),
+}));
+
+jest.mock("next-intl", () => ({
+  useLocale: jest.fn(),
+  useTranslations: jest.fn(),
+}));
+
+jest.mock("@/components/ui/use-toast", () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+jest.mock("@/features/posts/lib/api", () => ({
+  updateCommentAPI: (...args: unknown[]) => updateCommentAPIMock(...args),
+  deleteCommentAPI: (...args: unknown[]) => deleteCommentAPIMock(...args),
+}));
+
+jest.mock("@/features/posts/components/CollapsibleText", () => ({
+  CollapsibleText: ({ text }: { text: string }) => <span>{text}</span>,
+}));
+
+jest.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+jest.mock("@/components/ui/alert-dialog", () => ({
+  AlertDialog: ({
+    children,
+    open,
+  }: {
+    children: React.ReactNode;
+    open?: boolean;
+  }) => (
+    <div>{open ? children : null}</div>
+  ),
+  AlertDialogAction: ({ children }: { children: React.ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+  AlertDialogCancel: ({ children }: { children: React.ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+  AlertDialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogDescription: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogFooter: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogHeader: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+const useLocaleMock = useLocale as jest.MockedFunction<typeof useLocale>;
+const useTranslationsMock = useTranslations as jest.MockedFunction<
+  typeof useTranslations
+>;
+
+function createComment(overrides: Partial<ParentComment> = {}): ParentComment {
+  return {
+    id: "comment-1",
+    user_id: "user-1",
+    image_id: "post-1",
+    parent_comment_id: null,
+    content: "comment body",
+    created_at: "2026-04-17T00:00:00.000Z",
+    updated_at: "2026-04-17T00:00:00.000Z",
+    deleted_at: null,
+    user_nickname: "User",
+    user_avatar_url: null,
+    reply_count: 0,
+    last_activity_at: "2026-04-17T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("EditableComment", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 390,
+      writable: true,
+    });
+
+    useLocaleMock.mockReturnValue("ja");
+    useTranslationsMock.mockImplementation(() => {
+      return ((key: string) => key) as ReturnType<typeof useTranslations>;
+    });
+  });
+
+  test("選択可能なコメント領域に button semantics を付与する", () => {
+    render(
+      <EditableComment
+        comment={createComment()}
+        currentUserId="viewer-1"
+        onCommentUpdated={() => undefined}
+        onCommentDeleted={() => undefined}
+        onCommentSelected={() => undefined}
+      />,
+    );
+
+    const trigger = screen.getByRole("button");
+
+    expect(trigger).toHaveAttribute("tabindex", "0");
+  });
+
+  test("Enter キーで返信画面を開く", () => {
+    const onCommentSelected = jest.fn();
+
+    render(
+      <EditableComment
+        comment={createComment()}
+        currentUserId="viewer-1"
+        onCommentUpdated={() => undefined}
+        onCommentDeleted={() => undefined}
+        onCommentSelected={onCommentSelected}
+      />,
+    );
+
+    fireEvent.keyDown(screen.getByRole("button"), { key: "Enter" });
+
+    expect(onCommentSelected).toHaveBeenCalledTimes(1);
+  });
+
+  test("Space キーで返信画面を開く", () => {
+    const onCommentSelected = jest.fn();
+
+    render(
+      <EditableComment
+        comment={createComment()}
+        currentUserId="viewer-1"
+        onCommentUpdated={() => undefined}
+        onCommentDeleted={() => undefined}
+        onCommentSelected={onCommentSelected}
+      />,
+    );
+
+    fireEvent.keyDown(screen.getByRole("button"), { key: " " });
+
+    expect(onCommentSelected).toHaveBeenCalledTimes(1);
+  });
+
+  test("選択不可のコメント領域は button semantics を持たない", () => {
+    render(
+      <EditableComment
+        comment={createComment({ deleted_at: "2026-04-17T00:10:00.000Z" })}
+        currentUserId="viewer-1"
+        onCommentUpdated={() => undefined}
+        onCommentDeleted={() => undefined}
+      />,
+    );
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### 概要
`app/globals.css` を更新

### 変更内容
- `app/globals.css` を更新
- `app/globals.css`
- `features/posts/components/CommentItem.tsx`
- `features/posts/components/CommentList.tsx`
- `features/posts/components/CommentSection.tsx`
- `features/posts/components/EditableComment.tsx`
- `features/posts/components/ReplyPanel.tsx`
- `features/posts/components/ReplyPanelSkeleton.tsx`
- `features/posts/hooks/useReplies.ts`
- `tests/unit/features/posts/comment-item.test.tsx`
- `tests/unit/features/posts/comment-section.test.tsx`

### 実機テスト
- [ ] ブラウザで主要導線を操作し、対象機能が期待どおり完了すること
- [ ] バリデーションエラー条件を操作し、ユーザー向けエラーメッセージが表示されること
- [ ] PC（Chrome）/ iOS Safari / Android Chrome で表示崩れがないこと

### テスト方法
- 自動テスト: `npm test -- tests/unit/features/posts/comment-item.test.tsx tests/unit/features/posts/comment-section.test.tsx`

### テスト結果
- [x] 実行コマンド: `npm test -- tests/unit/features/posts/comment-item.test.tsx tests/unit/features/posts/comment-section.test.tsx`
- [x] Test Suites: 2 passed, 2 total
- [x] Tests:       4 passed, 4 total
- [x] failed のテスト項目: なし
