### PR TITLE
管理ダッシュボードの売上にサブスク実決済額を反映

### DIFF
--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -317,6 +317,7 @@ async function grantSubscriptionPercoins(params: {
       billingInterval: params.billingInterval,
       revenueYen,
       revenueSource: "stripe_subscription",
+      mode: isStripeTestMode() ? "test" : "live",
     },
   });
 

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -109,6 +109,17 @@ function getPlanFromSubscription(
   return getSubscriptionPlanFromStripeSubscription(subscription);
 }
 
+function normalizeRevenueYen(value?: number | null): number | null {
+  if (
+    typeof value === "number" &&
+    Number.isFinite(value)
+  ) {
+    return Math.max(value, 0);
+  }
+
+  return null;
+}
+
 function getSubscriptionIdFromInvoice(
   invoice: Stripe.Invoice
 ): string | null {
@@ -288,17 +299,25 @@ async function grantSubscriptionPercoins(params: {
   plan: SubscriptionPlan;
   billingInterval: SubscriptionBillingInterval | null;
   invoiceId: string;
+  paidAmountYen?: number | null;
 }) {
   const amount = getSubscriptionMonthlyPercoins(params.plan);
   if (amount <= 0) {
     return;
   }
 
+  const revenueYen = normalizeRevenueYen(params.paidAmountYen);
   const supabase = createAdminClient();
   const { error } = await supabase.rpc("grant_subscription_percoins", {
     p_user_id: params.userId,
     p_amount: amount,
     p_invoice_id: params.invoiceId,
+    p_metadata: {
+      plan: params.plan,
+      billingInterval: params.billingInterval,
+      revenueYen,
+      revenueSource: "stripe_subscription",
+    },
   });
 
   if (error) {
@@ -459,6 +478,8 @@ async function handlePercoinCheckoutCompleted(
       checkoutSessionId: session.id,
       customerEmail,
       mode: isStripeTestMode() ? "test" : "live",
+      revenueYen: normalizeRevenueYen(session.amount_total),
+      revenueSource: "stripe_checkout",
     },
     supabaseClient: supabase,
   });
@@ -531,6 +552,7 @@ async function handleSubscriptionCheckoutCompleted(
     plan,
     billingInterval,
     invoiceId,
+    paidAmountYen: session.amount_total,
   });
   await revalidateSubscriptionSurfaces(userId);
 
@@ -630,6 +652,7 @@ async function handleSubscriptionInvoicePaid(
     plan,
     billingInterval,
     invoiceId: invoice.id,
+    paidAmountYen: invoice.amount_paid,
   });
   await revalidateSubscriptionSurfaces(userId);
 

