### PR TITLE
feat(posts): 投稿カードのレイアウトを再構成（三点リーダーを右上、下段を Like/Comment/View 順）

### DIFF
--- a/features/posts/components/AnimatedLikeCount.tsx
+++ b/features/posts/components/AnimatedLikeCount.tsx
@@ -30,6 +30,15 @@ export function AnimatedLikeCount({
     setRenderKey((k) => k + 1);
   }
 
+  // 0 のときは数字を描画せずアイコンのみとする仕様。
+  // 親 (PostCardLikeButton) は本コンポーネントを常時マウントしているため、
+  // 0 → 1 への遷移時には previousValue=0 が保持されており、
+  // 上の比較ロジックが direction="up" を立てて slide-up アニメが走る。
+  // 1 → 0 への遷移は直接 null を返すため即時非表示（snap）。
+  if (value === 0) {
+    return null;
+  }
+
   const animationClass =
     direction === "up"
       ? "like-fx-count-up"

--- a/features/posts/components/PostCard.tsx
+++ b/features/posts/components/PostCard.tsx
@@ -184,7 +184,7 @@ export function PostCard({
             <div className="flex shrink-0 items-center gap-1">
               <MessageCircle className="h-4 w-4 text-gray-500" />
               {(post.comment_count || 0) > 0 && (
-                <span className="text-xs text-gray-600">
+                <span className="text-xs font-medium tabular-nums text-gray-600">
                   {formatCountEnUS(post.comment_count || 0)}
                 </span>
               )}
@@ -192,7 +192,7 @@ export function PostCard({
             <div className="flex shrink-0 items-center gap-1">
               <Eye className="h-4 w-4 text-gray-500" />
               {(post.view_count || 0) > 0 && (
-                <span className="text-xs text-gray-600">
+                <span className="text-xs font-medium tabular-nums text-gray-600">
                   {formatCountEnUS(post.view_count || 0)}
                 </span>
               )}

--- a/features/posts/components/PostCard.tsx
+++ b/features/posts/components/PostCard.tsx
@@ -5,12 +5,12 @@ import Image from "next/image";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { Card, CardContent } from "@/components/ui/card";
-import { User } from "lucide-react";
+import { Eye, MessageCircle, User } from "lucide-react";
 import { PostCardLikeButton } from "./PostCardLikeButton";
 import { getPostThumbUrl } from "../lib/utils";
 import type { Post } from "../types";
 import { PostModerationMenu } from "@/features/moderation/components/PostModerationMenu";
-import { cn } from "@/lib/utils";
+import { cn, formatCountEnUS } from "@/lib/utils";
 
 interface PostCardProps {
   post: Post;
@@ -96,18 +96,34 @@ export function PostCard({
           "border-emerald-300 bg-emerald-50/40 ring-2 ring-emerald-300/70 shadow-[0_18px_40px_-24px_rgba(16,185,129,0.65)]"
       )}
     >
-      {post.id ? (
-        <Link 
-          href={`/posts/${encodeURIComponent(post.id)}`}
-          prefetch={false}
-          onMouseEnter={handlePreload}
-          onTouchStart={handlePreload}
-        >
-          {imageContent}
-        </Link>
-      ) : (
-        imageContent
-      )}
+      <div className="relative">
+        {post.id ? (
+          <Link
+            href={`/posts/${encodeURIComponent(post.id)}`}
+            prefetch={false}
+            onMouseEnter={handlePreload}
+            onTouchStart={handlePreload}
+          >
+            {imageContent}
+          </Link>
+        ) : (
+          imageContent
+        )}
+        {post.id && (
+          // 三点リーダーは Link の外側（兄弟要素）に置く：
+          // 中に置くと詳細ページに遷移してしまうため。
+          <div className="absolute right-2 top-2 z-10">
+            <PostModerationMenu
+              postId={post.id}
+              authorUserId={post.user_id}
+              currentUserId={currentUserId}
+              onHidden={() => setIsHidden(true)}
+              showShare
+              showBlock={false}
+            />
+          </div>
+        )}
+      </div>
 
       <CardContent className="px-1 pt-0 pb-1">
         <div className="flex items-center gap-1">
@@ -151,25 +167,37 @@ export function PostCard({
             )}
           </div>
 
-          {/* いいねボタン + いいね数 + ビュー数 */}
-          {post.id && (
-            <PostCardLikeButton
-              imageId={post.id}
-              initialLikeCount={post.like_count || 0}
-              initialViewCount={post.view_count || 0}
-              currentUserId={currentUserId}
-            />
-          )}
-          {post.id && (
-            <PostModerationMenu
-              postId={post.id}
-              authorUserId={post.user_id}
-              currentUserId={currentUserId}
-              onHidden={() => setIsHidden(true)}
-              showShare
-              showBlock={false}
-            />
-          )}
+          {/*
+           * いいね → コメント → ビューの順で配置。コメント・ビューは 0 のときアイコンのみ。
+           * 数字の有無にかかわらずアイコン間に視覚的な余白が入るよう、
+           * 3指標だけを内側 flex (gap-2) でまとめる。
+           * 親 (gap-1) は Avatar↔DisplayName 用の詰めた間隔のまま。
+           */}
+          <div className="flex shrink-0 items-center gap-2">
+            {post.id && (
+              <PostCardLikeButton
+                imageId={post.id}
+                initialLikeCount={post.like_count || 0}
+                currentUserId={currentUserId}
+              />
+            )}
+            <div className="flex shrink-0 items-center gap-1">
+              <MessageCircle className="h-4 w-4 text-gray-500" />
+              {(post.comment_count || 0) > 0 && (
+                <span className="text-xs text-gray-600">
+                  {formatCountEnUS(post.comment_count || 0)}
+                </span>
+              )}
+            </div>
+            <div className="flex shrink-0 items-center gap-1">
+              <Eye className="h-4 w-4 text-gray-500" />
+              {(post.view_count || 0) > 0 && (
+                <span className="text-xs text-gray-600">
+                  {formatCountEnUS(post.view_count || 0)}
+                </span>
+              )}
+            </div>
+          </div>
         </div>
       </CardContent>
     </Card>

--- a/features/posts/components/PostCardLikeButton.tsx
+++ b/features/posts/components/PostCardLikeButton.tsx
@@ -1,13 +1,11 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Eye } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { toggleLikeAPI, getUserLikeStatusAPI } from "../lib/api";
 import { createClient } from "@/lib/supabase/client";
 import { useToast } from "@/components/ui/use-toast";
-import { formatCountEnUS } from "@/lib/utils";
 import { AuthModal } from "@/features/auth/components/AuthModal";
 import { usePathname, useSearchParams } from "next/navigation";
 import { LikeHeartIcon, type LikeHeartPhase } from "./LikeHeartIcon";
@@ -16,7 +14,6 @@ import { AnimatedLikeCount } from "./AnimatedLikeCount";
 interface PostCardLikeButtonProps {
   imageId: string;
   initialLikeCount: number;
-  initialViewCount: number;
   currentUserId?: string | null;
 }
 
@@ -27,7 +24,6 @@ interface PostCardLikeButtonProps {
 export function PostCardLikeButton({
   imageId,
   initialLikeCount,
-  initialViewCount,
   currentUserId,
 }: PostCardLikeButtonProps) {
   const t = useTranslations("posts");
@@ -164,12 +160,6 @@ export function PostCardLikeButton({
           className="text-xs font-medium"
         />
       </Button>
-      {initialViewCount > 0 && (
-        <div className="flex items-center gap-1">
-          <Eye className="h-4 w-4 text-gray-500" />
-          <span className="text-xs text-gray-600">{formatCountEnUS(initialViewCount)}</span>
-        </div>
-      )}
       <AuthModal
         open={showAuthModal && !currentUserId}
         onClose={() => setShowAuthModal(false)}


### PR DESCRIPTION
### 概要
ホーム画面の投稿カードのアクション配置を見直し、情報優先度と視認性を改善。
従来は下段に [Avatar] [Name] [いいね+ビュー] [三点リーダー] と一列に並んでおり、三点リーダーが他の操作より目立っていた。三点リーダー（シェア／通報）を画像右上に逃がし、下段はエンゲージメント指標（いいね／コメント／ビュー）専用にして読みやすくした。

### 変更内容
- **三点リーダーの位置変更**：カード下段 → 画像エリア右上（`absolute right-2 top-2`）。`<Link>` の外側に置いて詳細遷移との干渉を防止。
- **下段アクション順を再整理**：`いいね → コメント → ビュー` の順に。コメント数は新規で表示（データは既に `Post.comment_count` で取得済み）。
- **0 件時の表示仕様統一**：いずれの指標も `count === 0` ならアイコンのみ、`count >= 1` でアイコン + 数字。
- **3 指標のレイアウト**：内側 flex (`gap-2`) でまとめ、数字の有無に関わらずアイコン同士に視覚的な余白を確保。グループ内 `gap-1` ／ グループ間 `gap-2` の階層化。
- **責務分離**：`PostCardLikeButton` からビュー描画を切り離し、いいね機能（リアルタイム購読・楽観的更新）に純化。
- **`AnimatedLikeCount`**：`value === 0` のとき `null` を返す。親が常時マウントするため `previousValue` 状態は保持され、0 → 1 遷移時の slide-up アニメは引き続き発火（1 → 0 は即時非表示）。

#### スクリーンショット（Before / After）
<!-- TODO: 添付 -->
- Before: _（差し替え）_
- After: _（差し替え）_

### 実機テスト
- [ ] iOS Safari で主要導線を確認
- [ ] Android Chrome で主要導線を確認
- [ ] PC（Chrome）で主要導線を確認
- [ ] レスポンシブ表示崩れがないことを確認（Masonry 2 列モバイル幅、3 列タブレット幅、4 列デスクトップ）
- [ ] エラーメッセージやバリデーション表示を確認

確認観点：
- 画像右上の三点リーダーをタップ → シェア／通報メニューが開く。タップで詳細遷移しない。
- いいね 0 件の投稿 → ハートのみ表示。タップで「1」が下からスライドアップ。再タップで即時非表示。
- コメント／ビュー 0 件 → アイコンのみ表示。1 件以上 → アイコン + 数字。
- ニックネームが長い投稿で 3 指標が押しつぶされない（`flex-1 min-w-0 truncate` でニックネーム側が縮む）。

### テスト方法
- `npm run lint`：main と同件数（72）、新規エラー無し。
- `npm run typecheck`：`PostCard*` 由来の新規エラー無し（既存 main 由来の test ファイルエラーのみ）。
- `npm run test`：**918 / 918 passed**（13 suites）。
- ローカル `npm run dev` で HMR 反映を都度目視確認しながら微調整。

🤖 Generated with [Claude Code](https://claude.com/claude-code)