### PR TITLE
fix(coordinate): OpenAI バッチ生成の RPC ambiguous id エラーを修正

### DIFF
--- a/supabase/migrations/20260501170000_fix_complete_image_job_rpc_ambiguous_id.sql
+++ b/supabase/migrations/20260501170000_fix_complete_image_job_rpc_ambiguous_id.sql
@@ -1,0 +1,173 @@
+-- complete_image_job_with_generated_images の `WHERE id = p_job_id` が
+-- RETURNS TABLE (id uuid, ...) の OUT パラメータ `id` と曖昧になり、
+-- 本番で `column reference "id" is ambiguous` エラーが発生していた。
+--
+-- - 全ての列参照を `image_jobs.id` のようにテーブル名で qualify
+-- - 念のため `#variable_conflict use_column` を宣言し、変数より列名を優先する解決順に固定
+--
+-- 関数 signature と挙動は 20260501150000 と同等。CREATE OR REPLACE で置換のみ。
+
+CREATE OR REPLACE FUNCTION public.complete_image_job_with_generated_images(
+  p_job_id uuid,
+  p_images jsonb,
+  p_generation_metadata jsonb DEFAULT NULL::jsonb,
+  p_result_image_url text DEFAULT NULL::text
+)
+RETURNS TABLE (
+  id uuid,
+  image_url text,
+  storage_path text,
+  image_job_result_index integer
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+#variable_conflict use_column
+DECLARE
+  v_job public.image_jobs%ROWTYPE;
+  v_expected_count integer;
+  v_image_count integer;
+  v_image jsonb;
+  v_index integer := 0;
+  v_image_url text;
+  v_storage_path text;
+  v_inserted_id uuid;
+  v_first_image_id uuid;
+  v_first_image_url text;
+BEGIN
+  IF p_images IS NULL OR jsonb_typeof(p_images) <> 'array' THEN
+    RAISE EXCEPTION 'p_images must be a JSON array';
+  END IF;
+
+  SELECT *
+  INTO v_job
+  FROM public.image_jobs
+  WHERE image_jobs.id = p_job_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'image job not found: %', p_job_id;
+  END IF;
+
+  IF v_job.status = 'succeeded' THEN
+    RETURN QUERY
+    SELECT
+      gi.id,
+      gi.image_url,
+      gi.storage_path,
+      gi.image_job_result_index
+    FROM public.generated_images AS gi
+    WHERE gi.image_job_id = p_job_id
+    ORDER BY gi.image_job_result_index ASC NULLS LAST, gi.created_at ASC;
+    RETURN;
+  END IF;
+
+  IF v_job.status <> 'processing' THEN
+    RAISE EXCEPTION 'image job must be processing to complete: %, status=%', p_job_id, v_job.status;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.generated_images AS gi
+    WHERE gi.image_job_id = p_job_id
+  ) THEN
+    -- This RPC is currently used only by OpenAI batched coordinate jobs.
+    -- Gemini's existing path leaves image_job_id NULL, so it must not be
+    -- switched to this RPC until that path also writes per-job result indexes.
+    RAISE EXCEPTION 'generated images already exist for job: %', p_job_id;
+  END IF;
+
+  v_expected_count := COALESCE(v_job.requested_image_count, 1);
+  v_image_count := jsonb_array_length(p_images);
+
+  IF v_image_count <> v_expected_count THEN
+    RAISE EXCEPTION 'generated image count mismatch for job %, expected %, got %',
+      p_job_id,
+      v_expected_count,
+      v_image_count;
+  END IF;
+
+  FOR v_image IN
+    SELECT element
+    FROM jsonb_array_elements(p_images) AS elements(element)
+  LOOP
+    v_image_url := NULLIF(TRIM(v_image->>'image_url'), '');
+    v_storage_path := NULLIF(TRIM(v_image->>'storage_path'), '');
+
+    IF v_image_url IS NULL THEN
+      RAISE EXCEPTION 'image_url is required for job %, index %', p_job_id, v_index;
+    END IF;
+
+    IF v_storage_path IS NULL THEN
+      RAISE EXCEPTION 'storage_path is required for job %, index %', p_job_id, v_index;
+    END IF;
+
+    INSERT INTO public.generated_images AS gi (
+      user_id,
+      image_url,
+      storage_path,
+      prompt,
+      background_mode,
+      is_posted,
+      generation_type,
+      generation_metadata,
+      model,
+      source_image_stock_id,
+      image_job_id,
+      image_job_result_index
+    )
+    VALUES (
+      v_job.user_id,
+      v_image_url,
+      v_storage_path,
+      v_job.prompt_text,
+      v_job.background_mode,
+      false,
+      v_job.generation_type,
+      COALESCE(p_generation_metadata, v_job.generation_metadata),
+      v_job.model,
+      v_job.source_image_stock_id,
+      p_job_id,
+      v_index
+    )
+    RETURNING gi.id INTO v_inserted_id;
+
+    IF v_index = 0 THEN
+      v_first_image_id := v_inserted_id;
+      v_first_image_url := v_image_url;
+    END IF;
+
+    v_index := v_index + 1;
+  END LOOP;
+
+  UPDATE public.image_jobs
+  SET
+    status = 'succeeded',
+    processing_stage = 'completed',
+    result_image_url = COALESCE(NULLIF(TRIM(p_result_image_url), ''), v_first_image_url),
+    error_message = NULL,
+    completed_at = now(),
+    generation_metadata = COALESCE(p_generation_metadata, v_job.generation_metadata),
+    updated_at = now()
+  WHERE image_jobs.id = p_job_id
+    AND image_jobs.status = 'processing';
+
+  UPDATE public.credit_transactions
+  SET related_generation_id = v_first_image_id
+  WHERE credit_transactions.user_id = v_job.user_id
+    AND credit_transactions.related_generation_id IS NULL
+    AND credit_transactions.transaction_type = 'consumption'
+    AND credit_transactions.metadata->>'job_id' = p_job_id::text;
+
+  RETURN QUERY
+  SELECT
+    gi.id,
+    gi.image_url,
+    gi.storage_path,
+    gi.image_job_result_index
+  FROM public.generated_images AS gi
+  WHERE gi.image_job_id = p_job_id
+  ORDER BY gi.image_job_result_index ASC NULLS LAST, gi.created_at ASC;
+END;
+$function$;


