### PR TITLE
Gemini生成画像のBefore表示用ジョブ紐付けを修正

### DIFF
--- a/supabase/functions/image-gen-worker/index.ts
+++ b/supabase/functions/image-gen-worker/index.ts
@@ -2125,6 +2125,8 @@ Deno.serve(async () => {
                   generation_metadata: job.generation_metadata ?? null,
                   model: dbModel,
                   source_image_stock_id: latestSourceImageStockId,
+                  image_job_id: jobId,
+                  image_job_result_index: 0,
                   style_template_id: job.style_template_id ?? null,
                   override_target: job.override_target ?? null,
                 })

--- a/supabase/migrations/20260504110000_backfill_generated_images_image_job_id.sql
+++ b/supabase/migrations/20260504110000_backfill_generated_images_image_job_id.sql
@@ -1,0 +1,37 @@
+-- Gemini/manual worker path used to insert generated_images without image_job_id.
+-- Before-image fallback and persistence depend on this link, so recover legacy
+-- rows by matching the succeeded image_job's result_image_url to generated_images.image_url.
+WITH candidate_matches AS (
+  SELECT
+    gi.id AS generated_image_id,
+    ij.id AS image_job_id,
+    row_number() OVER (
+      PARTITION BY gi.id
+      ORDER BY ij.completed_at DESC NULLS LAST, ij.created_at DESC
+    ) AS generated_image_rank,
+    row_number() OVER (
+      PARTITION BY ij.id
+      ORDER BY gi.created_at DESC
+    ) AS image_job_rank
+  FROM public.generated_images gi
+  JOIN public.image_jobs ij
+    ON ij.user_id = gi.user_id
+   AND ij.result_image_url = gi.image_url
+  WHERE gi.image_job_id IS NULL
+    AND gi.image_job_result_index IS NULL
+    AND ij.status = 'succeeded'
+    AND ij.result_image_url IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1
+      FROM public.generated_images linked
+      WHERE linked.image_job_id = ij.id
+    )
+)
+UPDATE public.generated_images gi
+SET
+  image_job_id = candidate_matches.image_job_id,
+  image_job_result_index = 0
+FROM candidate_matches
+WHERE gi.id = candidate_matches.generated_image_id
+  AND candidate_matches.generated_image_rank = 1
+  AND candidate_matches.image_job_rank = 1;


### PR DESCRIPTION
## 概要

Gemini 系モデルで生成した画像の投稿モーダルに Before 画像が表示されない問題を修正します。

## 背景

Before 画像の表示・永続化は `generated_images.image_job_id` 経由で `image_jobs.input_image_url` を参照します。

OpenAI 経路では RPC により `image_job_id` が保存されていましたが、Gemini/manual worker 経路では `generated_images` への insert 時に `image_job_id` が保存されていませんでした。そのため、Gemini 生成画像では Before 画像の fallback と永続化ができませんでした。

## 変更内容

- `image-gen-worker` の Gemini/manual worker 経路で `generated_images.image_job_id` を保存
- 同経路で `image_job_result_index = 0` を保存
- 既存の未紐付け Gemini 生成画像を `image_jobs.result_image_url = generated_images.image_url` の一致で backfill する migration を追加

## 確認

- `npm run test -- tests/unit/features/posts/before-image-storage.test.ts`
  - PASS: 31 tests

## 補足

`npm run typecheck` は既存の test 型エラーにより失敗しますが、今回変更した `image-gen-worker` と migration に起因するものではありません。

## 本番反映後に必要な作業

```bash
supabase db push --project-ref hnrccaxrvhtbuihfvitc
supabase functions deploy image-gen-worker --project-ref hnrccaxrvhtbuihfvitc
