### PR TITLE
chore(worktree): ワークツリー作成を自動化するスクリプトとスキルを追加

### DIFF
--- a/.agents/skills/git-create-worktree/README.md
+++ b/.agents/skills/git-create-worktree/README.md
@@ -1,0 +1,11 @@
+# git-create-worktree スキル
+
+`/git-create-worktree`（または「ワークツリーを切って」）で、新しい git worktree を作成し、
+開発に必要な未追跡ファイルを自動セットアップするスキルです。
+
+- worktree を `<repo>.worktrees/<branch>` に作成
+- `.env.local` を main チェックアウトへの symlink で配置
+- `node_modules` を APFS clonefile で高速コピー（`npm install` の待ち時間なし）
+- `npm install` で lockfile との整合を確認
+
+実体は [`scripts/worktree-add.sh`](../../../scripts/worktree-add.sh)、詳細ルールは [SKILL.md](./SKILL.md) を参照してください。

--- a/.agents/skills/git-create-worktree/SKILL.md
+++ b/.agents/skills/git-create-worktree/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: git-create-worktree
+description: Create a new git worktree under <repo>.worktrees/ and auto-run the setup script (symlink .env.local, clone node_modules via APFS clonefile, npm install). Use when user invokes /git-create-worktree or says "ワークツリーを切って", "ワークツリーを作って", "新しいworktreeを用意して", "create a worktree".
+---
+
+# Git Create Worktree
+
+## Trigger
+
+- `/git-create-worktree`
+- 「ワークツリーを切って」「ワークツリーを作って」「新しい worktree を用意して」
+- `create a worktree`
+
+## Workflow
+
+1. ブランチ名を決める。
+   - 引数で渡されていればそれを使う。
+   - 渡されていなければユーザーに確認する。現在の作業内容から推定できる場合は `<prefix>/<slug>` 形式（`git-create-branch` と同じ命名規則）の候補を1つ提示してから実行する。
+2. `bash scripts/worktree-add.sh <branch> [base-branch]` を実行する。
+   - base-branch 未指定時は `origin/main` 起点で新規ブランチを切る。
+   - 既存ブランチ名を渡した場合は、それをチェックアウトする。
+3. スクリプトの出力を確認し、作成された worktree のパス（`<main-root>.worktrees/<branch をハイフン化>`)をユーザーに報告する。
+4. 以降の作業を続ける場合は、新しい worktree のパスを作業ディレクトリとして扱う。
+
+## What the script does
+
+`scripts/worktree-add.sh` が以下を自動セットアップする（手動の `npm install` / `.env.local` コピーは不要）:
+
+- worktree を `<main-root>.worktrees/<branch をハイフン化>` に作成
+- `.env.local` を main チェックアウトへの **symlink** で配置（常に同期、`.gitignore` 対象なのでコミットされない）
+- `node_modules` を **APFS clonefile** でコピー（一瞬・コピーオンライト・各 worktree 独立）。APFS でなければ通常コピーにフォールバック
+- `npm install --prefer-offline --no-audit --no-fund` で lockfile との整合を確認
+
+## Safety
+
+- 同名の worktree ディレクトリが既に存在する場合、スクリプトがエラーで停止する（上書きしない）。
+- ブランチ名が不明なまま実行しない。
+- main/master へ直接コミット・push はしない（worktree 作成のみ）。

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -39,7 +39,8 @@
       "mcp__plugin_playwright_playwright__browser_console_messages",
       "mcp__context7__resolve-library-id",
       "mcp__context7__query-docs",
-      "Bash(git worktree *)"
+      "Bash(git worktree *)",
+      "Bash(bash scripts/worktree-add.sh *)"
     ]
   }
 }

--- a/.claude/skills/git-create-worktree
+++ b/.claude/skills/git-create-worktree
@@ -1,0 +1,1 @@
+../../.agents/skills/git-create-worktree

--- a/scripts/worktree-add.sh
+++ b/scripts/worktree-add.sh
@@ -64,12 +64,16 @@ fi
 mkdir -p "${WT_PARENT}"
 
 # --- worktree 作成 ---------------------------------------------------------
-if git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+# リモートにのみ存在するブランチも拾えるよう、先に fetch を試みる。
+git fetch origin --quiet || echo "  (git fetch に失敗: オフラインのまま続行)"
+
+if git show-ref --verify --quiet "refs/heads/${BRANCH}" || \
+   git show-ref --verify --quiet "refs/remotes/origin/${BRANCH}"; then
   echo "▶ 既存ブランチ '${BRANCH}' を ${WT_DIR} にチェックアウト"
