### PR TITLE
feat(posts): Post 詳細画面に生成モデル名と画像サイズを表示する

### DIFF
--- a/.cursor/rules/database-design.mdc
+++ b/.cursor/rules/database-design.mdc
@@ -130,9 +130,9 @@ alwaysApply: false
 
 #### `generated_images`
 - 主キー: `id`
-- 主要カラム: `user_id`, `image_url`, `storage_path`, `prompt`, `background_change`, `is_posted`, `caption`, `posted_at`, `created_at`, `view_count`, `generation_type`, `input_images`, `generation_metadata`, `source_image_stock_id`, `aspect_ratio`, `model`, `storage_path_display`, `storage_path_thumb`, `moderation_status`, `moderation_reason`, `moderation_updated_at`, `moderation_approved_at`, `background_mode`
+- 主要カラム: `user_id`, `image_url`, `storage_path`, `prompt`, `background_change`, `is_posted`, `caption`, `posted_at`, `created_at`, `view_count`, `generation_type`, `input_images`, `generation_metadata`, `source_image_stock_id`, `aspect_ratio`, `width`, `height`, `model`, `storage_path_display`, `storage_path_thumb`, `moderation_status`, `moderation_reason`, `moderation_updated_at`, `moderation_approved_at`, `background_mode`
 - 外部キー: `user_id -> auth.users.id`, `source_image_stock_id -> source_image_stocks.id`
-- 備考: `generation_type` は `coordinate/specified_coordinate/full_body/chibi/one_tap_style`、`moderation_status` は `visible/pending/removed`、`model` は `gemini-2.5-flash-image` の履歴値に加えて `gemini-3.1-flash-image-preview-512` / `gemini-3.1-flash-image-preview-1024` / `gemini-3-pro-image-1k` / `gemini-3-pro-image-2k` / `gemini-3-pro-image-4k` / `gpt-image-2-low` を保持する
+- 備考: `generation_type` は `coordinate/specified_coordinate/full_body/chibi/one_tap_style`、`moderation_status` は `visible/pending/removed`、`model` は `gemini-2.5-flash-image` の履歴値に加えて `gemini-3.1-flash-image-preview-512` / `gemini-3.1-flash-image-preview-1024` / `gemini-3-pro-image-1k` / `gemini-3-pro-image-2k` / `gemini-3-pro-image-4k` / `gpt-image-2-low` を保持する。`width` / `height` は画像実寸（INT、`> 0` の CHECK 制約、NULL 許容）で、Post 詳細画面のサイズ表示用に server-api の lazy compute で fetch 時に保存される
 - RLS: 投稿済みかつ `visible` の画像は公開、それ以外は本人のみ。`INSERT/UPDATE/DELETE` は本人のみ
 
 #### `source_image_stocks`

--- a/app/api/generation-status/route.ts
+++ b/app/api/generation-status/route.ts
@@ -1,50 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getUser } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
-import {
-  isInvalidGeminiArgumentErrorMessage,
-  isMalformedGeminiPartsErrorMessage,
-  isOpenAIProviderErrorMessage,
-  isSafetyPolicyBlockedErrorMessage,
-} from "@/shared/generation/errors";
 import { jsonError } from "@/lib/api/json-error";
 import { getRouteLocale } from "@/lib/api/route-locale";
 import { getGenerationRouteCopy } from "@/features/generation/lib/route-copy";
