### PR TITLE
legacy画像メタデータ列を削除する

### DIFF
--- a/.cursor/rules/database-design.mdc
+++ b/.cursor/rules/database-design.mdc
@@ -123,16 +123,16 @@ alwaysApply: false
 
 #### `image_jobs`
 - 主キー: `id`
-- 主要カラム: `user_id`, `prompt_text`, `input_image_url`, `source_image_stock_id`, `generation_type`, `generation_metadata`, `model`, `background_change`, `status`, `processing_stage`, `result_image_url`, `error_message`, `attempts`, `created_at`, `updated_at`, `started_at`, `completed_at`, `background_mode`, `source_image_type`
+- 主要カラム: `user_id`, `prompt_text`, `input_image_url`, `source_image_stock_id`, `generation_type`, `generation_metadata`, `model`, `status`, `processing_stage`, `result_image_url`, `error_message`, `attempts`, `created_at`, `updated_at`, `started_at`, `completed_at`, `background_mode`, `source_image_type`
 - 外部キー: `user_id -> auth.users.id`, `source_image_stock_id -> source_image_stocks.id`
-- 備考: `status` は `queued/processing/succeeded/failed`、`processing_stage` は `queued/processing/charging/generating/uploading/persisting/completed/failed`、`generation_type` は `coordinate/specified_coordinate/full_body/chibi/one_tap_style`、`source_image_type` は `illustration/real`、`model` は `gemini-2.5-flash-image` の履歴値に加えて `gemini-3.1-flash-image-preview-512` / `gemini-3.1-flash-image-preview-1024` / `gemini-3-pro-image-1k` / `gemini-3-pro-image-2k` / `gemini-3-pro-image-4k` / `gpt-image-2-low` を保持する
+- 備考: `status` は `queued/processing/succeeded/failed`、`processing_stage` は `queued/processing/charging/generating/uploading/persisting/completed/failed`、`generation_type` は `coordinate/specified_coordinate/full_body/chibi/one_tap_style`、`source_image_type` は `illustration/real`、`background_mode` は `keep/ai_auto/include_in_prompt`、`model` は `gemini-2.5-flash-image` の履歴値に加えて `gemini-3.1-flash-image-preview-512` / `gemini-3.1-flash-image-preview-1024` / `gemini-3-pro-image-1k` / `gemini-3-pro-image-2k` / `gemini-3-pro-image-4k` / `gpt-image-2-low` を保持する
 - RLS: 本人のみ `SELECT/INSERT/UPDATE/DELETE`
 
 #### `generated_images`
 - 主キー: `id`
-- 主要カラム: `user_id`, `image_url`, `storage_path`, `prompt`, `background_change`, `is_posted`, `caption`, `posted_at`, `created_at`, `view_count`, `generation_type`, `input_images`, `generation_metadata`, `source_image_stock_id`, `aspect_ratio`, `width`, `height`, `model`, `storage_path_display`, `storage_path_thumb`, `moderation_status`, `moderation_reason`, `moderation_updated_at`, `moderation_approved_at`, `background_mode`
+- 主要カラム: `user_id`, `image_url`, `storage_path`, `prompt`, `is_posted`, `caption`, `posted_at`, `created_at`, `view_count`, `generation_type`, `input_images`, `generation_metadata`, `source_image_stock_id`, `width`, `height`, `model`, `storage_path_display`, `storage_path_thumb`, `moderation_status`, `moderation_reason`, `moderation_updated_at`, `moderation_approved_at`, `background_mode`
 - 外部キー: `user_id -> auth.users.id`, `source_image_stock_id -> source_image_stocks.id`
