### PR TITLE
fix(image-gen-worker): 水着生成のため Gemini SEXUALLY_EXPLICIT を BLOCK_NONE に緩和

### DIFF
--- a/supabase/functions/image-gen-worker/index.ts
+++ b/supabase/functions/image-gen-worker/index.ts
@@ -1492,7 +1492,7 @@ Deno.serve(async () => {
                         | "HARM_CATEGORY_HATE_SPEECH"
                         | "HARM_CATEGORY_SEXUALLY_EXPLICIT"
                         | "HARM_CATEGORY_DANGEROUS_CONTENT";
-                      threshold: "BLOCK_ONLY_HIGH";
+                      threshold: "BLOCK_ONLY_HIGH" | "BLOCK_NONE";
                     }>;
                     generationConfig?: {
                       candidateCount?: number;
@@ -1510,7 +1510,7 @@ Deno.serve(async () => {
                     safetySettings: [
                       { category: "HARM_CATEGORY_HARASSMENT", threshold: "BLOCK_ONLY_HIGH" },
                       { category: "HARM_CATEGORY_HATE_SPEECH", threshold: "BLOCK_ONLY_HIGH" },
-                      { category: "HARM_CATEGORY_SEXUALLY_EXPLICIT", threshold: "BLOCK_ONLY_HIGH" },
+                      { category: "HARM_CATEGORY_SEXUALLY_EXPLICIT", threshold: "BLOCK_NONE" },
                       { category: "HARM_CATEGORY_DANGEROUS_CONTENT", threshold: "BLOCK_ONLY_HIGH" },
                     ],
                   };


### PR DESCRIPTION
### 概要
画像生成 worker（`image-gen-worker`）の Gemini API 呼び出しにおいて、水着といったスタイル指定が `safetySettings` の `HARM_CATEGORY_SEXUALLY_EXPLICIT`（`BLOCK_ONLY_HIGH`）によって誤ブロックされるケースがあった。本プロジェクトのユースケース上これらは生成可能である必要があるため、当カテゴリのみ `BLOCK_NONE` に緩和する。なお Gemini モデル本体のハードポリシー（CSAM・露骨な性行為描写など）は `safetySettings` の値に関わらず常に有効である。

### 変更内容
- `supabase/functions/image-gen-worker/index.ts`
  - `safetySettings` の `HARM_CATEGORY_SEXUALLY_EXPLICIT` を `BLOCK_ONLY_HIGH` → `BLOCK_NONE` に変更
  - これに伴い `safetySettings` の `threshold` 型を `"BLOCK_ONLY_HIGH" | "BLOCK_NONE"` に拡張
- 他 3 カテゴリ（`HARM_CATEGORY_HARASSMENT` / `HARM_CATEGORY_HATE_SPEECH` / `HARM_CATEGORY_DANGEROUS_CONTENT`）は `BLOCK_ONLY_HIGH` のまま据え置き

### 実機テスト
- [ ] iOS Safari で主要導線を確認
- [ ] Android Chrome で主要導線を確認
- [ ] PC（Chrome）で主要導線を確認
- [ ] レスポンシブ表示崩れがないことを確認
- [ ] エラーメッセージやバリデーション表示を確認

### テスト方法
- 水着 / 下着 / セクシーな衣装などのプロンプトで生成し、従来 `safety_blocked` で失敗していたケースが通ることを確認
- 通常の衣装プロンプトで従来通り生成できることを確認（リグレッションがないこと）
- Gemini ハードポリシー違反となるプロンプトが引き続き拒否されること（`finishReason` が `SAFETY` または `PROHIBITED_CONTENT` 等で弾かれること）を確認