--- a/docs/planning/admin-dashboard-real-revenue-implementation-plan.md
+++ b/docs/planning/admin-dashboard-real-revenue-implementation-plan.md
@@ -1,0 +1,285 @@
+# Admin Dashboard Real Revenue Implementation Plan
+
+## コードベース調査結果
+
+- Supabase 接続確認: Supabase MCP の `list_tables` で `public.credit_transactions` と `public.user_subscriptions` を確認できた。`credit_transactions` は RLS 有効、主要カラムは `user_id`, `amount`, `transaction_type`, `stripe_payment_intent_id`, `metadata`, `created_at`。`user_subscriptions` は `plan`, `status`, `billing_interval`, `stripe_subscription_id` を持つ。
+- データ方針: `docs/architecture/data.ja.md` では、Stripe 購入確定は `/api/stripe/webhook` が担い、ウォレット更新や冪等性が必要な処理は SQL RPC に寄せる方針。今回も webhook で実決済額を取り、既存取引台帳 `credit_transactions.metadata` に追記する。
+- 既存購入フロー: `app/api/stripe/webhook/route.ts` の `handlePercoinCheckoutCompleted` が `checkout.session.completed` を処理し、`recordPercoinPurchase` を呼ぶ。`features/credits/lib/percoin-service.ts` は `apply_percoin_transaction` RPC に `metadata` を渡せるため、コイン購入は新規テーブルなしで `metadata.revenueYen` を追加できる。
+- 既存サブスクフロー: `app/api/stripe/webhook/route.ts` の `handleSubscriptionCheckoutCompleted` と `handleSubscriptionInvoicePaid` がサブスク初回決済と更新決済を扱い、`grant_subscription_percoins` RPC を呼ぶ。現行 RPC は `p_metadata` を受け取らないため、サブスク決済額を台帳へ残すには migration で拡張が必要。
+- 過去分反映: 既存のサブスク取引には `metadata.revenueYen` がないため、過去分は Stripe の invoice または Checkout Session を再取得して、実決済額のみを `credit_transactions.metadata` に backfill する。プラン定価からの推定補完は行わない。
+- 年額サブスク月次付与: `supabase/migrations/20260331193000_add_yearly_subscription_monthly_grants.sql` の `grant_due_yearly_subscription_percoins()` が `yearly-monthly` 形式の invoice id で追加付与を行う。これは実決済ではないため、売上対象にしてはいけない。
+- 既存 admin dashboard 集計: `features/admin-dashboard/lib/get-admin-dashboard-data.ts` は `credit_transactions` を期間取得し、`transaction_type = "purchase"` かつ `metadata.mode = "live"` のみを売上 KPI、売上トレンド、平均購入単価、最新購入、ファネルの購入ステップに使っている。
+- 既存売上金額解決: `features/admin-dashboard/lib/purchase-value.ts` は `priceId`, `packageId`, `amount` から `PERCOIN_PACKAGES` の定価へ解決する。これは過去コイン購入データ互換のため残すが、今後のコイン購入は `metadata.revenueYen` を優先する。
+- UI 配置: admin dashboard UI は `features/admin-dashboard/components/` にあり、ページは `app/(app)/admin/page.tsx` から Server Component で `getAdminDashboardData` を呼び、props で表示している。新規ページや API は不要。
+- Admin 認証: admin ページは `app/(app)/admin/layout.tsx` で `getUser()` と `getAdminUserIds()` により保護される。今回の集計はページ配下の server-side データ取得であり、追加 API 認証は不要。
+- 参照ドキュメント: `docs/development/project-conventions.ja.md` は feature 固有コードを `features/` に置き、複数テーブルに跨る業務処理を SQL RPC に寄せる方針。`.cursor/rules/database-design.mdc` は schema ledger だが、現行 migration に対して `subscription` 関連の備考が一部古いため、DB 挙動変更時に更新対象とする。
+
+## 1. 概要図
+
+#### 決済記録と売上集計フロー
+
+```mermaid
+flowchart TD
+    A["Stripe が決済 webhook を送信"] --> B["Webhook が実決済額を取得"]
+    B --> C{"決済種別を判定"}
+    C -->|コイン購入| D["recordPercoinPurchase に revenueYen を渡す"]
+    C -->|サブスク決済| E["grant_subscription_percoins に revenueYen を渡す"]
+    D --> F["credit_transactions に取引を保存"]
+    E --> F
+    F --> G["admin dashboard が期間内取引を取得"]
+    G --> H{"売上対象を判定"}
+    H -->|purchase| I["revenueYen を優先し過去分は定価で補完"]
+    H -->|subscription| J["revenueYen がある取引のみ集計"]
+    I --> K["売上 KPI とグラフに表示"]
+    J --> K
+    L["Backfill スクリプト"] --> M["Stripe invoice を再取得"]
+    M --> F
+```
+
+#### Webhook と DB 更新シーケンス
+
+```mermaid
+sequenceDiagram
+    participant S as Stripe
+    participant W as Webhook
+    participant RPC as SupabaseRPC
+    participant DB as Postgres
+    participant A as AdminDashboard
+    S->>W: 決済イベント
+    W->>W: 実決済額を抽出
+    W->>RPC: 取引 RPC を実行
+    RPC->>DB: credit_transactions を保存
+    A->>DB: 期間内の取引を取得
+    DB-->>A: 取引一覧
+    A->>A: revenueYen を基準に売上集計
+```
+
+#### データモデル
+
+```mermaid
+erDiagram
+    auth_users ||--o{ credit_transactions : "has"
+    credit_transactions ||--o| free_percoin_batches : "may grant"
+    auth_users ||--|| user_subscriptions : "has"
+    credit_transactions {
+        uuid id PK
+        uuid user_id FK
+        integer amount
+        text transaction_type
+        text stripe_payment_intent_id
+        jsonb metadata
+        timestamptz created_at
+    }
+    user_subscriptions {
+        uuid user_id PK
+        text stripe_subscription_id
+        text plan
+        text status
+        text billing_interval
+    }
+```
+
+## 2. EARS 要件定義
+
+| ID | Type | Requirement |
+| --- | --- | --- |
+| REV-001 | Event-driven | When a live Percoin Checkout Session is completed, the system shall store Stripe's actual paid amount in `credit_transactions.metadata.revenueYen`. / ライブのペルコイン Checkout Session が完了した場合、システムは Stripe の実決済額を `credit_transactions.metadata.revenueYen` に保存しなければならない。 |
+| REV-002 | Event-driven | When a subscription checkout or renewal invoice is paid, the system shall store Stripe's actual paid amount in the subscription credit transaction metadata. / サブスクリプションの初回決済または更新 invoice が支払われた場合、システムは実決済額をサブスク付与取引の metadata に保存しなければならない。 |
+| REV-003 | State-driven | While rendering the admin dashboard revenue KPI and trend, the system shall include purchase transactions using `metadata.revenueYen` when present. / 管理ダッシュボードの売上 KPI とトレンドを表示している間、システムは `metadata.revenueYen` がある購入取引ではその値を使用しなければならない。 |
+| REV-004 | State-driven | While rendering legacy purchase revenue, the system shall keep the existing package-price fallback only for purchase transactions without `metadata.revenueYen`. / 既存購入データの売上を表示している間、システムは `metadata.revenueYen` がない購入取引に限り既存のパッケージ価格補完を維持しなければならない。 |
+| REV-005 | State-driven | While rendering subscription revenue, the system shall include only subscription transactions that have numeric `metadata.revenueYen`. / サブスク売上を表示している間、システムは数値の `metadata.revenueYen` を持つサブスク取引のみを含めなければならない。 |
+| REV-006 | State-driven | While processing yearly subscription monthly grants, the system shall not count non-payment grant transactions as revenue. / 年額サブスクの月次付与を処理している間、システムは追加決済を伴わない付与取引を売上として数えてはならない。 |
+| REV-007 | Event-driven | When displaying recent revenue transactions, the admin dashboard shall label the list as latest payments and include both Percoin purchases and subscription payments. / 最新売上取引を表示する場合、管理ダッシュボードは一覧を最新決済として表示し、ペルコイン購入とサブスク決済の両方を含めなければならない。 |
+| REV-008 | Error-driven | If Stripe paid amount is missing from a subscription payment event, then the system shall not infer subscription revenue from plan price. / サブスク決済イベントで Stripe の実決済額が取得できない場合、システムはプラン価格からサブスク売上を推定してはならない。 |
+| REV-009 | Error-driven | If Stripe webhook processing receives a duplicate payment event, then the system shall preserve existing idempotency and avoid duplicate revenue transactions. / Stripe webhook が重複決済イベントを受け取った場合、システムは既存の冪等性を維持し、売上取引を重複作成してはならない。 |
+| REV-010 | Event-driven | When a revenue backfill is executed for historical subscription transactions, the system shall retrieve the actual paid amount from Stripe invoice or Checkout Session before updating metadata. / 過去サブスク取引の売上 backfill を実行する場合、システムは metadata 更新前に Stripe invoice または Checkout Session から実決済額を取得しなければならない。 |
+| REV-011 | Error-driven | If a historical subscription transaction cannot be matched to Stripe or is not JPY, then the backfill shall skip the transaction and report the reason. / 過去サブスク取引が Stripe と照合できない、または JPY ではない場合、backfill はその取引をスキップし理由を出力しなければならない。 |
+
+## 3. ADR
+
+### ADR-001: 実決済額は `credit_transactions.metadata` に保存する
+
+- **Context**: 売上集計は `credit_transactions` を既に参照しており、コイン購入とサブスク付与はどちらも同じ台帳に記録される。
+- **Decision**: 新規テーブルは作らず、`metadata.revenueYen` と `metadata.revenueSource` を追加する。
+- **Reason**: 既存集計ルートに合流でき、RLS と service role 書き込みの既存モデルを維持できる。サブスク月次付与は `revenueYen` の有無で売上対象から除外できる。
+- **Consequence**: JSONB metadata の規約をテストで固定する必要がある。将来、返金や税内訳まで扱う場合は専用 payment ledger の検討余地がある。
+
+### ADR-002: サブスク売上はプラン価格で補完しない
+
+- **Context**: サブスクでは割引、クーポン、日割り、更新失敗、年額月次付与などにより、プラン定価と実売上が一致しない可能性がある。
+- **Decision**: サブスクは数値の `metadata.revenueYen` がある取引だけ売上対象にする。
+- **Reason**: ユーザー要件は「Stripe の実決済額のみ」。推定補完は売上の過大計上につながる。
+- **Consequence**: 過去のサブスク決済で `revenueYen` がないものは最小実装では集計されない。必要なら別途バックフィル計画を作る。
+
+### ADR-003: コイン購入は過去互換のため定価補完を残す
+
+- **Context**: 既存のコイン購入取引には `revenueYen` がないため、完全に実決済額のみへ切り替えると過去の売上グラフが欠落する。
+- **Decision**: コイン購入は `metadata.revenueYen` を優先し、ない場合のみ既存のパッケージ価格解決を使う。
+- **Reason**: 過去表示を壊さず、今後の精度を上げられる。
+- **Consequence**: コイン購入とサブスクで fallback 方針が異なるため、`resolveTransactionRevenue` のテストで明示する。
+
+### ADR-004: 過去サブスク売上は Stripe から backfill する
+
+- **Context**: 実装前に発生したサブスク決済は `credit_transactions.metadata.revenueYen` を持たない。
+- **Decision**: 一回限りの script を用意し、dry-run で対象と取得金額を確認してから `--apply` で metadata を更新する。
+- **Reason**: Stripe の invoice / Checkout Session が実決済額の source of truth であり、プラン価格推定より正確。DB migration に推定ロジックを埋め込まず、運用時に範囲を限定できる。
+- **Consequence**: backfill 実行には Stripe secret key と Supabase service role key が必要。取得できない取引はスキップされ、必要なら手動調査する。
+
+## 4. 実装計画
+
+#### フェーズ間の依存関係
+
+```mermaid
+flowchart LR
+    P1["Phase 1 DB と RPC"] --> P2["Phase 2 Webhook 保存"]
+    P2 --> P3["Phase 3 過去分 Backfill"]
+    P3 --> P4["Phase 4 Admin 集計"]
+    P4 --> P5["Phase 5 UI 表示"]
+    P5 --> P6["Phase 6 テストとドキュメント"]
+```
+
+#### Phase 1: DB と RPC 拡張
+
+目的: サブスク付与 RPC が任意 metadata を受け取り、実決済額を `credit_transactions.metadata` に保存できるようにする。
+ビルド確認: migration SQL が既存 `grant_subscription_percoins(uuid, integer, text)` 呼び出しと互換であること。
+
+- [ ] `supabase/migrations/` に `grant_subscription_percoins(p_metadata jsonb default '{}'::jsonb)` を追加する migration を作成する。既存の `supabase/migrations/20260331110000_add_subscription_system.sql` を参考。
+- [ ] `p_metadata` を既存の `invoice_id`, `requested_amount`, `granted_amount`, `granted_at` と merge して保存する。
+- [ ] 既存の年額月次付与 `supabase/migrations/20260331193000_add_yearly_subscription_monthly_grants.sql` の呼び出しは引数追加なしで動くよう default を維持する。
+- [ ] `.cursor/rules/database-design.mdc` の `credit_transactions.transaction_type` と `free_percoin_batches.source` 備考が現行 schema と一致するよう更新する。
+
+#### Phase 2: Stripe webhook 保存
+
+目的: コイン購入とサブスク決済の実決済額を台帳 metadata に保存する。
+ビルド確認: `app/api/stripe/webhook/route.ts` が型チェック上、Stripe の `amount_total` / `amount_paid` を安全に扱うこと。
+
+- [ ] `app/api/stripe/webhook/route.ts` の `handlePercoinCheckoutCompleted` で `session.amount_total` を `metadata.revenueYen` として `recordPercoinPurchase` に渡す。既存の `priceId`, `checkoutSessionId`, `mode` metadata を参考。
+- [ ] `handleSubscriptionCheckoutCompleted` で `session.amount_total` を `grantSubscriptionPercoins` に渡す。
+- [ ] `handleSubscriptionInvoicePaid` で `invoice.amount_paid` を `grantSubscriptionPercoins` に渡す。
+- [ ] `amount_total` / `amount_paid` が数値でない場合は `revenueYen` を `null` 相当にし、サブスク売上では推定補完しない。
+- [ ] 既存の `stripe_payment_intent_id` / `invoice_id` による冪等性を維持する。
+
+#### Phase 3: 過去分 Backfill
+
+目的: 実装前に発生したサブスク決済を、Stripe の実決済額に基づき `metadata.revenueYen` へ反映する。
+ビルド確認: script が dry-run で対象取引と取得元を表示し、`--apply` なしでは DB を変更しないこと。
+
+- [ ] `scripts/backfill-subscription-revenue.mjs` を追加する。既存 `scripts/verify-banners.mjs` の env 読み込みパターンを参考。
+- [ ] `--from` と `--to` で `credit_transactions.created_at` の範囲を限定する。
+- [ ] `transaction_type = "subscription"` かつ `metadata.revenueYen` が未設定の取引だけを候補にする。
+- [ ] `stripe_payment_intent_id` または `metadata.invoice_id` が `in_` で始まる場合は Stripe invoice を取得し、`amount_paid` と `currency` を確認する。
+- [ ] `cs_` で始まる Checkout Session しかない場合は session を取得し、`amount_total` と `currency` を確認する。
+- [ ] JPY 以外、Stripe オブジェクト不明、金額欠落は skip し、理由をログに出す。
+- [ ] `--apply` がある場合だけ `metadata.revenueYen`, `revenueSource`, `revenueCurrency`, `revenueBackfilledAt`, `revenueBackfillStripeObjectId` を更新する。
+
+#### Phase 4: Admin 売上集計
+
+目的: 既存の売上 KPI とグラフに、実決済額ベースのサブスク決済を合流させる。
+ビルド確認: `features/admin-dashboard/lib/get-admin-dashboard-data.ts` と `purchase-value.ts` のユニットテストが通ること。
+
+- [ ] `features/admin-dashboard/lib/purchase-value.ts` に `resolveTransactionRevenue` を追加する。既存 `resolvePurchasePackage` を参考。
+- [ ] コイン購入は `metadata.revenueYen` を優先し、ない場合は既存の `resolvePurchasePackage` で過去互換を維持する。
+- [ ] サブスクは `metadata.revenueYen` が数値の場合だけ `yenValue` を返し、プラン価格補完は行わない。
+- [ ] `features/admin-dashboard/lib/get-admin-dashboard-data.ts` の売上対象を `transaction_type = purchase` の live 取引と、`transaction_type = subscription` かつ `revenueYen` がある取引へ拡張する。
+- [ ] 売上 KPI、売上トレンド、平均決済単価、決済ユーザー数、ファネルの購入ステップ、最新決済一覧が同じ revenue transaction set を使うようにする。
+
+#### Phase 5: UI 表示調整
+
+目的: 既存 admin dashboard UI を、購入だけでなく決済全体を表す表示へ調整する。
+ビルド確認: admin dashboard の RSC props と client chart props の型が一致すること。
+
+- [ ] `features/admin-dashboard/components/AdminRecentPurchasesTable.tsx` の見出しを「最新決済」に変更する。既存テーブル構造を参考に新規コンポーネントは作らない。
+- [ ] 空状態文言を「この期間に決済はありません。」へ変更する。
+- [ ] `features/admin-dashboard/components/AdminOpsSummaryCard.tsx` の説明を平均決済単価、売上対象の決済件数、決済ユーザー数へ変更する。
+- [ ] サブスク行のラベルは `サブスクリプション light 月額` のようにし、追加の詳細画面は作らない。
+
+#### Phase 6: テストとドキュメント
+
+目的: 実決済額優先、サブスク非補完、過去コイン購入互換をテストと docs に固定する。
+ビルド確認: 対象ユニットテスト、変更ファイル lint、可能なら build が通ること。
+
+- [ ] `tests/unit/features/admin-dashboard/purchase-value.test.ts` を追加し、コイン購入の `revenueYen` 優先、コイン購入の定価 fallback、サブスクの `revenueYen` 必須、年額月次付与除外を確認する。
+- [ ] backfill script は dry-run と apply の手順を手動確認し、実行ログを PR または作業メモに残す。
+- [ ] 必要に応じて webhook route の unit test に metadata 伝播のケースを追加する。既存 `tests/unit/app/api/subscription/checkout-route.test.ts` などの route test パターンを参考。
+- [ ] `docs/API.md` と `docs/openapi.yaml` の Stripe webhook 説明が実際の処理イベントと大きくズレている場合は更新する。
+- [ ] `docs/architecture/data.ja.md` は購入フローに `metadata.revenueYen` を追記するか、別 PR に分ける判断をする。
+
+## 5. 修正対象ファイル一覧
+
+| ファイル | 操作 | 変更内容 |
+| --- | --- | --- |
+| `supabase/migrations/20260501120000_add_subscription_revenue_metadata.sql` | 新規 | `grant_subscription_percoins` に `p_metadata` を追加し、サブスク決済額を metadata に保存可能にする |
+| `scripts/backfill-subscription-revenue.mjs` | 新規 | 過去サブスク取引の `revenueYen` を Stripe 実決済額から backfill する |
+| `app/api/stripe/webhook/route.ts` | 修正 | コイン購入とサブスク決済で Stripe 実決済額を `revenueYen` として渡す |
+| `features/admin-dashboard/lib/purchase-value.ts` | 修正 | `resolveTransactionRevenue` を追加し、purchase と subscription の売上金額解決を統一 |
+| `features/admin-dashboard/lib/get-admin-dashboard-data.ts` | 修正 | 売上対象取引を purchase live と subscription revenueYen 付き取引に拡張 |
+| `features/admin-dashboard/components/AdminRecentPurchasesTable.tsx` | 修正 | 最新購入を最新決済の表示へ変更 |
+| `features/admin-dashboard/components/AdminOpsSummaryCard.tsx` | 修正 | 購入件数表現を決済件数表現へ変更 |
+| `tests/unit/features/admin-dashboard/purchase-value.test.ts` | 新規 | 売上金額解決ルールをユニットテストで固定 |
+| `.cursor/rules/database-design.mdc` | 修正 | `subscription` transaction type と source の schema ledger を現行に合わせる |
+| `docs/API.md` / `docs/openapi.yaml` | 修正 | 必要に応じて Stripe webhook の対象イベント説明を更新 |
+
+## 6. 品質・テスト観点
+
+#### 品質チェックリスト
+
+- [ ] **エラーハンドリング**: Stripe の金額が欠ける場合、サブスク売上を推定補完しない。
+- [ ] **権限制御**: admin dashboard は既存 `app/(app)/admin/layout.tsx` の `getUser()` と `getAdminUserIds()` で保護される。新規公開 API は作らない。
+- [ ] **データ整合性**: コイン購入は既存 `apply_percoin_transaction`、サブスクは `grant_subscription_percoins` に寄せ、台帳と残高更新の原子性を維持する。
+- [ ] **冪等性**: コイン購入は `stripe_payment_intent_id`、サブスクは `invoice_id` を使う既存重複防止を維持する。
+- [ ] **セキュリティ**: `revenueYen` はクライアント入力ではなく Stripe webhook の server-side payload から解決する。
+- [ ] **i18n**: admin UI の固定日本語文言のみ変更。ユーザー向け i18n 翻訳は不要。
+
+#### テスト観点
+
+| カテゴリ | テスト内容 |
+| --- | --- |
+| 正常系 | コイン購入で `metadata.revenueYen` がある場合、その金額が売上に使われる |
+| 正常系 | コイン購入で `metadata.revenueYen` がない過去データは、既存パッケージ価格で表示される |
+| 正常系 | サブスクで `metadata.revenueYen` がある場合、売上 KPI とトレンドに含まれる |
+| 異常系 | サブスクで `metadata.revenueYen` がない場合、プラン価格で補完されず売上対象外になる |
+| 異常系 | 年額サブスク月次付与の `yearly-monthly` 取引が売上対象外になる |
+| 運用 | backfill dry-run で対象件数、取得元、更新予定金額が確認できる |
+| 運用 | backfill apply で `metadata.revenueYen` が追加され、再実行時は対象外になる |
+| 表示 | 最新決済一覧でコイン購入とサブスク決済が時系列に混在表示される |
+| 回帰 | 既存の purchase live フィルタと mock/test 除外が維持される |
+
+#### 実行コマンド
+
+- `npm test -- tests/unit/features/admin-dashboard/purchase-value.test.ts --runInBand`
+- `npx eslint app/api/stripe/webhook/route.ts features/admin-dashboard/lib/get-admin-dashboard-data.ts features/admin-dashboard/lib/purchase-value.ts features/admin-dashboard/components/AdminRecentPurchasesTable.tsx features/admin-dashboard/components/AdminOpsSummaryCard.tsx tests/unit/features/admin-dashboard/purchase-value.test.ts`
+- `node --env-file=.env.local scripts/backfill-subscription-revenue.mjs --from 2026-04-30 --to 2026-05-01`
+- `node --env-file=.env.local scripts/backfill-subscription-revenue.mjs --from 2026-04-30 --to 2026-05-01 --apply`
+- `npm run typecheck`
+- 必要に応じて `npm run build -- --webpack`
+
+## 7. ロールバック方針
+
+- **Git**: Phase 単位で commit し、問題発生時は該当 commit を revert する。
+- **DB migration**: 追加する RPC 変更は default 引数付きで後方互換にする。問題があれば旧シグネチャ相当の `grant_subscription_percoins(uuid, integer, text)` 定義へ戻す migration を作る。
+- **外部サービス**: Stripe webhook の既存処理は維持し、metadata 追加のみとする。metadata 追加に失敗する場合は既存の取引保存自体を壊さない設計を優先する。
+- **表示**: Admin 集計ロジックを元の `purchase live` のみへ戻せば、UI は既存売上表示へ復帰できる。
+- **バックフィルなし**: 過去サブスク売上は最小実装では対象外なので、rollback 時に過去データ修正は不要。
+
+## 8. 使用スキル
+
+| スキル | 用途 | フェーズ |
+| --- | --- | --- |
+| `implementation-planning` | EARS、ADR、フェーズ別計画作成 | 計画 |
+| `project-database-context` | DB、RLS、RPC、migration 方針の確認 | Phase B、Phase 1 |
+| `test-flow` | 実装後のテストワークフロー整理 | Phase 5 |
+| `spec-extracting` | 実装後の EARS 仕様抽出 | Phase 5 |
+| `spec-writing` | 仕様精査 | Phase 5 |
+| `test-generating` | テスト追加 | Phase 5 |
+| `test-reviewing` | テスト品質確認 | Phase 5 |
+| `spec-verifying` | 仕様とテストの整合確認 | Phase 5 |
+| `codex-webpack-build` | 本番 build 確認 | Phase 5 |
+
+## 整合性チェック
+
+- **図とスキーマの整合性**: 新規 status は追加しない。既存 `transaction_type` の `purchase` と `subscription`、既存 `metadata` を使う。
+- **認証モデルの一貫性**: 書き込みは Stripe webhook の service role、読み取りは admin dashboard の server-side `createAdminClient()`。ユーザー入力由来の金額は使わない。
+- **データフェッチの整合性**: 既存 `app/(app)/admin/page.tsx` から `getAdminDashboardData` を呼ぶ RSC パターンを維持する。
+- **イベント網羅性**: 新規イベントテーブルは作らず、Stripe の既存決済イベントに metadata を追加する。表示されなかった状態などの UI analytics は対象外。
+- **APIパラメータのソース安全性**: `userId` は webhook の既存 Stripe metadata または session reference から解決し、`revenueYen` は Stripe server-side payload から解決する。
+- **ビジネスルールのDB層での強制**: 冪等性とウォレット更新は既存 RPC と unique index に従う。サブスク売上対象判定は admin 集計層で `metadata.revenueYen` の有無を明示的に検証する。