-- 備考: `generation_type` は `coordinate/specified_coordinate/full_body/chibi/one_tap_style`、`moderation_status` は `visible/pending/removed`、`model` は `gemini-2.5-flash-image` の履歴値に加えて `gemini-3.1-flash-image-preview-512` / `gemini-3.1-flash-image-preview-1024` / `gemini-3-pro-image-1k` / `gemini-3-pro-image-2k` / `gemini-3-pro-image-4k` / `gpt-image-2-low` を保持する。`width` / `height` は画像実寸（INT、`> 0` の CHECK 制約、NULL 許容）で、Post 詳細画面のサイズ表示用に server-api の lazy compute で fetch 時に保存される
+- 備考: `generation_type` は `coordinate/specified_coordinate/full_body/chibi/one_tap_style`、`moderation_status` は `visible/pending/removed`、`background_mode` は `keep/ai_auto/include_in_prompt`、`model` は `gemini-2.5-flash-image` の履歴値に加えて `gemini-3.1-flash-image-preview-512` / `gemini-3.1-flash-image-preview-1024` / `gemini-3-pro-image-1k` / `gemini-3-pro-image-2k` / `gemini-3-pro-image-4k` / `gpt-image-2-low` を保持する。`width` / `height` は画像実寸（INT、`> 0` の CHECK 制約、NULL 許容）で、Post 詳細画面のサイズ表示と画像向き判定用に server-api の lazy compute で fetch 時に保存される
 - RLS: 投稿済みかつ `visible` の画像は公開、それ以外は本人のみ。`INSERT/UPDATE/DELETE` は本人のみ
 
 #### `source_image_stocks`
@@ -334,7 +334,6 @@ alwaysApply: false
 - `idx_generated_images_created_at`
 - `idx_generated_images_generation_type`
 - `idx_generated_images_user_coord_created`（`generation_type = 'coordinate'` 部分索引、`user_id` + `created_at DESC`）
-- `idx_generated_images_aspect_ratio`
 - `idx_generated_images_source_stock_id`
 - `idx_generated_images_moderation_approved_at`
 - `idx_generated_images_prompt_trgm`（`prompt` の trigram 検索用）