+  # ローカルに無くリモートにある場合、git が追跡ブランチを張ってチェックアウトする。
   git worktree add "${WT_DIR}" "${BRANCH}"
 else
   echo "▶ '${BASE}' を基点に新規ブランチ '${BRANCH}' を ${WT_DIR} に作成"
-  git fetch origin --quiet || echo "  (git fetch に失敗: オフラインのまま続行)"
   git worktree add -b "${BRANCH}" "${WT_DIR}" "${BASE}"
 fi
 
@@ -88,9 +92,13 @@ fi
 if [[ -d "${MAIN_ROOT}/node_modules" ]]; then
   echo "▶ node_modules をコピー中..."
   # macOS APFS: `cp -c` は clonefile(2) を使い一瞬で完了。COW なので main を壊さない。
-  # APFS でない / GNU coreutils 環境では通常コピーにフォールバック。
-  if ! cp -cR "${MAIN_ROOT}/node_modules" "${WT_DIR}/node_modules" 2>/dev/null; then
-    echo "  (clonefile が使えないため通常コピー)"
+  # Linux (Btrfs/XFS): `cp --reflink=auto` で reflink コピー。いずれも不可なら通常コピー。
+  if cp -cR "${MAIN_ROOT}/node_modules" "${WT_DIR}/node_modules" 2>/dev/null; then
+    : # macOS APFS clonefile 成功
+  elif cp -R --reflink=auto "${MAIN_ROOT}/node_modules" "${WT_DIR}/node_modules" 2>/dev/null; then
+    : # Linux reflink 成功
+  else
+    echo "  (clonefile/reflink が使えないため通常コピー)"
     cp -R "${MAIN_ROOT}/node_modules" "${WT_DIR}/node_modules"
   fi
   echo "✔ node_modules をコピーしました"

--- a/scripts/worktree-add.sh
+++ b/scripts/worktree-add.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+# 新しい git worktree を作り、開発に必要な未追跡ファイルを自動でセットアップする。
+#
+# やること:
+#   1. ../<repo>.worktrees/<branch> に worktree を作成
+#      （既存ブランチならそれを、無ければ base から新規ブランチを切る）
+#   2. .env.local を main チェックアウトへの symlink で配置（常に同期）
+#   3. node_modules を APFS clonefile でコピー（一瞬・コピーオンライト・各worktree独立）
+#   4. 念のため `npm install` で lockfile との整合をチェック
+#
+# 使い方:
+#   bash scripts/worktree-add.sh <branch> [base-branch]
+#
+# 例:
+#   bash scripts/worktree-add.sh feature/foo            # origin/main から新規ブランチ
+#   bash scripts/worktree-add.sh feature/foo main       # main から新規ブランチ
+#   bash scripts/worktree-add.sh existing-branch        # 既存ブランチをチェックアウト
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/worktree-add.sh <branch> [base-branch]
+
+Arguments:
+  <branch>        作成/チェックアウトするブランチ名
+  [base-branch]   新規ブランチを切る場合の基点（既定: origin/main）
+
+セットアップ内容:
+  - .env.local           → main チェックアウトへの symlink
+  - node_modules         → APFS clonefile コピー（高速・独立）
+  - npm install          → lockfile との整合チェック
+EOF
+}
+
+case "${1:-}" in
+  -h | --help | "")
+    usage
+    [[ -z "${1:-}" ]] && exit 1 || exit 0
+    ;;
+esac
+
+BRANCH="$1"
+BASE="${2:-origin/main}"
+
+# このスクリプトはどの worktree から実行しても良い。
+# git-common-dir の親が main チェックアウト。
+GIT_COMMON_DIR="$(git rev-parse --git-common-dir)"
+GIT_COMMON_DIR="$(cd "${GIT_COMMON_DIR}" && pwd)"
+MAIN_ROOT="$(dirname "${GIT_COMMON_DIR}")"
+
+# worktree 配置先: <main-root>.worktrees/<branch をスラッシュ→ハイフン化>
+WT_PARENT="${MAIN_ROOT}.worktrees"
+WT_NAME="${BRANCH//\//-}"
+WT_DIR="${WT_PARENT}/${WT_NAME}"
+
+if [[ -e "${WT_DIR}" ]]; then
+  echo "❌ 既に存在します: ${WT_DIR}" >&2
+  exit 1
+fi
+
+mkdir -p "${WT_PARENT}"
+
+# --- worktree 作成 ---------------------------------------------------------
+if git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+  echo "▶ 既存ブランチ '${BRANCH}' を ${WT_DIR} にチェックアウト"
+  git worktree add "${WT_DIR}" "${BRANCH}"
+else
+  echo "▶ '${BASE}' を基点に新規ブランチ '${BRANCH}' を ${WT_DIR} に作成"
+  git fetch origin --quiet || echo "  (git fetch に失敗: オフラインのまま続行)"
+  git worktree add -b "${BRANCH}" "${WT_DIR}" "${BASE}"
+fi
+
+# --- .env.local を symlink -------------------------------------------------
+if [[ -f "${MAIN_ROOT}/.env.local" ]]; then
+  ln -sf "${MAIN_ROOT}/.env.local" "${WT_DIR}/.env.local"
+  echo "✔ .env.local → ${MAIN_ROOT}/.env.local (symlink)"
+else
+  echo "⚠ ${MAIN_ROOT}/.env.local が見つかりません。手動で用意してください。"
+fi
+
+# 他にも worktree ごとに必要な未追跡ファイルがあればここに追記する:
+#   ln -sf "${MAIN_ROOT}/.claude/settings.local.json" "${WT_DIR}/.claude/settings.local.json"
+
+# --- node_modules を clonefile コピー --------------------------------------
+if [[ -d "${MAIN_ROOT}/node_modules" ]]; then
+  echo "▶ node_modules をコピー中..."
+  # macOS APFS: `cp -c` は clonefile(2) を使い一瞬で完了。COW なので main を壊さない。
+  # APFS でない / GNU coreutils 環境では通常コピーにフォールバック。
+  if ! cp -cR "${MAIN_ROOT}/node_modules" "${WT_DIR}/node_modules" 2>/dev/null; then
+    echo "  (clonefile が使えないため通常コピー)"
+    cp -R "${MAIN_ROOT}/node_modules" "${WT_DIR}/node_modules"
+  fi
+  echo "✔ node_modules をコピーしました"
+fi
+
+# --- lockfile との整合チェック --------------------------------------------
+echo "▶ npm install で lockfile との整合を確認..."
+( cd "${WT_DIR}" && npm install --prefer-offline --no-audit --no-fund )
+
+echo ""
+echo "✅ worktree 準備完了: ${WT_DIR}"
+echo "   cd ${WT_DIR}"


