### PR TITLE
feat(posts): 投稿caption・コメント・マイページ詳細でURL自動リンク化を有効化

### DIFF
--- a/features/my-page/components/ImageDetailPageClient.tsx
+++ b/features/my-page/components/ImageDetailPageClient.tsx
@@ -13,6 +13,7 @@ import { DeletePostDialog } from "@/features/posts/components/DeletePostDialog";
 import type { BackgroundMode } from "@/features/generation/types";
 import type { GeneratedImageRecord } from "@/features/generation/lib/database";
 import { OneTapStyleDetailCard } from "@/features/style/components/OneTapStyleDetailCard";
+import { CollapsibleText } from "@/features/posts/components/CollapsibleText";
 import {
   getPromptSafeAltText,
   getVisiblePrompt,
@@ -195,7 +196,14 @@ export function ImageDetailPageClient({ image }: ImageDetailPageClientProps) {
                 <p className="text-sm font-medium text-gray-700">
                   {myPageT("detailCaptionLabel")}
                 </p>
-                <p className="mt-1 text-sm text-gray-600">{image.caption}</p>
+                <div className="mt-1">
+                  <CollapsibleText
+                    text={image.caption}
+                    maxLines={3}
+                    textClassName="text-sm text-gray-600"
+                    linkify
+                  />
+                </div>
               </div>
             )}
 

--- a/features/posts/components/EditableComment.tsx
+++ b/features/posts/components/EditableComment.tsx
@@ -269,7 +269,7 @@ export function EditableComment({
                 textClassName={
                   isDeleted ? "italic text-gray-500" : "text-gray-900"
                 }
-                linkify
+                linkify={!isDeleted}
               />
             )}
           </div>

--- a/features/posts/components/EditableComment.tsx
+++ b/features/posts/components/EditableComment.tsx
@@ -269,6 +269,7 @@ export function EditableComment({
                 textClassName={
                   isDeleted ? "italic text-gray-500" : "text-gray-900"
                 }
+                linkify
               />
             )}
           </div>

--- a/features/posts/components/PostDetailStatic.tsx
+++ b/features/posts/components/PostDetailStatic.tsx
@@ -420,7 +420,7 @@ export function PostDetailStatic({
         {/* キャプション */}
         {post.caption && (
           <div className="bg-white px-4 py-3">
-            <CollapsibleText text={post.caption} maxLines={3} />
+            <CollapsibleText text={post.caption} maxLines={3} linkify />
           </div>
         )}
 


### PR DESCRIPTION
### 概要

自己紹介欄では既に動作している URL 自動リンク化を、**投稿の caption・コメント本文・マイページの画像詳細 caption** にも展開する。これまで「URL を書いてもただのテキストとして表示される」状態だったため、閲覧者が外部リンクへ遷移しづらかった。リンク化ロジックは `lib/linkify.ts` + `CollapsibleText` の `linkify` prop として既存資産が揃っており、呼び出し側で有効化するだけで済む。

### 変更内容

- **`features/posts/components/PostDetailStatic.tsx:423`**  
  投稿詳細 caption の `<CollapsibleText>` に `linkify` prop を追加
- **`features/posts/components/EditableComment.tsx:266`**  
  コメント本文の `<CollapsibleText>` に `linkify` prop を追加（`CommentItem` / `ReplyItem` の両方が `EditableComment` を経由するため、コメント＋返信の両方をカバー）
- **`features/my-page/components/ImageDetailPageClient.tsx:198`**  
  生 `<p>` で表示していた caption を `<CollapsibleText ... linkify />` にリプレース。長文時の折りたたみ（maxLines=3）も同時に有効化

#### 旧 PostDetail.tsx の現役確認

`grep -r "from.*PostDetail['\"]"` で確認した結果、`features/posts/components/PostDetail.tsx`（旧版）の import 元は **テスト 1 件のみ**（`tests/unit/features/posts/post-detail.test.tsx`）。app routes は `CachedPostDetail → PostDetailContent → PostDetailStatic` の経路で **新版を使用しており、旧 `PostDetail.tsx` は実質孤児**のため今回は手を入れていない（テストの期待値も変えない）。

### 実機テスト

- [ ] iOS Safari で主要導線を確認
- [ ] Android Chrome で主要導線を確認
- [ ] PC（Chrome）で主要導線を確認
- [ ] レスポンシブ表示崩れがないことを確認
- [ ] エラーメッセージやバリデーション表示を確認

### テスト方法

#### 自動テスト（PR 提出までに実施済み）

- `npm run lint` ✅（既存 22 errors はすべて他テストファイルの pre-existing 問題、本変更ファイルでは新規 issue ゼロ）
- `npm run typecheck` ✅
- `npm test -- --testPathPattern='linkify|collapsible-text|editable-comment|post-detail|image-detail'` ✅ 4 suites / 62 tests passed

`tests/unit/lib/linkify.test.ts` と `tests/unit/features/posts/collapsible-text.test.tsx` で linkify ロジック自体は既にカバー済みのため、新規ユニットテストは追加していない。

#### 手動確認シナリオ（Vercel Preview で実施推奨）

1. **投稿 caption**: 既存の任意の投稿の caption に `https://example.com` を含む文字列を入力 → `/posts/{id}` でクリック可能なリンクとして表示されること
2. **コメント・返信**: 任意の投稿に URL を含むコメント / 返信を投稿 → リンク化されること
3. **マイページ画像詳細**: マイページから自分の画像詳細を開く → caption 内 URL がリンク化、長文の場合は折りたたみが効くこと
4. リンクは `target="_blank"` + `rel="noopener noreferrer nofollow"` で開く（タブナビング・SEO 悪用対策済み）
5. `https://` 始まりのみリンク化される（プレーンドメイン `example.com` 単体は対象外、`javascript:` / `data:` URL は弾かれる）

### 影響範囲

| 範囲 | 影響 |
|---|---|
| **DB** | なし |
| **入力フォーム** | なし（caption / コメント入力 UI は変更せず）|
| **既存データ** | URL を含む過去 caption / コメントもそのまま自動リンク化される（破壊的変更なし）|
| **表示変更** | 投稿詳細・コメント・マイページ画像詳細の 3 箇所のみ |
| **未対応の表示箇所** | ホームの投稿カード（caption 本文を表示していないため対象外）、編集モーダル（プレビューがないため対象外）、旧 `PostDetail.tsx`（孤児コード）|

### セキュリティ

`lib/linkify.ts` の URL マッチは `https?://` 始まりに限定し、`new URL()` で再パース検証を実施。React JSX の自動エスケープと `rel="noopener noreferrer nofollow"` で XSS / タブナビング / SEO 悪用を防御済み（自己紹介欄と同等の保護レベル）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)