### PR TITLE
fix(openai-image): moderation を auto から low に緩和

### DIFF
--- a/features/generation/lib/openai-image.ts
+++ b/features/generation/lib/openai-image.ts
@@ -219,7 +219,7 @@ export async function callOpenAIImageEditBatch(
   form.append("image[]", file);
   form.append("size", targetSize);
   form.append("quality", "low");
-  form.append("moderation", "auto");
+  form.append("moderation", "low");
   form.append("output_format", "png");
   form.append("n", String(requestedImageCount));
 

--- a/supabase/functions/image-gen-worker/openai-image.ts
+++ b/supabase/functions/image-gen-worker/openai-image.ts
@@ -200,7 +200,7 @@ export async function callOpenAIImageEditBatch(
   form.append("image[]", file);
   form.append("size", targetSize);
   form.append("quality", "low");
-  form.append("moderation", "auto");
+  form.append("moderation", "low");
   form.append("output_format", "png");
   form.append("n", String(requestedImageCount));
 


### PR DESCRIPTION
### 概要
OpenAI 画像生成 API（`gpt-image-2`）の `moderation` パラメータを `auto`（デフォルト＝厳しめ）から `low`（緩和）に変更する。これにより水着・下着・露出を含む健全な範囲のコーディネート生成（例: 「可愛い水着」）が、これまで `safety_policy_blocked` で弾かれていたケースで通りやすくなる。なお OpenAI のハードポリシー（CSAM、実在人物の同意なき性的描写、露骨な性行為描写など）は `low` でも常時有効である。

### 変更内容
- `supabase/functions/image-gen-worker/openai-image.ts`
  - 画像編集リクエスト時の `moderation` パラメータを `auto` → `low` に変更
- `features/generation/lib/openai-image.ts`
  - 画像編集リクエスト時の `moderation` パラメータを `auto` → `low` に変更

### 背景
- 先行 PR #248（マージ済み）で Gemini の `safetySettings` の `HARM_CATEGORY_SEXUALLY_EXPLICIT` を `BLOCK_NONE` に緩和したが、Gemini 側は出力画像フィルタ `IMAGE_SAFETY` を API パラメータでは制御できないため、コーデ生成（i2i）における水着等は依然弾かれる。
- 一方 OpenAI 側は `moderation: "low"` で出力フィルタも含めて緩和できるため、本変更は当アプリで水着系コーデを通すための実効的な手段となる。

### 実機テスト
- [ ] iOS Safari で主要導線を確認
- [ ] Android Chrome で主要導線を確認
- [ ] PC（Chrome）で主要導線を確認
- [ ] レスポンシブ表示崩れがないことを確認
- [ ] エラーメッセージやバリデーション表示を確認

### テスト方法
- OpenAI 系モデル（`gpt-image-2-low`）で「可愛い水着」等のプロンプトを実行し、これまで `safety_policy_blocked` で失敗していたケースが通ることを確認
- 通常の衣装プロンプトで従来通り生成できること（リグレッションがないこと）を確認
- 明確なポリシー違反プロンプトが引き続き拒否されること（ハードポリシーが効いていること）を確認