--- a/docs/planning/drop-legacy-image-metadata-columns-implementation-summary.md
+++ b/docs/planning/drop-legacy-image-metadata-columns-implementation-summary.md
@@ -1,0 +1,162 @@
+# Phase B 実装サマリ: legacy画像メタデータ列のDROP
+
+## ブランチ
+
+- `refactor/drop-legacy-image-metadata-columns`
+
+## 目的
+
+Phase Aでアプリケーション・Edge Function・型・テストから `aspect_ratio` / `background_change` への依存を削除済みのため、Phase BではDB上に残っている legacy カラムと関連indexを削除する。
+
+## 変更ファイル
+
+| ファイル | 内容 |
+| --- | --- |
+| `supabase/migrations/20260426170000_drop_legacy_image_metadata_columns.sql` | legacy列と関連indexをDROPするmigrationを追加 |
+| `.cursor/rules/database-design.mdc` | schema ledgerからDROP対象カラム・indexを削除し、現行source of truthを明記 |
+| `docs/planning/remove-legacy-image-metadata-usage-plan.md` | Phase Bの実装migrationファイル名を追記 |
+| `docs/planning/drop-legacy-image-metadata-columns-implementation-summary.md` | レビュー用の実装サマリと復旧方針を記載 |
+
+## 追加migration
+
+```sql
+-- supabase/migrations/20260426170000_drop_legacy_image_metadata_columns.sql
+
+-- Drop legacy image metadata columns after Phase A removed all runtime usage.
+-- `background_mode` is the source of truth for background behavior.
+-- `width` / `height` are the source of truth for image dimensions and orientation derivation.
+
+DROP INDEX IF EXISTS public.idx_generated_images_aspect_ratio;
+
+ALTER TABLE public.generated_images
+  DROP COLUMN IF EXISTS aspect_ratio,
+  DROP COLUMN IF EXISTS background_change;
+
+ALTER TABLE public.image_jobs
+  DROP COLUMN IF EXISTS background_change;
+```
+
+## DROP対象
+
+| 対象 | 理由 |
+| --- | --- |
+| `public.idx_generated_images_aspect_ratio` | `generated_images.aspect_ratio` 削除に伴い不要 |
+| `public.generated_images.aspect_ratio` | `width` / `height` から向き判定を派生するため不要 |
+| `public.generated_images.background_change` | `background_mode` が背景設定のsource of truthになったため不要 |
+| `public.image_jobs.background_change` | `background_mode` がjob側のsource of truthになったため不要 |
+
+## schema ledger更新
+
+`.cursor/rules/database-design.mdc` を更新。
+
+### `image_jobs`
+
+- `background_change` を主要カラム一覧から削除
+- 備考に `background_mode` の値を明記
+  - `keep`
+  - `ai_auto`
+  - `include_in_prompt`
+
+### `generated_images`
+
+- `background_change` を主要カラム一覧から削除
+- `aspect_ratio` を主要カラム一覧から削除
+- 備考に `background_mode` の値を明記
+  - `keep`
+  - `ai_auto`
+  - `include_in_prompt`
+- `width` / `height` の説明を「サイズ表示と画像向き判定用」に更新
+
+### index一覧
+
+- `idx_generated_images_aspect_ratio` を削除
+
+## 計画書更新
+
+`docs/planning/remove-legacy-image-metadata-usage-plan.md` の Phase B セクションに、実装migrationファイル名を追記。
+
+```md
+実装ファイル: `supabase/migrations/20260426170000_drop_legacy_image_metadata_columns.sql`
+```
+
+## 事前確認
+
+### Supabase remote上のDROP対象存在確認
+
+remote DB上で以下が存在することを確認済み。
+
+| 対象 | 存在 |
+| --- | --- |
+| `generated_images.aspect_ratio` | true |
+| `generated_images.background_change` | true |
+| `image_jobs.background_change` | true |
+| `idx_generated_images_aspect_ratio` | true |
+
+### runtime参照ゼロ確認
+
+以下のコマンドで、アプリ・Edge Function・テスト配下に legacy名の参照がないことを確認済み。
+
+```bash
+rg -n "background_change|aspect_ratio" app features supabase/functions tests -g '!node_modules'
+```
+
+結果: 0件
+
+### schema ledger参照ゼロ確認
+
+```bash
+rg -n "background_change|aspect_ratio|idx_generated_images_aspect_ratio" .cursor/rules/database-design.mdc
+```
+
+結果: 0件
+
+### migration dry-run
+
+```bash
+supabase db push --dry-run
+```
+
+結果:
+
+```text
+DRY RUN: migrations will *not* be pushed to the database.
+Would push these migrations:
+ • 20260426170000_drop_legacy_image_metadata_columns.sql
+Finished supabase db push.
+```
+
+実DBには未適用。
+
+### Post詳細表示の確認
+
+Phase A後の実生成で、生成結果が `generated_images.width` / `height` を保持していることを確認済み。
+Post詳細は `width` / `height` 由来でモデル名・サイズ表示と画像レイアウトを維持する前提であり、`aspect_ratio` 列には依存しない。
+
+## 期待する状態
+
+Migration適用後:
+
+- `generated_images.aspect_ratio` は存在しない
+- `generated_images.background_change` は存在しない
+- `image_jobs.background_change` は存在しない
+- `idx_generated_images_aspect_ratio` は存在しない
+- 生成背景のsource of truthは `background_mode`
+- 画像サイズ・向き判定のsource of truthは `width` / `height`
+
+## 注意点
+
+- これは破壊的DB変更のため、Phase Aが本番deploy済みであることが前提。
+- Phase A後の実生成で、`image_jobs` -> `image-gen-worker` -> `generated_images` の成功確認済み。
+- 直近生成では `background_mode` が保存され、`width` / `height` も保存されていることを確認済み。
+- 古い行では `generated_images.generation_metadata` JSONB 内に `{"background_change": ...}` が残る可能性がある。これは列DROP対象外の履歴メタデータであり、Phase A後のruntimeでは読み取らないため動作影響はない。
+- `supabase db push --dry-run` のみ実行しており、migrationはまだremote DBへ適用していない。
+
+## 復旧方針
+
+`DROP COLUMN` は列データを削除するため、通常のrollback migrationでは元データを完全復元できない。問題が発生した場合は、まずPhase B migration適用前のバックアップまたはPoint-in-Time Recoveryで復旧する。
+
+やむを得ず列だけを再作成する場合の復元方針:
+
+- `generated_images.aspect_ratio`: `width` / `height` が揃う行は `height > width` なら `portrait`、それ以外は `landscape` として再計算する。
+- `generated_images.background_change`: `background_mode = 'ai_auto'` の行を `true`、それ以外を `false` として再作成する。
+- `image_jobs.background_change`: `background_mode = 'ai_auto'` の行を `true`、それ以外を `false` として再作成する。

