### PR TITLE
style画面に生成枚数カードを追加し4/15以降の累計を表示

### DIFF
--- a/app/(app)/style/page.tsx
+++ b/app/(app)/style/page.tsx
@@ -3,6 +3,7 @@ import { getLocale, getTranslations } from "next-intl/server";
 import { StylePageClient } from "@/features/style/components/StylePageClient";
 import { StylePageShareButton } from "@/features/style/components/StylePageShareButton";
 import { getPublishedStylePresets } from "@/features/style-presets/lib/get-public-style-presets";
+import { getTotalStyleGenerateCount } from "@/features/style/lib/style-usage-stats";
 import { DEFAULT_LOCALE, isLocale } from "@/i18n/config";
 import { getUser } from "@/lib/auth";
 import { createMarketingPageMetadata } from "@/lib/metadata";
@@ -49,11 +50,29 @@ export default async function StylePage({ searchParams }: StylePageProps) {
   const presets = await getPublishedStylePresets();
   const user = await getUser();
   const params = (await searchParams) ?? {};
+  const totalGenerationCount = await getTotalStyleGenerateCount().catch(
+    () => null
+  );
 
   return (
     <div className="min-h-screen bg-gray-50">
       <div className="px-4 pb-8 pt-6 md:pb-10 md:pt-8">
         <div className="mx-auto max-w-3xl space-y-8">
+          {typeof totalGenerationCount === "number" &&
+          totalGenerationCount > 0 ? (
+            <div
+              data-testid="style-total-generation-count"
+              className="relative overflow-hidden rounded-xl border border-[#B7BDC6] bg-[linear-gradient(135deg,#F9FBFF_0%,#E6F0FF_20%,#E5E4E2_45%,#CBD6E3_70%,#FFFFFF_100%)] px-4 py-3 text-center shadow-[0_0_12px_rgba(216,235,255,0.8),0_0_28px_rgba(216,235,255,0.45)] transition-shadow hover:shadow-[0_0_16px_rgba(216,235,255,0.9),0_0_32px_rgba(216,235,255,0.6)]"
+            >
+              <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(110deg,transparent,45%,#D8EBFF,55%,transparent)] bg-[length:250%_100%] animate-shine opacity-60 mix-blend-overlay" />
+              <span className="relative z-10 block text-sm font-semibold text-slate-900">
+                {t("totalGenerationCount", {
+                  count: totalGenerationCount.toLocaleString(),
+                })}
+              </span>
+            </div>
+          ) : null}
+
           <div className="space-y-2">
             <div className="flex items-start justify-between gap-3">
               <h1 className="text-3xl font-bold text-gray-900">

--- a/features/style/lib/style-usage-stats.ts
+++ b/features/style/lib/style-usage-stats.ts
@@ -1,0 +1,32 @@
+import "server-only";
+
+import { cacheLife, cacheTag } from "next/cache";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export const STYLE_USAGE_STATS_CACHE_TAG = "style-usage-stats";
+export const STYLE_TOTAL_GENERATION_COUNT_START_AT =
+  "2026-04-15T00:00:00+09:00";
+
+async function fetchTotalStyleGenerateCount(): Promise<number> {
+  const supabase = createAdminClient();
+
+  const { count, error } = await supabase
+    .from("style_usage_events")
+    .select("*", { count: "exact", head: true })
+    .eq("event_type", "generate")
+    .gte("created_at", STYLE_TOTAL_GENERATION_COUNT_START_AT);
+
+  if (error) {
+    throw error;
+  }
+
+  return count ?? 0;
+}
+
+export async function getTotalStyleGenerateCount(): Promise<number> {
+  "use cache";
+  cacheTag(STYLE_USAGE_STATS_CACHE_TAG);
+  cacheLife("minutes");
+
+  return fetchTotalStyleGenerateCount();
+}

--- a/messages/en.ts
+++ b/messages/en.ts
@@ -1057,6 +1057,7 @@ export const enMessages = {
     pageTitle: "One-Tap Style",
     pageDescription:
       "No prompt needed. Pick a style and transform your look in one tap.",
+    totalGenerationCount: "{count} images have been generated so far!",
     sectionTitle: "Choose a Style",
     sectionDescription: "Select the style you want to try on.",
     characterSectionTitle: "Choose My Character",

--- a/messages/ja.ts
+++ b/messages/ja.ts
@@ -1002,6 +1002,7 @@ export const jaMessages = {
     pageTitle: "One-Tap Style",
     pageDescription:
       "プロンプト不要！好きなスタイルを選択するだけで、そのスタイルに変身！！",
+    totalGenerationCount: "これまでに生成された枚数 {count} 枚！",
     sectionTitle: "スタイル選択",
     sectionDescription: "着せ替えたいスタイルを選択してください。",
     characterSectionTitle: "マイキャラ選択",


### PR DESCRIPTION
### 概要
/style 画面に生成枚数カードを追加し、4/15以降の累計件数が分かるようにしました。

### 変更内容
- `style_usage_events` の `generate` を 2026-04-15 00:00 JST 以降で集計するサーバー側ヘルパーを追加
- `/style` に生成枚数カードを追加し、`/thanks-sample` の Platinum Supporter カードに寄せたシャイン演出を適用
- 生成枚数カードの文言を i18n に追加

### 実機テスト
- [ ] iOS Safari で主要導線を確認
- [ ] Android Chrome で主要導線を確認
- [ ] PC（Chrome）で主要導線を確認
- [ ] レスポンシブ表示崩れがないことを確認
- [ ] エラーメッセージやバリデーション表示を確認

### テスト方法
- [x] `npm run lint -- app/(app)/style/page.tsx messages/ja.ts messages/en.ts features/style/lib/style-usage-stats.ts`
- [ ] `npm run typecheck` は既存のテスト型エラーにより未通過