### PR TITLE
fix: claude-issue-to-pr.yml に必須ツールの明示的許可を追加

### DIFF
--- a/.github/workflows/claude-issue-to-pr.yml
+++ b/.github/workflows/claude-issue-to-pr.yml
@@ -46,6 +46,7 @@ jobs:
 
           claude_args: |
             --max-turns 40
+            --allowedTools Edit,Read,Write,Bash,Glob,Grep,MultiEdit,WebFetch
 
           prompt: |
             あなたは ai_coordinate (Persta.AI) の自律開発エージェントです。


### PR DESCRIPTION
### 概要
Issue #223 の試運転で自動実装が早期失敗した原因を修正する。
claude-code-action v1 のデフォルトでは Bash / Edit などのツールが無効のため、
`claude_args` に `--allowedTools` を追加して自動実装に必要なツールを明示的に許可する。

### 変更内容
- `.github/workflows/claude-issue-to-pr.yml` の `claude_args` に `--allowedTools Edit,Read,Write,Bash,Glob,Grep,MultiEdit,WebFetch` を追加

### 実機テスト
- [ ] マージ後、新しい試運転 Issue を起票して、Claude が実装・Draft PR 作成まで実行できることを確認
- [ ] `permission_denials_count` が 0 または少数であることをログで確認

### テスト方法
- YAML 構文は GitHub Actions が自動検証
- 動作確認はマージ後に試運転で実施

### 背景
Issue #223 の実行ログより:
- `permission_denials_count: 3` (権限拒否が発生)
- `duration_ms: 23810` (約24秒で早期終了、実装が進まなかった)
- `No buffered inline comments` (作業成果物なし)

claude-code-action 公式ドキュメントで確認した通り、Bash は明示的に `allowed_tools` で許可する必要がある仕様。
参考: https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md

### レビューで特に見てほしい点
- 許可するツールのリストに**過不足がないか**
- 特に Write/WebFetch の必要性(あっても困らないが、最小化すべきか)
- セキュリティ上の懸念(Bash 許可が広すぎないか)