### PR TITLE
お知らせ本文で安全なリンク挿入を可能にする

### DIFF
--- a/features/announcements/components/AnnouncementDetail.tsx
+++ b/features/announcements/components/AnnouncementDetail.tsx
@@ -41,7 +41,7 @@ export function AnnouncementDetail({ bodyJson }: AnnouncementDetailProps) {
   return (
     <EditorContent
       editor={editor}
-      className="[&_.ProseMirror_img]:my-4 [&_.ProseMirror_img]:max-h-[420px] [&_.ProseMirror_img]:w-full [&_.ProseMirror_img]:rounded-xl [&_.ProseMirror_img]:border [&_.ProseMirror_img]:border-slate-200 [&_.ProseMirror_img]:object-contain"
+      className="[&_.ProseMirror_img]:my-4 [&_.ProseMirror_img]:max-h-[420px] [&_.ProseMirror_img]:w-full [&_.ProseMirror_img]:rounded-xl [&_.ProseMirror_img]:border [&_.ProseMirror_img]:border-slate-200 [&_.ProseMirror_img]:object-contain [&_.ProseMirror_a]:text-sky-600 [&_.ProseMirror_a]:underline [&_.ProseMirror_a]:underline-offset-2 [&_.ProseMirror_a:hover]:text-sky-700"
     />
   );
 }

--- a/features/announcements/components/AnnouncementDetail.tsx
+++ b/features/announcements/components/AnnouncementDetail.tsx
@@ -3,7 +3,11 @@
 import type { Content } from "@tiptap/core";
 import { useEffect, useRef } from "react";
 import { EditorContent, useEditor } from "@tiptap/react";