### PR DESCRIPTION
### 概要
ワークツリーを作るたびに `npm install` の実行や `.env.local` のコピーが必要で手間だった。これらを自動化するセットアップスクリプトと、それを呼び出すスキルを追加する。

### 変更内容
- `scripts/worktree-add.sh` を追加。新規 worktree を `<repo>.worktrees/<branch をハイフン化>` に作成し、
  - `.env.local` を main チェックアウトへの **symlink** で配置（常に同期、`.gitignore` 対象なのでコミットされない）
  - `node_modules` を **APFS clonefile**（`cp -c`）で高速コピー（コピーオンライト・各 worktree 独立）。APFS でなければ通常コピーにフォールバック
  - `npm install --prefer-offline --no-audit --no-fund` で lockfile との整合を確認
- `.agents/skills/git-create-worktree/`（`SKILL.md` / `README.md`）を追加。「ワークツリーを切って」「ワークツリーを作って」や `/git-create-worktree` で上記スクリプトを呼ぶ。`.claude/skills/git-create-worktree` は既存スキルと同様 `.agents/skills/` へのシンボリックリンク
- `.claude/settings.json` に `Bash(bash scripts/worktree-add.sh *)` を許可として追加（毎回の確認プロンプト回避）

### 実機テスト
本変更はアプリ挙動に影響しない（シェルスクリプト + スキル定義 + `.claude/settings.json`）ため、UI/実機テスト項目は対象外。
- [ ] iOS Safari で主要導線を確認（対象外）
- [ ] Android Chrome で主要導線を確認（対象外）
- [ ] PC（Chrome）で主要導線を確認（対象外）
- [ ] レスポンシブ表示崩れがないことを確認（対象外）
- [ ] エラーメッセージやバリデーション表示を確認（対象外）

### テスト方法
- `bash -n scripts/worktree-add.sh` で構文チェック（パス）
- 実際に `bash scripts/worktree-add.sh chore/worktree-setup-helper` を実行してこのブランチ用の worktree を作成し、`.env.local` の symlink 配置・`node_modules` の clonefile コピー・`npm install` が "up to date in 1s" で完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
