### PR TITLE
feat(coordinate): /coordinate ゲスト画面にダウンロードボタンを追加 (Step 3/3)

### DIFF
--- a/features/generation/components/GuestResultPreview.tsx
+++ b/features/generation/components/GuestResultPreview.tsx
@@ -4,6 +4,18 @@ import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Lock } from "lucide-react";
 import { GenerationResultPanel } from "./GenerationResultPanel";
+import { ImageDownloadButton } from "./ImageDownloadButton";
+
+/**
+ * ゲスト DL のファイル名規則。`determineFileName` がこの ID を fallback
+ * として使う。連続 DL 時の重複は OS 側の連番付与（"... (1).png" 等）に任せる。
+ *
+ * 当初は `coordinate-guest-{timestamp}` で結果ごとにユニークにする計画だったが、
+ * React Compiler ルールが render/effect 中の `Date.now()` 呼び出しを禁止して
+ * いるため固定 ID に変更した。実害（同名ファイルの上書き）は OS の連番付与で
+ * 回避される。
+ */
+const GUEST_DOWNLOAD_ID = "coordinate-guest";
 
 export interface GuestResultPreviewImage {
   url: string;
@@ -29,9 +41,9 @@ export interface GuestResultPreviewProps {
  * - DB 保存しない data URL を直接表示する
  * - リロードで消える（state が消えるため）
  * - 結果が無い間は placeholder 文言（/style と同じ panel シェル）
- * - 結果がある時は「保存するにはログイン」 CTA をパネル下に表示
+ * - 結果がある時はパネル右上にダウンロードボタン、footer に「ログインで履歴に残せる」CTA
  *
- * UCL-017 / 計画書 Phase 6
+ * UCL-017 / 計画書 Phase 6 / Step 3 (ゲスト DL 追加)
  */
 export function GuestResultPreview({
   result,
@@ -46,6 +58,24 @@ export function GuestResultPreview({
       resultImageUrl={result?.url ?? null}
       resultImageAlt={t("guestResultAlt")}
       aspectRatio={1}
+      action={
+        result ? (
+          <ImageDownloadButton
+            imageUrl={result.url}
+            id={GUEST_DOWNLOAD_ID}
+            variant="outline"
+            label={t("guestResultDownloadAction")}
+            ariaLabel={t("guestResultDownloadAriaLabel")}
+            messages={{
+              accessDenied: t("guestResultDownloadFailed"),
+              fetchFailed: () => t("guestResultDownloadFailed"),
+              failedFallback: t("guestResultDownloadFailed"),
+              successTitle: t("guestResultDownloadSuccessTitle"),
+              successDescription: t("guestResultDownloadSuccessDescription"),
+            }}
+          />
+        ) : null
+      }
       footer={
         result ? (
           <div

--- a/messages/en.ts
+++ b/messages/en.ts
@@ -814,6 +814,12 @@ export const enMessages = {
     guestResultSaveHint:
       "This preview disappears when you leave the page.",
     guestResultLoginCta: "Sign in / Sign up",
+    guestResultDownloadAction: "Download",
+    guestResultDownloadAriaLabel: "Download generated result",
+    guestResultDownloadSuccessTitle: "Downloaded",
+    guestResultDownloadSuccessDescription: "Image saved.",
+    guestResultDownloadFailed:
+      "Failed to download the image. Please try again.",
     guestLoginCtaTitle: "Try without signing in",
     guestLoginCtaDescription:
       "You can try ChatGPT Image 2.0 and Nano Banana 2 (0.5K) once per day. Results are not saved.",

--- a/messages/ja.ts
+++ b/messages/ja.ts
@@ -782,6 +782,11 @@ export const jaMessages = {
     guestResultPlaceholder: "ここに生成結果が表示されます",
     guestResultSaveHint: "結果はこのページを離れると消えます。",
     guestResultLoginCta: "ログイン / 新規登録",
+    guestResultDownloadAction: "ダウンロード",
+    guestResultDownloadAriaLabel: "生成結果をダウンロード",
+    guestResultDownloadSuccessTitle: "ダウンロードしました",
+    guestResultDownloadSuccessDescription: "画像を保存しました。",
+    guestResultDownloadFailed: "画像のダウンロードに失敗しました。もう一度お試しください。",
     guestLoginCtaTitle: "未ログインでお試しいただけます",
     guestLoginCtaDescription:
       "ChatGPT Image 2.0 と Nano Banana 2 (0.5K) を 1 日 1 回までお試しいただけます。保存はされません。",

--- a/tests/unit/features/generation/guest-result-preview.test.tsx
+++ b/tests/unit/features/generation/guest-result-preview.test.tsx
@@ -1,0 +1,126 @@
+/** @jest-environment jsdom */
+
+/**
+ * `GuestResultPreview` の挙動テスト。
+ *
+ * Step 3 で追加したダウンロードボタンが、結果表示中だけ render され、
+ * クリック時に共通ヘルパへ data URL と coordinate-guest-* の id が渡る
+ * ことを検証する。あわせて既存のログイン CTA も併存していることを確認する。
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useTranslations } from "next-intl";
+
+jest.mock("next-intl", () => ({
+  useTranslations: jest.fn(),
+}));
+
+const mockToast = jest.fn();
+jest.mock("@/components/ui/use-toast", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+const mockShareOrDownload = jest.fn();
+jest.mock("@/features/generation/lib/download-image", () => ({
+  shareOrDownloadGeneratedImage: (...args: unknown[]) =>
+    mockShareOrDownload(...args),
+}));
+
+import { GuestResultPreview } from "@/features/generation/components/GuestResultPreview";
+
+const labels: Record<string, string> = {
+  guestResultTitle: "Result",
+  guestResultPlaceholder: "placeholder",
+  guestResultAlt: "alt",
+  guestResultSaveHint: "leave-page-warning",
+  guestResultLoginCta: "Sign in",
+  guestResultDownloadAction: "Download",
+  guestResultDownloadAriaLabel: "Download generated result",
+  guestResultDownloadSuccessTitle: "downloaded",
+  guestResultDownloadSuccessDescription: "saved",
+  guestResultDownloadFailed: "download-failed",
+};
+
+const useTranslationsMock = useTranslations as jest.MockedFunction<
+  typeof useTranslations
+>;
+
+beforeEach(() => {
+  useTranslationsMock.mockImplementation(
+    () =>
+      ((key: string) => labels[key] ?? key) as ReturnType<typeof useTranslations>,
+  );
+  mockToast.mockReset();
+  mockShareOrDownload.mockReset();
+  mockShareOrDownload.mockImplementation(async (_image, _msgs, callbacks) => {
+    callbacks?.onDownloadSuccess?.();
+  });
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("GuestResultPreview", () => {
+  test("result が null のときは DL ボタンも CTA も描画しない", () => {
+    render(<GuestResultPreview result={null} onLoginCtaClick={jest.fn()} />);
+
+    expect(
+      screen.queryByRole("button", { name: "Download generated result" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Sign in" }),
+    ).not.toBeInTheDocument();
+  });
+
+  test("result があるとき DL ボタンとログイン CTA が併存する", () => {
+    render(
+      <GuestResultPreview
+        result={{ url: "data:image/png;base64,abc", mimeType: "image/png" }}
+        onLoginCtaClick={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Download generated result" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Sign in" }),
+    ).toBeInTheDocument();
+    // ヒント文も維持されている
+    expect(screen.getByText("leave-page-warning")).toBeInTheDocument();
+  });
+
+  test("DL ボタンクリックで共通ヘルパに data URL と coordinate-guest の id を渡す", () => {
+    render(
+      <GuestResultPreview
+        result={{ url: "data:image/png;base64,abc", mimeType: "image/png" }}
+        onLoginCtaClick={jest.fn()}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Download generated result" }),
+    );
+
+    expect(mockShareOrDownload).toHaveBeenCalledTimes(1);
+    const [target] = mockShareOrDownload.mock.calls[0];
+    expect(target).toEqual({
+      url: "data:image/png;base64,abc",
+      id: "coordinate-guest",
+    });
+  });
+
+  test("CTA クリックで onLoginCtaClick が呼ばれる", () => {
+    const onLogin = jest.fn();
+    render(
+      <GuestResultPreview
+        result={{ url: "data:image/png;base64,abc", mimeType: "image/png" }}
+        onLoginCtaClick={onLogin}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+    expect(onLogin).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## 概要

ダウンロードボタン共通化計画 (Step 3/3) の最終 PR。Step 2 で切り出した `<ImageDownloadButton>` を `/coordinate` ゲスト画面にも置き、**未ログインユーザーも生成結果をローカル保存できる**ようにします。

- Step 1 (#265): ロジック共通化 — マージ済み
- Step 2 (#266): UI コンポーネント切り出し — マージ済み
- **Step 3 (本PR)**: `/coordinate` ゲスト画面に DL ボタン追加

## 変更内容

### `features/generation/components/GuestResultPreview.tsx`

`GenerationResultPanel` の `action` prop に `<ImageDownloadButton variant="outline">` を追加（`/style` 即時結果と同一構造）。

- 結果表示中だけ DL ボタンを描画
- footer の amber パネル + 「ログイン / 新規登録」CTA はそのまま維持
- ヒント文 `guestResultSaveHint`（"結果はこのページを離れると消えます。"）も現状維持
  → DL したローカルファイルは OS に残るため、文言と矛盾しません（ページ離脱で消えるのは画面上のプレビュー）

### `messages/ja.ts` / `messages/en.ts`

`coordinate.guestResultDownload*` 系の i18n キーを 5 件追加：
- `guestResultDownloadAction` ("ダウンロード" / "Download")
- `guestResultDownloadAriaLabel` ("生成結果をダウンロード" / "Download generated result")
- `guestResultDownloadSuccessTitle` / `guestResultDownloadSuccessDescription`
- `guestResultDownloadFailed`

### `tests/unit/features/generation/guest-result-preview.test.tsx`（新規）

4 ケース：
- `result` null 時は DL ボタンも CTA も描画しない
- `result` 表示時は DL ボタンとログイン CTA が併存する
- DL ボタンクリックで共通ヘルパに data URL と `"coordinate-guest"` の id が渡る
- CTA クリックで `onLoginCtaClick` が呼ばれる

## ファイル名規則について（仕様変更）

事前計画では **`coordinate-guest-{timestamp}`** で結果ごとにユニーク化する予定でしたが、実装中に **React Compiler ルール**に阻まれました：

```
error  Calling setState synchronously within an effect can trigger cascading renders
error  Cannot call impure function during render
```

`Date.now()` を render / effect 内で呼ぶことが許されないため、**固定 ID `coordinate-guest` に変更**しました。連続 DL 時の重複は OS 側の連番付与（`coordinate-guest.png` → `coordinate-guest (1).png` など）に任せる方針です。実害は最小限と判断しています。

## 既存ユーザーフローへの影響

- **ゲスト**: 「結果を表示するだけ → ログイン促し」だった動線が **「DL もできる + ログイン促し」** に拡張
- **ログインユーザー**: 影響なし（このコンポーネントはゲスト専用）
- **`/style` ゲスト**: 元から DL 可能だった挙動はそのまま

## Test plan

- [x] `npm run lint` — 私の変更箇所に新規 warning/error なし
- [x] `npm run typecheck` — 私の変更箇所に新規エラーなし
- [x] `npm run test` — 1051 件 Pass（Step 2 から +4件）
- [x] `npm run build -- --webpack` — Pass
- [ ] **PC / モバイル実機確認**（マージ前にお願いします）
  - [ ] /coordinate にログインせずアクセスし、画像生成 → DL ボタンクリックで PC では直接 DL、モバイルでは Web Share シートが立ち上がる
  - [ ] DL ファイル名が `coordinate-guest.png` になる（連続 DL すると `coordinate-guest (1).png` 等）
  - [ ] 「ログイン / 新規登録」CTA も従来通り表示・動作する
  - [ ] data URL（`data:image/png;base64,...`）でも fetch → blob → download/share が成功する

## Step 1〜3 全体まとめ

| 画面 | Step 1前 | Step 3後 |
|---|---|---|
| 投稿詳細 (ホーム/マイページ) | 独自実装 | 共通ヘルパ + `<ImageDownloadButton variant="ghost">` |
| /coordinate 生成結果 (grid/list/モーダル) | 共通ヘルパ | 共通ヘルパ（変更なし） |
| /coordinate ゲスト | **DL不可** | **`<ImageDownloadButton variant="outline">`（新規）** |
| /style 即時結果 | 独自実装 | 共通ヘルパ + `<ImageDownloadButton variant="outline">` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)