--- a/features/admin-dashboard/components/AdminOpsSummaryCard.tsx
+++ b/features/admin-dashboard/components/AdminOpsSummaryCard.tsx
@@ -30,21 +30,21 @@ export function AdminOpsSummaryCard({
         opsSummary.averageOrderValueYen === null
           ? "-"
           : `¥${opsSummary.averageOrderValueYen.toLocaleString("ja-JP")}`,
-      description: "平均購入単価",
+      description: "平均決済単価",
       icon: BadgeDollarSign,
       tone: "text-violet-700 bg-violet-100",
     },
     {
-      label: "purchase count",
+      label: "payment count",
       value: `${opsSummary.purchaseCount.toLocaleString("ja-JP")}件`,
-      description: "購入件数",
+      description: "売上対象の決済件数",
       icon: ReceiptText,
       tone: "text-emerald-700 bg-emerald-100",
     },
     {
-      label: "purchasing users",
+      label: "paying users",
       value: `${opsSummary.purchasingUsers.toLocaleString("ja-JP")}人`,
-      description: "購入ユーザー数",
+      description: "決済ユーザー数",
       icon: Users,
       tone: "text-fuchsia-700 bg-fuchsia-100",
     },

--- a/features/admin-dashboard/components/AdminRecentPurchasesTable.tsx
+++ b/features/admin-dashboard/components/AdminRecentPurchasesTable.tsx
@@ -19,7 +19,7 @@ export function AdminRecentPurchasesTable({
 }: AdminRecentPurchasesTableProps) {
   const emptyState = (
     <div className="rounded-xl border border-dashed border-slate-200 bg-slate-50/70 p-8 text-center text-sm text-slate-500">
-      この期間に購入はありません。
+      この期間に決済はありません。
     </div>
   );
 
@@ -32,7 +32,7 @@ export function AdminRecentPurchasesTable({
             fontFamily: "var(--font-admin-heading), ui-monospace, monospace",
           }}
         >
-          最新購入
+          最新決済
         </CardTitle>
       </CardHeader>
       <CardContent

--- a/features/admin-dashboard/lib/get-admin-dashboard-data.ts
+++ b/features/admin-dashboard/lib/get-admin-dashboard-data.ts
@@ -698,8 +698,12 @@ export async function getAdminDashboardData(
   );
 
   const revenueTransactions = transactions.filter((transaction) => {
+    if (getPurchaseMode(transaction.metadata) !== "live") {
+      return false;
+    }
+
     if (transaction.transaction_type === "purchase") {
-      return getPurchaseMode(transaction.metadata) === "live";
+      return true;
     }
 
     if (transaction.transaction_type === "subscription") {
@@ -708,7 +712,7 @@ export async function getAdminDashboardData(
         transactionType: transaction.transaction_type,
         metadata: transaction.metadata,
       });
-      return yenValue !== null && yenValue > 0;
+      return yenValue !== null;
     }
 
     return false;

--- a/features/admin-dashboard/lib/get-admin-dashboard-data.ts
+++ b/features/admin-dashboard/lib/get-admin-dashboard-data.ts
@@ -109,6 +109,19 @@ const revenueSeriesColors = [
   "#6EE7B7",
 ] as const;
 
+const subscriptionRevenueSeriesColors: Record<string, string> = {
+  "subscription-light-month": "#D97706",
+  "subscription-light-year": "#D97706",
+  "subscription-standard-month": "#0284C7",
+  "subscription-standard-year": "#0284C7",
+  "subscription-premium-month": "#059669",
+  "subscription-premium-year": "#059669",
+};
+
+function getDynamicRevenueSeriesColor(key: string): string {
+  return subscriptionRevenueSeriesColors[key] ?? "#94A3B8";
+}
+
 function formatInteger(value: number): string {
   return value.toLocaleString("ja-JP");
 }
@@ -257,7 +270,7 @@ function buildRevenueTrend(params: {
       dynamicSeries.set(resolvedPackage.key, {
         key: resolvedPackage.key,
         label: resolvedPackage.label,
-        color: "#94A3B8",
+        color: getDynamicRevenueSeriesColor(resolvedPackage.key),
       });
     }
 

--- a/features/admin-dashboard/lib/get-admin-dashboard-data.ts
+++ b/features/admin-dashboard/lib/get-admin-dashboard-data.ts
@@ -12,7 +12,7 @@ import {
 } from "./dashboard-range";
 import {
   getPurchaseMode,
-  resolvePurchasePackage,
+  resolveTransactionRevenue,
 } from "./purchase-value";
 import {
   buildOneTapStyleAnalytics,
@@ -207,7 +207,7 @@ function buildTrend(params: {
 }
 
 function buildRevenueTrend(params: {
-  livePurchases: CreditTransactionRow[];
+  revenueTransactions: CreditTransactionRow[];
   currentStart: Date;
   now: Date;
 }): DashboardRevenueTrend {
@@ -236,15 +236,16 @@ function buildRevenueTrend(params: {
   const dynamicSeries = new Map<string, { key: string; label: string; color: string }>();
   const usedSeriesKeys = new Set<string>();
 
-  for (const purchase of params.livePurchases) {
-    const point = pointsMap.get(toJstDateKey(purchase.created_at));
+  for (const transaction of params.revenueTransactions) {
+    const point = pointsMap.get(toJstDateKey(transaction.created_at));
     if (!point) {
       continue;
     }
 
-    const resolvedPackage = resolvePurchasePackage({
-      amount: purchase.amount,
-      metadata: purchase.metadata,
+    const resolvedPackage = resolveTransactionRevenue({
+      amount: transaction.amount,
+      transactionType: transaction.transaction_type,
+      metadata: transaction.metadata,
     });
 
     if (resolvedPackage.yenValue === null) {
@@ -342,7 +343,7 @@ function buildFunnel(params: {
 
 function buildOpsSummary(params: {
   jobs: ImageJobRow[];
-  livePurchases: CreditTransactionRow[];
+  revenueTransactions: CreditTransactionRow[];
   balances: CreditBalanceRow[];
   expiringBatches: FreePercoinBatchRow[];
 }): DashboardOpsSummary {
@@ -363,16 +364,17 @@ function buildOpsSummary(params: {
     (sum, batch) => sum + (batch.remaining_amount ?? 0),
     0
   );
-  const liveRevenueTotal = params.livePurchases.reduce((sum, purchase) => {
-    const { yenValue } = resolvePurchasePackage({
-      amount: purchase.amount,
-      metadata: purchase.metadata,
+  const liveRevenueTotal = params.revenueTransactions.reduce((sum, transaction) => {
+    const { yenValue } = resolveTransactionRevenue({
+      amount: transaction.amount,
+      transactionType: transaction.transaction_type,
+      metadata: transaction.metadata,
     });
 
     return sum + (yenValue ?? 0);
   }, 0);
-  const purchasingUsers = distinctUsers(params.livePurchases).size;
-  const purchaseCount = params.livePurchases.length;
+  const purchasingUsers = distinctUsers(params.revenueTransactions).size;
+  const purchaseCount = params.revenueTransactions.length;
   const averageOrderValueYen =
     purchaseCount > 0
       ? Math.round(liveRevenueTotal / purchaseCount)
@@ -401,8 +403,9 @@ function buildRecentPurchases(params: {
     )
     .slice(0, 8)
     .map((purchase) => {
-      const { label, yenValue } = resolvePurchasePackage({
+      const { label, yenValue } = resolveTransactionRevenue({
         amount: purchase.amount,
+        transactionType: purchase.transaction_type,
         metadata: purchase.metadata,
       });
 
@@ -681,34 +684,42 @@ export async function getAdminDashboardData(
     isWithinDateRange(generation.created_at, previousStart, currentStart)
   );
 
-  const purchaseTransactions = transactions.filter(
-    (transaction) => transaction.transaction_type === "purchase"
+  const revenueTransactions = transactions.filter((transaction) => {
+    if (transaction.transaction_type === "purchase") {
+      return getPurchaseMode(transaction.metadata) === "live";
+    }
+
+    if (transaction.transaction_type === "subscription") {
+      const { yenValue } = resolveTransactionRevenue({
+        amount: transaction.amount,
+        transactionType: transaction.transaction_type,
+        metadata: transaction.metadata,
+      });
+      return yenValue !== null && yenValue > 0;
+    }
+
+    return false;
+  });
+  const currentRevenueTransactions = revenueTransactions.filter((transaction) =>
+    isWithinDateRange(transaction.created_at, currentStart, now)
   );
-  const currentPurchases = purchaseTransactions.filter((purchase) =>
-    isWithinDateRange(purchase.created_at, currentStart, now)
-  );
-  const previousPurchases = purchaseTransactions.filter((purchase) =>
-    isWithinDateRange(purchase.created_at, previousStart, currentStart)
+  const previousRevenueTransactions = revenueTransactions.filter((transaction) =>
+    isWithinDateRange(transaction.created_at, previousStart, currentStart)
   );
 
-  const currentLivePurchases = currentPurchases.filter(
-    (purchase) => getPurchaseMode(purchase.metadata) === "live"
-  );
-  const previousLivePurchases = previousPurchases.filter(
-    (purchase) => getPurchaseMode(purchase.metadata) === "live"
-  );
-
-  const currentLiveRevenue = currentLivePurchases.reduce((sum, purchase) => {
-    const { yenValue } = resolvePurchasePackage({
-      amount: purchase.amount,
-      metadata: purchase.metadata,
+  const currentLiveRevenue = currentRevenueTransactions.reduce((sum, transaction) => {
+    const { yenValue } = resolveTransactionRevenue({
+      amount: transaction.amount,
+      transactionType: transaction.transaction_type,
+      metadata: transaction.metadata,
     });
     return sum + (yenValue ?? 0);
   }, 0);
-  const previousLiveRevenue = previousLivePurchases.reduce((sum, purchase) => {
-    const { yenValue } = resolvePurchasePackage({
-      amount: purchase.amount,
-      metadata: purchase.metadata,
+  const previousLiveRevenue = previousRevenueTransactions.reduce((sum, transaction) => {
+    const { yenValue } = resolveTransactionRevenue({
+      amount: transaction.amount,
+      transactionType: transaction.transaction_type,
+      metadata: transaction.metadata,
     });
     return sum + (yenValue ?? 0);
   }, 0);
@@ -744,7 +755,7 @@ export async function getAdminDashboardData(
       current: currentLiveRevenue,
       previous: previousLiveRevenue,
       formatValue: formatYen,
-      subtext: `購入 ${formatInteger(currentLivePurchases.length)}件`,
+      subtext: `決済 ${formatInteger(currentRevenueTransactions.length)}件`,
     }),
     {
       key: "pendingModeration",
@@ -780,26 +791,26 @@ export async function getAdminDashboardData(
     now: oneTapStyleBounds.now,
   });
   const revenueTrend = buildRevenueTrend({
-    livePurchases: currentLivePurchases,
+    revenueTransactions: currentRevenueTransactions,
     currentStart,
     now,
   });
   const funnel = buildFunnel({
     signups: currentProfiles,
     generations: currentGeneratedImages,
-    purchases: currentPurchases,
+    purchases: currentRevenueTransactions,
   });
   const modelMix = buildModelMix(currentGeneratedImages);
   const opsSummary = buildOpsSummary({
     jobs,
-    livePurchases: currentLivePurchases,
+    revenueTransactions: currentRevenueTransactions,
     balances,
     expiringBatches,
   });
 
   const recentPurchaseUserIds = Array.from(
     new Set(
-      currentPurchases
+      currentRevenueTransactions
         .map((purchase) => purchase.user_id)
         .filter(Boolean) as string[]
     )
@@ -827,7 +838,7 @@ export async function getAdminDashboardData(
   );
 
   const recentPurchases = buildRecentPurchases({
-    purchases: currentPurchases,
+    purchases: currentRevenueTransactions,
     nicknameMap: purchaseNicknameMap,
   });
   const alerts = buildAlerts({

--- a/features/admin-dashboard/lib/purchase-value.ts
+++ b/features/admin-dashboard/lib/purchase-value.ts
@@ -1,5 +1,9 @@
 import { PERCOIN_PACKAGES } from "@/features/credits/percoin-packages";
 import { getPercoinsFromPriceId } from "@/features/credits/lib/stripe-price-mapping";
+import type {
+  PaidSubscriptionPlan,
+  SubscriptionBillingInterval,
+} from "@/features/subscription/subscription-config";
 
 type PurchaseMetadata = Record<string, unknown> | null | undefined;
 
@@ -16,6 +20,30 @@ function getStringValue(
 ): string | null {
   const value = metadata?.[key];
   return typeof value === "string" ? value : null;
+}
+
+function getNumberValue(
+  metadata: PurchaseMetadata,
+  key: string
+): number | null {
+  const value = metadata?.[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function getSubscriptionPlan(
+  metadata: PurchaseMetadata
+): PaidSubscriptionPlan | null {
+  const value = getStringValue(metadata, "plan");
+  return value === "light" || value === "standard" || value === "premium"
+    ? value
+    : null;
+}
+
+function getSubscriptionBillingInterval(
+  metadata: PurchaseMetadata
+): SubscriptionBillingInterval | null {
+  const value = getStringValue(metadata, "billingInterval");
+  return value === "month" || value === "year" ? value : null;
 }
 
 export function getPurchaseMode(metadata: PurchaseMetadata): string {
@@ -45,5 +73,49 @@ export function resolvePurchasePackage(params: {
     key: matchedPackage?.id ?? fallbackKey,
     label: matchedPackage?.name ?? `${params.amount.toLocaleString()}ペルコイン`,
     yenValue: matchedPackage?.priceYen ?? null,
+  };
+}
+
+export function resolveTransactionRevenue(params: {
+  amount: number;
+  transactionType: string;
+  metadata: PurchaseMetadata;
+}) {
+  const revenueYen = getNumberValue(params.metadata, "revenueYen");
+
+  if (params.transactionType === "purchase") {
+    const resolvedPackage = resolvePurchasePackage({
+      amount: params.amount,
+      metadata: params.metadata,
+    });
+
+    return {
+      ...resolvedPackage,
+      yenValue: revenueYen ?? resolvedPackage.yenValue,
+    };
+  }
+
+  if (params.transactionType === "subscription") {
+    const plan = getSubscriptionPlan(params.metadata);
+    const billingInterval = getSubscriptionBillingInterval(params.metadata);
+    const label =
+      plan && billingInterval
+        ? `サブスクリプション ${plan} ${billingInterval === "year" ? "年額" : "月額"}`
+        : "サブスクリプション";
+
+    return {
+      key:
+        plan && billingInterval
+          ? `subscription-${plan}-${billingInterval}`
+          : "subscription",
+      label,
+      yenValue: revenueYen,
+    };
+  }
+
+  return {
+    key: params.transactionType,
+    label: params.transactionType,
+    yenValue: null,
   };
 }

--- a/scripts/backfill-subscription-revenue.mjs
+++ b/scripts/backfill-subscription-revenue.mjs
@@ -1,0 +1,362 @@
+#!/usr/bin/env node
+/**
+ * Backfill subscription revenue into credit_transactions.metadata.revenueYen.
+ *
+ * Usage:
+ *   node --env-file=.env.local scripts/backfill-subscription-revenue.mjs --from 2026-04-30 --to 2026-05-01 --stripe-mode live
+ *   node --env-file=.env.local scripts/backfill-subscription-revenue.mjs --from 2026-04-30 --to 2026-05-01 --stripe-mode live --apply
+ *
+ * Default is dry-run. The script updates only subscription transactions that:
+ * - do not already have numeric metadata.revenueYen
+ * - can be matched to a Stripe invoice or Checkout Session
+ * - have JPY currency
+ */
+
+import Stripe from "stripe";
+import { createClient } from "@supabase/supabase-js";
+
+const args = process.argv.slice(2);
+
+function getArg(name) {
+  const index = args.indexOf(name);
+  if (index === -1) return null;
+  return args[index + 1] ?? null;
+}
+
+function hasFlag(name) {
+  return args.includes(name);
+}
+
+function printUsage() {
+  console.log(`Usage:
+  node --env-file=.env.local scripts/backfill-subscription-revenue.mjs --from YYYY-MM-DD --to YYYY-MM-DD [--stripe-mode live|test|default] [--apply]
+
+Options:
+  --from <date>         Inclusive lower bound for credit_transactions.created_at
+  --to <date>           Exclusive upper bound for credit_transactions.created_at
+  --stripe-mode <mode>  Stripe key selector. default uses STRIPE_SECRET_KEY first.
+  --apply               Persist updates. Omit for dry-run.
+`);
+}
+
+const from = getArg("--from");
+const to = getArg("--to");
+const stripeMode = getArg("--stripe-mode") ?? "default";
+const shouldApply = hasFlag("--apply");
+
+if (hasFlag("--help") || !from || !to) {
+  printUsage();
+  process.exit(hasFlag("--help") ? 0 : 1);
+}
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+function resolveStripeSecretKey(mode) {
+  if (mode === "live") {
+    return process.env.STRIPE_SECRET_KEY_LIVE || process.env.STRIPE_SECRET_KEY;
+  }
+
+  if (mode === "test") {
+    return process.env.STRIPE_SECRET_KEY_TEST || process.env.STRIPE_SECRET_KEY;
+  }
+
+  if (mode !== "default") {
+    throw new Error("--stripe-mode must be one of: live, test, default");
+  }
+
+  return (
+    process.env.STRIPE_SECRET_KEY ||
+    process.env.STRIPE_SECRET_KEY_LIVE ||
+    process.env.STRIPE_SECRET_KEY_TEST
+  );
+}
+
+const stripeSecretKey = resolveStripeSecretKey(stripeMode);
+
+if (!supabaseUrl || !serviceRoleKey || !stripeSecretKey) {
+  console.error(
+    "Missing required env vars: NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, STRIPE_SECRET_KEY"
+  );
+  process.exit(1);
+}
+
+function toIsoBound(value, endOfDay = false) {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return `${value}T${endOfDay ? "23:59:59.999" : "00:00:00.000"}+09:00`;
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`Invalid date: ${value}`);
+  }
+  return date.toISOString();
+}
+
+function getInvoiceId(row) {
+  const stripeId =
+    typeof row.stripe_payment_intent_id === "string"
+      ? row.stripe_payment_intent_id
+      : null;
+  const metadataInvoiceId =
+    typeof row.metadata?.invoice_id === "string"
+      ? row.metadata.invoice_id
+      : null;
+
+  return stripeId?.startsWith("in_")
+    ? stripeId
+    : metadataInvoiceId?.startsWith("in_")
+      ? metadataInvoiceId
+      : null;
+}
+
+function getCheckoutSessionId(row) {
+  const stripeId =
+    typeof row.stripe_payment_intent_id === "string"
+      ? row.stripe_payment_intent_id
+      : null;
+  const metadataSessionId =
+    typeof row.metadata?.checkoutSessionId === "string"
+      ? row.metadata.checkoutSessionId
+      : null;
+  const metadataInvoiceId =
+    typeof row.metadata?.invoice_id === "string"
+      ? row.metadata.invoice_id
+      : null;
+
+  return stripeId?.startsWith("cs_")
+    ? stripeId
+    : metadataSessionId?.startsWith("cs_")
+      ? metadataSessionId
+      : metadataInvoiceId?.startsWith("cs_")
+        ? metadataInvoiceId
+        : null;
+}
+
+function toStripeCreatedRange(createdAt) {
+  const createdMs = new Date(createdAt).getTime();
+  if (Number.isNaN(createdMs)) {
+    return null;
+  }
+
+  return {
+    gte: Math.floor((createdMs - 24 * 60 * 60 * 1000) / 1000),
+    lte: Math.floor((createdMs + 24 * 60 * 60 * 1000) / 1000),
+  };
+}
+
+function resolveInvoiceRevenue(invoice, source) {
+  if (invoice.currency !== "jpy") {
+    return {
+      skipped: true,
+      reason: `invoice currency is ${invoice.currency}`,
+    };
+  }
+
+  return {
+    revenueYen: invoice.amount_paid,
+    source,
+    stripeObjectId: invoice.id,
+    currency: invoice.currency,
+  };
+}
+
+async function resolveRevenueYen(stripe, row, subscription) {
+  const lookupErrors = [];
+  const invoiceId = getInvoiceId(row);
+  if (invoiceId) {
+    try {
+      const invoice = await stripe.invoices.retrieve(invoiceId);
+      return resolveInvoiceRevenue(invoice, "stripe_invoice_backfill");
+    } catch (error) {
+      lookupErrors.push(
+        error instanceof Error
+          ? `invoice lookup failed: ${error.message}`
+          : "invoice lookup failed"
+      );
+    }
+  }
+
+  const checkoutSessionId = getCheckoutSessionId(row);
+  if (checkoutSessionId) {
+    try {
+      const session = await stripe.checkout.sessions.retrieve(checkoutSessionId);
+      if (session.currency !== "jpy") {
+        return {
+          skipped: true,
+          reason: `checkout session currency is ${session.currency}`,
+        };
+      }
+
+      if (typeof session.amount_total !== "number") {
+        return {
+          skipped: true,
+          reason: "checkout session amount_total is missing",
+        };
+      }
+
+      return {
+        revenueYen: session.amount_total,
+        source: "stripe_checkout_session_backfill",
+        stripeObjectId: session.id,
+        currency: session.currency,
+      };
+    } catch (error) {
+      lookupErrors.push(
+        error instanceof Error
+          ? `checkout session lookup failed: ${error.message}`
+          : "checkout session lookup failed"
+      );
+    }
+  }
+
+  if (subscription?.stripe_subscription_id) {
+    try {
+      const created = toStripeCreatedRange(row.created_at);
+      const invoices = await stripe.invoices.list({
+        subscription: subscription.stripe_subscription_id,
+        limit: 10,
+        ...(created ? { created } : {}),
+      });
+      const paidInvoice = invoices.data.find(
+        (invoice) => invoice.status === "paid" && invoice.amount_paid > 0
+      );
+
+      if (paidInvoice) {
+        return resolveInvoiceRevenue(
+          paidInvoice,
+          "stripe_subscription_invoice_backfill"
+        );
+      }
+
+      lookupErrors.push("subscription invoice list had no paid invoice");
+    } catch (error) {
+      lookupErrors.push(
+        error instanceof Error
+          ? `subscription invoice list failed: ${error.message}`
+          : "subscription invoice list failed"
+      );
+    }
+  }
+
+  return {
+    skipped: true,
+    reason:
+      lookupErrors.length > 0
+        ? lookupErrors.join("; ")
+        : "no Stripe invoice, Checkout Session, or subscription id found",
+  };
+}
+
+const supabase = createClient(supabaseUrl, serviceRoleKey, {
+  auth: {
+    autoRefreshToken: false,
+    persistSession: false,
+  },
+});
+const stripe = new Stripe(stripeSecretKey, {
+  apiVersion: "2025-12-15.clover",
+});
+
+async function main() {
+  const fromIso = toIsoBound(from);
+  const toIso = toIsoBound(to);
+
+  const { data, error } = await supabase
+    .from("credit_transactions")
+    .select("id, user_id, amount, transaction_type, stripe_payment_intent_id, metadata, created_at")
+    .eq("transaction_type", "subscription")
+    .gte("created_at", fromIso)
+    .lt("created_at", toIso)
+    .order("created_at", { ascending: true });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  const rows = data ?? [];
+  const candidates = rows.filter(
+    (row) =>
+      !(
+        row.metadata &&
+        typeof row.metadata.revenueYen === "number" &&
+        Number.isFinite(row.metadata.revenueYen)
+      )
+  );
+  const userIds = [...new Set(candidates.map((row) => row.user_id).filter(Boolean))];
+  const subscriptionsByUserId = new Map();
+
+  if (userIds.length > 0) {
+    const { data: subscriptions, error: subscriptionsError } = await supabase
+      .from("user_subscriptions")
+      .select("user_id, stripe_subscription_id")
+      .in("user_id", userIds);
+
+    if (subscriptionsError) {
+      throw new Error(subscriptionsError.message);
+    }
+
+    for (const subscription of subscriptions ?? []) {
+      subscriptionsByUserId.set(subscription.user_id, subscription);
+    }
+  }
+
+  console.log(
+    `${shouldApply ? "APPLY" : "DRY-RUN"} subscription revenue backfill`
+  );
+  console.log(`Stripe mode: ${stripeMode}`);
+  console.log(`Range: ${fromIso} <= created_at < ${toIso}`);
+  console.log(`Fetched rows: ${rows.length}`);
+  console.log(`Candidates: ${candidates.length}`);
+
+  let updated = 0;
+  let skipped = 0;
+
+  for (const row of candidates) {
+    const resolved = await resolveRevenueYen(
+      stripe,
+      row,
+      subscriptionsByUserId.get(row.user_id)
+    );
+
+    if (resolved.skipped) {
+      skipped += 1;
+      console.log(`SKIP ${row.id} ${row.created_at}: ${resolved.reason}`);
+      continue;
+    }
+
+    const nextMetadata = {
+      ...(row.metadata ?? {}),
+      revenueYen: resolved.revenueYen,
+      revenueSource: resolved.source,
+      revenueCurrency: resolved.currency,
+      revenueBackfilledAt: new Date().toISOString(),
+      revenueBackfillStripeObjectId: resolved.stripeObjectId,
+    };
+
+    console.log(
+      `${shouldApply ? "UPDATE" : "WOULD UPDATE"} ${row.id} ${row.created_at}: revenueYen=${resolved.revenueYen} source=${resolved.source}`
+    );
+
+    if (shouldApply) {
+      const { error: updateError } = await supabase
+        .from("credit_transactions")
+        .update({ metadata: nextMetadata })
+        .eq("id", row.id);
+
+      if (updateError) {
+        throw new Error(`Failed to update ${row.id}: ${updateError.message}`);
+      }
+    }
+
+    updated += 1;
+  }
+
+  console.log("---");
+  console.log(`${shouldApply ? "Updated" : "Would update"}: ${updated}`);
+  console.log(`Skipped: ${skipped}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/backfill-subscription-revenue.mjs
+++ b/scripts/backfill-subscription-revenue.mjs
@@ -165,6 +165,18 @@ function getMetadataString(metadata, key) {
   return typeof value === "string" ? value : null;
 }
 
+function hasMetadataKey(metadata, key) {
+  return metadata != null && Object.prototype.hasOwnProperty.call(metadata, key);
+}
+
+function getMetadataMode() {
+  if (stripeMode === "live" || stripeMode === "test") {
+    return stripeMode;
+  }
+
+  return null;
+}
+
 function hasRevenueYen(row) {
   return (
     row.metadata &&
@@ -190,6 +202,7 @@ function getBillingIntervalMetadata(subscription) {
 function needsBackfill(row) {
   return (
     !hasRevenueYen(row) ||
+    !hasMetadataKey(row.metadata, "mode") ||
     getMetadataString(row.metadata, "plan") === null ||
     getMetadataString(row.metadata, "billingInterval") === null
   );
@@ -370,6 +383,7 @@ async function main() {
       revenueCurrency: resolved.currency,
       revenueBackfilledAt: new Date().toISOString(),
       revenueBackfillStripeObjectId: resolved.stripeObjectId,
+      mode: getMetadataMode(),
       ...(plan ? { plan } : {}),
       ...(billingInterval ? { billingInterval } : {}),
     };

--- a/scripts/backfill-subscription-revenue.mjs
+++ b/scripts/backfill-subscription-revenue.mjs
@@ -7,9 +7,9 @@
  *   node --env-file=.env.local scripts/backfill-subscription-revenue.mjs --from 2026-04-30 --to 2026-05-01 --stripe-mode live --apply
  *
  * Default is dry-run. The script updates only subscription transactions that:
- * - do not already have numeric metadata.revenueYen
- * - can be matched to a Stripe invoice or Checkout Session
- * - have JPY currency
+ * - do not already have numeric metadata.revenueYen, or lack plan metadata
+ * - can be matched to a Stripe invoice or Checkout Session when revenue is missing
+ * - have JPY currency when revenue is resolved from Stripe
  */
 
 import Stripe from "stripe";
@@ -160,6 +160,41 @@ function resolveInvoiceRevenue(invoice, source) {
   };
 }
 
+function getMetadataString(metadata, key) {
+  const value = metadata?.[key];
+  return typeof value === "string" ? value : null;
+}
+
+function hasRevenueYen(row) {
+  return (
+    row.metadata &&
+    typeof row.metadata.revenueYen === "number" &&
+    Number.isFinite(row.metadata.revenueYen)
+  );
+}
+
+function getPlanMetadata(subscription) {
+  const plan = subscription?.plan;
+  return plan === "light" || plan === "standard" || plan === "premium"
+    ? plan
+    : null;
+}
+
+function getBillingIntervalMetadata(subscription) {
+  const billingInterval = subscription?.billing_interval;
+  return billingInterval === "month" || billingInterval === "year"
+    ? billingInterval
+    : null;
+}
+
+function needsBackfill(row) {
+  return (
+    !hasRevenueYen(row) ||
+    getMetadataString(row.metadata, "plan") === null ||
+    getMetadataString(row.metadata, "billingInterval") === null
+  );
+}
+
 async function resolveRevenueYen(stripe, row, subscription) {
   const lookupErrors = [];
   const invoiceId = getInvoiceId(row);
@@ -275,12 +310,7 @@ async function main() {
 
   const rows = data ?? [];
   const candidates = rows.filter(
-    (row) =>
-      !(
-        row.metadata &&
-        typeof row.metadata.revenueYen === "number" &&
-        Number.isFinite(row.metadata.revenueYen)
-      )
+    (row) => needsBackfill(row)
   );
   const userIds = [...new Set(candidates.map((row) => row.user_id).filter(Boolean))];
   const subscriptionsByUserId = new Map();
@@ -288,7 +318,7 @@ async function main() {
   if (userIds.length > 0) {
     const { data: subscriptions, error: subscriptionsError } = await supabase
       .from("user_subscriptions")
-      .select("user_id, stripe_subscription_id")
+      .select("user_id, stripe_subscription_id, plan, billing_interval")
       .in("user_id", userIds);
 
     if (subscriptionsError) {
@@ -312,11 +342,20 @@ async function main() {
   let skipped = 0;
 
   for (const row of candidates) {
-    const resolved = await resolveRevenueYen(
-      stripe,
-      row,
-      subscriptionsByUserId.get(row.user_id)
-    );
+    const subscription = subscriptionsByUserId.get(row.user_id);
+    const plan = getPlanMetadata(subscription);
+    const billingInterval = getBillingIntervalMetadata(subscription);
+    const resolved = hasRevenueYen(row)
+      ? {
+          revenueYen: row.metadata.revenueYen,
+          source: getMetadataString(row.metadata, "revenueSource") ?? "existing",
+          currency: getMetadataString(row.metadata, "revenueCurrency") ?? "jpy",
+          stripeObjectId:
+            getMetadataString(row.metadata, "revenueBackfillStripeObjectId") ??
+            getInvoiceId(row) ??
+            getCheckoutSessionId(row),
+        }
+      : await resolveRevenueYen(stripe, row, subscription);
 
     if (resolved.skipped) {
       skipped += 1;
@@ -331,10 +370,12 @@ async function main() {
       revenueCurrency: resolved.currency,
       revenueBackfilledAt: new Date().toISOString(),
       revenueBackfillStripeObjectId: resolved.stripeObjectId,
+      ...(plan ? { plan } : {}),
+      ...(billingInterval ? { billingInterval } : {}),
     };
 
     console.log(
-      `${shouldApply ? "UPDATE" : "WOULD UPDATE"} ${row.id} ${row.created_at}: revenueYen=${resolved.revenueYen} source=${resolved.source}`
+      `${shouldApply ? "UPDATE" : "WOULD UPDATE"} ${row.id} ${row.created_at}: revenueYen=${resolved.revenueYen} source=${resolved.source} plan=${plan ?? "unknown"} billingInterval=${billingInterval ?? "unknown"}`
     );
 
     if (shouldApply) {

--- a/supabase/migrations/20260501120000_add_subscription_revenue_metadata.sql
+++ b/supabase/migrations/20260501120000_add_subscription_revenue_metadata.sql
@@ -1,0 +1,108 @@
+create or replace function public.grant_subscription_percoins(
+  p_user_id uuid,
+  p_amount integer,
+  p_invoice_id text,
+  p_metadata jsonb default '{}'::jsonb
+)
+returns integer
+language plpgsql
+security definer
+set search_path to 'public'
+as $function$
+declare
+  v_existing_transaction_count integer;
+  v_grant_amount integer;
+  v_tx_id uuid;
+  v_expire_at timestamptz;
+begin
+  if p_amount is null or p_amount <= 0 then
+    return 0;
+  end if;
+
+  perform pg_advisory_xact_lock(
+    hashtext('subscription:' || p_user_id::text || ':' || coalesce(p_invoice_id, ''))
+  );
+
+  select count(*)
+  into v_existing_transaction_count
+  from public.credit_transactions
+  where user_id = p_user_id
+    and transaction_type = 'subscription'
+    and stripe_payment_intent_id = p_invoice_id;
+
+  if v_existing_transaction_count > 0 then
+    return 0;
+  end if;
+
+  v_grant_amount := public.get_grantable_free_percoin_amount(p_user_id, p_amount);
+
+  if v_grant_amount <= 0 then
+    return 0;
+  end if;
+
+  v_expire_at := (
+    date_trunc('month', now() at time zone 'Asia/Tokyo')
+    + interval '7 months' - interval '1 second'
+  ) at time zone 'Asia/Tokyo';
+
+  insert into public.credit_transactions (
+    user_id,
+    amount,
+    transaction_type,
+    stripe_payment_intent_id,
+    metadata
+  )
+  values (
+    p_user_id,
+    v_grant_amount,
+    'subscription',
+    p_invoice_id,
+    coalesce(p_metadata, '{}'::jsonb) || jsonb_build_object(
+      'invoice_id', p_invoice_id,
+      'requested_amount', p_amount,
+      'granted_amount', v_grant_amount,
+      'granted_at', now()
+    )
+  )
+  returning id into v_tx_id;
+
+  insert into public.free_percoin_batches (
+    user_id,
+    amount,
+    remaining_amount,
+    granted_at,
+    expire_at,
+    source,
+    credit_transaction_id
+  )
+  values (
+    p_user_id,
+    v_grant_amount,
+    v_grant_amount,
+    now(),
+    v_expire_at,
+    'subscription',
+    v_tx_id
+  );
+
+  insert into public.user_credits (user_id, balance, paid_balance)
+  values (p_user_id, v_grant_amount, 0)
+  on conflict (user_id) do update
+  set balance = public.user_credits.balance + v_grant_amount,
+      updated_at = now();
+
+  return v_grant_amount;
+end;
+$function$;
+
+revoke all on function public.grant_subscription_percoins(uuid, integer, text)
+from public, anon, authenticated;
+
+revoke all on function public.grant_subscription_percoins(uuid, integer, text, jsonb)
+from public, anon, authenticated;
+
+grant execute on function public.grant_subscription_percoins(uuid, integer, text)
+to service_role;
+
+grant execute on function public.grant_subscription_percoins(uuid, integer, text, jsonb)
+to service_role;

--- a/tests/unit/features/admin-dashboard/purchase-value.test.ts
+++ b/tests/unit/features/admin-dashboard/purchase-value.test.ts
@@ -1,0 +1,84 @@
+import { resolveTransactionRevenue } from "@/features/admin-dashboard/lib/purchase-value";
+
+describe("resolveTransactionRevenue", () => {
+  test("単発購入はパッケージ価格を売上として解決する", () => {
+    expect(
+      resolveTransactionRevenue({
+        amount: 1000,
+        transactionType: "purchase",
+        metadata: { mode: "live", packageId: "credit-240" },
+      })
+    ).toMatchObject({
+      label: "240ペルコイン",
+      yenValue: 1000,
+    });
+  });
+
+  test("単発購入は metadata の実決済金額を優先する", () => {
+    expect(
+      resolveTransactionRevenue({
+        amount: 240,
+        transactionType: "purchase",
+        metadata: {
+          mode: "live",
+          packageId: "credit-240",
+          revenueYen: 800,
+        },
+      })
+    ).toMatchObject({
+      label: "240ペルコイン",
+      yenValue: 800,
+    });
+  });
+
+  test("サブスクリプションは metadata の決済金額を売上として解決する", () => {
+    expect(
+      resolveTransactionRevenue({
+        amount: 300,
+        transactionType: "subscription",
+        metadata: {
+          plan: "light",
+          billingInterval: "month",
+          revenueYen: 980,
+        },
+      })
+    ).toEqual({
+      key: "subscription-light-month",
+      label: "サブスクリプション light 月額",
+      yenValue: 980,
+    });
+  });
+
+  test("決済金額がないサブスクリプション付与は売上対象にしない", () => {
+    expect(
+      resolveTransactionRevenue({
+        amount: 2500,
+        transactionType: "subscription",
+        metadata: {
+          plan: "premium",
+          billingInterval: "year",
+        },
+      })
+    ).toEqual({
+      key: "subscription-premium-year",
+      label: "サブスクリプション premium 年額",
+      yenValue: null,
+    });
+  });
+
+  test("決済情報がないサブスクリプション付与は売上対象にしない", () => {
+    expect(
+      resolveTransactionRevenue({
+        amount: 300,
+        transactionType: "subscription",
+        metadata: {
+          invoice_id: "yearly-monthly:sub_123:20260501000000",
+        },
+      })
+    ).toEqual({
+      key: "subscription",
+      label: "サブスクリプション",
+      yenValue: null,
+    });
+  });
+});

--- a/tests/unit/features/admin-dashboard/purchase-value.test.ts
+++ b/tests/unit/features/admin-dashboard/purchase-value.test.ts
@@ -1,4 +1,13 @@
-import { resolveTransactionRevenue } from "@/features/admin-dashboard/lib/purchase-value";
+import {
+  getPurchaseMode,
+  resolveTransactionRevenue,
+} from "@/features/admin-dashboard/lib/purchase-value";
+
+describe("getPurchaseMode", () => {
+  test("metadata に mode がなければ unknown を返す", () => {
+    expect(getPurchaseMode({})).toBe("unknown");
+  });
+});
 
 describe("resolveTransactionRevenue", () => {
   test("単発購入はパッケージ価格を売上として解決する", () => {
@@ -37,6 +46,7 @@ describe("resolveTransactionRevenue", () => {
         amount: 300,
         transactionType: "subscription",
         metadata: {
+          mode: "live",
           plan: "light",
           billingInterval: "month",
           revenueYen: 980,
@@ -55,6 +65,7 @@ describe("resolveTransactionRevenue", () => {
         amount: 2500,
         transactionType: "subscription",
         metadata: {
+          mode: "live",
           plan: "premium",
           billingInterval: "year",
         },
@@ -72,12 +83,27 @@ describe("resolveTransactionRevenue", () => {
         amount: 300,
         transactionType: "subscription",
         metadata: {
+          mode: "live",
           invoice_id: "yearly-monthly:sub_123:20260501000000",
         },
       })
     ).toEqual({
       key: "subscription",
       label: "サブスクリプション",
+      yenValue: null,
+    });
+  });
+
+  test("未知の取引種別は売上対象にしない", () => {
+    expect(
+      resolveTransactionRevenue({
+        amount: 100,
+        transactionType: "bonus",
+        metadata: { mode: "live", revenueYen: 100 },
+      })
+    ).toEqual({
+      key: "bonus",
+      label: "bonus",
       yenValue: null,
     });
   });


### PR DESCRIPTION
### 概要
管理ダッシュボードの売上がペルコイン単発購入のみを対象としていたため、サブスクリプション決済の実売上が反映されるようにしました。Stripe の実決済額を `credit_transactions.metadata.revenueYen` に保存し、admin 側の売上集計では実決済額を優先して扱います。

### 変更内容
- Stripe webhook でコイン購入とサブスク決済の実決済額を metadata に保存
- サブスク付与 RPC に任意 metadata を渡せる Supabase migration を追加
- admin ダッシュボードの売上 KPI、売上トレンド、最新決済、オペレーションサマリーを実決済額ベースに拡張
- サブスクは `revenueYen` がある取引のみ売上対象にし、プラン価格での推定補完はしない
- 過去サブスク売上を Stripe invoice / Checkout Session から反映する dry-run 対応 backfill script を追加
- 実装計画書と売上解決ロジックのユニットテストを追加

### 実機テスト
- [ ] iOS Safari で主要導線を確認
- [ ] Android Chrome で主要導線を確認
- [ ] PC（Chrome）で主要導線を確認
- [ ] レスポンシブ表示崩れがないことを確認
- [ ] エラーメッセージやバリデーション表示を確認

### テスト方法
- `npm test -- tests/unit/features/admin-dashboard/purchase-value.test.ts --runInBand`
- `npx eslint scripts/backfill-subscription-revenue.mjs app/api/stripe/webhook/route.ts features/admin-dashboard/lib/purchase-value.ts tests/unit/features/admin-dashboard/purchase-value.test.ts`
- `git diff --check`

### 補足
- Supabase migration `add_subscription_revenue_metadata` は適用済みです。
- 過去分 backfill は正しい Stripe key で dry-run 後、必要に応じて `--apply` で実行します。