-import { announcementTiptapExtensions } from "@/features/announcements/lib/tiptap-extensions";
+import {
+  ANNOUNCEMENT_LINK_CLASS_NAME,
+  announcementTiptapExtensions,
+} from "@/features/announcements/lib/tiptap-extensions";
+import { cn } from "@/lib/utils";
 
 interface AnnouncementDetailProps {
   bodyJson: unknown;
@@ -41,7 +45,10 @@ export function AnnouncementDetail({ bodyJson }: AnnouncementDetailProps) {
   return (
     <EditorContent
       editor={editor}
-      className="[&_.ProseMirror_img]:my-4 [&_.ProseMirror_img]:max-h-[420px] [&_.ProseMirror_img]:w-full [&_.ProseMirror_img]:rounded-xl [&_.ProseMirror_img]:border [&_.ProseMirror_img]:border-slate-200 [&_.ProseMirror_img]:object-contain [&_.ProseMirror_a]:text-sky-600 [&_.ProseMirror_a]:underline [&_.ProseMirror_a]:underline-offset-2 [&_.ProseMirror_a:hover]:text-sky-700"
+      className={cn(
+        "[&_.ProseMirror_img]:my-4 [&_.ProseMirror_img]:max-h-[420px] [&_.ProseMirror_img]:w-full [&_.ProseMirror_img]:rounded-xl [&_.ProseMirror_img]:border [&_.ProseMirror_img]:border-slate-200 [&_.ProseMirror_img]:object-contain",
+        ANNOUNCEMENT_LINK_CLASS_NAME
+      )}
     />
   );
 }

--- a/features/announcements/components/AnnouncementEditor.tsx
+++ b/features/announcements/components/AnnouncementEditor.tsx
@@ -6,7 +6,12 @@ import { EditorContent, useEditor } from "@tiptap/react";
 import { ImagePlus, Link as LinkIcon, Unlink } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/components/ui/use-toast";
-import { announcementTiptapExtensions } from "@/features/announcements/lib/tiptap-extensions";
+import {
+  ANNOUNCEMENT_LINK_CLASS_NAME,
+  ANNOUNCEMENT_LINK_REL,
+  ANNOUNCEMENT_LINK_TARGET,
+  announcementTiptapExtensions,
+} from "@/features/announcements/lib/tiptap-extensions";
 import { isSafeAnnouncementLinkUrl } from "@/features/announcements/lib/announcement-rich-text";
 import { ANNOUNCEMENT_FONT_SIZE_VALUES } from "@/features/announcements/lib/schema";
 import { cn } from "@/lib/utils";
@@ -121,7 +126,11 @@ export function AnnouncementEditor({
       .chain()
       .focus()
       .extendMarkRange("link")
-      .setLink({ href: trimmed })
+      .setLink({
+        href: trimmed,
+        target: ANNOUNCEMENT_LINK_TARGET,
+        rel: ANNOUNCEMENT_LINK_REL,
+      })
       .run();
   };
 
@@ -325,7 +334,10 @@ export function AnnouncementEditor({
       >
         <EditorContent
           editor={editor}
-          className="[&_.ProseMirror_p.is-editor-empty:first-child::before]:pointer-events-none [&_.ProseMirror_p.is-editor-empty:first-child::before]:float-left [&_.ProseMirror_p.is-editor-empty:first-child::before]:h-0 [&_.ProseMirror_p.is-editor-empty:first-child::before]:text-slate-400 [&_.ProseMirror_p.is-editor-empty:first-child::before]:content-['本文を入力してください'] [&_.ProseMirror_img]:my-3 [&_.ProseMirror_img]:max-h-[360px] [&_.ProseMirror_img]:rounded-lg [&_.ProseMirror_img]:border [&_.ProseMirror_img]:border-slate-200 [&_.ProseMirror_img]:object-contain [&_.ProseMirror_a]:text-sky-600 [&_.ProseMirror_a]:underline [&_.ProseMirror_a]:underline-offset-2 [&_.ProseMirror_a:hover]:text-sky-700"
+          className={cn(
+            "[&_.ProseMirror_p.is-editor-empty:first-child::before]:pointer-events-none [&_.ProseMirror_p.is-editor-empty:first-child::before]:float-left [&_.ProseMirror_p.is-editor-empty:first-child::before]:h-0 [&_.ProseMirror_p.is-editor-empty:first-child::before]:text-slate-400 [&_.ProseMirror_p.is-editor-empty:first-child::before]:content-['本文を入力してください'] [&_.ProseMirror_img]:my-3 [&_.ProseMirror_img]:max-h-[360px] [&_.ProseMirror_img]:rounded-lg [&_.ProseMirror_img]:border [&_.ProseMirror_img]:border-slate-200 [&_.ProseMirror_img]:object-contain",
+            ANNOUNCEMENT_LINK_CLASS_NAME
+          )}
         />
       </div>
     </div>

--- a/features/announcements/components/AnnouncementEditor.tsx
+++ b/features/announcements/components/AnnouncementEditor.tsx
@@ -3,10 +3,11 @@
 import type { Content } from "@tiptap/core";
 import { useEffect, useRef, useState } from "react";
 import { EditorContent, useEditor } from "@tiptap/react";
-import { ImagePlus } from "lucide-react";
+import { ImagePlus, Link as LinkIcon, Unlink } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/components/ui/use-toast";
 import { announcementTiptapExtensions } from "@/features/announcements/lib/tiptap-extensions";
+import { isSafeAnnouncementLinkUrl } from "@/features/announcements/lib/announcement-rich-text";
 import { ANNOUNCEMENT_FONT_SIZE_VALUES } from "@/features/announcements/lib/schema";
 import { cn } from "@/lib/utils";
 
@@ -82,6 +83,54 @@ export function AnnouncementEditor({
   const currentTextStyle = editor?.getAttributes("textStyle") as {
     color?: string | null;
     fontSize?: string | null;
+  };
+
+  const handleSetLink = () => {
+    if (!editor) {
+      return;
+    }
+
+    const previousHref = (editor.getAttributes("link") as { href?: string })
+      .href;
+    const input = window.prompt(
+      "リンク URL を入力してください (https:// または / で始まる内部リンク)",
+      previousHref ?? "https://"
+    );
+
+    if (input === null) {
+      return;
+    }
+
+    const trimmed = input.trim();
+    if (!trimmed) {
+      editor.chain().focus().extendMarkRange("link").unsetLink().run();
+      return;
+    }
+
+    if (!isSafeAnnouncementLinkUrl(trimmed)) {
+      toast({
+        title: "エラー",
+        description:
+          "リンクは https:// で始まる URL か、/ で始まる内部リンクのみ指定できます",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    editor
+      .chain()
+      .focus()
+      .extendMarkRange("link")
+      .setLink({ href: trimmed })
+      .run();
+  };
+
+  const handleUnsetLink = () => {
+    if (!editor) {
+      return;
+    }
+
+    editor.chain().focus().extendMarkRange("link").unsetLink().run();
   };
 
   const handleImageUpload = async (
@@ -225,6 +274,30 @@ export function AnnouncementEditor({
 
         <Button
           type="button"
+          variant={editor?.isActive("link") ? "default" : "outline"}
+          size="sm"
+          disabled={!editor || disabled}
+          onClick={handleSetLink}
+          className="min-h-[40px] cursor-pointer"
+        >
+          <LinkIcon className="mr-2 h-4 w-4" aria-hidden />
+          リンク
+        </Button>
+
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={!editor || disabled || !editor?.isActive("link")}
+          onClick={handleUnsetLink}
+          className="min-h-[40px] cursor-pointer"
+        >
+          <Unlink className="mr-2 h-4 w-4" aria-hidden />
+          リンク解除
+        </Button>
+
+        <Button
+          type="button"
           variant="outline"
           size="sm"
           disabled={!editor || disabled || isUploadingImage}
@@ -252,7 +325,7 @@ export function AnnouncementEditor({
       >
         <EditorContent
           editor={editor}
-          className="[&_.ProseMirror_p.is-editor-empty:first-child::before]:pointer-events-none [&_.ProseMirror_p.is-editor-empty:first-child::before]:float-left [&_.ProseMirror_p.is-editor-empty:first-child::before]:h-0 [&_.ProseMirror_p.is-editor-empty:first-child::before]:text-slate-400 [&_.ProseMirror_p.is-editor-empty:first-child::before]:content-['本文を入力してください'] [&_.ProseMirror_img]:my-3 [&_.ProseMirror_img]:max-h-[360px] [&_.ProseMirror_img]:rounded-lg [&_.ProseMirror_img]:border [&_.ProseMirror_img]:border-slate-200 [&_.ProseMirror_img]:object-contain"
+          className="[&_.ProseMirror_p.is-editor-empty:first-child::before]:pointer-events-none [&_.ProseMirror_p.is-editor-empty:first-child::before]:float-left [&_.ProseMirror_p.is-editor-empty:first-child::before]:h-0 [&_.ProseMirror_p.is-editor-empty:first-child::before]:text-slate-400 [&_.ProseMirror_p.is-editor-empty:first-child::before]:content-['本文を入力してください'] [&_.ProseMirror_img]:my-3 [&_.ProseMirror_img]:max-h-[360px] [&_.ProseMirror_img]:rounded-lg [&_.ProseMirror_img]:border [&_.ProseMirror_img]:border-slate-200 [&_.ProseMirror_img]:object-contain [&_.ProseMirror_a]:text-sky-600 [&_.ProseMirror_a]:underline [&_.ProseMirror_a]:underline-offset-2 [&_.ProseMirror_a:hover]:text-sky-700"
         />
       </div>
     </div>

--- a/features/announcements/lib/announcement-rich-text.ts
+++ b/features/announcements/lib/announcement-rich-text.ts
@@ -91,6 +91,60 @@ function isValidImageDimension(value: unknown): boolean {
   return false;
 }
 
+const ALLOWED_LINK_TARGETS = new Set<string>(["_blank"]);
+const REQUIRED_LINK_REL_TOKENS = ["noopener", "noreferrer"] as const;
+
+function validateLinkMark(typedMark: RichTextMark): string | null {
+  if (!isObject(typedMark.attrs)) {
+    return "link mark の属性が不正です";
+  }
+
+  const attrs = typedMark.attrs;
+  for (const key of Object.keys(attrs)) {
+    if (!["href", "target", "rel", "class", "title"].includes(key)) {
+      return "許可されていない link 属性が含まれています";
+    }
+  }
+
+  if (typeof attrs.href !== "string" || !isSafeAnnouncementLinkUrl(attrs.href)) {
+    return "リンク URL が不正です";
+  }
+
+  if (attrs.target != null) {
+    if (
+      typeof attrs.target !== "string" ||
+      !ALLOWED_LINK_TARGETS.has(attrs.target)
+    ) {
+      return "リンクの target 属性が不正です";
+    }
+  }
+
+  if (attrs.rel != null) {
+    if (typeof attrs.rel !== "string") {
+      return "リンクの rel 属性が不正です";
+    }
+    const tokens = attrs.rel.split(/\s+/).filter(Boolean);
+    for (const required of REQUIRED_LINK_REL_TOKENS) {
+      if (!tokens.includes(required)) {
+        return "リンクの rel 属性が不正です";
+      }
+    }
+  }
+
+  if (attrs.class != null && attrs.class !== "") {
+    return "リンクの class 属性は指定できません";
+  }
+
+  if (
+    attrs.title != null &&
+    (typeof attrs.title !== "string" || attrs.title.length > 200)
+  ) {
+    return "リンクの title 属性が不正です";
+  }
+
+  return null;
+}
+
 function validateMark(mark: unknown): string | null {
   if (!isObject(mark)) {
     return "mark が不正です";
@@ -99,6 +153,10 @@ function validateMark(mark: unknown): string | null {
   const typedMark = mark as RichTextMark;
   if (typedMark.type === "bold") {
     return typedMark.attrs == null ? null : "bold mark の属性が不正です";
+  }
+
+  if (typedMark.type === "link") {
+    return validateLinkMark(typedMark);
   }
 
   if (typedMark.type !== "textStyle") {

--- a/features/announcements/lib/announcement-rich-text.ts
+++ b/features/announcements/lib/announcement-rich-text.ts
@@ -13,6 +13,8 @@ const ALLOWED_FONT_SIZES = new Set<AnnouncementFontSize>([
 const COLOR_PATTERN = /^#(?:[0-9a-fA-F]{3}){1,2}$/;
 const STORAGE_PATH_PATTERN = /^(?!\/)(?!.*\.\.)[\w./-]+\.webp$/;
 const IMAGE_DIMENSION_PATTERN = /^\d+(?:\.\d+)?$/;
+const LINK_FORBIDDEN_CHARACTER_PATTERN = /[\u0000-\u001F\u007F\s\\]/;
+const MAX_LINK_URL_LENGTH = 2048;
 
 type RichTextNode = {
   type?: unknown;
@@ -42,7 +44,12 @@ function getAnnouncementImagePublicPrefix() {
 
 export function isSafeAnnouncementLinkUrl(url: string): boolean {
   const trimmed = url.trim();
-  if (!trimmed) {
+  if (
+    !trimmed ||
+    trimmed !== url ||
+    trimmed.length > MAX_LINK_URL_LENGTH ||
+    LINK_FORBIDDEN_CHARACTER_PATTERN.test(trimmed)
+  ) {
     return false;
   }
 
@@ -50,7 +57,12 @@ export function isSafeAnnouncementLinkUrl(url: string): boolean {
     return true;
   }
 
-  return trimmed.startsWith("https://");
+  try {
+    const parsed = new URL(trimmed);
+    return parsed.protocol === "https:" && Boolean(parsed.hostname);
+  } catch {
+    return false;
+  }
 }
 
 export function isValidAnnouncementImageUrl(url: string): boolean {
@@ -110,24 +122,21 @@ function validateLinkMark(typedMark: RichTextMark): string | null {
     return "リンク URL が不正です";
   }
 
-  if (attrs.target != null) {
-    if (
-      typeof attrs.target !== "string" ||
-      !ALLOWED_LINK_TARGETS.has(attrs.target)
-    ) {
-      return "リンクの target 属性が不正です";
-    }
+  if (
+    typeof attrs.target !== "string" ||
+    !ALLOWED_LINK_TARGETS.has(attrs.target)
+  ) {
+    return "リンクの target 属性が不正です";
   }
 
-  if (attrs.rel != null) {
-    if (typeof attrs.rel !== "string") {
+  if (typeof attrs.rel !== "string") {
+    return "リンクの rel 属性が不正です";
+  }
+
+  const tokens = attrs.rel.split(/\s+/).filter(Boolean);
+  for (const required of REQUIRED_LINK_REL_TOKENS) {
+    if (!tokens.includes(required)) {
       return "リンクの rel 属性が不正です";
-    }
-    const tokens = attrs.rel.split(/\s+/).filter(Boolean);
-    for (const required of REQUIRED_LINK_REL_TOKENS) {
-      if (!tokens.includes(required)) {
-        return "リンクの rel 属性が不正です";
-      }
     }
   }
 

--- a/features/announcements/lib/tiptap-extensions.ts
+++ b/features/announcements/lib/tiptap-extensions.ts
@@ -8,6 +8,8 @@ import { isSafeAnnouncementLinkUrl } from "./announcement-rich-text";
 
 export const ANNOUNCEMENT_LINK_REL = "noopener noreferrer nofollow";
 export const ANNOUNCEMENT_LINK_TARGET = "_blank";
+export const ANNOUNCEMENT_LINK_CLASS_NAME =
+  "[&_.ProseMirror_a]:text-sky-600 [&_.ProseMirror_a]:underline [&_.ProseMirror_a]:underline-offset-2 [&_.ProseMirror_a:hover]:text-sky-700";
 
 export const AnnouncementImage = Image.extend({
   addAttributes() {

--- a/features/announcements/lib/tiptap-extensions.ts
+++ b/features/announcements/lib/tiptap-extensions.ts
@@ -60,6 +60,7 @@ export const AnnouncementLink = Link.configure({
     rel: ANNOUNCEMENT_LINK_REL,
   },
   isAllowedUri: (url) => isSafeAnnouncementLinkUrl(url),
+  shouldAutoLink: (url) => isSafeAnnouncementLinkUrl(url),
 });
 
 export const announcementTiptapExtensions = [

--- a/features/announcements/lib/tiptap-extensions.ts
+++ b/features/announcements/lib/tiptap-extensions.ts
@@ -1,8 +1,13 @@
 import { Extension } from "@tiptap/core";
 import Color from "@tiptap/extension-color";
 import Image from "@tiptap/extension-image";
+import { Link } from "@tiptap/extension-link";
 import StarterKit from "@tiptap/starter-kit";
 import { TextStyle } from "@tiptap/extension-text-style";
+import { isSafeAnnouncementLinkUrl } from "./announcement-rich-text";
+
+export const ANNOUNCEMENT_LINK_REL = "noopener noreferrer nofollow";
+export const ANNOUNCEMENT_LINK_TARGET = "_blank";
 
 export const AnnouncementImage = Image.extend({
   addAttributes() {
@@ -46,6 +51,17 @@ export const FontSize = Extension.create({
   },
 });
 
+export const AnnouncementLink = Link.configure({
+  autolink: false,
+  linkOnPaste: true,
+  openOnClick: false,
+  HTMLAttributes: {
+    target: ANNOUNCEMENT_LINK_TARGET,
+    rel: ANNOUNCEMENT_LINK_REL,
+  },
+  isAllowedUri: (url) => isSafeAnnouncementLinkUrl(url),
+});
+
 export const announcementTiptapExtensions = [
   StarterKit.configure({
     blockquote: false,
@@ -57,12 +73,15 @@ export const announcementTiptapExtensions = [
     heading: false,
     horizontalRule: false,
     italic: false,
+    link: false,
     listItem: false,
     orderedList: false,
     strike: false,
+    underline: false,
   }),
   TextStyle,
   Color,
   FontSize,
   AnnouncementImage,
+  AnnouncementLink,
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@supabase/supabase-js": "^2.90.1",
         "@tiptap/extension-color": "^3.22.4",
         "@tiptap/extension-image": "^3.22.4",
+        "@tiptap/extension-link": "^3.22.4",
         "@tiptap/extension-text-style": "^3.22.4",
         "@tiptap/react": "^3.22.4",
         "@tiptap/starter-kit": "^3.22.4",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@supabase/supabase-js": "^2.90.1",
     "@tiptap/extension-color": "^3.22.4",
     "@tiptap/extension-image": "^3.22.4",
+    "@tiptap/extension-link": "^3.22.4",
     "@tiptap/extension-text-style": "^3.22.4",
     "@tiptap/react": "^3.22.4",
     "@tiptap/starter-kit": "^3.22.4",

--- a/tests/unit/features/announcements/announcement-rich-text.test.ts
+++ b/tests/unit/features/announcements/announcement-rich-text.test.ts
@@ -14,7 +14,7 @@ const safeLinkMark = {
   },
 };
 
-function linkDocument(markAttrs: Record<string, unknown>) {
+function linkMarkDocument(mark: unknown) {
   return {
     type: "doc",
     content: [
@@ -25,16 +25,20 @@ function linkDocument(markAttrs: Record<string, unknown>) {
             type: "text",
             text: "お知らせ",
             marks: [
-              {
-                type: "link",
-                attrs: markAttrs,
-              },
+              mark,
             ],
           },
         ],
       },
     ],
   };
+}
+
+function linkDocument(markAttrs: Record<string, unknown>) {
+  return linkMarkDocument({
+    type: "link",
+    attrs: markAttrs,
+  });
 }
 
 describe("announcement rich text link validation", () => {
@@ -53,6 +57,7 @@ describe("announcement rich text link validation", () => {
       expect(isSafeAnnouncementLinkUrl("//example.com")).toBe(false);
       expect(isSafeAnnouncementLinkUrl("/\\example.com")).toBe(false);
       expect(isSafeAnnouncementLinkUrl(" https://example.com")).toBe(false);
+      expect(isSafeAnnouncementLinkUrl("x".repeat(2049))).toBe(false);
     });
   });
 
@@ -64,6 +69,43 @@ describe("announcement rich text link validation", () => {
           bodyJson: linkDocument(safeLinkMark.attrs),
         }
       );
+    });
+
+    test("attrs が不正な link mark を拒否する", () => {
+      expect(
+        validateAnnouncementDocument(linkMarkDocument({ type: "link" }))
+      ).toEqual({
+        ok: false,
+        error: "link mark の属性が不正です",
+      });
+    });
+
+    test("許可されていない link 属性を拒否する", () => {
+      expect(
+        validateAnnouncementDocument(
+          linkDocument({
+            ...safeLinkMark.attrs,
+            onclick: "alert(1)",
+          })
+        )
+      ).toEqual({
+        ok: false,
+        error: "許可されていない link 属性が含まれています",
+      });
+    });
+
+    test("不正な href を持つ link mark を拒否する", () => {
+      expect(
+        validateAnnouncementDocument(
+          linkDocument({
+            ...safeLinkMark.attrs,
+            href: "http://example.com",
+          })
+        )
+      ).toEqual({
+        ok: false,
+        error: "リンク URL が不正です",
+      });
     });
 
     test("target が欠落した link mark を拒否する", () => {
@@ -103,6 +145,34 @@ describe("announcement rich text link validation", () => {
       ).toEqual({
         ok: false,
         error: "リンクの rel 属性が不正です",
+      });
+    });
+
+    test("class 属性を持つ link mark を拒否する", () => {
+      expect(
+        validateAnnouncementDocument(
+          linkDocument({
+            ...safeLinkMark.attrs,
+            class: "text-red-500",
+          })
+        )
+      ).toEqual({
+        ok: false,
+        error: "リンクの class 属性は指定できません",
+      });
+    });
+
+    test("長すぎる title 属性を持つ link mark を拒否する", () => {
+      expect(
+        validateAnnouncementDocument(
+          linkDocument({
+            ...safeLinkMark.attrs,
+            title: "x".repeat(201),
+          })
+        )
+      ).toEqual({
+        ok: false,
+        error: "リンクの title 属性が不正です",
       });
     });
 

--- a/tests/unit/features/announcements/announcement-rich-text.test.ts
+++ b/tests/unit/features/announcements/announcement-rich-text.test.ts
@@ -1,0 +1,123 @@
+/** @jest-environment node */
+
+import {
+  isSafeAnnouncementLinkUrl,
+  validateAnnouncementDocument,
+} from "@/features/announcements/lib/announcement-rich-text";
+
+const safeLinkMark = {
+  type: "link",
+  attrs: {
+    href: "https://example.com/news",
+    target: "_blank",
+    rel: "noopener noreferrer nofollow",
+  },
+};
+
+function linkDocument(markAttrs: Record<string, unknown>) {
+  return {
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: [
+          {
+            type: "text",
+            text: "お知らせ",
+            marks: [
+              {
+                type: "link",
+                attrs: markAttrs,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe("announcement rich text link validation", () => {
+  describe("isSafeAnnouncementLinkUrl", () => {
+    test("https URL と内部リンクを許可する", () => {
+      expect(isSafeAnnouncementLinkUrl("https://example.com/news")).toBe(true);
+      expect(isSafeAnnouncementLinkUrl("/notifications/announcements")).toBe(
+        true
+      );
+    });
+
+    test("不正または危険な URL を拒否する", () => {
+      expect(isSafeAnnouncementLinkUrl("http://example.com")).toBe(false);
+      expect(isSafeAnnouncementLinkUrl("javascript:alert(1)")).toBe(false);
+      expect(isSafeAnnouncementLinkUrl("https://")).toBe(false);
+      expect(isSafeAnnouncementLinkUrl("//example.com")).toBe(false);
+      expect(isSafeAnnouncementLinkUrl("/\\example.com")).toBe(false);
+      expect(isSafeAnnouncementLinkUrl(" https://example.com")).toBe(false);
+    });
+  });
+
+  describe("validateAnnouncementDocument", () => {
+    test("安全属性を持つ link mark を許可する", () => {
+      expect(validateAnnouncementDocument(linkDocument(safeLinkMark.attrs))).toEqual(
+        {
+          ok: true,
+          bodyJson: linkDocument(safeLinkMark.attrs),
+        }
+      );
+    });
+
+    test("target が欠落した link mark を拒否する", () => {
+      const attrs: Record<string, unknown> = { ...safeLinkMark.attrs };
+      delete attrs.target;
+
+      expect(validateAnnouncementDocument(linkDocument(attrs))).toEqual({
+        ok: false,
+        error: "リンクの target 属性が不正です",
+      });
+    });
+
+    test("rel が欠落した link mark を拒否する", () => {
+      const attrs: Record<string, unknown> = { ...safeLinkMark.attrs };
+      delete attrs.rel;
+
+      expect(validateAnnouncementDocument(linkDocument(attrs))).toEqual({
+        ok: false,
+        error: "リンクの rel 属性が不正です",
+      });
+    });
+
+    test("target または rel が null の link mark を拒否する", () => {
+      expect(
+        validateAnnouncementDocument(
+          linkDocument({ ...safeLinkMark.attrs, target: null })
+        )
+      ).toEqual({
+        ok: false,
+        error: "リンクの target 属性が不正です",
+      });
+
+      expect(
+        validateAnnouncementDocument(
+          linkDocument({ ...safeLinkMark.attrs, rel: null })
+        )
+      ).toEqual({
+        ok: false,
+        error: "リンクの rel 属性が不正です",
+      });
+    });
+
+    test("noopener noreferrer が揃っていない link mark を拒否する", () => {
+      expect(
+        validateAnnouncementDocument(
+          linkDocument({
+            ...safeLinkMark.attrs,
+            rel: "noopener nofollow",
+          })
+        )
+      ).toEqual({
+        ok: false,
+        error: "リンクの rel 属性が不正です",
+      });
+    });
+  });
+});


### PR DESCRIPTION
### 概要
お知らせ本文のリッチテキスト編集で、`Persta.AI` のような文字列が意図せずリンク扱いになって保存できない問題を解消しつつ、管理画面から安全にリンクを挿入・解除できるようにしました。

### 変更内容
- StarterKit の自動リンク化を無効化し、`@tiptap/extension-link` を安全設定付きで明示的に追加
- 管理画面のお知らせエディタにリンク挿入・リンク解除ボタンを追加
- リンク URL を `https://` または `/` で始まる内部リンクに制限
- link mark の `target="_blank"` と `rel="noopener noreferrer ..."` を保存バリデーションで必須化
- お知らせ詳細・編集画面のリンク表示スタイルを統一
- リンク URL と link mark 属性のバリデーションテストを追加

### 実機テスト
- [ ] iOS Safari で主要導線を確認
- [ ] Android Chrome で主要導線を確認
- [ ] PC（Chrome）で主要導線を確認
- [ ] レスポンシブ表示崩れがないことを確認
- [ ] エラーメッセージやバリデーション表示を確認

### テスト方法
- `npm test -- tests/unit/features/announcements/announcement-rich-text.test.ts --runInBand`
- `npm run lint -- features/announcements/lib/announcement-rich-text.ts features/announcements/lib/tiptap-extensions.ts tests/unit/features/announcements/announcement-rich-text.test.ts`
- `git diff --check`