--- a/docs/planning/remove-legacy-image-metadata-usage-plan.md
+++ b/docs/planning/remove-legacy-image-metadata-usage-plan.md
@@ -514,6 +514,8 @@ ALTER TABLE public.image_jobs
   DROP COLUMN IF EXISTS background_change;
 ```
 
+実装ファイル: `supabase/migrations/20260426170000_drop_legacy_image_metadata_columns.sql`
+
 Phase B では migration と同じ PR で以下を更新する。
 
 - `.cursor/rules/database-design.mdc`

--- a/supabase/migrations/20260426170000_drop_legacy_image_metadata_columns.sql
+++ b/supabase/migrations/20260426170000_drop_legacy_image_metadata_columns.sql
@@ -1,0 +1,12 @@
+-- Drop legacy image metadata columns after Phase A removed all runtime usage.
+-- `background_mode` is the source of truth for background behavior.
+-- `width` / `height` are the source of truth for image dimensions and orientation derivation.
+
+DROP INDEX IF EXISTS public.idx_generated_images_aspect_ratio;
+
+ALTER TABLE public.generated_images
+  DROP COLUMN IF EXISTS aspect_ratio,
+  DROP COLUMN IF EXISTS background_change;
+
+ALTER TABLE public.image_jobs
+  DROP COLUMN IF EXISTS background_change;


### PR DESCRIPTION
### 概要
Phase Aでアプリケーション・Edge Function・型・テストから `aspect_ratio` / `background_change` への依存を削除済みのため、Phase BとしてDB上に残っているlegacy画像メタデータ列と関連indexを削除します。

このPRは破壊的DB変更を含みます。migrationはまだremote DBへ適用しておらず、`supabase db push --dry-run` で適用対象がこのPRのmigration 1件のみであることを確認しています。

### 変更内容
- `supabase/migrations/20260426170000_drop_legacy_image_metadata_columns.sql` を追加
  - `public.idx_generated_images_aspect_ratio` をDROP
  - `public.generated_images.aspect_ratio` をDROP
  - `public.generated_images.background_change` をDROP
  - `public.image_jobs.background_change` をDROP
- `.cursor/rules/database-design.mdc` から削除対象の3列と1indexを削除
- `background_mode` と `width` / `height` を現行のsource of truthとしてschema ledgerに明記
- Phase B計画書に実装migration名を追記
- レビュー用の実装サマリに復旧方針、JSONB内legacy key、Post詳細確認前提を記載

### 前提・注意点
- Phase A PR #233 はマージ済み
- Phase A後の `image-gen-worker` は本番Supabaseへデプロイ済み
- 実生成で `image_jobs` → `image-gen-worker` → `generated_images` まで成功確認済み
- 直近生成で `background_mode` と `width` / `height` が保存されていることを確認済み
- 古い行の `generated_images.generation_metadata` JSONB 内に `background_change` key が残る可能性はあるが、列DROP対象外の履歴メタデータでありruntimeでは参照しない
- 問題発生時は、原則としてmigration適用前バックアップまたはPoint-in-Time Recoveryで復旧する

### 実機テスト
- [ ] iOS Safari で主要導線を確認
- [ ] Android Chrome で主要導線を確認
- [ ] PC（Chrome）で主要導線を確認
- [ ] レスポンシブ表示崩れがないことを確認
- [ ] エラーメッセージやバリデーション表示を確認
- [ ] Preview DBでmigration適用後、生成導線とPost詳細表示を確認

### テスト方法
- [x] `rg -n "background_change|aspect_ratio" app features supabase/functions tests -g "!node_modules"` でruntime参照0件を確認
- [x] `rg -n "background_change|aspect_ratio|idx_generated_images_aspect_ratio" .cursor/rules/database-design.mdc` でschema ledger参照0件を確認
- [x] Supabase remote DB上にDROP対象3列とindexが存在することを確認
- [x] `supabase db push --dry-run` で適用予定migrationが `20260426170000_drop_legacy_image_metadata_columns.sql` のみであることを確認
- [x] `git diff --check`