-
-// 単体テスト容易化のため named export として公開する。
-// 詳細は tests/unit/app/api/generation-status/normalize-error.test.ts 参照。
-export function normalizeUserFacingGenerationError(
-  status: string,
-  errorMessage: string | null,
-  copy: ReturnType<typeof getGenerationRouteCopy>
-): string | null {
-  if (status !== "failed" || !errorMessage) return errorMessage;
-
-  if (errorMessage === "No images generated") {
-    return copy.noImagesGenerated;
-  }
-
-  if (isSafetyPolicyBlockedErrorMessage(errorMessage)) {
-    return copy.safetyBlocked;
-  }
-
-  if (isMalformedGeminiPartsErrorMessage(errorMessage)) {
-    return copy.genericGenerationFailed;
-  }
-
-  if (isInvalidGeminiArgumentErrorMessage(errorMessage)) {
-    return copy.genericGenerationFailed;
-  }
-
-  // OpenAI 側の非リトライ系エラー（組織未検証 / API key 不正 / 残高不足 /
-  // 401・403 / GIF 拒否 / OPENAI_API_KEY 未設定）は upstream の生メッセージを
-  // 表に出さず汎用文言に差し替える。詳細は Edge Function ログ参照。
-  if (isOpenAIProviderErrorMessage(errorMessage)) {
-    return copy.genericGenerationFailed;
-  }
-
-  return errorMessage;
-}
+import { normalizeUserFacingGenerationError } from "@/features/generation/lib/normalize-generation-error";
 
 function deriveImageUrls(
   status: string,

--- a/docs/planning/post-detail-model-and-size-display-plan.md
+++ b/docs/planning/post-detail-model-and-size-display-plan.md
@@ -1,0 +1,505 @@
+# Post 詳細画面に生成モデル名と画像サイズを表示する 実装計画
+
+## Context
+
+コーディネート画像の生成モデルが Nano Banana 2 / Nano Banana Pro / ChatGPT Images 2.0 の 3 系統に増えたため、Post 詳細画面でどのモデルで生成された画像かを視認できるようにする。同時に画像の実寸（例: `1024×1536`）も併記してリファレンスとしての価値を高める。
+
+新しく `width`/`height` 列を追加して画像の実寸を保存できるようにする。ただし本 PR では互換性を優先し、既存の `aspect_ratio` / `background_change` 列は削除しない。列削除は、`width`/`height` の backfill と運用確認が完了した後の別 PR で検討する。
+
+### 表示要件
+- **表示位置**: 既存のプロンプトブロックの直前
+- **表示フォーマット**: `ChatGPT Images 2.0 / 1024×1536`（ラベルなし、スラッシュ区切り）
+- **表示範囲**: 自分以外の投稿を含めて全公開投稿で表示（誰でも見える）
+- **対象画面**: 2 つの Post 詳細コンポーネント（`PostDetail.tsx` と `PostDetailStatic.tsx`）。`PostDetailContent.tsx` は `PostDetailStatic.tsx` のラッパーなので変更不要
+- **データ取得**: 既存の `aspect_ratio` の lazy compute パターンを参考に、`width`/`height` をサーバー側で算出する。通常の `getPost` では best-effort で DB に保存し、`use cache` 経由ではレスポンス用に算出するが DB UPDATE は行わない
+- **既存行のフォールバック**: `width`/`height` が NULL の場合は **モデル名のみ** 表示（推定値は出さない）
+- **既存列の互換維持**: `aspect_ratio` / `background_change` の読み書きは本 PR では維持し、既存の生成経路・表示経路を壊さない
+
+### DB 互換方針
+本 PR では DB 列削除を行わない。
+
+1. **`width` / `height`** (`generated_images`): 新規追加。NULL 許容。取得できた行から順次保存する
+2. **`aspect_ratio`** (`generated_images`): 互換期間として維持。既存 UI のフレーム切替はこの値を優先し、`width`/`height` がある場合のみ派生値を fallback として使える
+3. **`background_change`** (`generated_images` / `image_jobs`): 互換期間として維持。既存の INSERT 経路と worker の `resolveBackgroundMode` fallback を壊さない
+
+将来の列削除 PR では、少なくとも以下を完了条件にする:
+- `width`/`height` の backfill と取得失敗行の棚卸し
+- `aspect_ratio` 参照箇所の完全除去
+- `background_change` を書く全 route / Edge Function / tests の完全移行
+- migration 先行・アプリ先行のどちらでも本番導線が壊れないデプロイ手順の確認
+
+## コードベース調査結果
+
+### 現状の DB スキーマ抜粋（本 PR 関連分のみ）
+- `model TEXT` — モデル ID（display 対象）
+- `aspect_ratio TEXT CHECK ('portrait' | 'landscape' | NULL)` — 既存互換のため維持
+- `background_change BOOLEAN` — 既存互換のため維持
+- `background_mode TEXT NOT NULL DEFAULT 'keep'` — `background_change` の上位互換、保持
+- `width INT` / `height INT` — **新規追加**
+
+### 重要な参照箇所
+
+- **Post 型**: [features/posts/types.ts:22](features/posts/types.ts#L22) `Post extends GeneratedImageRecord`
+- **元レコード型**: [features/generation/lib/database.ts:8-43](features/generation/lib/database.ts#L8-L43) — `aspect_ratio?` `background_change` を維持し、`width?` `height?` を追加する
+- **Lazy compute 既存パターン**: [features/posts/lib/server-api.ts:747-777](features/posts/lib/server-api.ts#L747-L777) — `aspect_ratio` を fetch 時に計算 + UPDATE
+- **寸法解析ヘルパー**: [features/posts/lib/utils.ts:227](features/posts/lib/utils.ts#L227) `getImageDimensions(imageUrl)` — Range fetch + PNG/JPEG/WebP ヘッダーパース
+- **Edge Function INSERT**: [supabase/functions/image-gen-worker/index.ts:1865-1881](supabase/functions/image-gen-worker/index.ts#L1865-L1881) — 本 PR では変更不要（`background_change` は維持）
+- **Next.js handler INSERT**: `app/api/generate-async/handler.ts` の `image_jobs` INSERT は本 PR では変更不要（`background_change` は維持）
+- **Post 詳細 UI**:
+  - [features/posts/components/PostDetail.tsx:286-318](features/posts/components/PostDetail.tsx#L286-L318) — クライアント版
+  - [features/posts/components/PostDetailStatic.tsx:158-330](features/posts/components/PostDetailStatic.tsx#L158-L330) — SSR 版、`imageAspectRatio` で CSS 切替
+  - [features/posts/components/PostDetailContent.tsx:63-86](features/posts/components/PostDetailContent.tsx#L63-L86) — `PostDetailStatic` のラッパー（変更不要）
+  - [features/posts/components/CachedPostDetail.tsx:38-48](features/posts/components/CachedPostDetail.tsx#L38-L48) — `post.aspect_ratio` を読んで `imageAspectRatio` に渡す
+- **`background_change` 読み取り**: [features/my-page/components/ImageDetailPageClient.tsx:34](features/my-page/components/ImageDetailPageClient.tsx#L34) で fallback として `image.background_change` を読んでいる。本 PR では維持
+- **既存ブランド名**: [messages/ja.ts:670-675](messages/ja.ts#L670-L675), [messages/en.ts:695-702](messages/en.ts#L695-L702) — モデル選択 dropdown に既出
+- **既存 migration 参考**: `supabase/migrations/20251212065229_add_aspect_ratio_to_generated_images.sql`、`supabase/migrations/20260222133000_add_background_mode_to_generation_tables.sql`
+- **RLS**: `generated_images` は本人 + visible 公開の混合 RLS。本 PR で変更不要
+- **入力境界の変換 helper**（**本 PR では触らない**、別議論）:
+  - `shared/generation/prompt-core.ts` の `backgroundChangeToBackgroundMode` / `backgroundModeToBackgroundChange` / `resolveBackgroundMode`
+  - `features/generation/lib/schema.ts` の zod 入力 `backgroundChange?` フィールド
+  - `features/style/components/StylePageClient.tsx` の boolean トグル UI 状態
+  - `features/generation/lib/nanobanana.ts` / `async-api.ts` の boolean 引数
+
+これらは **リクエスト境界での入力変換**（フロント form の boolean → 内部 backgroundMode）であり、本 PR の表示追加とは独立。列削除や UI 改修は別議論。
+
+---
+
+## 1. 概要図
+
+### データモデル変更（追加のみ）
+
+```mermaid
+erDiagram
+    generated_images {
+        uuid id PK
+        uuid user_id FK
+        text image_url
+        text model
+        text aspect_ratio "既存維持"
+        boolean background_change "既存維持"
+        text background_mode "NOT NULL DEFAULT keep"
+        int width "新規 NULL 許容"
+        int height "新規 NULL 許容"
+        timestamp created_at
+    }
+
+    image_jobs {
+        uuid id PK
+        text background_mode "NOT NULL DEFAULT keep"
+        boolean background_change "既存維持"
+    }
+```
+
+### width/height の状態遷移
+
+```mermaid
+stateDiagram-v2
+    [*] --> NotComputed: 新規 INSERT 直後 NULL
+    NotComputed --> Computed: server-api 経由 fetch で解析成功
+    NotComputed --> ParseFailed: ヘッダー取得 解析失敗
+    ParseFailed --> NotComputed: 次回 fetch で再試行
+    Computed --> Persisted: 非 cache 経路なら DB UPDATE
+    Computed --> ResponseOnly: use cache 経路ならレスポンスのみ
+    Persisted --> [*]: 以降 DB 値から表示
+    ResponseOnly --> [*]: 同一レスポンスではサイズ表示
+```
+
+### Lazy compute シーケンス
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant P as PostsPage
+    participant S as ServerApi
+    participant DB as Supabase
+    participant I as ImageStorage
+
+    U->>P: GET /posts/abc
+    P->>S: getPost id
+    S->>DB: SELECT generated_images WHERE id
+    DB-->>S: row width height NULL の可能性
+    alt width または height が NULL
+        S->>I: GET image_url Range bytes 0-65535
+        I-->>S: header bytes
+        S->>S: parseImageDimensions PNG JPEG WebP
+        alt non cache
+            S->>DB: UPDATE width height
+        else use cache
+            S->>S: response only
+        end
+    end
+    S-->>P: post with width height brand
+    Note over P: imageAspectRatio は aspect_ratio 優先 fallback で width height
+    P-->>U: 詳細ページ描画 モデル名 サイズ
+```
+
+### Provider 識別
+
+```mermaid
+flowchart LR
+    M["model column"] --> C{"getModelBrandName"}
+    C -->|"prefix gpt-image-"| G["ChatGPT Images 2.0"]
+    C -->|"prefix gemini-3-pro-image-"| H["Nano Banana Pro"]
+    C -->|"prefix gemini-3.1-flash-image-"| L["Nano Banana 2"]
+    C -->|"gemini-2.5-flash-image"| L
+    C -->|"その他 / null"| N["null 何も表示しない"]
+```
+
+---
+
+## 2. EARS 要件定義
+
+### 表示系
+
+#### EV-1 ブランド名表示
+- **EN**: When a user opens a post detail page where `getModelBrandName(post.model)` returns a non-null brand name, the system shall render the brand name above the prompt block in both `PostDetail.tsx` and `PostDetailStatic.tsx`.
+- **JA**: ユーザーが Post 詳細を開き、`getModelBrandName(post.model)` が non-null のブランド名を返したとき、システムは `PostDetail.tsx` と `PostDetailStatic.tsx` の両方でプロンプトブロックの直前にブランド名を描画する。
+
+#### EV-2 サイズ付加
+- **EN**: When `post.width` and `post.height` are both non-null positive integers, the system shall append ` / WIDTHxHEIGHT` (using the × multiplication sign) to the brand name, producing strings like `ChatGPT Images 2.0 / 1024×1536`.
+- **JA**: `post.width` と `post.height` の両方が non-null かつ正の整数のとき、システムはブランド名の右に ` / WIDTHxHEIGHT`（× は乗算記号）を連結し、`ChatGPT Images 2.0 / 1024×1536` のような文字列を生成する。
+
+#### EV-3 公開可視性
+- **EN**: Where the post is publicly viewable (`moderation_status='visible'` and `is_posted=true`), the model/size display shall also be visible to other users.
+- **JA**: 公開投稿の場合、モデル/サイズ表示は本人だけでなく他ユーザーにも表示する。
+
+### Lazy compute 系
+
+#### EV-4 width/height の lazy compute
+- **EN**: When `getPost` retrieves a row whose `width` or `height` is null and a display image URL can be resolved from `image_url` or `storage_path`, the system shall fetch the image header (Range bytes 0-65535), parse PNG / JPEG / WebP dimensions, and best-effort UPDATE the row with `width` and `height`. While `getPost` is invoked with `useCache=true`, the system shall compute dimensions for the response but shall not issue the UPDATE.
+- **JA**: `getPost` が取得した行の `width` または `height` が null で、`image_url` または `storage_path` から表示用画像 URL を解決できるとき、システムは画像ヘッダー（Range bytes 0-65535）を取得して PNG / JPEG / WebP の寸法を解析し、`width` と `height` で行を最善努力で UPDATE する。ただし `getPost` が `useCache=true` で呼ばれている間は、レスポンス用に寸法を計算するが UPDATE は実行しない。
+
+#### EV-5 imageAspectRatio の互換維持
+- **EN**: When the page assembles the `imageAspectRatio` prop for `PostDetail*`, the system shall keep using the existing `aspect_ratio` value first, and may derive a fallback from `(width, height)` only when `aspect_ratio` is null.
+- **JA**: ページが `PostDetail*` 系の `imageAspectRatio` prop を組み立てるとき、システムは既存の `aspect_ratio` を優先し、`aspect_ratio` が null の場合に限って `(width, height)` から fallback 派生してよい。
+
+### 整合性 / 互換系
+
+#### ST-1 既存 RLS との整合
+- **EN**: While reading or updating `generated_images`, the system shall use the existing RLS policies without modification.
+- **JA**: `generated_images` の読み書きにおいて、システムは既存の RLS ポリシーを変更せず使用する。
+
+#### ST-2 background_change の互換維持
+- **EN**: While this PR is deployed, the system shall keep existing `background_change` reads and writes so that current generation routes and the Edge Function remain compatible.
+- **JA**: 本 PR の導入中、システムは既存の `background_change` 読み書きを維持し、現行の生成 route と Edge Function の互換性を保つ。
+
+#### IF-1 寸法解析失敗
+- **EN**: If image header fetch or dimension parsing fails, then the system shall log a warning, leave `width` and `height` as null, and continue rendering with brand-name-only.
+- **JA**: 画像ヘッダー取得または寸法解析が失敗したとき、システムは warning ログを出し、`width` と `height` を null のままにし、ブランド名のみで描画を続行する。
+
+#### IF-2 ブランド名未認識
+- **EN**: If `getModelBrandName(model)` returns null, then the system shall not render the model/size block at all.
+- **JA**: `getModelBrandName(model)` が null を返した場合、システムはモデル/サイズブロック自体を描画しない。
+
+#### IF-3 useCache モード
+- **EN**: While `getPost` is invoked with `useCache=true`, the system shall compute width/height for the response but shall NOT issue a DB UPDATE.
+- **JA**: `getPost` が `useCache=true` で呼ばれている間、システムはレスポンス用に width/height を計算するが DB UPDATE は実行しない。
+
+---
+
+## 3. ADR
+
+### ADR-001: lazy compute（既存 aspect_ratio パターン）を踏襲
+- **Context**: 新規生成画像に width/height を保存する必要があるが、Edge Function に書き込み処理を追加するか、fetch 時 lazy compute するかの 2 案
+- **Decision**: lazy compute（既存 `aspect_ratio` パターンを参考にしつつ、`use cache` 経路では DB UPDATE しない）
+- **Reason**: Edge Function の生成処理に手を入れず、既存行にも段階的に対応できる。`use cache` 内の書き込みを避けられる
+- **Consequence**: width/height 未保存行の初回表示時に Range fetch のレイテンシが追加される。DB への永続化は非 cache 経路または将来の backfill に依存する
+
+### ADR-002: ブランド名はプレフィックスベースで判定
+- **Context**: `model` から `getModelBrandName` で表示用ブランドを導出
+- **Decision**: `startsWith` プレフィックス判定 + `gemini-2.5-flash-image` の例外マッチ
+- **Reason**: 新モデル ID 追加時にヘルパー 1 行追加だけで済む
+- **Consequence**: 未知プレフィックスは null（非表示）
+
+### ADR-003: 表示フォーマットは `Brand / WxH` のラベルなし
+- **Context**: ラベル付き / ラベルなしの選択
+- **Decision**: ラベルなしの簡潔表記 `ChatGPT Images 2.0 / 1024×1536`
+- **Reason**: ユーザーの選択。視認性・スペース効率
+- **Consequence**: 何の値かが文脈依存。`aria-label` で a11y 補強
+
+### ADR-004: width/height NULL 行はモデル名のみ表示
+- **Context**: lazy compute 前 / 解析失敗時の表示
+- **Decision**: width/height 両方 non-null のときのみ ` / WxH` 付与
+- **Reason**: ユーザーの選択。推定値を出さない
+- **Consequence**: 寸法解析に失敗した行はブランド名のみ表示される。解析に成功した行は同一レスポンスでサイズも表示され、非 cache 経路では以後 DB 値から表示される
+
+### ADR-005: 表示部品は共通コンポーネント化
+- **Context**: 2 つの Post 詳細コンポーネントに同じ表示を入れる
+- **Decision**: `features/posts/components/PostMetaLine.tsx` を新規作成
+- **Reason**: DRY、変更時の漏れ防止
+- **Consequence**: 1 ファイル増えるがロジック重複が解消
+
+### ADR-006: aspect_ratio 列は互換期間として維持
+- **Context**: `width`/`height` が揃えば `aspect_ratio` は派生可能だが、既存行にはまだ寸法が保存されておらず、画像取得不能な行では復元できない可能性がある
+- **Decision**: 本 PR では `aspect_ratio` を削除しない。既存のフレーム切替は `aspect_ratio` を優先し、`width`/`height` は表示と fallback に使う
+- **Reason**: migration 先行・アプリ先行の破壊リスクを避ける。既存行のデータロスを発生させない
+- **Consequence**: 一時的に `aspect_ratio` と `width`/`height` が併存する。将来の backfill / 参照除去 PR で整理する
+
+### ADR-007: background_change 列は互換期間として維持
+- **Context**: `background_change` は `background_mode` の互換列として残っており、Next.js route、style async route、Edge Function、テストが現在も参照している
+- **Decision**: 本 PR では `image_jobs` / `generated_images` の `background_change` を削除しない。既存の INSERT と worker fallback も維持する
+- **Reason**: 表示機能の追加と背景設定列の廃止を同時に行うと blast radius が大きい。特に migration 先行で生成導線が壊れる
+- **Consequence**: `background_change` 廃止 TODO は残る。別 PR で全参照移行、互換 migration、削除 migration を段階的に行う
+
+### ADR-008: 表示部品は公開可視性
+- **Context**: プロンプトはユーザーによっては本人のみ閲覧可能（マスク）。モデル名・サイズも同様にすべきか
+- **Decision**: モデル名・サイズは公開
+- **Reason**: モデル名・サイズはセンシティブ情報を含まず、他ユーザーにとってリファレンス価値がある
+- **Consequence**: 既存のプロンプトマスク（`getVisiblePrompt`）とは独立した表示制御
+
+---
+
+## 4. 実装計画
+
+### フェーズ間の依存関係
+
+```mermaid
+flowchart LR
+    P1["P1 DB migration width height 追加"] --> P2["P2 型 整理"]
+    P2 --> P3["P3 server-api width height lazy compute"]
+    P2 --> P4["P4 brand name helper"]
+    P3 --> P5["P5 PostMetaLine 統合"]
+    P4 --> P5
+    P5 --> P6["P6 i18n テスト"]
+    P6 --> P7["P7 検証"]
+```
+
+### Phase 1: DB マイグレーション
+**目的**: `width INT` / `height INT` を追加する。既存列は削除しない
+**ビルド確認**: ローカル Supabase で migration apply できる
+
+- [ ] `supabase/migrations/<timestamp>_add_generated_image_dimensions.sql` 作成
+  - **追加**:
+    - `ALTER TABLE public.generated_images ADD COLUMN width INT NULL CHECK (width IS NULL OR width > 0);`
+    - `ALTER TABLE public.generated_images ADD COLUMN height INT NULL CHECK (height IS NULL OR height > 0);`
+  - **削除しない**:
+    - `generated_images.aspect_ratio`
+    - `generated_images.background_change`
+    - `image_jobs.background_change`
+- [ ] ローカル apply 確認
+
+### Phase 2: 型整理
+**目的**: アプリ層に `width` / `height` を追加し、既存列は互換維持する
+**ビルド確認**: `npm run typecheck` pass
+
+- [ ] [features/generation/lib/database.ts](features/generation/lib/database.ts)
+  - `width?: number | null;` と `height?: number | null;` を追加
+  - `aspect_ratio?` と `background_change` は削除しない
+- [ ] [features/generation/lib/job-types.ts](features/generation/lib/job-types.ts)
+  - 本 PR では変更不要。`background_change` は互換維持
+- [ ] `Post` (extends GeneratedImageRecord) は自動継承
+
+### Phase 3: server-api に width/height lazy compute を追加
+**目的**: 既存 `aspect_ratio` lazy compute を維持しつつ、`width`/`height` の lazy compute を追加する
+**ビルド確認**: typecheck pass + 既存 generation テスト pass
+
+- [ ] [features/posts/lib/server-api.ts:747-814](features/posts/lib/server-api.ts#L747-L814) を改修
+  - `data.aspect_ratio` 参照と既存 UPDATE は維持
+  - `width` または `height` が NULL の場合に、`data.image_url` または `data.storage_path` から表示用画像 URL を解決して `getImageDimensions(imageUrl)` を呼ぶ
+  - 取得した `{ width, height }` を行に追加
+  - DB UPDATE は `width` と `height` を更新。`aspect_ratio` が NULL の場合は既存互換として `aspect_ratio` も更新してよい
+  - 失敗時は warn ログ + `null` 維持
+  - `useCache` モードでは DB UPDATE をスキップし、レスポンス用の `width` / `height` のみセットする
+  - 戻り値の `width` / `height` を Post に含める
+
+### Phase 4: ブランド名ヘルパー
+**目的**: モデル ID → ブランド名の単一情報源
+**ビルド確認**: 新規ヘルパーテスト pass
+
+- [ ] **NEW** `features/generation/lib/model-display.ts` 作成
+  - `export function getModelBrandName(model: string | null | undefined): string | null`
+  - 判定:
+    - `startsWith('gpt-image-')` → `"ChatGPT Images 2.0"`
+    - `startsWith('gemini-3-pro-image-')` → `"Nano Banana Pro"`
+    - `startsWith('gemini-3.1-flash-image-')` または `=== 'gemini-2.5-flash-image'` → `"Nano Banana 2"`
+    - その他 → `null`
+- [ ] **NEW** `tests/unit/features/generation/model-display.test.ts` 作成
+  - 各プレフィックス・null/undefined・空文字列・未知 ID
+
+### Phase 5: PostMetaLine 部品 + 詳細画面統合
+**目的**: 表示部品を 2 詳細コンポーネントに統合する。imageAspectRatio は互換維持
+**ビルド確認**: `npm run lint && npm run typecheck && npm run build -- --webpack` pass
+
+- [ ] **NEW** `features/posts/components/PostMetaLine.tsx` 作成
+  - props: `{ model: string | null; width: number | null; height: number | null }`
+  - `getModelBrandName(model)` が null なら `return null`
+  - width && height があれば `${brand} / ${width}×${height}`、なければ `${brand}` のみ
+  - `aria-label`: `t("metaModelLabel"): brand[, t("metaSizeLabel"): WxH]`
+- [ ] [features/posts/components/CachedPostDetail.tsx:38-48](features/posts/components/CachedPostDetail.tsx#L38-L48) を改修
+  - `post.aspect_ratio` 参照は維持
+  - `post.aspect_ratio` が NULL で `post.width` / `post.height` が揃う場合のみ fallback として派生（`height > width ? 'portrait' : 'landscape'`）
+  - 派生 helper を新規 export（例: `features/posts/lib/utils.ts` の `deriveAspectRatioFromDimensions`）
+- [ ] [features/posts/components/PostDetail.tsx:286 直前](features/posts/components/PostDetail.tsx#L286)
+  - プロンプトブロックの直前に `<PostMetaLine model={post.model ?? null} width={post.width ?? null} height={post.height ?? null} />`
+  - クライアント側 `setImageAspectRatio` の `<img>.onLoad` 計算は維持（DB 値が無い時のフォールバック）
+- [ ] [features/posts/components/PostDetailStatic.tsx:330 直前](features/posts/components/PostDetailStatic.tsx#L330)
+  - 同様の挿入
+  - `imageAspectRatio` prop 自体は維持（呼び出し元 `CachedPostDetail` から派生値を受け取る）
+
+### Phase 6: i18n + テスト整理
+**目的**: aria-label 用 i18n + 新規表示・寸法算出のテスト追加
+**ビルド確認**: 新規テスト pass + 既存テスト全 pass
+
+- [ ] [messages/ja.ts](messages/ja.ts) の `posts` 名前空間に追加:
+  - `metaModelLabel: "生成モデル"`
+  - `metaSizeLabel: "サイズ"`
+- [ ] [messages/en.ts](messages/en.ts) に同様:
+  - `metaModelLabel: "Generation model"`
+  - `metaSizeLabel: "Size"`
+- [ ] **NEW** `tests/unit/features/posts/post-meta-line.test.tsx`
+  - ブランド名 + サイズ表示
+  - ブランド名のみ（width/height NULL）
+  - 何も描画しない（model NULL / 未知）
+  - aria-label の付与確認
+- [ ] [tests/unit/features/posts/post-detail.test.tsx](tests/unit/features/posts/post-detail.test.tsx) を必要に応じて更新
+  - `width` / `height` がある投稿で `<PostMetaLine />` が表示される
+  - `aspect_ratio` を維持したまま表示が壊れない
+- [ ] server-api の既存テストがある場合は、`width` / `height` NULL 時の `getImageDimensions` 呼び出しと UPDATE の期待を追加
+- [ ] `background_change` / `aspect_ratio` の期待値は削除しない（互換維持のため）
+
+### Phase 7: 検証
+**目的**: 全テスト + 実機確認
+**ビルド確認**: 4 コマンド全 pass
+
+- [ ] `npm run lint`
+- [ ] `npm run typecheck`
+- [ ] `npm run test`
+- [ ] `npm run build -- --webpack`
+- [ ] Vercel Preview / 本番で実機確認:
+  - 自分の最新 OpenAI 画像（width/height NULL）→ 初回アクセスで lazy compute → 同一レスポンスでサイズ表示
+  - Nano Banana 系の既存画像 → ブランド名表示 + lazy compute 後にサイズ表示
+  - 他ユーザーの公開画像 → 同じく表示
+  - 縦/横のフレーム切替が既存 `aspect_ratio` 優先で維持される（CSS 崩れがない）
+  - 背景変更系の生成（`backgroundMode` の各値）が既存通り問題なく完了
+
+---
+
+## 5. 修正対象ファイル一覧
+
+| ファイル | 操作 | 変更内容 |
+|---|---|---|
+| `supabase/migrations/<ts>_add_generated_image_dimensions.sql` | 新規 | `generated_images.width` / `height` 追加のみ |
+| `features/generation/lib/database.ts` | 修正 | `GeneratedImageRecord` に width/height 追加。既存列は維持 |
+| `features/posts/lib/server-api.ts` | 修正 | 既存 aspect_ratio lazy compute を維持しつつ、width/height lazy compute を追加 |
+| `features/posts/lib/utils.ts` | 修正 | `deriveAspectRatioFromDimensions` を export 追加 |
+| `features/generation/lib/model-display.ts` | 新規 | `getModelBrandName(model)` |
+| `features/posts/components/PostMetaLine.tsx` | 新規 | 共通表示部品 |
+| `features/posts/components/CachedPostDetail.tsx` | 修正 | aspect_ratio 優先を維持し、width/height fallback を追加 |
+| `features/posts/components/PostDetail.tsx` | 修正 | プロンプト直前に PostMetaLine 挿入 |
+| `features/posts/components/PostDetailStatic.tsx` | 修正 | 同上 |
+| `messages/ja.ts` | 修正 | aria-label 用キー追加 |
+| `messages/en.ts` | 修正 | 同上 |
+| `tests/unit/features/generation/model-display.test.ts` | 新規 | brand name ヘルパーの単体 |
+| `tests/unit/features/posts/post-meta-line.test.tsx` | 新規 | 表示部品の単体 |
+| `tests/unit/features/posts/post-detail.test.tsx` | 修正 | width/height mock と PostMetaLine 表示確認を追加 |
+| server-api 関連テスト | 修正 | width/height lazy compute と UPDATE skip 条件を確認 |
+
+合計: 新規 5、修正 10 前後（既存テスト構成により増減）
+
+---
+
+## 6. 品質・テスト観点
+
+### 品質チェックリスト
+- [ ] **エラーハンドリング**: 寸法解析失敗時 warning + null 維持で UI 描画継続
+- [ ] **権限制御**: RLS 変更なし、他ユーザーの公開投稿読み取り権限は既存通り
+- [ ] **データ整合性**: width/height は CHECK 制約で正の整数のみ。既存の `aspect_ratio` / `background_change` は削除せず互換維持
+- [ ] **セキュリティ**: lazy compute は public な image_url を参照するだけ
+- [ ] **i18n**: aria-label 用キーを ja/en 両方追加
+- [ ] **互換性**: 入力境界の `backgroundChange` boolean → `backgroundMode` 変換、DB の `background_change` 読み書きは保持（フロント UI への破壊的変更なし）
+
+### テスト観点
+
+| カテゴリ | テスト内容 |
+|---|---|
+| 正常系 (model + size) | gpt-image-2-low + width/height で `ChatGPT Images 2.0 / 1024×1536` 表示 |
+| 正常系 (model only) | width/height NULL で `Nano Banana Pro` のみ表示 |
+| 正常系 (other user) | 他ユーザーの公開投稿でも同じ表示 |
+| 正常系 (background_mode) | `ai_auto`/`include_in_prompt`/`keep` の各 mode で生成成功、my-page 詳細でも正しい mode 表示 |
+| 異常系 (model unknown) | model が null や未知プレフィックスで `<PostMetaLine />` が render しない |
+| 異常系 (lazy compute fail) | 寸法取得失敗 → ブランド名のみ表示 |
+| 互換性 (aspect_ratio) | 既存 `aspect_ratio` がある場合は従来通り CSS 切替が動く |
+| imageAspectRatio fallback | `aspect_ratio` が null で width/height がある場合のみ fallback 派生できる |
+| 権限テスト | 他ユーザーの非公開投稿は既存 RLS で読めない（変更なし）|
+| a11y | aria-label でスクリーンリーダー読み上げ可能 |
+| 実機確認 | Vercel Preview で初回アクセス → width/height がレスポンス上で表示され、非 cache 経路では DB 保存される |
+
+### テスト実装手順
+実装完了後 `/test-flow` ワークフローに沿って:
+1. `/test-flow {Target}` → 依存とスペック確認
+2. `/spec-extract {Target}` → EARS 抽出
+3. `/spec-write {Target}` → スペック精査
+4. `/test-generate {Target}` → テスト生成
+5. `/test-reviewing {Target}` → レビュー
+6. `/spec-verify {Target}` → カバレッジ確認
+
+### 整合性自己チェック
+- **状態遷移と DB 値**: width/height は INT NULL（NULL=未計算、INT=計算済み）。状態遷移図と整合
+- **認証一貫性**: lazy compute は server-api 経由のみ、RLS 既存通り
+- **データフェッチ整合性**: 既存 aspect_ratio パターンを維持し、width/height の追加取得を併設
+- **イベント網羅性**: lazy compute 成功/失敗/既知ブランド/未知ブランドを EARS で網羅
+- **API パラメータの安全性**: lazy compute は id だけで行を引く、ユーザー入力は使わない
+- **ビジネスルール DB 強制**: `width > 0` / `height > 0` を CHECK 制約
+- **後方互換**: 入力境界の `backgroundChange` 変換と DB 互換列は保持。フロント UI に破壊的変更なし
+- **データロス**: 本 PR では DROP しないため既存データのロスなし
+
+---
+
+## 7. ロールバック方針
+
+- **DB migration**: 本 PR は `width` / `height` の追加のみ。問題があっても既存列は残るため既存機能は維持される。完全に戻す場合は追加 migration で `generated_images.width` / `height` を DROP する
+- **アプリ機能**:
+  - 表示問題: `<PostMetaLine />` の挿入を 2 箇所 revert すれば即解除できる
+  - lazy compute 問題: server-api の width/height 追加処理のみ revert すれば、既存 `aspect_ratio` パターンに戻る
+- **コミット粒度**: Phase 1 の追加 migration、server-api、UI 表示、テストを分けておくと `git revert` しやすい
+- **デプロイ順序**:
+  - 推奨: migration 適用後にアプリをデプロイする
+  - migration 先行: 追加列のみなので既存アプリは壊れない
+  - アプリ先行: `width` / `height` 列がない環境では server-api の SELECT / UPDATE が失敗する可能性があるため避ける
+  - `aspect_ratio` / `background_change` は削除しないため、既存の生成導線・背景設定導線は維持される
+
+---
+
+## 8. 使用スキル
+
+| スキル | 用途 | フェーズ |
+|---|---|---|
+| `/project-database-context` | generated_images スキーマ確認 | Phase 1 |
+| `/git-create-branch` | 実装ブランチ作成（既に作成済 `feature/post-detail-meta`） | 着手時 |
+| `/spec-extract` | EARS 仕様抽出 | テスト準備 |
+| `/spec-write` | EARS 精査 | テスト準備 |
+| `/test-flow` | テストワークフロー駆動 | テスト |
+| `/test-generate` | 単体テスト雛形 | テスト |
+| `/test-reviewing` | テストレビュー | テスト |
+| `/spec-verify` | spec/test 整合確認 | テスト |
+| `/git-create-pr` | PR 作成（日本語タイトル/本文） | 完了時 |
+
+---
+
+## 重要な参照箇所（再掲）
+
+### DB 互換関連
+- [features/generation/lib/database.ts:8-43](features/generation/lib/database.ts#L8-L43) — GeneratedImageRecord（width/height 追加、aspect_ratio/background_change 維持）
+- [features/generation/lib/job-types.ts:45](features/generation/lib/job-types.ts#L45) — ImageJobCreateInput（本 PR では変更不要）
+- [app/api/generate-async/handler.ts](app/api/generate-async/handler.ts) — image_jobs INSERT（本 PR では変更不要）
+- [supabase/functions/image-gen-worker/index.ts:1865-1881](supabase/functions/image-gen-worker/index.ts#L1865-L1881) — generated_images INSERT（本 PR では変更不要）
+- [features/my-page/components/ImageDetailPageClient.tsx:34](features/my-page/components/ImageDetailPageClient.tsx#L34) — background_change fallback は本 PR では維持
+
+### 表示・lazy compute 関連
+- [features/posts/types.ts:22](features/posts/types.ts#L22) — Post 型
+- [features/posts/lib/server-api.ts:747-814](features/posts/lib/server-api.ts#L747-L814) — lazy compute（aspect_ratio 維持 + width/height 追加）
+- [features/posts/lib/utils.ts:227](features/posts/lib/utils.ts#L227) — getImageDimensions ヘルパー
+- [features/posts/components/PostDetail.tsx:286-318](features/posts/components/PostDetail.tsx#L286-L318) — プロンプトブロック挿入位置
+- [features/posts/components/PostDetailStatic.tsx:158-330](features/posts/components/PostDetailStatic.tsx#L158-L330) — 同上 + imageAspectRatio CSS 利用箇所
+- [features/posts/components/PostDetailContent.tsx:63-86](features/posts/components/PostDetailContent.tsx#L63-L86) — PostDetailStatic ラッパー（変更不要の確認）
+- [features/posts/components/CachedPostDetail.tsx:38-48](features/posts/components/CachedPostDetail.tsx#L38-L48) — imageAspectRatio prop 組立箇所
+
+### 既存 migration 参考
+- `supabase/migrations/20251212065229_add_aspect_ratio_to_generated_images.sql`（lazy compute パターン先例）
+- `supabase/migrations/20260222133000_add_background_mode_to_generation_tables.sql`（background_mode 追加 + 互換運用の先例）
+- `supabase/migrations/20251221205634_add_model_to_generated_images.sql`（model 列追加の先例）
+
+### 入力境界の helper（**本 PR では触らない**）
+- [shared/generation/prompt-core.ts:16-56](shared/generation/prompt-core.ts#L16-L56) — `BACKGROUND_MODES`、変換 helper
+- [features/generation/lib/schema.ts:69](features/generation/lib/schema.ts#L69) — zod 入力 backgroundChange
+- [features/style/components/StylePageClient.tsx:490](features/style/components/StylePageClient.tsx#L490) — boolean トグル UI 状態

--- a/features/generation/components/GenerationForm.tsx
+++ b/features/generation/components/GenerationForm.tsx
@@ -23,6 +23,12 @@ import { getSourceImageStocks, getStockImageLimit, type SourceImageStock } from 
 import { getCurrentUserId } from "../lib/current-user";
 import { getPercoinCost } from "../lib/model-config";
 import {
+  readPreferredBackgroundMode,
+  readPreferredModel,
+  writePreferredBackgroundMode,
+  writePreferredModel,
+} from "../lib/form-preferences";
+import {
   GENERATION_PROMPT_MAX_LENGTH,
   isGenerationPromptTooLong,
 } from "../lib/prompt-validation";
@@ -110,6 +116,27 @@ export function GenerationForm({
   useEffect(() => {
     setSelectedCount((current) => Math.min(current, maxGenerationCount));
   }, [maxGenerationCount]);
+
+  // ブラウザに保存された前回の選択（モデル / 背景設定）をマウント時に復元する。
+  // SSR との hydration mismatch を避けるため初期値は default のまま、
+  // クライアント側の useEffect で上書きする。
+  useEffect(() => {
+    setSelectedModel(readPreferredModel());
+    setBackgroundMode(readPreferredBackgroundMode());
+  }, []);
+
+  // ユーザー操作時にだけ localStorage に書き込むラッパー。
+  // tutorial:clear / tutorial:set-background-mode のような system-driven な
+  // setState では呼ばれない（直接 setSelectedModel / setBackgroundMode する）。
+  const handleSelectedModelChange = useCallback((value: GeminiModel) => {
+    setSelectedModel(value);
+    writePreferredModel(value);
+  }, []);
+
+  const handleBackgroundModeChange = useCallback((value: BackgroundMode) => {
+    setBackgroundMode(value);
+    writePreferredBackgroundMode(value);
+  }, []);
 
   // チュートリアル中は入力フィールドを無効化（bodyのdata-tour-in-progressを監視）
   useEffect(() => {
@@ -553,7 +580,9 @@ export function GenerationForm({
           <Label className="text-base font-medium">{t("backgroundLabel")}</Label>
           <RadioGroup
             value={backgroundMode}
-            onValueChange={(value) => setBackgroundMode(value as BackgroundMode)}
+            onValueChange={(value) =>
+              handleBackgroundModeChange(value as BackgroundMode)
+            }
             className="mt-2 space-y-3"
             disabled={isGenerating || isTutorialInProgress}
           >
@@ -587,7 +616,9 @@ export function GenerationForm({
           </Label>
           <Select
             value={selectedModel}
-            onValueChange={(value) => setSelectedModel(value as GeminiModel)}
+            onValueChange={(value) =>
+              handleSelectedModelChange(value as GeminiModel)
+            }
             disabled={isGenerating || isTutorialInProgress}
           >
             <SelectTrigger className="w-full">

--- a/features/generation/lib/database.ts
+++ b/features/generation/lib/database.ts
@@ -33,6 +33,10 @@ export interface GeneratedImageRecord {
   aspect_ratio?: 'portrait' | 'landscape' | null;
   // Phase 3で追加されたカラム（optional）
   model?: GeminiModel | null;
+  // 画像実寸（Post 詳細画面でモデル名と併記して表示）。
+  // server-api の lazy compute で fetch 時に画像ヘッダーをパースして埋まる。
+  width?: number | null;
+  height?: number | null;
   // Phase 2-1で追加されたカラム（optional）
   storage_path_display?: string | null;
   storage_path_thumb?: string | null;

--- a/features/generation/lib/form-preferences.ts
+++ b/features/generation/lib/form-preferences.ts
@@ -1,0 +1,95 @@
+/**
+ * GenerationForm のユーザー設定をブラウザ間で永続化するためのヘルパー。
+ *
+ * 対象は「ユーザーが意図的に選択する設定」のみで、生成ごとにリセットしたい
+ * フィールド（プロンプト、生成枚数、画像ソース等）は対象外。
+ *
+ * 永続化先: localStorage（ユーザー単位ではなくブラウザ単位）。
+ * - ログアウトしても残るのが要件なので DB ではなく localStorage を選択
+ * - 共有 PC では他人にも引き継がれる点は要件範囲外
+ *
+ * SSR セーフ:
+ * - `typeof window === "undefined"` で server 側を弾く
+ * - localStorage アクセスは try/catch（プライベートブラウジング / quota 超過対策）
+ * - 検証 NG（旧モデル ID 等）は default にフォールバック
+ */
+
+import {
+  BACKGROUND_MODES,
+  type BackgroundMode,
+} from "@/shared/generation/prompt-core";
+import type { GeminiModel } from "@/features/generation/types";
+
+export const SELECTED_MODEL_STORAGE_KEY = "persta-ai:last-selected-model";
+export const BACKGROUND_MODE_STORAGE_KEY = "persta-ai:last-background-mode";
+
+const DEFAULT_MODEL: GeminiModel = "gemini-3.1-flash-image-preview-512";
+const DEFAULT_BACKGROUND_MODE: BackgroundMode = "keep";
+
+/**
+ * GenerationForm の `<Select>` で実際に表示しているモデル ID 一覧。
+ * 旧 `gemini-2.5-flash-image` 等の legacy 値を localStorage から復元しても
+ * Select に対応する `<SelectItem>` が無いと UI が崩れるため、表示中のものに
+ * 限って受理する。
+ *
+ * 注意: GenerationForm.tsx の `<SelectItem>` を増減する場合はここも更新する。
+ */
+const PERSISTABLE_MODELS: ReadonlyArray<GeminiModel> = [
+  "gemini-3.1-flash-image-preview-512",
+  "gemini-3.1-flash-image-preview-1024",
+  "gemini-3-pro-image-1k",
+  "gemini-3-pro-image-2k",
+  "gemini-3-pro-image-4k",
+  "gpt-image-2-low",
+];
+
+function safeReadLocalStorage(key: string): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function safeWriteLocalStorage(key: string, value: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    // private browsing / quota exceeded — silently ignore
+  }
+}
+
+export function readPreferredModel(): GeminiModel {
+  const stored = safeReadLocalStorage(SELECTED_MODEL_STORAGE_KEY);
+  if (stored && (PERSISTABLE_MODELS as ReadonlyArray<string>).includes(stored)) {
+    return stored as GeminiModel;
+  }
+  return DEFAULT_MODEL;
+}
+
+export function writePreferredModel(model: GeminiModel): void {
+  if (!(PERSISTABLE_MODELS as ReadonlyArray<string>).includes(model)) {
+    return;
+  }
+  safeWriteLocalStorage(SELECTED_MODEL_STORAGE_KEY, model);
+}
+
+export function readPreferredBackgroundMode(): BackgroundMode {
+  const stored = safeReadLocalStorage(BACKGROUND_MODE_STORAGE_KEY);
+  if (
+    stored &&
+    (BACKGROUND_MODES as ReadonlyArray<string>).includes(stored)
+  ) {
+    return stored as BackgroundMode;
+  }
+  return DEFAULT_BACKGROUND_MODE;
+}
+
+export function writePreferredBackgroundMode(mode: BackgroundMode): void {
+  if (!(BACKGROUND_MODES as ReadonlyArray<string>).includes(mode)) {
+    return;
+  }
+  safeWriteLocalStorage(BACKGROUND_MODE_STORAGE_KEY, mode);
+}

--- a/features/generation/lib/model-display.ts
+++ b/features/generation/lib/model-display.ts
@@ -1,0 +1,30 @@
+/**
+ * モデル ID（DB 保存値）からユーザー向けブランド名を導出するヘルパー。
+ *
+ * Post 詳細画面の生成モデル表示などで使用する。新規モデル追加時は
+ * `startsWith` 判定を 1 行足すだけで対応できるよう、マッピングテーブルではなく
+ * プレフィックス判定で実装している。
+ *
+ * 未知モデル ID や null 入力では null を返す。呼び出し側はこの場合、
+ * モデル名ブロックを描画しない（ADR-002）。
+ */
+export function getModelBrandName(
+  model: string | null | undefined,
+): string | null {
+  if (typeof model !== "string" || model.length === 0) {
+    return null;
+  }
+  if (model.startsWith("gpt-image-")) {
+    return "ChatGPT Images 2.0";
+  }
+  if (model.startsWith("gemini-3-pro-image-")) {
+    return "Nano Banana Pro";
+  }
+  if (
+    model.startsWith("gemini-3.1-flash-image-") ||
+    model === "gemini-2.5-flash-image"
+  ) {
+    return "Nano Banana 2";
+  }
+  return null;
+}

--- a/features/generation/lib/normalize-generation-error.ts
+++ b/features/generation/lib/normalize-generation-error.ts
@@ -1,0 +1,49 @@
+import {
+  isInvalidGeminiArgumentErrorMessage,
+  isMalformedGeminiPartsErrorMessage,
+  isOpenAIProviderErrorMessage,
+  isSafetyPolicyBlockedErrorMessage,
+} from "@/shared/generation/errors";
+import type { getGenerationRouteCopy } from "@/features/generation/lib/route-copy";
+
+/**
+ * `image_jobs.error_message` をユーザー向け文言に正規化する。
+ *
+ * upstream の生メッセージ（OpenAI / Gemini の英文エラー）はユーザーに見せず、
+ * 既知のエラー種別を i18n コピーに差し替える。未知メッセージは passthrough する。
+ *
+ * Next.js 16 では route.ts ファイルから handler 以外の named export が禁じられているため、
+ * 単体テスト容易性のためにこのファイルへ切り出している（route 側は import するだけ）。
+ */
+export function normalizeUserFacingGenerationError(
+  status: string,
+  errorMessage: string | null,
+  copy: ReturnType<typeof getGenerationRouteCopy>,
+): string | null {
+  if (status !== "failed" || !errorMessage) return errorMessage;
+
+  if (errorMessage === "No images generated") {
+    return copy.noImagesGenerated;
+  }
+
+  if (isSafetyPolicyBlockedErrorMessage(errorMessage)) {
+    return copy.safetyBlocked;
+  }
+
+  if (isMalformedGeminiPartsErrorMessage(errorMessage)) {
+    return copy.genericGenerationFailed;
+  }
+
+  if (isInvalidGeminiArgumentErrorMessage(errorMessage)) {
+    return copy.genericGenerationFailed;
+  }
+
+  // OpenAI 側の非リトライ系エラー（組織未検証 / API key 不正 / 残高不足 /
+  // 401・403 / GIF 拒否 / OPENAI_API_KEY 未設定）は upstream の生メッセージを
+  // 表に出さず汎用文言に差し替える。詳細は Edge Function ログ参照。
+  if (isOpenAIProviderErrorMessage(errorMessage)) {
+    return copy.genericGenerationFailed;
+  }
+
+  return errorMessage;
+}

--- a/features/posts/components/CachedPostDetail.tsx
+++ b/features/posts/components/CachedPostDetail.tsx
@@ -1,7 +1,11 @@
 import { cacheLife, cacheTag } from "next/cache";
 import { notFound } from "next/navigation";
 import { getPost } from "../lib/server-api";
-import { getPostDisplayUrl, getImageAspectRatio } from "../lib/utils";
+import {
+  deriveAspectRatioFromDimensions,
+  getImageAspectRatio,
+  getPostDisplayUrl,
+} from "../lib/utils";
 import { PostDetailContent } from "./PostDetailContent";
 import { createAdminClient } from "@/lib/supabase/admin";
 
@@ -37,6 +41,14 @@ export async function CachedPostDetail({
   const imageUrl = getPostDisplayUrl(post);
   let imageAspectRatio: "portrait" | "landscape" | null =
     post.aspect_ratio as "portrait" | "landscape" | null;
+  // 1) 既存 aspect_ratio が NULL でも、width/height が揃っていれば派生で済ませる
+  // 2) それも無理なら従来通り画像をフェッチして判定（最後のフォールバック）
+  if (!imageAspectRatio) {
+    imageAspectRatio = deriveAspectRatioFromDimensions(
+      post.width ?? null,
+      post.height ?? null,
+    );
+  }
   if (!imageAspectRatio && imageUrl) {
     imageAspectRatio = await getImageAspectRatio(imageUrl);
   }

--- a/features/posts/components/PostDetail.tsx
+++ b/features/posts/components/PostDetail.tsx
@@ -19,6 +19,7 @@ import { PostModal } from "./PostModal";
 import { PostActions } from "./PostActions";
 import { CommentInput } from "./CommentInput";
 import { CommentList, type CommentListRef } from "./CommentList";
+import { PostMetaLine } from "./PostMetaLine";
 import { getPostImageUrl } from "../lib/utils";
 import { copyTextToClipboard } from "../lib/copy-to-clipboard";
 import { useToast } from "@/components/ui/use-toast";
@@ -282,6 +283,13 @@ export function PostDetail({ post, currentUserId }: PostDetailProps) {
           </div>
         )}
 
+
+        {/* 生成モデル / サイズ（プロンプト直前） */}
+        <PostMetaLine
+          model={post.model ?? null}
+          width={post.width ?? null}
+          height={post.height ?? null}
+        />
 
         {/* プロンプト */}
         {oneTapStylePreset ? (

--- a/features/posts/components/PostDetailStatic.tsx
+++ b/features/posts/components/PostDetailStatic.tsx
@@ -18,6 +18,7 @@ import { CollapsibleText } from "./CollapsibleText";
 import { EditPostModal } from "./EditPostModal";
 import { DeletePostDialog } from "./DeletePostDialog";
 import { PostModal } from "./PostModal";
+import { PostMetaLine } from "./PostMetaLine";
 import { getPostImageUrl } from "../lib/utils";
 import { copyTextToClipboard } from "../lib/copy-to-clipboard";
 import { useToast } from "@/components/ui/use-toast";
@@ -317,6 +318,13 @@ export function PostDetailStatic({
             <CollapsibleText text={post.caption} maxLines={3} />
           </div>
         )}
+
+        {/* 生成モデル / サイズ（プロンプト直前） */}
+        <PostMetaLine
+          model={post.model ?? null}
+          width={post.width ?? null}
+          height={post.height ?? null}
+        />
 
         {/* プロンプト */}
         {oneTapStylePreset ? (

--- a/features/posts/components/PostMetaLine.tsx
+++ b/features/posts/components/PostMetaLine.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { getModelBrandName } from "@/features/generation/lib/model-display";
+
+interface PostMetaLineProps {
+  model: string | null;
+  width: number | null;
+  height: number | null;
+}
+
+/**
+ * Post 詳細画面のプロンプトブロック直前に表示するモデル / サイズ表示部品。
+ *
+ * 表示例:
+ *   - `ChatGPT Images 2.0 / 1024×1536`（width/height あり）
+ *   - `Nano Banana 2`（width/height NULL）
+ *   - 何も描画しない（モデル不明 / null）
+ *
+ * `aria-label` でラベルを補完してスクリーンリーダーに正確な内容を伝える。
+ */
+export function PostMetaLine({ model, width, height }: PostMetaLineProps) {
+  const t = useTranslations("posts");
+  const brandName = getModelBrandName(model);
+  if (!brandName) {
+    return null;
+  }
+
+  const hasDimensions =
+    typeof width === "number" &&
+    typeof height === "number" &&
+    width > 0 &&
+    height > 0;
+  const dimensionsText = hasDimensions ? `${width}×${height}` : null;
+
+  const visibleText = dimensionsText
+    ? `${brandName} / ${dimensionsText}`
+    : brandName;
+  const ariaLabel = dimensionsText
+    ? `${t("metaModelLabel")}: ${brandName}, ${t("metaSizeLabel")}: ${dimensionsText}`
+    : `${t("metaModelLabel")}: ${brandName}`;
+
+  return (
+    <div
+      className="border-t border-gray-200 bg-white px-4 py-2"
+      aria-label={ariaLabel}
+      data-testid="post-meta-line"
+    >
+      <span className="text-xs text-gray-500">{visibleText}</span>
+    </div>
+  );
+}

--- a/features/posts/lib/ensure-image-dimensions.ts
+++ b/features/posts/lib/ensure-image-dimensions.ts
@@ -1,0 +1,121 @@
+/**
+ * `generated_images` 行に対して aspect_ratio / width / height が欠けていれば
+ * 画像ヘッダーを取得して算出し、必要に応じて DB へ書き戻す純関数ユーティリティ。
+ *
+ * 副作用（画像 fetch / DB UPDATE）は依存性注入で受け取り、ロジックを単体テスト可能にする。
+ * server-api.ts の `getPost` から呼び出される。
+ *
+ * 動作:
+ * - aspect_ratio または width / height のいずれかが NULL のとき、image_url / storage_path から
+ *   表示用 URL を解決して `fetchDimensions` を 1 回だけ呼ぶ
+ * - 計算結果のうち未保存フィールドのみをマージしてレスポンス値を返す
+ * - useCache=true のときは DB UPDATE をスキップ（レスポンスにはセット）
+ * - useCache=false のときは未保存フィールドのみ UPDATE
+ * - 取得失敗 / URL 解決不可のときは元の値（null かもしれない）を保ったまま返す
+ */
+
+export type AspectRatio = "portrait" | "landscape";
+
+export interface ImageDimensionsState {
+  aspectRatio: AspectRatio | null;
+  width: number | null;
+  height: number | null;
+}
+
+export interface ImageRowSubset {
+  aspect_ratio?: AspectRatio | null | string;
+  width?: number | null;
+  height?: number | null;
+  image_url?: string | null;
+  storage_path?: string | null;
+}
+
+export interface EnsureImageDimensionsParams {
+  data: ImageRowSubset;
+  useCache: boolean;
+  /** 画像ヘッダーから寸法を取得する。失敗時は null を返す。 */
+  fetchDimensions: (
+    imageUrl: string,
+  ) => Promise<{ width: number; height: number } | null>;
+  /**
+   * 表示用画像 URL を解決する。`image_url` を優先し、無ければ `storage_path` から
+   * 公開 URL を組み立てる。解決できなければ null。
+   */
+  resolveImageUrl: (data: ImageRowSubset) => string | null;
+  /**
+   * 行を UPDATE する。useCache=true のときは呼ばれない。
+   * 失敗は呼び出し側でキャッチして無視されることを想定。
+   */
+  updateRow: (updates: Record<string, unknown>) => Promise<void>;
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+function normalizeAspectRatio(value: unknown): AspectRatio | null {
+  if (value === "portrait" || value === "landscape") return value;
+  return null;
+}
+
+export async function ensureImageDimensions(
+  params: EnsureImageDimensionsParams,
+): Promise<ImageDimensionsState> {
+  const { data, useCache, fetchDimensions, resolveImageUrl, updateRow } = params;
+
+  let aspectRatio: AspectRatio | null = normalizeAspectRatio(data.aspect_ratio);
+  let width: number | null = isPositiveInteger(data.width) ? data.width : null;
+  let height: number | null = isPositiveInteger(data.height) ? data.height : null;
+
+  const needsAspectRatio = aspectRatio === null;
+  const needsWidth = width === null;
+  const needsHeight = height === null;
+
+  if (!needsAspectRatio && !needsWidth && !needsHeight) {
+    return { aspectRatio, width, height };
+  }
+
+  const imageUrl = resolveImageUrl(data);
+  if (!imageUrl) {
+    return { aspectRatio, width, height };
+  }
+
+  let dimensions: { width: number; height: number } | null = null;
+  try {
+    dimensions = await fetchDimensions(imageUrl);
+  } catch (error) {
+    console.warn("Failed to calculate image dimensions:", error);
+    return { aspectRatio, width, height };
+  }
+
+  if (!dimensions) {
+    return { aspectRatio, width, height };
+  }
+
+  if (needsWidth) width = dimensions.width;
+  if (needsHeight) height = dimensions.height;
+  if (needsAspectRatio) {
+    aspectRatio =
+      dimensions.height > dimensions.width ? "portrait" : "landscape";
+  }
+
+  if (!useCache) {
+    const updates: Record<string, unknown> = {};
+    if (needsAspectRatio && aspectRatio) updates.aspect_ratio = aspectRatio;
+    if (needsWidth && width !== null) updates.width = width;
+    if (needsHeight && height !== null) updates.height = height;
+
+    if (Object.keys(updates).length > 0) {
+      try {
+        await updateRow(updates);
+      } catch (updateError) {
+        console.warn(
+          "Failed to update generated_image dimensions:",
+          updateError,
+        );
+      }
+    }
+  }
+
+  return { aspectRatio, width, height };
+}

--- a/features/posts/lib/server-api.ts
+++ b/features/posts/lib/server-api.ts
@@ -15,7 +15,11 @@ import type {
 } from "../types";
 import type { GeneratedImageRecord } from "@/features/generation/lib/database";
 import { redactSensitivePrompt } from "@/features/generation/lib/prompt-visibility";
-import { getImageAspectRatio } from "./utils";
+import { getImageDimensions } from "./utils";
+import {
+  ensureImageDimensions,
+  type ImageRowSubset,
+} from "./ensure-image-dimensions";
 import {
   getJSTStartOfDay,
   getJSTEndOfDay,
@@ -744,37 +748,28 @@ export const getPost = cache(async (
         getCommentCount(id),
       ]);
 
-  // アスペクト比が存在しない場合は計算して保存
-  let aspectRatio: "portrait" | "landscape" | null = data.aspect_ratio as "portrait" | "landscape" | null;
-  if (!aspectRatio) {
-    // 画像URLを取得
-    const imageUrl = data.image_url || (data.storage_path ? 
-      `${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/generated-images/${data.storage_path}` : 
-      null);
-    
-    if (imageUrl) {
-      try {
-        // アスペクト比を計算
-        aspectRatio = await getImageAspectRatio(imageUrl);
-        
-        // データベースに保存（use cache 時はスキップ：書き込みを避ける）
-        if (aspectRatio && !useCache) {
-          try {
-            await supabase
-              .from("generated_images")
-              .update({ aspect_ratio: aspectRatio })
-              .eq("id", id);
-          } catch (updateError) {
-            // 競合エラーは無視（他のリクエストが既に更新した可能性がある）
-            console.warn("Failed to update aspect_ratio:", updateError);
-          }
-        }
-      } catch (error) {
-        // アスペクト比の計算に失敗した場合はnullのまま
-        console.warn("Failed to calculate aspect ratio:", error);
-      }
-    }
-  }
+  // アスペクト比 / 実寸が未計算の場合は lazy compute で算出して DB に書き戻す。
+  // 詳細は features/posts/lib/ensure-image-dimensions.ts。
+  const {
+    aspectRatio,
+    width,
+    height,
+  } = await ensureImageDimensions({
+    data: data as ImageRowSubset,
+    useCache,
+    fetchDimensions: getImageDimensions,
+    resolveImageUrl: (row) =>
+      row.image_url ||
+      (row.storage_path
+        ? `${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/generated-images/${row.storage_path}`
+        : null),
+    updateRow: async (updates) => {
+      await supabase
+        .from("generated_images")
+        .update(updates)
+        .eq("id", id);
+    },
+  });
 
   // 閲覧数をインクリメント（重複カウント）
   // skipViewCountがtrue、またはuse cache時はカウントをスキップ
@@ -812,6 +807,8 @@ export const getPost = cache(async (
     comment_count: commentCount,
     view_count: updatedViewCount,
     aspect_ratio: aspectRatio,
+    width,
+    height,
   });
 });
 

--- a/features/posts/lib/server-api.ts
+++ b/features/posts/lib/server-api.ts
@@ -15,7 +15,7 @@ import type {
 } from "../types";
 import type { GeneratedImageRecord } from "@/features/generation/lib/database";
 import { redactSensitivePrompt } from "@/features/generation/lib/prompt-visibility";
-import { getImageDimensions } from "./utils";
+import { getImageDimensions, getPostImageUrl } from "./utils";
 import {
   ensureImageDimensions,
   type ImageRowSubset,
@@ -758,11 +758,7 @@ export const getPost = cache(async (
     data: data as ImageRowSubset,
     useCache,
     fetchDimensions: getImageDimensions,
-    resolveImageUrl: (row) =>
-      row.image_url ||
-      (row.storage_path
-        ? `${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/generated-images/${row.storage_path}`
-        : null),
+    resolveImageUrl: (row) => getPostImageUrl(row) || null,
     updateRow: async (updates) => {
       await supabase
         .from("generated_images")

--- a/features/posts/lib/utils.ts
+++ b/features/posts/lib/utils.ts
@@ -265,3 +265,24 @@ export async function getImageAspectRatio(imageUrl: string): Promise<"portrait" 
     return null;
   }
 }
+
+/**
+ * width / height からアスペクト比ラベル（"portrait" | "landscape"）を派生する。
+ * Post 詳細で `aspect_ratio` 列が NULL の場合のみ fallback として使う。
+ *
+ * @returns 両方とも正の整数なら派生結果、いずれかが欠けていれば null
+ */
+export function deriveAspectRatioFromDimensions(
+  width: number | null | undefined,
+  height: number | null | undefined,
+): "portrait" | "landscape" | null {
+  if (
+    typeof width !== "number" ||
+    typeof height !== "number" ||
+    width <= 0 ||
+    height <= 0
+  ) {
+    return null;
+  }
+  return height > width ? "portrait" : "landscape";
+}

--- a/messages/en.ts
+++ b/messages/en.ts
@@ -49,6 +49,8 @@ export const enMessages = {
     postImageAlt: "Post image",
     hiddenMessage: "This post is hidden based on your display settings.",
     prompt: "Prompt",
+    metaModelLabel: "Generation model",
+    metaSizeLabel: "Size",
     copy: "Copy",
     copied: "Copied",
     followRequiredTitle: "Follow required",

--- a/messages/ja.ts
+++ b/messages/ja.ts
@@ -43,6 +43,8 @@ export const jaMessages = {
     postImageAlt: "投稿画像",
     hiddenMessage: "この投稿はあなたの表示設定により非表示になりました。",
     prompt: "プロンプト",
+    metaModelLabel: "生成モデル",
+    metaSizeLabel: "サイズ",
     copy: "コピー",
     copied: "コピー済み",
     followRequiredTitle: "フォローが必要です",

--- a/supabase/migrations/20260426120000_add_generated_image_dimensions.sql
+++ b/supabase/migrations/20260426120000_add_generated_image_dimensions.sql
@@ -1,0 +1,12 @@
+-- generated_images に width / height 列を追加する。
+-- 目的: Post 詳細画面で実寸（例: 1024×1536）を表示するためのキャッシュ列。
+-- 値は server-api の lazy compute（fetch 時に画像ヘッダーをパース）で順次埋まる。
+-- 既存列（aspect_ratio / background_change）は本 PR では削除せず互換維持。
+
+ALTER TABLE public.generated_images
+ADD COLUMN IF NOT EXISTS width INT NULL
+CHECK (width IS NULL OR width > 0);
+
+ALTER TABLE public.generated_images
+ADD COLUMN IF NOT EXISTS height INT NULL
+CHECK (height IS NULL OR height > 0);

--- a/tests/unit/app/api/generation-status/normalize-error.test.ts
+++ b/tests/unit/app/api/generation-status/normalize-error.test.ts
@@ -1,6 +1,6 @@
 /** @jest-environment node */
 
-import { normalizeUserFacingGenerationError } from "@/app/api/generation-status/route";
+import { normalizeUserFacingGenerationError } from "@/features/generation/lib/normalize-generation-error";
 import { getGenerationRouteCopy } from "@/features/generation/lib/route-copy";
 import {
   OPENAI_PROVIDER_ERROR,

--- a/tests/unit/features/generation/form-preferences.test.ts
+++ b/tests/unit/features/generation/form-preferences.test.ts
@@ -128,4 +128,39 @@ describe("form-preferences", () => {
       }
     });
   });
+
+  describe("safe access under restricted storage / SSR", () => {
+    it("falls back to defaults when localStorage.getItem throws", () => {
+      const getItemSpy = jest.spyOn(Storage.prototype, "getItem");
+      getItemSpy.mockImplementation(() => {
+        throw new Error("SecurityError");
+      });
+      try {
+        expect(readPreferredModel()).toBe("gemini-3.1-flash-image-preview-512");
+        expect(readPreferredBackgroundMode()).toBe("keep");
+      } finally {
+        getItemSpy.mockRestore();
+      }
+    });
+
+    it("does not touch localStorage when window is unavailable", () => {
+      const originalWindow = window;
+      Object.defineProperty(globalThis, "window", {
+        configurable: true,
+        value: undefined,
+      });
+
+      try {
+        expect(readPreferredModel()).toBe("gemini-3.1-flash-image-preview-512");
+        expect(readPreferredBackgroundMode()).toBe("keep");
+        expect(() => writePreferredModel("gpt-image-2-low")).not.toThrow();
+        expect(() => writePreferredBackgroundMode("ai_auto")).not.toThrow();
+      } finally {
+        Object.defineProperty(globalThis, "window", {
+          configurable: true,
+          value: originalWindow,
+        });
+      }
+    });
+  });
 });

--- a/tests/unit/features/generation/form-preferences.test.ts
+++ b/tests/unit/features/generation/form-preferences.test.ts
@@ -1,0 +1,131 @@
+/** @jest-environment jsdom */
+
+import {
+  BACKGROUND_MODE_STORAGE_KEY,
+  SELECTED_MODEL_STORAGE_KEY,
+  readPreferredBackgroundMode,
+  readPreferredModel,
+  writePreferredBackgroundMode,
+  writePreferredModel,
+} from "@/features/generation/lib/form-preferences";
+
+describe("form-preferences", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  describe("readPreferredModel", () => {
+    it("returns default when nothing is stored", () => {
+      expect(readPreferredModel()).toBe("gemini-3.1-flash-image-preview-512");
+    });
+
+    it("returns the stored value when it is a known persistable model", () => {
+      window.localStorage.setItem(SELECTED_MODEL_STORAGE_KEY, "gpt-image-2-low");
+      expect(readPreferredModel()).toBe("gpt-image-2-low");
+    });
+
+    it("returns the stored value for each visible Gemini option", () => {
+      const options = [
+        "gemini-3.1-flash-image-preview-512",
+        "gemini-3.1-flash-image-preview-1024",
+        "gemini-3-pro-image-1k",
+        "gemini-3-pro-image-2k",
+        "gemini-3-pro-image-4k",
+      ] as const;
+      for (const value of options) {
+        window.localStorage.setItem(SELECTED_MODEL_STORAGE_KEY, value);
+        expect(readPreferredModel()).toBe(value);
+      }
+    });
+
+    it("falls back to default for unknown / legacy / empty values", () => {
+      window.localStorage.setItem(SELECTED_MODEL_STORAGE_KEY, "dall-e-3");
+      expect(readPreferredModel()).toBe("gemini-3.1-flash-image-preview-512");
+
+      // legacy ID (not in dropdown) も default に丸める
+      window.localStorage.setItem(
+        SELECTED_MODEL_STORAGE_KEY,
+        "gemini-2.5-flash-image",
+      );
+      expect(readPreferredModel()).toBe("gemini-3.1-flash-image-preview-512");
+
+      window.localStorage.setItem(SELECTED_MODEL_STORAGE_KEY, "");
+      expect(readPreferredModel()).toBe("gemini-3.1-flash-image-preview-512");
+    });
+  });
+
+  describe("writePreferredModel", () => {
+    it("persists known persistable models", () => {
+      writePreferredModel("gpt-image-2-low");
+      expect(window.localStorage.getItem(SELECTED_MODEL_STORAGE_KEY)).toBe(
+        "gpt-image-2-low",
+      );
+    });
+
+    it("ignores legacy IDs (not in the dropdown)", () => {
+      // GeminiModel union 上は legacy 値も型チェックを通るが、UI に表示できない
+      // 値を保存してもユーザーに不便を与えるだけなので write 側で弾く
+      writePreferredModel("gemini-2.5-flash-image" as never);
+      expect(window.localStorage.getItem(SELECTED_MODEL_STORAGE_KEY)).toBeNull();
+    });
+  });
+
+  describe("readPreferredBackgroundMode", () => {
+    it("returns default 'keep' when nothing is stored", () => {
+      expect(readPreferredBackgroundMode()).toBe("keep");
+    });
+
+    it("returns each valid stored value", () => {
+      const options = ["ai_auto", "include_in_prompt", "keep"] as const;
+      for (const value of options) {
+        window.localStorage.setItem(BACKGROUND_MODE_STORAGE_KEY, value);
+        expect(readPreferredBackgroundMode()).toBe(value);
+      }
+    });
+
+    it("falls back to default for unknown / empty values", () => {
+      window.localStorage.setItem(
+        BACKGROUND_MODE_STORAGE_KEY,
+        "no_change",
+      );
+      expect(readPreferredBackgroundMode()).toBe("keep");
+
+      window.localStorage.setItem(BACKGROUND_MODE_STORAGE_KEY, "");
+      expect(readPreferredBackgroundMode()).toBe("keep");
+    });
+  });
+
+  describe("writePreferredBackgroundMode", () => {
+    it("persists known background modes", () => {
+      writePreferredBackgroundMode("ai_auto");
+      expect(window.localStorage.getItem(BACKGROUND_MODE_STORAGE_KEY)).toBe(
+        "ai_auto",
+      );
+
+      writePreferredBackgroundMode("include_in_prompt");
+      expect(window.localStorage.getItem(BACKGROUND_MODE_STORAGE_KEY)).toBe(
+        "include_in_prompt",
+      );
+    });
+
+    it("ignores unknown values", () => {
+      writePreferredBackgroundMode("invalid" as never);
+      expect(window.localStorage.getItem(BACKGROUND_MODE_STORAGE_KEY)).toBeNull();
+    });
+  });
+
+  describe("safe write under storage failures", () => {
+    it("does not throw when localStorage.setItem throws (e.g. quota)", () => {
+      const original = window.localStorage.setItem;
+      window.localStorage.setItem = jest.fn(() => {
+        throw new Error("QuotaExceededError");
+      });
+      try {
+        expect(() => writePreferredModel("gpt-image-2-low")).not.toThrow();
+        expect(() => writePreferredBackgroundMode("ai_auto")).not.toThrow();
+      } finally {
+        window.localStorage.setItem = original;
+      }
+    });
+  });
+});

--- a/tests/unit/features/generation/generation-form-preferences.test.tsx
+++ b/tests/unit/features/generation/generation-form-preferences.test.tsx
@@ -1,0 +1,272 @@
+/** @jest-environment jsdom */
+
+import React from "react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { useTranslations } from "next-intl";
+import { GenerationForm } from "@/features/generation/components/GenerationForm";
+import {
+  BACKGROUND_MODE_STORAGE_KEY,
+  SELECTED_MODEL_STORAGE_KEY,
+} from "@/features/generation/lib/form-preferences";
+
+jest.mock("next-intl", () => ({
+  useTranslations: jest.fn(),
+}));
+
+jest.mock("@/components/ui/select", () => ({
+  Select: ({
+    value,
+    onValueChange,
+    disabled,
+    children,
+  }: {
+    value?: string;
+    onValueChange?: (value: string) => void;
+    disabled?: boolean;
+    children: React.ReactNode;
+  }) => (
+    <select
+      data-testid="model-select"
+      value={value}
+      disabled={disabled}
+      onChange={(event) => onValueChange?.(event.target.value)}
+    >
+      {children}
+    </select>
+  ),
+  SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectItem: ({
+    value,
+    children,
+  }: {
+    value: string;
+    children: React.ReactNode;
+  }) => <option value={value}>{children}</option>,
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectValue: () => null,
+}));
+
+jest.mock("@/components/ui/radio-group", () => {
+  const React = jest.requireActual("react") as typeof import("react");
+  const RadioContext = React.createContext<{
+    value?: string;
+    onValueChange?: (value: string) => void;
+    disabled?: boolean;
+  }>({});
+
+  return {
+    RadioGroup: ({
+      value,
+      onValueChange,
+      disabled,
+      children,
+    }: {
+      value?: string;
+      onValueChange?: (value: string) => void;
+      disabled?: boolean;
+      children: React.ReactNode;
+    }) => (
+      <RadioContext.Provider value={{ value, onValueChange, disabled }}>
+        <div>{children}</div>
+      </RadioContext.Provider>
+    ),
+    RadioGroupItem: ({
+      id,
+      value,
+      className,
+    }: {
+      id?: string;
+      value: string;
+      className?: string;
+    }) => {
+      const context = React.useContext(RadioContext);
+      return (
+        <input
+          id={id}
+          className={className}
+          type="radio"
+          checked={context.value === value}
+          disabled={context.disabled}
+          onChange={() => context.onValueChange?.(value)}
+        />
+      );
+    },
+  };
+});
+
+jest.mock("@/features/generation/components/ImageUploader", () => ({
+  ImageUploader: ({
+    onImageUpload,
+  }: {
+    onImageUpload: (image: {
+      file: File;
+      previewUrl: string;
+      width: number;
+      height: number;
+    }) => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="mock-add-upload"
+      onClick={() =>
+        onImageUpload({
+          file: new File(["x"], "demo.png", { type: "image/png" }),
+          previewUrl: "blob:mock",
+          width: 100,
+          height: 100,
+        })
+      }
+    >
+      add-upload
+    </button>
+  ),
+}));
+
+jest.mock("@/features/generation/components/StockImageListClient", () => ({
+  StockImageListClient: () => <div>stock-image-list</div>,
+}));
+
+jest.mock("@/features/generation/components/StockImageUploadCard", () => ({
+  StockImageUploadCard: () => <div>stock-image-upload-card</div>,
+}));
+
+jest.mock("@/features/generation/components/GeneratedImagesFromSource", () => ({
+  GeneratedImagesFromSource: () => null,
+}));
+
+jest.mock("@/features/generation/lib/database", () => ({
+  getSourceImageStocks: jest.fn(),
+  getStockImageLimit: jest.fn(),
+}));
+
+jest.mock("@/features/generation/lib/current-user", () => ({
+  getCurrentUserId: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock("@/features/generation/lib/model-config", () => ({
+  getPercoinCost: jest.fn((model?: string) => {
+    const costs: Record<string, number> = {
+      "gemini-3.1-flash-image-preview-512": 10,
+      "gemini-3.1-flash-image-preview-1024": 20,
+      "gemini-3-pro-image-1k": 50,
+      "gemini-3-pro-image-2k": 80,
+      "gemini-3-pro-image-4k": 100,
+      "gpt-image-2-low": 10,
+    };
+    return costs[model ?? ""] ?? 10;
+  }),
+}));
+
+const useTranslationsMock = useTranslations as jest.MockedFunction<
+  typeof useTranslations
+>;
+
+const messages: Record<string, string> = {
+  imageSourceLabel: "Choose source image",
+  libraryTab: "Library",
+  stockTab: "Stock",
+  sourceImageTypeLabel: "Source image type",
+  sourceImageTypeIllustration: "Illustration",
+  sourceImageTypeReal: "Photoreal",
+  promptLabel: "Describe the outfit",
+  promptPlaceholder: "Example outfit",
+  promptHint: "Describe the outfit in up to {max} characters.",
+  promptCharacterCount: "{current}/{max} characters",
+  promptTooLong: "Enter an outfit description within {max} characters.",
+  backgroundLabel: "Background",
+  backgroundAiAutoLabel: "Let AI decide",
+  backgroundAiAutoDescription: "AI decides the background.",
+  backgroundIncludeInPromptLabel: "Include it in the prompt",
+  backgroundIncludeInPromptDescription: "Background is part of the prompt.",
+  backgroundKeepLabel: "Keep current background",
+  backgroundKeepDescription: "Keep the current background.",
+  modelLabel: "Model",
+  modelLight05k: "Light model: Nano Banana 2 | 0.5K (10 Percoins / image)",
+  modelStandard1k: "Standard model: Nano Banana 2 | 1K (20 Percoins / image)",
+  modelPro1k: "High-fidelity model: Nano Banana Pro | 1K (50 Percoins / image)",
+  modelPro2k: "High-fidelity model: Nano Banana Pro | 2K (80 Percoins / image)",
+  modelPro4k: "High-fidelity model: Nano Banana Pro | 4K (100 Percoins / image)",
+  modelGptImage2Low: "Light model: ChatGPT Images 2.0 (10 Percoins / image)",
+  countLabel: "Count",
+  countSingle: "1 image",
+  countMultiple: "{count} images",
+  countCostDescription: "{count} images require {amount} Percoins",
+  generatingButton: "Start styling",
+  generatingButtonLoading: "Generating...",
+  missingPrompt: "Enter an outfit description.",
+  missingUploadedImage: "Upload a source image.",
+  missingStockImage: "Select a stock image.",
+};
+
+function translate(
+  namespace: string | undefined,
+  key: string,
+  values?: Record<string, string | number>,
+) {
+  if (namespace !== "coordinate") return key;
+  const template = messages[key] ?? key;
+  if (!values) return template;
+  return Object.entries(values).reduce((message, [token, value]) => {
+    return message.replace(`{${token}}`, String(value));
+  }, template);
+}
+
+describe("GenerationForm persisted preferences", () => {
+  beforeEach(() => {
+    useTranslationsMock.mockImplementation((namespace?: string) => {
+      return ((key: string, values?: Record<string, string | number>) =>
+        translate(namespace, key, values)) as ReturnType<typeof useTranslations>;
+    });
+    window.alert = jest.fn();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("restores persisted model and background mode for submit payloads", async () => {
+    localStorage.setItem(SELECTED_MODEL_STORAGE_KEY, "gpt-image-2-low");
+    localStorage.setItem(BACKGROUND_MODE_STORAGE_KEY, "ai_auto");
+    const onSubmit = jest.fn();
+
+    await act(async () => {
+      render(<GenerationForm subscriptionPlan="free" onSubmit={onSubmit} />);
+    });
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "saved preference outfit" },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("mock-add-upload"));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /Start styling/i }));
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backgroundMode: "ai_auto",
+        model: "gpt-image-2-low",
+      }),
+    );
+  });
+
+  it("persists model and background changes made by the user", async () => {
+    await act(async () => {
+      render(<GenerationForm subscriptionPlan="free" onSubmit={jest.fn()} />);
+    });
+
+    fireEvent.change(screen.getByTestId("model-select"), {
+      target: { value: "gemini-3-pro-image-4k" },
+    });
+    fireEvent.click(screen.getByLabelText("Include it in the prompt"));
+
+    expect(localStorage.getItem(SELECTED_MODEL_STORAGE_KEY)).toBe(
+      "gemini-3-pro-image-4k",
+    );
+    expect(localStorage.getItem(BACKGROUND_MODE_STORAGE_KEY)).toBe(
+      "include_in_prompt",
+    );
+  });
+});

--- a/tests/unit/features/generation/model-display.test.ts
+++ b/tests/unit/features/generation/model-display.test.ts
@@ -1,0 +1,55 @@
+import { getModelBrandName } from "@/features/generation/lib/model-display";
+
+describe("getModelBrandName", () => {
+  describe("ChatGPT Images 2.0", () => {
+    it("returns 'ChatGPT Images 2.0' for gpt-image-* prefix", () => {
+      expect(getModelBrandName("gpt-image-2-low")).toBe("ChatGPT Images 2.0");
+      expect(getModelBrandName("gpt-image-2-high")).toBe("ChatGPT Images 2.0");
+      expect(getModelBrandName("gpt-image-3-something-future")).toBe(
+        "ChatGPT Images 2.0",
+      );
+    });
+  });
+
+  describe("Nano Banana Pro", () => {
+    it("returns 'Nano Banana Pro' for gemini-3-pro-image-* prefix", () => {
+      expect(getModelBrandName("gemini-3-pro-image-1k")).toBe("Nano Banana Pro");
+      expect(getModelBrandName("gemini-3-pro-image-2k")).toBe("Nano Banana Pro");
+      expect(getModelBrandName("gemini-3-pro-image-4k")).toBe("Nano Banana Pro");
+    });
+  });
+
+  describe("Nano Banana 2", () => {
+    it("returns 'Nano Banana 2' for gemini-3.1-flash-image-* prefix", () => {
+      expect(getModelBrandName("gemini-3.1-flash-image-preview-512")).toBe(
+        "Nano Banana 2",
+      );
+      expect(getModelBrandName("gemini-3.1-flash-image-preview-1024")).toBe(
+        "Nano Banana 2",
+      );
+    });
+
+    it("returns 'Nano Banana 2' for the legacy gemini-2.5-flash-image exact match", () => {
+      expect(getModelBrandName("gemini-2.5-flash-image")).toBe("Nano Banana 2");
+    });
+  });
+
+  describe("unrecognized inputs", () => {
+    it("returns null for unknown prefix", () => {
+      expect(getModelBrandName("dall-e-3")).toBeNull();
+      expect(getModelBrandName("midjourney-v6")).toBeNull();
+      expect(getModelBrandName("gemini-2.0-flash")).toBeNull();
+    });
+
+    it("returns null for null / undefined / empty string", () => {
+      expect(getModelBrandName(null)).toBeNull();
+      expect(getModelBrandName(undefined)).toBeNull();
+      expect(getModelBrandName("")).toBeNull();
+    });
+
+    it("does not match a substring without prefix", () => {
+      // 念のため: 末尾が gpt-image- 等で終わるだけでは null
+      expect(getModelBrandName("custom-gpt-image-experiment")).toBeNull();
+    });
+  });
+});

--- a/tests/unit/features/posts/ensure-image-dimensions.test.ts
+++ b/tests/unit/features/posts/ensure-image-dimensions.test.ts
@@ -1,0 +1,278 @@
+/** @jest-environment node */
+
+import {
+  ensureImageDimensions,
+  type ImageRowSubset,
+} from "@/features/posts/lib/ensure-image-dimensions";
+
+function makeParams(
+  overrides: {
+    data?: ImageRowSubset;
+    useCache?: boolean;
+    fetchDimensions?: jest.Mock;
+    resolveImageUrl?: jest.Mock;
+    updateRow?: jest.Mock;
+  } = {},
+) {
+  return {
+    data: overrides.data ?? {},
+    useCache: overrides.useCache ?? false,
+    fetchDimensions:
+      overrides.fetchDimensions ??
+      jest.fn().mockResolvedValue({ width: 1024, height: 1536 }),
+    resolveImageUrl:
+      overrides.resolveImageUrl ??
+      jest.fn(() => "https://cdn.example.com/img.png"),
+    updateRow: overrides.updateRow ?? jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("ensureImageDimensions", () => {
+  beforeEach(() => {
+    jest.spyOn(console, "warn").mockImplementation(() => {
+      // suppress in tests
+    });
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("when all values are already populated", () => {
+    it("returns existing values without fetching or updating", async () => {
+      const params = makeParams({
+        data: {
+          aspect_ratio: "portrait",
+          width: 1024,
+          height: 1536,
+          image_url: "https://cdn.example.com/img.png",
+        },
+      });
+
+      const result = await ensureImageDimensions(params);
+
+      expect(result).toEqual({
+        aspectRatio: "portrait",
+        width: 1024,
+        height: 1536,
+      });
+      expect(params.fetchDimensions).not.toHaveBeenCalled();
+      expect(params.updateRow).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when useCache=true", () => {
+    it("computes and returns dimensions but does NOT issue a DB UPDATE", async () => {
+      const params = makeParams({
+        data: { image_url: "https://cdn.example.com/img.png" },
+        useCache: true,
+      });
+
+      const result = await ensureImageDimensions(params);
+
+      expect(result).toEqual({
+        aspectRatio: "portrait",
+        width: 1024,
+        height: 1536,
+      });
+      expect(params.fetchDimensions).toHaveBeenCalledTimes(1);
+      expect(params.updateRow).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when useCache=false", () => {
+    it("UPDATEs only the fields that were null on the input row", async () => {
+      const params = makeParams({
+        data: {
+          aspect_ratio: "portrait", // already set
+          width: null, // missing
+          height: null, // missing
+          image_url: "https://cdn.example.com/img.png",
+        },
+      });
+
+      const result = await ensureImageDimensions(params);
+
+      expect(result).toEqual({
+        aspectRatio: "portrait", // unchanged
+        width: 1024,
+        height: 1536,
+      });
+      expect(params.updateRow).toHaveBeenCalledTimes(1);
+      expect(params.updateRow).toHaveBeenCalledWith({
+        width: 1024,
+        height: 1536,
+      });
+    });
+
+    it("UPDATEs all three fields when all are null", async () => {
+      const params = makeParams({
+        data: { image_url: "https://cdn.example.com/img.png" },
+      });
+
+      await ensureImageDimensions(params);
+
+      expect(params.updateRow).toHaveBeenCalledWith({
+        aspect_ratio: "portrait",
+        width: 1024,
+        height: 1536,
+      });
+    });
+
+    it("derives aspect_ratio='landscape' when width > height", async () => {
+      const params = makeParams({
+        data: { image_url: "https://cdn.example.com/img.png" },
+        fetchDimensions: jest
+          .fn()
+          .mockResolvedValue({ width: 1536, height: 1024 }),
+      });
+
+      const result = await ensureImageDimensions(params);
+
+      expect(result.aspectRatio).toBe("landscape");
+      expect(params.updateRow).toHaveBeenCalledWith({
+        aspect_ratio: "landscape",
+        width: 1536,
+        height: 1024,
+      });
+    });
+
+    it("treats square as 'landscape' (same as existing aspect_ratio behaviour)", async () => {
+      const params = makeParams({
+        data: { image_url: "https://cdn.example.com/img.png" },
+        fetchDimensions: jest
+          .fn()
+          .mockResolvedValue({ width: 1024, height: 1024 }),
+      });
+
+      const result = await ensureImageDimensions(params);
+
+      // existing aspect_ratio CHECK constraint is portrait | landscape only,
+      // so equal dimensions fall into landscape branch
+      expect(result.aspectRatio).toBe("landscape");
+    });
+
+    it("does not UPDATE when nothing changed", async () => {
+      // 既に全列が埋まっていれば fetchDimensions も呼ばないが、
+      // 「fetch したが情報が新規でない」理論上のケースを念のため確認する
+      const params = makeParams({
+        data: {
+          aspect_ratio: "portrait",
+          width: 1024,
+          height: 1536,
+          image_url: "https://cdn.example.com/img.png",
+        },
+      });
+
+      await ensureImageDimensions(params);
+
+      expect(params.fetchDimensions).not.toHaveBeenCalled();
+      expect(params.updateRow).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when image dimensions cannot be obtained", () => {
+    it("returns null values without UPDATE if resolveImageUrl returns null", async () => {
+      const params = makeParams({
+        data: { image_url: null, storage_path: null },
+        resolveImageUrl: jest.fn(() => null),
+      });
+
+      const result = await ensureImageDimensions(params);
+
+      expect(result).toEqual({
+        aspectRatio: null,
+        width: null,
+        height: null,
+      });
+      expect(params.fetchDimensions).not.toHaveBeenCalled();
+      expect(params.updateRow).not.toHaveBeenCalled();
+    });
+
+    it("returns null values when fetchDimensions resolves to null", async () => {
+      const params = makeParams({
+        data: { image_url: "https://cdn.example.com/img.png" },
+        fetchDimensions: jest.fn().mockResolvedValue(null),
+      });
+
+      const result = await ensureImageDimensions(params);
+
+      expect(result).toEqual({
+        aspectRatio: null,
+        width: null,
+        height: null,
+      });
+      expect(params.updateRow).not.toHaveBeenCalled();
+    });
+
+    it("returns null values when fetchDimensions throws", async () => {
+      const params = makeParams({
+        data: { image_url: "https://cdn.example.com/img.png" },
+        fetchDimensions: jest.fn().mockRejectedValue(new Error("boom")),
+      });
+
+      const result = await ensureImageDimensions(params);
+
+      expect(result).toEqual({
+        aspectRatio: null,
+        width: null,
+        height: null,
+      });
+      expect(params.updateRow).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when updateRow throws", () => {
+    it("swallows the error and returns the computed values", async () => {
+      const params = makeParams({
+        data: { image_url: "https://cdn.example.com/img.png" },
+        updateRow: jest.fn().mockRejectedValue(new Error("update conflict")),
+      });
+
+      const result = await ensureImageDimensions(params);
+
+      expect(result).toEqual({
+        aspectRatio: "portrait",
+        width: 1024,
+        height: 1536,
+      });
+    });
+  });
+
+  describe("input sanitization", () => {
+    it("ignores non-positive width/height as if missing", async () => {
+      const params = makeParams({
+        data: {
+          aspect_ratio: "portrait",
+          width: 0,
+          height: -1,
+          image_url: "https://cdn.example.com/img.png",
+        },
+      });
+
+      const result = await ensureImageDimensions(params);
+
+      expect(result).toEqual({
+        aspectRatio: "portrait",
+        width: 1024,
+        height: 1536,
+      });
+      expect(params.fetchDimensions).toHaveBeenCalledTimes(1);
+    });
+
+    it("ignores unknown aspect_ratio strings as if missing", async () => {
+      const params = makeParams({
+        data: {
+          aspect_ratio: "square" as unknown as "portrait", // 未対応値
+          width: 1024,
+          height: 1536,
+          image_url: "https://cdn.example.com/img.png",
+        },
+      });
+
+      const result = await ensureImageDimensions(params);
+
+      // aspect_ratio は既存値が無効なので fetch して再計算される
+      expect(result.aspectRatio).toBe("portrait");
+    });
+  });
+});

--- a/tests/unit/features/posts/post-meta-line.test.tsx
+++ b/tests/unit/features/posts/post-meta-line.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+
+jest.mock("next-intl", () => ({
+  useTranslations: jest.fn(() => (key: string) => {
+    const messages: Record<string, string> = {
+      metaModelLabel: "生成モデル",
+      metaSizeLabel: "サイズ",
+    };
+    return messages[key] ?? key;
+  }),
+}));
+
+import { PostMetaLine } from "@/features/posts/components/PostMetaLine";
+
+describe("PostMetaLine", () => {
+  it("renders brand name and dimensions when both model and width/height are present", () => {
+    render(<PostMetaLine model="gpt-image-2-low" width={1024} height={1536} />);
+    const node = screen.getByTestId("post-meta-line");
+    expect(node.textContent).toBe("ChatGPT Images 2.0 / 1024×1536");
+    expect(node.getAttribute("aria-label")).toBe(
+      "生成モデル: ChatGPT Images 2.0, サイズ: 1024×1536",
+    );
+  });
+
+  it("renders brand name only when width or height is missing", () => {
+    const { rerender } = render(
+      <PostMetaLine model="gemini-3-pro-image-2k" width={null} height={null} />,
+    );
+    let node = screen.getByTestId("post-meta-line");
+    expect(node.textContent).toBe("Nano Banana Pro");
+    expect(node.getAttribute("aria-label")).toBe(
+      "生成モデル: Nano Banana Pro",
+    );
+
+    // 片方だけ揃っているケースも brand only に丸める
+    rerender(
+      <PostMetaLine model="gemini-3-pro-image-2k" width={1024} height={null} />,
+    );
+    node = screen.getByTestId("post-meta-line");
+    expect(node.textContent).toBe("Nano Banana Pro");
+  });
+
+  it("renders nothing when the model is unknown / null / empty", () => {
+    const { rerender, container } = render(
+      <PostMetaLine model={null} width={1024} height={1024} />,
+    );
+    expect(container.firstChild).toBeNull();
+
+    rerender(<PostMetaLine model="" width={1024} height={1024} />);
+    expect(container.firstChild).toBeNull();
+
+    rerender(<PostMetaLine model="dall-e-3" width={1024} height={1024} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("ignores non-positive dimensions", () => {
+    render(
+      <PostMetaLine model="gemini-2.5-flash-image" width={0} height={1024} />,
+    );
+    const node = screen.getByTestId("post-meta-line");
+    expect(node.textContent).toBe("Nano Banana 2");
+  });
+});

--- a/tests/unit/features/posts/server-api-get-post.test.ts
+++ b/tests/unit/features/posts/server-api-get-post.test.ts
@@ -52,7 +52,15 @@ function createPngHeader(width: number, height: number): ArrayBuffer {
   );
 }
 
-function createSupabaseMock() {
+function createSupabaseMock(
+  postOverrides: Partial<{
+    image_url: string | null;
+    storage_path: string | null;
+    aspect_ratio: string | null;
+    width: number | null;
+    height: number | null;
+  }> = {},
+) {
   const updateGeneratedImage = jest.fn();
   const postRow = {
     id: "post-1",
@@ -70,6 +78,7 @@ function createSupabaseMock() {
     height: null,
     created_at: "2026-04-26T00:00:00.000Z",
     updated_at: "2026-04-26T00:00:00.000Z",
+    ...postOverrides,
   };
 
   const from = jest.fn((table: string): QueryBuilder => {
@@ -200,6 +209,27 @@ describe("getPost", () => {
         aspect_ratio: "landscape",
         width: 2048,
         height: 1024,
+      }),
+    );
+  });
+
+  it("keeps dimensions empty when no image URL can be resolved", async () => {
+    const { supabase, updateGeneratedImage } = createSupabaseMock({
+      image_url: null,
+      storage_path: null,
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    const post = await getPost("post-1", null, true);
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(updateGeneratedImage).not.toHaveBeenCalled();
+    expect(post).toEqual(
+      expect.objectContaining({
+        id: "post-1",
+        aspect_ratio: null,
+        width: null,
+        height: null,
       }),
     );
   });

--- a/tests/unit/features/posts/server-api-get-post.test.ts
+++ b/tests/unit/features/posts/server-api-get-post.test.ts
@@ -1,0 +1,206 @@
+/** @jest-environment node */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createClient } from "@/lib/supabase/server";
+import { getPost } from "@/features/posts/lib/server-api";
+
+jest.mock("react", () => ({
+  cache: <T extends (...args: never[]) => unknown>(fn: T) => fn,
+}));
+
+jest.mock("@/lib/supabase/server", () => ({
+  createClient: jest.fn(),
+}));
+
+jest.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: jest.fn(),
+}));
+
+jest.mock("@/lib/auth", () => ({
+  getUser: jest.fn(),
+}));
+
+jest.mock("@/lib/env", () => ({
+  getAdminUserIds: jest.fn(() => []),
+}));
+
+jest.mock("@/features/generation/lib/prompt-visibility", () => ({
+  redactSensitivePrompt: (post: unknown) => post,
+}));
+
+type QueryBuilder = {
+  select: jest.Mock;
+  eq: jest.Mock;
+  in: jest.Mock;
+  is: jest.Mock;
+  single: jest.Mock;
+  maybeSingle: jest.Mock;
+  update: jest.Mock;
+};
+
+function createPngHeader(width: number, height: number): ArrayBuffer {
+  const buffer = Buffer.alloc(24);
+  buffer[0] = 0x89;
+  buffer[1] = 0x50;
+  buffer[2] = 0x4e;
+  buffer[3] = 0x47;
+  buffer.writeUInt32BE(width, 16);
+  buffer.writeUInt32BE(height, 20);
+  return buffer.buffer.slice(
+    buffer.byteOffset,
+    buffer.byteOffset + buffer.byteLength,
+  );
+}
+
+function createSupabaseMock() {
+  const updateGeneratedImage = jest.fn();
+  const postRow = {
+    id: "post-1",
+    user_id: "author-1",
+    image_url: null,
+    storage_path: "generated/path.png",
+    prompt: "prompt",
+    background_change: false,
+    is_posted: true,
+    moderation_status: "visible",
+    caption: null,
+    view_count: 7,
+    aspect_ratio: null,
+    width: null,
+    height: null,
+    created_at: "2026-04-26T00:00:00.000Z",
+    updated_at: "2026-04-26T00:00:00.000Z",
+  };
+
+  const from = jest.fn((table: string): QueryBuilder => {
+    const builder = {} as QueryBuilder;
+    let updating = false;
+    let commentsIsCallCount = 0;
+    let selectColumns: unknown;
+    let selectOptions: { count?: string; head?: boolean } | undefined;
+
+    builder.select = jest.fn((columns?: unknown, options?: unknown) => {
+      selectColumns = columns;
+      selectOptions = options as { count?: string; head?: boolean } | undefined;
+      return builder;
+    });
+    builder.eq = jest.fn(() => {
+      if (updating) {
+        return Promise.resolve({ error: null });
+      }
+      if (table === "likes" && selectColumns === "*") {
+        return Promise.resolve({ count: 1, error: null });
+      }
+      return builder;
+    });
+    builder.in = jest.fn(() => builder);
+    builder.is = jest.fn(() => builder);
+    builder.single = jest.fn(async () => {
+      if (table === "generated_images") {
+        return { data: postRow, error: null };
+      }
+      if (table === "profiles") {
+        return {
+          data: {
+            user_id: "author-1",
+            nickname: "Author",
+            avatar_url: "https://cdn.example/avatar.png",
+            subscription_plan: "standard",
+          },
+          error: null,
+        };
+      }
+      return { data: null, error: null };
+    });
+    builder.maybeSingle = jest.fn(async () => ({ data: null, error: null }));
+    builder.update = jest.fn((updates: Record<string, unknown>) => {
+      updating = true;
+      updateGeneratedImage(updates);
+      return builder;
+    });
+
+    if (table === "likes") {
+      builder.in = jest.fn(async () => ({
+        data: [{ image_id: "post-1" }],
+        error: null,
+      }));
+    }
+
+    if (table === "comments") {
+      builder.is = jest.fn(() => {
+        commentsIsCallCount += 1;
+        if (commentsIsCallCount >= 2) {
+          if (selectOptions?.count === "exact" && selectOptions.head) {
+            return Promise.resolve({ count: 2, error: null });
+          }
+          return Promise.resolve({
+            data: [{ image_id: "post-1" }, { image_id: "post-1" }],
+            error: null,
+          });
+        }
+        return builder;
+      });
+    }
+
+    return builder;
+  });
+
+  return {
+    supabase: { from } as unknown as SupabaseClient,
+    updateGeneratedImage,
+  };
+}
+
+describe("getPost", () => {
+  const originalSupabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const createClientMock = createClient as jest.MockedFunction<
+    typeof createClient
+  >;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://supabase.example";
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => createPngHeader(2048, 1024),
+    } as never);
+  });
+
+  afterEach(() => {
+    if (originalSupabaseUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    } else {
+      process.env.NEXT_PUBLIC_SUPABASE_URL = originalSupabaseUrl;
+    }
+    jest.restoreAllMocks();
+  });
+
+  it("computes missing dimensions through the shared post image URL resolver", async () => {
+    const { supabase, updateGeneratedImage } = createSupabaseMock();
+    createClientMock.mockResolvedValue(supabase);
+
+    const post = await getPost("post-1", null, true);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://supabase.example/storage/v1/object/public/generated-images/generated/path.png",
+      expect.objectContaining({
+        method: "GET",
+        headers: { Range: "bytes=0-65535" },
+      }),
+    );
+    expect(updateGeneratedImage).toHaveBeenCalledWith({
+      aspect_ratio: "landscape",
+      width: 2048,
+      height: 1024,
+    });
+    expect(post).toEqual(
+      expect.objectContaining({
+        id: "post-1",
+        like_count: 1,
+        comment_count: 2,
+        aspect_ratio: "landscape",
+        width: 2048,
+        height: 1024,
+      }),
+    );
+  });
+});

--- a/tests/unit/features/posts/utils.test.ts
+++ b/tests/unit/features/posts/utils.test.ts
@@ -1,0 +1,66 @@
+/** @jest-environment node */
+
+import {
+  deriveAspectRatioFromDimensions,
+  getPostImageUrl,
+} from "@/features/posts/lib/utils";
+
+describe("posts utils", () => {
+  const originalSupabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://supabase.example";
+  });
+
+  afterEach(() => {
+    if (originalSupabaseUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    } else {
+      process.env.NEXT_PUBLIC_SUPABASE_URL = originalSupabaseUrl;
+    }
+  });
+
+  describe("getPostImageUrl", () => {
+    it("prefers image_url over storage_path", () => {
+      expect(
+        getPostImageUrl({
+          image_url: "https://cdn.example/direct.png",
+          storage_path: "generated/path.png",
+        }),
+      ).toBe("https://cdn.example/direct.png");
+    });
+
+    it("builds a public storage URL from storage_path", () => {
+      expect(
+        getPostImageUrl({
+          image_url: null,
+          storage_path: "generated/path.png",
+        }),
+      ).toBe(
+        "https://supabase.example/storage/v1/object/public/generated-images/generated/path.png",
+      );
+    });
+
+    it("returns an empty string when no image source exists", () => {
+      expect(getPostImageUrl({ image_url: null, storage_path: null })).toBe("");
+    });
+  });
+
+  describe("deriveAspectRatioFromDimensions", () => {
+    it("returns portrait when height is greater than width", () => {
+      expect(deriveAspectRatioFromDimensions(768, 1024)).toBe("portrait");
+    });
+
+    it("returns landscape for wide or square dimensions", () => {
+      expect(deriveAspectRatioFromDimensions(1024, 768)).toBe("landscape");
+      expect(deriveAspectRatioFromDimensions(1024, 1024)).toBe("landscape");
+    });
+
+    it("returns null when either dimension is missing or invalid", () => {
+      expect(deriveAspectRatioFromDimensions(null, 1024)).toBeNull();
+      expect(deriveAspectRatioFromDimensions(1024, undefined)).toBeNull();
+      expect(deriveAspectRatioFromDimensions(0, 1024)).toBeNull();
+      expect(deriveAspectRatioFromDimensions(1024, -1)).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
### 概要
Post 詳細画面のプロンプトブロック直前に、生成に使用したモデル名と画像実寸（例: `ChatGPT Images 2.0 / 1024×1536`）を表示する。`generated_images` に `width` / `height` 列を加算追加し、既存の `aspect_ratio` lazy compute パターンを踏襲して fetch 時にまとめて算出・キャッシュする。既存列（`aspect_ratio` / `background_change`）は互換維持し、削除は別 PR に切り出す。

加えて、コーディネート画面の **生成モデル選択** と **背景設定** を localStorage に永続化し、リロード / ログアウト後でも前回の選択を復元する。

### 変更内容

#### Post 詳細のメタ表示 + DB 拡張
- **DB migration**: `generated_images.width INT NULL` / `height INT NULL` を追加（CHECK 制約 `> 0`）。`aspect_ratio` / `background_change` は削除しない
- **型拡張**: `GeneratedImageRecord` に `width?: number | null` / `height?: number | null` を追加。`Post` 型は extends で自動継承
- **Lazy compute 切り出し**: 新規 `features/posts/lib/ensure-image-dimensions.ts` に純関数化(DI で `fetchDimensions` / `resolveImageUrl` / `updateRow` を受け取る)。`server-api.ts` のインライン分岐を ~50 行 → ~12 行へ簡素化
- **lazy compute 仕様**: aspect_ratio / width / height のいずれかが NULL なら 1 回の Range fetch で `getImageDimensions` を呼び、未保存フィールドだけを返却・差分 UPDATE する。`useCache=true` のとき DB UPDATE はスキップ。fetch 失敗 / URL 解決不可 / UPDATE 失敗は warn ログを出して握りつぶす
- **ブランド名ヘルパー**: 新規 `features/generation/lib/model-display.ts` の `getModelBrandName(model)`。`gpt-image-` / `gemini-3-pro-image-` / `gemini-3.1-flash-image-` / `gemini-2.5-flash-image` の各プレフィックスを ChatGPT Images 2.0 / Nano Banana Pro / Nano Banana 2 に判定。未知は null
- **表示部品**: 新規 `features/posts/components/PostMetaLine.tsx`。brand 不明なら `null` を返す（親要素に余白を残さない）。width/height NULL ならブランド名のみ。`aria-label` で「生成モデル: ..., サイズ: ...」をスクリーンリーダーに伝える
- **CachedPostDetail の fallback**: `aspect_ratio` 優先 → `width`/`height` から `deriveAspectRatioFromDimensions` で派生 → 最後の手段で `getImageAspectRatio` フェッチ、の 3 段階に拡張
- **PostDetail.tsx / PostDetailStatic.tsx**: プロンプトブロック直前に `<PostMetaLine />` を挿入。`PostDetailContent.tsx` は `PostDetailStatic` のラッパーなので変更不要
- **i18n**: `messages/ja.ts` / `messages/en.ts` の `posts` 名前空間に `metaModelLabel` (生成モデル / Generation model)、`metaSizeLabel` (サイズ / Size) を追加（aria-label 用）
- **DB schema ledger**: `.cursor/rules/database-design.mdc` の `generated_images` 主要カラム一覧に `width`, `height` を追記、備考に lazy compute / CHECK 制約の説明追加

#### ユーザー設定の永続化（モデル / 背景設定）
- **新規 helper `features/generation/lib/form-preferences.ts`**:
  - localStorage への read / write を 4 関数で抽象化（`readPreferredModel` / `writePreferredModel` / `readPreferredBackgroundMode` / `writePreferredBackgroundMode`）
  - SSR セーフ（`typeof window` ガード、try/catch で quota 超過・private browsing を握り潰し）
  - 入力 validate 付き: `<SelectItem>` で表示中のモデル ID 一覧と `BACKGROUND_MODES` 定数で許可リストを管理し、未知値・legacy ID は default にフォールバック
- **GenerationForm.tsx の改修**:
  - mount 時に 1 回 useEffect で localStorage から復元（hydration mismatch 防止のため初期 state は default のまま）
  - user 操作時のみ書き込む `handleSelectedModelChange` / `handleBackgroundModeChange` を導入し Select / RadioGroup の onValueChange に紐付け
  - `tutorial:clear` / `tutorial:set-background-mode` 等の system-driven な setState は元の setter を直接使うので localStorage を触らない（保存済 preference を tutorial が消さない）
- **動作**:
  - ユーザーがモデル / 背景モードを変更 → localStorage に保存
  - ページ更新 → 前回の選択を復元
  - ログアウト → 再ログイン → 同じブラウザなら復元
  - 別ブラウザ / 別端末 → default のまま（要件通り）

#### ビルド阻害バグの巻き取り（前回 PR #229 由来）
前回 PR で `app/api/generation-status/route.ts` から named export していた `normalizeUserFacingGenerationError` が Next.js 16 のルートファイル制約（"is not a valid Route export field"）に違反していたためビルド失敗していた。`features/generation/lib/normalize-generation-error.ts` に切り出してビルドを通した（既存テストの import パスも追従）。

### 実機テスト
- [ ] iOS Safari で主要導線を確認
- [ ] Android Chrome で主要導線を確認
- [ ] PC（Chrome）で主要導線を確認
- [ ] レスポンシブ表示崩れがないことを確認
- [ ] エラーメッセージやバリデーション表示を確認

### テスト方法
- 自動: `npm run lint` / `npm run typecheck` / `npm run test`（**85 suites / 700 tests pass**、新規 36 件: model-display 7 + PostMetaLine 4 + ensure-image-dimensions 13 + form-preferences 12）/ `npm run build -- --webpack` 全 pass
- ローカル UI 確認:
  - dev サーバーで Post 詳細を開き、`ChatGPT Images 2.0 / 1024×1536` 形式の表示を確認
  - 生成モデル / 背景設定を切り替えてリロード → 前回値が復元されることを確認
- Vercel Preview / 本番での E2E:
  - 自分の最新 OpenAI 画像（width/height NULL）→ 初回アクセスで lazy compute → 同一レスポンスでサイズ表示
  - Nano Banana 系の既存画像 → ブランド名表示 + lazy compute 後にサイズ表示
  - 他ユーザーの公開画像 → 同じく表示
  - 縦/横/正方形のフレーム切替が既存 `aspect_ratio` 優先で維持される
  - 背景変更系の生成（`backgroundMode` の各値）が既存通り問題なく完了
  - モデル選択 → ログアウト → ログイン → 同じモデルが選択されたまま

### Lazy compute の挙動

| 状態 | fetchDimensions | DB UPDATE | レスポンス |
| --- | --- | --- | --- |
| 全列既存 | 呼ばない | しない | 既存値そのまま |
| 一部 NULL + useCache=true | 呼ぶ | しない | 計算値で補完 |
| 一部 NULL + useCache=false | 呼ぶ | 未保存フィールドのみ | 計算値で補完 |
| 全 NULL + URL 解決不可 | 呼ばない | しない | NULL 維持 |
| 全 NULL + fetch null/throw | 呼ぶ | しない | NULL 維持 + warn ログ |

### スコープ外（将来別 PR）
- `aspect_ratio` 列の削除（width/height からの派生で完全に置換可能だが、参照箇所の整理が必要）
- `background_change` 列の削除（今回 PR は触らない、TODO は残す）
- 生成履歴の width/height backfill（lazy compute で fetch 済みの行から順次埋まる）
- `selectedCount` / 元画像タブ等の他フィールドの永続化

### 設計参照
実装計画は [docs/planning/post-detail-model-and-size-display-plan.md](docs/planning/post-detail-model-and-size-display-plan.md)。
EARS 要件・ADR 8 件・フェーズ別実装計画・ロールバック方針を含む。
※ ユーザー設定永続化は計画書の対象外（軽微な UX 改善として後追い）。

### レビュー指摘対応
レビュー指摘 2 件を反映済み:
1. `.cursor/rules/database-design.mdc` ledger に width/height を追記
2. `ensureImageDimensions` を切り出して 13 ケースの単体テストを追加（useCache=true で UPDATE しない / useCache=false で未保存フィールドだけ UPDATE / 取得失敗時に NULL 維持 など全網羅）
