### PR TITLE
chore: .claude/worktrees を gitignore に追加し、settings.json の差分を同梱

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -38,7 +38,8 @@
       "mcp__plugin_playwright_playwright__browser_click",
       "mcp__plugin_playwright_playwright__browser_console_messages",
       "mcp__context7__resolve-library-id",
-      "mcp__context7__query-docs"
+      "mcp__context7__query-docs",
+      "Bash(git worktree *)"
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ yarn-error.log*
 # Claude Code local overrides (may contain account-specific settings)
 .claude/settings.local.json
 
+# Claude Code worktrees (independent working trees, not part of repo content)
+.claude/worktrees/
+
 # vercel
 .vercel
 


### PR DESCRIPTION
### 概要
`.claude/worktrees/` を gitignore に追加し、`git status` のノイズをなくす。あわせて harness が今 session で自動追加した `.claude/settings.json` の permission（`Bash(git worktree *)`）を同梱する。前例 #227 / #230 と同じ chore PR の形。

### 変更内容
- **`.gitignore`**: `.claude/worktrees/` を追加。`.claude/settings.local.json` の隣にコメント付きで配置
- **`.claude/settings.json`**: 今 session で permission として承認した `Bash(git worktree *)` を追記（PR #232 作業中のワークツリー操作で発行されたもの）

### なぜ必要か
- `.claude/worktrees/` は Claude Code が並行作業用に作る独立した working tree のコンテナ。リポジトリの content ではない
- 各 PR で worktree を `git worktree add` した後、`git worktree remove` するまで残っており、その間 `git status` に `?? .claude/worktrees/` が表示され続ける
- 別の Claude session が作った worktree（`claude/elastic-williams-3efc10` 等）も同様に残るため、同居する複数のワークツリーが常時 untracked として目立つ
- gitignore に入れると `git status` がクリーンになり、`git pull` 時の dirty 警告も発生しなくなる

### 互換性 / 影響
- gitignore は **追加のみ**で既存無視対象は変更なし
- `.claude/worktrees/` 配下のファイルは元々誰も commit していないため、tracked → untracked への移行は不要（純粋な追加）
- settings.json の差分は permission 追加 1 行のみで、既存の動作に影響なし

### 実機テスト
- [ ] PC（Chrome）で主要導線を確認（コード変更ゼロのため軽い確認のみで十分）

### テスト方法
- `git status` で `?? .claude/worktrees/` が消えることを確認
- 自動: lint / typecheck / test は対象差分なし（`.gitignore` と `settings.json` のみのため）