### PR DESCRIPTION
## Summary

- 本番で OpenAI バッチコーディネート生成が **column reference \"id\" is ambiguous** で全失敗していた問題を hotfix
- 既に本番 DB には適用済み (incident response として先行適用)
- 本 PR は git 履歴を本番状態に揃えるためのもの

## 原因

PR #245 で導入した RPC \`complete_image_job_with_generated_images\` が \`RETURNS TABLE (id uuid, ...)\` を宣言したため、関数本体の \`WHERE id = p_job_id\` が以下の 2 つの解釈で曖昧になり、PostgreSQL が \`column reference \"id\" is ambiguous\` を返していた。

- OUT パラメータ \`id\` (RETURNS TABLE 由来)
- \`image_jobs.id\` 列

worker のテストは RPC 呼び出しを mock で抑えていたため、ローカルでは検出できなかった。

## 修正

- 全ての列参照を \`image_jobs.id\` / \`credit_transactions.user_id\` のように **テーブル名で qualify**
- 関数本体先頭に \`#variable_conflict use_column\` を追加し、変数より列名を優先する解決順に固定 (二重防御)
- 関数 signature と挙動は 20260501150000 と完全に同等。CREATE OR REPLACE で置換のみ

## デプロイ済み

- DB migration \`20260501170000_fix_complete_image_job_rpc_ambiguous_id.sql\` を本番に適用済み
- App / Edge Function は変更なし、再デプロイ不要

## Test plan

- [ ] 本番で OpenAI \`gpt-image-2-low\` count=1 が成功する
- [ ] 本番で OpenAI \`gpt-image-2-low\` count=4 が 1 ジョブで 4 枚成功する
- [ ] Gemini 系の生成が従来通り動作する (リグレッション無し)
- [ ] 失敗時の returnError と refund フローが従来通り動作する

## 既知の影響範囲

incident 中に発生した OpenAI 生成リクエスト:
- 各ジョブは worker が 3 回まで retry した後、\"failed\" として確定
- ペルコイン課金は \`deduct_free_percoins\` の job_id 冪等性により 1 回のみ
- 失敗確定時に \`refund_percoins\` が呼ばれ全額返金されている想定
- Storage 側にアップロード途中で cleanup が間に合わなかった orphan ファイルが残る可能性 (\`{user_id}/{jobId}-{index}-...\` prefix で識別可)

🤖 Generated with [Claude Code](https://claude.com/claude-code)