### PR TITLE
chore(workflow): claude-code-review の --max-turns を 15→25 に引き上げ

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -50,4 +50,4 @@ jobs:
             - 良い実装も褒める
             - 問題がなければ「LGTM」と承認
           claude_args: |
-            --max-turns 15
+            --max-turns 25


### PR DESCRIPTION
## Summary
- `.github/workflows/claude-code-review.yml` の `--max-turns` を 15 → 25 に引き上げ。
- PR #230 で `claude-review` が `Reached maximum number of turns (15)` で失敗したのを受けた対症療法。

## 背景
- ワークフローのプロンプトはレビュー前に **CLAUDE.md / AGENTS.md / docs/architecture/ ディレクトリ全体 (3 ファイル) / docs/development/project-conventions.md** の必読を要求している
- ファイル読みだけで 6〜7 ターン消費するため、レビュー本体のターン予算が枯渇しやすい
- 25 ターンに緩めることで、必読ドキュメントを読んだ上でも一般的な PR のレビューが完走することを狙う

## Test plan
- [ ] このPR自体で claude-review が完走するかを確認
- [ ] コスト増(15→25 で最大 +66%)を許容範囲として観察。問題があれば次の改善(プロンプト軽量化や条件分岐スキップ)を別PRで検討

🤖 Generated with [Claude Code](https://claude.com/claude-code)