### PR TITLE
fix(posts): 投稿詳細のダウンロードを WebP から元の PNG/JPEG に修正

### DIFF
--- a/features/posts/components/CachedPostDetail.tsx
+++ b/features/posts/components/CachedPostDetail.tsx
@@ -5,6 +5,7 @@ import {
   deriveAspectRatioFromDimensions,
   getImageAspectRatio,
   getPostDisplayUrl,
+  getPostOriginalUrl,
 } from "../lib/utils";
 import { PostDetailContent } from "./PostDetailContent";
 import { createAdminClient } from "@/lib/supabase/admin";
@@ -39,6 +40,10 @@ export async function CachedPostDetail({
   }
 
   const imageUrl = getPostDisplayUrl(post);
+  // 表示は WebP（軽量）、ダウンロードは元の PNG/JPEG（高画質）。
+  // この経路だけ二段構成にし、`<DownloadButton>` の挙動を `/coordinate` や
+  // `/style` と揃える（生成直後の data URL と同じく拡張子で保存される）。
+  const originalImageUrl = getPostOriginalUrl(post);
   // 1) width/height が揃っていれば派生で済ませる
   // 2) それが無理なら画像をフェッチして判定（最後のフォールバック）
   let imageAspectRatio: "portrait" | "landscape" | null =
@@ -58,6 +63,7 @@ export async function CachedPostDetail({
       initialViewCount={post.view_count || 0}
       ownerId={post.user_id}
       imageUrl={imageUrl}
+      originalImageUrl={originalImageUrl}
     />
   );
 }

--- a/features/posts/components/DownloadButton.tsx
+++ b/features/posts/components/DownloadButton.tsx
@@ -31,7 +31,9 @@ export function DownloadButton({
 
   return (
     <ImageDownloadButton
-      imageUrl={originalImageUrl ?? imageUrl}
+      // `getPostOriginalUrl` は画像欠損時に空文字を返すため、空文字も
+      // imageUrl にフォールバックする必要がある。`??` ではなく `||` を使う。
+      imageUrl={originalImageUrl || imageUrl}
       id={postId}
       variant="ghost"
       ariaLabel={t("downloadAriaLabel")}

--- a/features/posts/components/DownloadButton.tsx
+++ b/features/posts/components/DownloadButton.tsx
@@ -5,19 +5,33 @@ import { ImageDownloadButton } from "@/features/generation/components/ImageDownl
 
 interface DownloadButtonProps {
   postId: string;
+  /** 表示用 URL（WebP の可能性あり）。`originalImageUrl` が無いときの fallback */
   imageUrl?: string | null;
+  /**
+   * ダウンロード用の元画像 URL（PNG/JPEG）。
+   * `getPostOriginalUrl(post)` で取得した値を渡す想定。
+   * 指定があれば DL 時はこちらを優先し、ユーザーには元画像（高画質）を保存させる。
+   */
+  originalImageUrl?: string | null;
 }
 
 /**
  * 投稿詳細用ダウンロードボタン。共通の `<ImageDownloadButton variant="ghost">`
  * に i18n 文言を流し込むだけの薄いラッパー。
+ *
+ * 表示用は WebP（軽量）、ダウンロード用は元の PNG/JPEG という二段構成にするため、
+ * `originalImageUrl` を優先し、未指定なら `imageUrl` に fallback する。
  */
-export function DownloadButton({ postId, imageUrl }: DownloadButtonProps) {
+export function DownloadButton({
+  postId,
+  imageUrl,
+  originalImageUrl,
+}: DownloadButtonProps) {
   const t = useTranslations("posts");
 
   return (
     <ImageDownloadButton
-      imageUrl={imageUrl}
+      imageUrl={originalImageUrl ?? imageUrl}
       id={postId}
       variant="ghost"
       ariaLabel={t("downloadAriaLabel")}

--- a/features/posts/components/PostActions.tsx
+++ b/features/posts/components/PostActions.tsx
@@ -19,6 +19,11 @@ interface PostActionsProps {
   isPosted?: boolean;
   caption?: string | null;
   imageUrl?: string | null;
+  /**
+   * ダウンロード用の元画像 URL（PNG/JPEG）。表示用 WebP と分離するため、
+   * オーナー DL 動線では `imageUrl` ではなくこちらが優先される。
+   */
+  originalImageUrl?: string | null;
   onPostClick?: () => void;
 }
 
@@ -36,6 +41,7 @@ export function PostActions({
   isPosted = true,
   caption,
   imageUrl,
+  originalImageUrl,
   onPostClick,
 }: PostActionsProps) {
   const t = useTranslations("posts");
@@ -56,6 +62,7 @@ export function PostActions({
           <DownloadButton
             postId={postId}
             imageUrl={imageUrl}
+            originalImageUrl={originalImageUrl}
           />
         )}
         {/* シェアボタン（投稿済みの場合のみ表示） */}

--- a/features/posts/components/PostDetailContent.tsx
+++ b/features/posts/components/PostDetailContent.tsx
@@ -18,6 +18,8 @@ interface PostDetailContentProps {
   initialViewCount: number;
   ownerId?: string | null;
   imageUrl?: string | null;
+  /** ダウンロード用の元画像 URL（PNG/JPEG）。`<DownloadButton>` まで流す */
+  originalImageUrl?: string | null;
 }
 
 export function PostDetailContent({
@@ -30,6 +32,7 @@ export function PostDetailContent({
   initialViewCount,
   ownerId,
   imageUrl,
+  originalImageUrl,
 }: PostDetailContentProps) {
   const [hiddenPostId, setHiddenPostId] = useState<string | null>(null);
   const router = useRouter();
@@ -72,6 +75,7 @@ export function PostDetailContent({
         initialViewCount={initialViewCount}
         ownerId={ownerId}
         imageUrl={imageUrl}
+        originalImageUrl={originalImageUrl}
         isHidden={isHidden}
         onHidden={() => setHiddenPostId(postId)}
       />

--- a/features/posts/components/PostDetailStatic.tsx
+++ b/features/posts/components/PostDetailStatic.tsx
@@ -43,6 +43,8 @@ interface PostDetailStaticProps {
   initialViewCount: number;
   ownerId?: string | null;
   imageUrl?: string | null;
+  /** ダウンロード用の元画像 URL（PNG/JPEG）。`<DownloadButton>` まで流す */
+  originalImageUrl?: string | null;
   isHidden?: boolean;
   onHidden?: () => void;
 }
@@ -61,6 +63,7 @@ export function PostDetailStatic({
   initialViewCount,
   ownerId,
   imageUrl,
+  originalImageUrl,
   isHidden = false,
   onHidden,
 }: PostDetailStaticProps) {
@@ -411,6 +414,7 @@ export function PostDetailStatic({
                 isPosted={post.is_posted || false}
                 caption={post.caption}
                 imageUrl={imageUrl}
+                originalImageUrl={originalImageUrl}
                 onPostClick={!post.is_posted ? () => setPostModalOpen(true) : undefined}
               />
             </Suspense>

--- a/features/posts/components/PostDetailStats.tsx
+++ b/features/posts/components/PostDetailStats.tsx
@@ -12,6 +12,8 @@ interface PostDetailStatsProps {
   isPosted?: boolean;
   caption?: string | null;
   imageUrl?: string | null;
+  /** ダウンロード用の元画像 URL（PNG/JPEG）。`<DownloadButton>` まで流す */
+  originalImageUrl?: string | null;
   onPostClick?: () => void;
 }
 
@@ -29,6 +31,7 @@ export function PostDetailStats({
   isPosted = true,
   caption,
   imageUrl,
+  originalImageUrl,
   onPostClick,
 }: PostDetailStatsProps) {
   return (
@@ -42,6 +45,7 @@ export function PostDetailStats({
       isPosted={isPosted}
       caption={caption}
       imageUrl={imageUrl}
+      originalImageUrl={originalImageUrl}
       onPostClick={onPostClick}
     />
   );

--- a/features/posts/components/PostDetailStatsContent.tsx
+++ b/features/posts/components/PostDetailStatsContent.tsx
@@ -12,6 +12,8 @@ interface PostDetailStatsContentProps {
   isPosted: boolean;
   caption?: string | null;
   imageUrl?: string | null;
+  /** ダウンロード用の元画像 URL（PNG/JPEG）。`<DownloadButton>` まで流す */
+  originalImageUrl?: string | null;
   onPostClick?: () => void;
 }
 
@@ -29,6 +31,7 @@ export function PostDetailStatsContent({
   isPosted,
   caption,
   imageUrl,
+  originalImageUrl,
   onPostClick,
 }: PostDetailStatsContentProps) {
   return (
@@ -42,6 +45,7 @@ export function PostDetailStatsContent({
       isPosted={isPosted}
       caption={caption}
       imageUrl={imageUrl}
+      originalImageUrl={originalImageUrl}
       onPostClick={onPostClick}
     />
   );

--- a/tests/unit/features/posts/download-button.test.tsx
+++ b/tests/unit/features/posts/download-button.test.tsx
@@ -1,0 +1,120 @@
+/** @jest-environment jsdom */
+
+/**
+ * `features/posts/components/DownloadButton.tsx` の挙動テスト。
+ *
+ * このボタンは表示用 WebP と DL 用 PNG/JPEG を分離する責務を持つ。
+ * `originalImageUrl` が渡されていればそちらを優先し、未指定なら
+ * `imageUrl` に fallback することを検証する。
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useTranslations } from "next-intl";
+
+jest.mock("next-intl", () => ({
+  useTranslations: jest.fn(),
+}));
+
+const mockToast = jest.fn();
+jest.mock("@/components/ui/use-toast", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+const mockShareOrDownload = jest.fn();
+jest.mock("@/features/generation/lib/download-image", () => ({
+  shareOrDownloadGeneratedImage: (...args: unknown[]) =>
+    mockShareOrDownload(...args),
+}));
+
+import { DownloadButton } from "@/features/posts/components/DownloadButton";
+
+const labels: Record<string, string> = {
+  downloadAriaLabel: "Download",
+  downloadUnauthorized: "denied",
+  downloadFetchFailed: "fetch-failed",
+  errorTitle: "Error",
+  downloadFailed: "download-failed",
+  downloadSuccessTitle: "downloaded",
+  downloadSuccessDescription: "saved",
+  downloadNoImage: "no-image",
+};
+
+const useTranslationsMock = useTranslations as jest.MockedFunction<
+  typeof useTranslations
+>;
+
+beforeEach(() => {
+  useTranslationsMock.mockImplementation(
+    () =>
+      ((key: string) => labels[key] ?? key) as ReturnType<
+        typeof useTranslations
+      >,
+  );
+  mockToast.mockReset();
+  mockShareOrDownload.mockReset();
+  mockShareOrDownload.mockImplementation(async (_image, _msgs, callbacks) => {
+    callbacks?.onDownloadSuccess?.();
+  });
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("DownloadButton (posts)", () => {
+  test("originalImageUrl が指定されていれば DL 時はそちらを使う（WebP ではなく PNG）", async () => {
+    render(
+      <DownloadButton
+        postId="post-1"
+        imageUrl="https://cdn.example.com/x_display.webp"
+        originalImageUrl="https://cdn.example.com/x.png"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Download" }));
+
+    await waitFor(() => {
+      expect(mockShareOrDownload).toHaveBeenCalledTimes(1);
+    });
+    const [target] = mockShareOrDownload.mock.calls[0];
+    expect(target).toEqual({
+      id: "post-1",
+      url: "https://cdn.example.com/x.png",
+    });
+  });
+
+  test("originalImageUrl が未指定なら imageUrl に fallback する（既存挙動）", async () => {
+    render(
+      <DownloadButton
+        postId="post-1"
+        imageUrl="https://cdn.example.com/x.png"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Download" }));
+
+    await waitFor(() => {
+      expect(mockShareOrDownload).toHaveBeenCalledTimes(1);
+    });
+    const [target] = mockShareOrDownload.mock.calls[0];
+    expect(target.url).toBe("https://cdn.example.com/x.png");
+  });
+
+  test("originalImageUrl が null のときも imageUrl に fallback する", async () => {
+    render(
+      <DownloadButton
+        postId="post-1"
+        imageUrl="https://cdn.example.com/x.png"
+        originalImageUrl={null}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Download" }));
+
+    await waitFor(() => {
+      expect(mockShareOrDownload).toHaveBeenCalledTimes(1);
+    });
+    const [target] = mockShareOrDownload.mock.calls[0];
+    expect(target.url).toBe("https://cdn.example.com/x.png");
+  });
+});

--- a/tests/unit/features/posts/download-button.test.tsx
+++ b/tests/unit/features/posts/download-button.test.tsx
@@ -117,4 +117,22 @@ describe("DownloadButton (posts)", () => {
     const [target] = mockShareOrDownload.mock.calls[0];
     expect(target.url).toBe("https://cdn.example.com/x.png");
   });
+
+  test("originalImageUrl が空文字のときも imageUrl に fallback する（getPostOriginalUrl 画像欠損時の挙動）", async () => {
+    render(
+      <DownloadButton
+        postId="post-1"
+        imageUrl="https://cdn.example.com/x_display.webp"
+        originalImageUrl=""
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Download" }));
+
+    await waitFor(() => {
+      expect(mockShareOrDownload).toHaveBeenCalledTimes(1);
+    });
+    const [target] = mockShareOrDownload.mock.calls[0];
+    expect(target.url).toBe("https://cdn.example.com/x_display.webp");
+  });
 });


### PR DESCRIPTION
## 背景

ユーザー報告：「ホーム画面 / マイページからのコンテンツ詳細でダウンロードすると WebP で保存される。/coordinate や /style では PNG/JPEG なので揃えたい。」

## 原因

`features/posts/lib/utils.ts` には用途別の URL ヘルパが**既に整備されていました**：

| ヘルパ | 用途 | URL 末尾 | Content-Type |
|---|---|---|---|
| `getPostDisplayUrl(post)` | 詳細画面の**表示用**（軽量化） | `_display.webp` | `image/webp` |
| `getPostOriginalUrl(post)` | **DL 用**（元画像、コメントに「PNG/JPEG」と明記） | `.png` | `image/png` |

しかし `<CachedPostDetail>` の配線で **`getPostDisplayUrl(post)` の WebP URL を表示と DL の両方に渡していた**ため、DL 時も WebP が保存されていました。

実証：
```
$ curl -sI "<元画像 URL>"          → content-type: image/png  / ~2.4 MB
$ curl -sI "<storage_path_display URL>"  → content-type: image/webp / ~158 KB
```

## 修正方針 (A 案)

`<DownloadButton>` に `originalImageUrl` prop を追加し、指定があればそちらを優先。
`<CachedPostDetail>` で `getPostOriginalUrl(post)` を計算し、7 階層下の `<DownloadButton>` まで prop で流す。**表示用 WebP 経路は無変更**（軽量化のメリットは維持）。

## 変更ファイル（順次 prop を追加）

| 階層 | ファイル | 変更 |
|---|---|---|
| 1 (起点) | `features/posts/components/CachedPostDetail.tsx` | `getPostOriginalUrl(post)` を計算、`originalImageUrl` を子に渡す |
| 2 | `features/posts/components/PostDetailContent.tsx` | prop 中継 |
| 3 | `features/posts/components/PostDetailStatic.tsx` | prop 中継 |
| 4 | `features/posts/components/PostDetailStatsContent.tsx` | prop 中継 |
| 5 | `features/posts/components/PostDetailStats.tsx` | prop 中継 |
| 6 | `features/posts/components/PostActions.tsx` | prop 中継 |
| 7 (終点) | `features/posts/components/DownloadButton.tsx` | `originalImageUrl ?? imageUrl` で優先選択 |

各階層で prop の追加・受け渡しのみで、ロジック変更はありません。

## テスト

`tests/unit/features/posts/download-button.test.tsx` を新設し、3ケースで `<DownloadButton>` の挙動を検証：

- `originalImageUrl` 指定時 → DL は元画像（PNG/JPEG）を fetch
- `originalImageUrl` 未指定時 → `imageUrl` に fallback（後方互換）
- `originalImageUrl` が `null` のとき → `imageUrl` に fallback

## 影響範囲

- ホーム / マイページからの**投稿詳細 DL** が WebP → PNG/JPEG に変わる
- 表示画像（プレビュー / OG 画像 / モーダル）は引き続き WebP（軽量）のまま
- `/coordinate` および `/style` の DL 動線は影響なし（元から PNG/JPEG）

## Test plan

- [x] `npm run lint` — 私の変更箇所に新規 warning/error なし
- [x] `npm run typecheck` — 私の変更箇所に新規エラーなし
- [x] `npm run test` — 1054 件 Pass（前回 +3件）
- [x] `npm run build -- --webpack` — Pass
- [ ] PC / モバイル実機での動作確認（マージ前にお願いします）
  - [ ] ホーム or マイページから自分の投稿詳細を開き、DL ボタンを押すと **`.png` 拡張子で保存**される
  - [ ] DL されたファイルを画像ビューワーで開いて PNG として表示できる
  - [ ] モバイル Web Share シートでも PNG として共有される
  - [ ] 投稿詳細の表示画像自体は引き続き WebP（軽量）で読み込まれる
  - [ ] Network タブで投稿詳細を読み込み時、DL されるのは `image_url` の元画像（~2.4MB）であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)