### PR TITLE
refactor(download): ダウンロードロジックを共通ヘルパに統一 (Step 1/3)

### DIFF
--- a/features/generation/lib/download-image.ts
+++ b/features/generation/lib/download-image.ts
@@ -1,9 +1,32 @@
 import { determineFileName } from "@/lib/utils";
-import type { GeneratedImageData } from "../types";
+
+/**
+ * ダウンロード対象画像の最小インターフェース。
+ * `GeneratedImageData` もこの形を満たすため、生成結果系の呼び出し側は
+ * 既存どおりそのまま渡せる。投稿詳細やスタイル画面のように `id` を
+ * 別の意味（postId / styleId）で使う場合もこの型に束ねて渡す。
+ */
+export interface DownloadableImage {
+  id: string;
+  url: string;
+}
 
 interface DownloadMessages {
   accessDenied: string;
   fetchFailed: (statusText: string) => string;
+}
+
+/**
+ * 成功パスごとに呼び出し側が任意の処理（成功トーストや usage tracking など）を
+ * 差し込めるようにするコールバック。
+ *
+ * - `onShareSuccess`: モバイルの Web Share API でシェアシートが完了した直後。
+ *   OS シェアシート側で完結するため、画面トーストは出さない呼び出し側が多い。
+ * - `onDownloadSuccess`: ブラウザダウンロード（PC、または Web Share fallback）成功時。
+ */
+export interface DownloadCallbacks {
+  onShareSuccess?: () => void;
+  onDownloadSuccess?: () => void;
 }
 
 interface FetchedImagePayload {
@@ -18,7 +41,7 @@ function isMobileUserAgent(): boolean {
 }
 
 async function fetchImagePayload(
-  image: GeneratedImageData,
+  image: DownloadableImage,
   messages: DownloadMessages,
   init?: RequestInit,
 ): Promise<FetchedImagePayload> {
@@ -56,11 +79,13 @@ function triggerBrowserDownload(payload: FetchedImagePayload): void {
  * 失敗時は呼び出し側でハンドリングできるよう例外を投げる。
  */
 export async function downloadGeneratedImage(
-  image: GeneratedImageData,
+  image: DownloadableImage,
   messages: DownloadMessages,
+  callbacks?: DownloadCallbacks,
 ): Promise<void> {
   const payload = await fetchImagePayload(image, messages);
   triggerBrowserDownload(payload);
+  callbacks?.onDownloadSuccess?.();
 }
 
 /**
@@ -71,14 +96,16 @@ export async function downloadGeneratedImage(
  *   通常のブラウザダウンロードへ fallback。
  * デスクトップ: 通常のブラウザダウンロード。
  *
- * グリッド／リスト／拡大表示モーダルの全ダウンロード動線をこの関数に統一する。
+ * 生成結果のグリッド／リスト／拡大表示モーダルに加え、投稿詳細とスタイル画面の
+ * ダウンロード動線もこの関数に統一する。
  */
 export async function shareOrDownloadGeneratedImage(
-  image: GeneratedImageData,
+  image: DownloadableImage,
   messages: DownloadMessages,
+  callbacks?: DownloadCallbacks,
 ): Promise<void> {
   if (!isMobileUserAgent()) {
-    await downloadGeneratedImage(image, messages);
+    await downloadGeneratedImage(image, messages, callbacks);
     return;
   }
 
@@ -102,6 +129,7 @@ export async function shareOrDownloadGeneratedImage(
   ) {
     try {
       await navigator.share({ files: [file], title: "Persta.AI" });
+      callbacks?.onShareSuccess?.();
       return;
     } catch (error) {
       const message =
@@ -119,4 +147,5 @@ export async function shareOrDownloadGeneratedImage(
   }
 
   triggerBrowserDownload(payload);
+  callbacks?.onDownloadSuccess?.();
 }

--- a/features/posts/components/DownloadButton.tsx
+++ b/features/posts/components/DownloadButton.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from "next-intl";
 import { Download } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/components/ui/use-toast";
-import { determineFileName } from "@/lib/utils";
+import { shareOrDownloadGeneratedImage } from "@/features/generation/lib/download-image";
 
 interface DownloadButtonProps {
   postId: string;
@@ -24,12 +24,7 @@ export function DownloadButton({
   const [isLoading, setIsLoading] = useState(false);
   const { toast } = useToast();
 
-  const isMobile = () => {
-    if (typeof navigator === "undefined") return false;
-    return /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
-  };
-
-  const handleDownload = async () => {
+  const handleClick = async () => {
     if (isLoading) return;
 
     if (!imageUrl) {
@@ -43,54 +38,24 @@ export function DownloadButton({
 
     setIsLoading(true);
     try {
-      // 画像をfetchで取得
-      const response = await fetch(imageUrl);
-      
-      // 認証エラーのハンドリング（401/403）
-      if (response.status === 401 || response.status === 403) {
-        throw new Error(t("downloadUnauthorized"));
-      }
-      
-      if (!response.ok) {
-        throw new Error(
-          t("downloadFetchFailed", { statusText: response.statusText })
-        );
-      }
-      
-      // Blobに変換（MIMEタイプを保持）
-      const blob = await response.blob();
-      
-      // MIMEタイプの取得順序: blob.type を優先、次にContent-Typeヘッダー、最後にデフォルト
-      const mimeType = blob.type || response.headers.get('content-type') || 'image/png';
-      
-      // ファイル名を決定（共通ロジックを使用）
-      const downloadFileName = determineFileName(
-        response,
-        imageUrl,
-        postId,
-        mimeType
+      await shareOrDownloadGeneratedImage(
+        { id: postId, url: imageUrl },
+        {
+          accessDenied: t("downloadUnauthorized"),
+          fetchFailed: (statusText) =>
+            t("downloadFetchFailed", { statusText }),
+        },
+        {
+          // モバイルの Web Share 成功時は OS シェアシートで完結するため、
+          // 画面側のトーストは出さない（既存挙動を踏襲）。
+          onDownloadSuccess: () => {
+            toast({
+              title: t("downloadSuccessTitle"),
+              description: t("downloadSuccessDescription"),
+            });
+          },
+        },
       );
-      
-      // ObjectURLを作成
-      const objectUrl = URL.createObjectURL(blob);
-      
-      // ダウンロードリンクを作成
-      const link = document.createElement("a");
-      link.href = objectUrl;
-      link.download = downloadFileName;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      
-      // メモリリークを防ぐためにObjectURLを解放
-      setTimeout(() => {
-        URL.revokeObjectURL(objectUrl);
-      }, 100);
-      
-      toast({
-        title: t("downloadSuccessTitle"),
-        description: t("downloadSuccessDescription"),
-      });
     } catch (error) {
       console.error("Download error:", error);
       toast({
@@ -104,107 +69,12 @@ export function DownloadButton({
     }
   };
 
-  const handleDownloadMobile = async () => {
-    if (isLoading) return;
-
-    if (!imageUrl) {
-      toast({
-        title: t("errorTitle"),
-        description: t("downloadNoImage"),
-        variant: "destructive",
-      });
-      return;
-    }
-
-    setIsLoading(true);
-    try {
-      // 画像をfetch（CORS対応）
-      const res = await fetch(imageUrl, { mode: "cors" });
-      
-      // 認証エラーのハンドリング（401/403）
-      if (res.status === 401 || res.status === 403) {
-        throw new Error(t("downloadUnauthorized"));
-      }
-      
-      if (!res.ok) {
-        throw new Error(
-          t("downloadFetchFailed", { statusText: res.statusText })
-        );
-      }
-      
-      // Blobに変換
-      const blob = await res.blob();
-      
-      // MIMEタイプの取得（handleDownloadと同じロジック）
-      const mimeType = blob.type || res.headers.get('content-type') || 'image/png';
-      
-      // ファイル名を決定（共通ロジックを使用）
-      const fileName = determineFileName(
-        res,
-        imageUrl,
-        postId,
-        mimeType
-      );
-      
-      // Fileオブジェクトを作成
-      const file = new File(
-        [blob],
-        fileName,
-        { type: mimeType }
-      );
-      
-      // Web Share API Level 2（files）のサポート確認
-      if (
-        typeof navigator !== "undefined" &&
-        navigator.canShare &&
-        navigator.canShare({ files: [file] })
-      ) {
-        await navigator.share({
-          files: [file],
-          title: "Persta.AI",
-        });
-        return;
-      }
-      
-      // フォールバック: 通常のダウンロード
-      await handleDownload();
-      // handleDownloadのfinallyでisLoadingはfalseになる
-    } catch (error) {
-      const message = error instanceof Error ? error.message.toLowerCase() : "";
-      // キャンセルやジェスチャー不足は無視
-      if (
-        (error instanceof DOMException && error.name === "AbortError") ||
-        message.includes("user gesture") ||
-        message.includes("share request")
-      ) {
-        setIsLoading(false);
-        return;
-      }
-      console.error("Share Sheet error:", error);
-      // エラー時もダウンロードにフォールバック
-      try {
-        await handleDownload();
-      } catch {
-        // handleDownloadのエラーは既にhandleDownload内で処理される
-        // ここでは何もしない
-      }
-    } finally {
-      // handleDownloadが呼ばれた場合は、そのfinallyでisLoadingがfalseになる
-      // 呼ばれなかった場合（早期リターンなど）のみここで設定
-      setIsLoading(false);
-    }
-  };
-
   return (
     <Button
       variant="ghost"
       size="sm"
       onClick={() => {
-        if (isMobile()) {
-          handleDownloadMobile();
-        } else {
-          handleDownload();
-        }
+        void handleClick();
       }}
       disabled={isLoading}
       className="flex items-center gap-1.5 px-2 py-1 h-auto"

--- a/features/style/components/StylePageClient.tsx
+++ b/features/style/components/StylePageClient.tsx
@@ -66,7 +66,7 @@ import {
   resolveEffectiveModelForAuthState,
 } from "@/features/generation/lib/model-config";
 import { buildStyleSignupPath } from "@/features/auth/lib/signup-source";
-import { determineFileName } from "@/lib/utils";
+import { shareOrDownloadGeneratedImage } from "@/features/generation/lib/download-image";
 import { normalizeSourceImage } from "@/features/generation/lib/normalize-source-image";
 import { LockableModelSelect } from "@/features/generation/components/LockableModelSelect";
 import { AuthModal } from "@/features/auth/components/AuthModal";
@@ -221,14 +221,6 @@ function StyleReferencePanel({
 // 旧 StyleResultPanel は features/generation/components/GenerationResultPanel.tsx
 // に抽出した。
 
-function isMobileDevice(): boolean {
-  if (typeof navigator === "undefined") {
-    return false;
-  }
-
-  return /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
-}
-
 async function fetchStyleRateLimitStatus(): Promise<StyleRateLimitStatusState | null> {
   const response = await fetch("/style/rate-limit-status", {
     method: "GET",
@@ -282,57 +274,43 @@ function StyleResultDownloadButton({
   const [isDownloading, setIsDownloading] = useState(false);
   const { toast } = useToast();
 
-  const downloadResponse = async () => {
-    const response = await fetch(imageUrl, { mode: "cors" });
-    if (response.status === 401 || response.status === 403) {
-      throw new Error(failedMessage);
-    }
-
-    if (!response.ok) {
-      throw new Error(failedMessage);
-    }
-
-    return response;
+  const trackDownloadUsage = () => {
+    void recordStyleUsageClientEvent({
+      eventType: "download",
+      styleId,
+    }).catch(() => {
+      // Usage tracking must not block the successful download/share flow.
+    });
   };
 
-  const triggerDownload = (blob: Blob, fileName: string) => {
-    const objectUrl = URL.createObjectURL(blob);
-    const link = document.createElement("a");
-    link.href = objectUrl;
-    link.download = fileName;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-
-    setTimeout(() => {
-      URL.revokeObjectURL(objectUrl);
-    }, 100);
-  };
-
-  const handleDownload = async () => {
+  const handleClick = async () => {
     if (isDownloading) {
       return;
     }
 
     setIsDownloading(true);
     try {
-      const response = await downloadResponse();
-      const blob = await response.blob();
-      const mimeType =
-        blob.type || response.headers.get("content-type") || "image/png";
-      const fileName = determineFileName(response, imageUrl, styleId, mimeType);
-
-      triggerDownload(blob, fileName);
-      toast({
-        title: successTitle,
-        description: successDescription,
-      });
-      void recordStyleUsageClientEvent({
-        eventType: "download",
-        styleId,
-      }).catch(() => {
-        // Usage tracking must not block the successful download flow.
-      });
+      await shareOrDownloadGeneratedImage(
+        { id: styleId, url: imageUrl },
+        {
+          accessDenied: failedMessage,
+          fetchFailed: () => failedMessage,
+        },
+        {
+          // モバイルの Web Share 成功時は OS シェアシートで完結するため、
+          // 画面側のトーストは出さず usage tracking のみ実行する（既存挙動）。
+          onShareSuccess: () => {
+            trackDownloadUsage();
+          },
+          onDownloadSuccess: () => {
+            toast({
+              title: successTitle,
+              description: successDescription,
+            });
+            trackDownloadUsage();
+          },
+        },
+      );
     } catch (error) {
       console.error("Style result download error:", error);
       toast({
@@ -344,74 +322,13 @@ function StyleResultDownloadButton({
     }
   };
 
-  const handleDownloadMobile = async () => {
-    if (isDownloading) {
-      return;
-    }
-
-    setIsDownloading(true);
-    try {
-      const response = await downloadResponse();
-      const blob = await response.blob();
-      const mimeType =
-        blob.type || response.headers.get("content-type") || "image/png";
-      const fileName = determineFileName(response, imageUrl, styleId, mimeType);
-      const file = new File([blob], fileName, { type: mimeType });
-
-      if (
-        typeof navigator !== "undefined" &&
-        navigator.canShare &&
-        navigator.canShare({ files: [file] })
-      ) {
-        await navigator.share({
-          files: [file],
-          title: "Persta.AI",
-        });
-        void recordStyleUsageClientEvent({
-          eventType: "download",
-          styleId,
-        }).catch(() => {
-          // Usage tracking must not block the successful share flow.
-        });
-        return;
-      }
-
-      await handleDownload();
-    } catch (error) {
-      const message = error instanceof Error ? error.message.toLowerCase() : "";
-      if (
-        (error instanceof DOMException && error.name === "AbortError") ||
-        message.includes("user gesture") ||
-        message.includes("share request")
-      ) {
-        setIsDownloading(false);
-        return;
-      }
-
-      console.error("Style share sheet error:", error);
-
-      try {
-        await handleDownload();
-      } catch {
-        // handleDownload already reports any fallback error.
-      }
-    } finally {
-      setIsDownloading(false);
-    }
-  };
-
   return (
     <Button
       type="button"
       variant="outline"
       size="sm"
       onClick={() => {
-        if (isMobileDevice()) {
-          void handleDownloadMobile();
-          return;
-        }
-
-        void handleDownload();
+        void handleClick();
       }}
       disabled={isDownloading}
       className="flex h-9 items-center gap-2 rounded-full border-slate-300 px-3 text-sm font-medium text-slate-700 shadow-sm"

--- a/tests/unit/features/generation/download-image.test.ts
+++ b/tests/unit/features/generation/download-image.test.ts
@@ -1,0 +1,196 @@
+/**
+ * `shareOrDownloadGeneratedImage` の単体テスト。
+ *
+ * 投稿詳細・スタイル画面・生成結果系の3系統で共通利用するため、各分岐
+ * （PC ダウンロード／モバイル Web Share／モバイル fallback／キャンセル／
+ * 認証エラー／その他失敗）を独立に検証する。
+ */
+
+import { shareOrDownloadGeneratedImage } from "@/features/generation/lib/download-image";
+
+const DESKTOP_UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)";
+const MOBILE_UA = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)";
+
+const messages = {
+  accessDenied: "denied",
+  fetchFailed: (statusText: string) => `failed:${statusText}`,
+};
+
+const target = { id: "asset-1", url: "https://cdn.example.com/x.png" };
+
+function setNavigator(opts: {
+  userAgent: string;
+  canShare?: ((data: ShareData) => boolean) | undefined;
+  share?: ((data: ShareData) => Promise<void>) | undefined;
+}) {
+  Object.defineProperty(window.navigator, "userAgent", {
+    configurable: true,
+    value: opts.userAgent,
+  });
+  Object.defineProperty(window.navigator, "canShare", {
+    configurable: true,
+    value: opts.canShare,
+  });
+  Object.defineProperty(window.navigator, "share", {
+    configurable: true,
+    value: opts.share,
+  });
+}
+
+function makeOkResponse(): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    blob: jest.fn().mockResolvedValue(new Blob(["x"], { type: "image/png" })),
+    headers: { get: () => "image/png" } as unknown as Headers,
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  global.fetch = jest.fn().mockResolvedValue(makeOkResponse());
+  // jsdom は createObjectURL / revokeObjectURL を実装していないので最低限の polyfill
+  if (typeof URL.createObjectURL !== "function") {
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: jest.fn(() => "blob:mock"),
+    });
+  } else {
+    jest.spyOn(URL, "createObjectURL").mockReturnValue("blob:mock");
+  }
+  if (typeof URL.revokeObjectURL !== "function") {
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: jest.fn(),
+    });
+  } else {
+    jest.spyOn(URL, "revokeObjectURL").mockReturnValue(undefined);
+  }
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  setNavigator({ userAgent: DESKTOP_UA, canShare: undefined, share: undefined });
+});
+
+describe("shareOrDownloadGeneratedImage", () => {
+  test("PC では Web Share に触らず onDownloadSuccess のみ発火する", async () => {
+    setNavigator({ userAgent: DESKTOP_UA });
+    const onDownloadSuccess = jest.fn();
+    const onShareSuccess = jest.fn();
+
+    await shareOrDownloadGeneratedImage(target, messages, {
+      onShareSuccess,
+      onDownloadSuccess,
+    });
+
+    expect(onDownloadSuccess).toHaveBeenCalledTimes(1);
+    expect(onShareSuccess).not.toHaveBeenCalled();
+  });
+
+  test("モバイル & canShare 可能なら share を呼び onShareSuccess のみ発火する", async () => {
+    const share = jest.fn().mockResolvedValue(undefined);
+    const canShare = jest.fn().mockReturnValue(true);
+    setNavigator({ userAgent: MOBILE_UA, canShare, share });
+
+    const onDownloadSuccess = jest.fn();
+    const onShareSuccess = jest.fn();
+
+    await shareOrDownloadGeneratedImage(target, messages, {
+      onShareSuccess,
+      onDownloadSuccess,
+    });
+
+    expect(canShare).toHaveBeenCalledWith({ files: expect.any(Array) });
+    expect(share).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Persta.AI" }),
+    );
+    expect(onShareSuccess).toHaveBeenCalledTimes(1);
+    expect(onDownloadSuccess).not.toHaveBeenCalled();
+  });
+
+  test("モバイルだが canShare が false のときはブラウザDLにフォールバックする", async () => {
+    const share = jest.fn();
+    const canShare = jest.fn().mockReturnValue(false);
+    setNavigator({ userAgent: MOBILE_UA, canShare, share });
+
+    const onDownloadSuccess = jest.fn();
+    const onShareSuccess = jest.fn();
+
+    await shareOrDownloadGeneratedImage(target, messages, {
+      onShareSuccess,
+      onDownloadSuccess,
+    });
+
+    expect(share).not.toHaveBeenCalled();
+    expect(onShareSuccess).not.toHaveBeenCalled();
+    expect(onDownloadSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  test("Web Share が AbortError でキャンセルされたときは callback を呼ばず例外も投げない", async () => {
+    const abort = new DOMException("canceled", "AbortError");
+    const share = jest.fn().mockRejectedValue(abort);
+    const canShare = jest.fn().mockReturnValue(true);
+    setNavigator({ userAgent: MOBILE_UA, canShare, share });
+
+    const onDownloadSuccess = jest.fn();
+    const onShareSuccess = jest.fn();
+
+    await expect(
+      shareOrDownloadGeneratedImage(target, messages, {
+        onShareSuccess,
+        onDownloadSuccess,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(onShareSuccess).not.toHaveBeenCalled();
+    expect(onDownloadSuccess).not.toHaveBeenCalled();
+  });
+
+  test("Web Share が予期しないエラーのときはダウンロードへフォールバックする", async () => {
+    const share = jest.fn().mockRejectedValue(new Error("network"));
+    const canShare = jest.fn().mockReturnValue(true);
+    setNavigator({ userAgent: MOBILE_UA, canShare, share });
+
+    const onDownloadSuccess = jest.fn();
+    const onShareSuccess = jest.fn();
+
+    await shareOrDownloadGeneratedImage(target, messages, {
+      onShareSuccess,
+      onDownloadSuccess,
+    });
+
+    expect(onShareSuccess).not.toHaveBeenCalled();
+    expect(onDownloadSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  test("401 のときは accessDenied メッセージで例外を投げる", async () => {
+    setNavigator({ userAgent: DESKTOP_UA });
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+      blob: jest.fn(),
+      headers: { get: () => null } as unknown as Headers,
+    } as unknown as Response);
+
+    await expect(
+      shareOrDownloadGeneratedImage(target, messages),
+    ).rejects.toThrow("denied");
+  });
+
+  test("その他の失敗は fetchFailed(statusText) で例外を投げる", async () => {
+    setNavigator({ userAgent: DESKTOP_UA });
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Server Error",
+      blob: jest.fn(),
+      headers: { get: () => null } as unknown as Headers,
+    } as unknown as Response);
+
+    await expect(
+      shareOrDownloadGeneratedImage(target, messages),
+    ).rejects.toThrow("failed:Server Error");
+  });
+});


### PR DESCRIPTION
## 概要

投稿詳細・/style 画面・生成結果系（grid/list/モーダル）に分散していた「画像ダウンロードのモバイル/PC 分岐ロジック」を、既存の `shareOrDownloadGeneratedImage()` に統一する純粋リファクタです。

ダウンロードボタン共通化計画 (Step 1/3) の第1弾で、**挙動変更はありません**。

- **Step 1 (本PR)**: ロジック共通化
- Step 2: UI コンポーネント (`<ImageDownloadButton>`) 切り出し
- Step 3: `/coordinate` ゲスト画面に DL ボタン追加

## 変更内容

### `features/generation/lib/download-image.ts`
- 入力型を `GeneratedImageData` から `DownloadableImage = { id, url }` に緩めて、投稿 (postId) や style (styleId) も同じ関数に渡せるように
- 第3引数として `DownloadCallbacks = { onShareSuccess?, onDownloadSuccess? }` を追加
  - 既存3コールサイト（`GeneratedImageGallery` / `GeneratedImageList` / `ImageModal`）は型サブセット化により**無修正**で動作

### `features/posts/components/DownloadButton.tsx`
- 約170行 → 約85行に縮小
- `handleDownload` / `handleDownloadMobile` の独自実装を撤去し共通ヘルパに統一
- 既存挙動を維持: PC = 成功トースト、モバイル Web Share 成功 = トーストなし、fallback = 成功トースト

### `features/style/components/StylePageClient.tsx`
- `StyleResultDownloadButton` 内の独自実装を撤去し共通ヘルパに統一
- 不要になった `isMobileDevice()` 関数定義と `determineFileName` import を削除
- usage tracking (`recordStyleUsageClientEvent`) は `onShareSuccess` / `onDownloadSuccess` に分離して既存挙動を完全再現

### `tests/unit/features/generation/download-image.test.ts` (新規)
共通ヘルパの分岐を網羅する単体テスト（7 ケース）
- PC では Web Share に触らず `onDownloadSuccess` のみ
- モバイル & canShare 可能なら share + `onShareSuccess`
- モバイル & canShare 不可なら fallback で `onDownloadSuccess`
- Web Share AbortError は callback 呼ばず例外も投げない
- Web Share 予期しないエラーは fallback
- 401 で `accessDenied` メッセージ
- その他失敗で `fetchFailed(statusText)` メッセージ

## 既存テストへの影響

- `tests/unit/features/style/style-page-client.test.tsx` の **「スマホでは/styleのダウンロードが共有シートを優先する」** テストが、リファクタ後の実装でもそのまま通過することを確認
- 全 1035 テスト Pass

## Test plan

- [x] `npm run lint` — 私の変更箇所に新規 warning/error なし
- [x] `npm run typecheck` — 私の変更箇所に新規エラーなし
- [x] `npm run test` — 1035 件 Pass
- [x] `npm run build -- --webpack` — Pass
- [ ] PC / モバイル実機での動作確認（投稿詳細 DL / /style DL / /coordinate 生成結果 DL すべて従来通り）

🤖 Generated with [Claude Code](https://claude.com/claude-code)