### PR TITLE
docs(agents): エージェントの破壊的操作に関するルールを追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,18 +21,18 @@
 
 Do **not** perform the following without an explicit user request or confirmation in the current session. When in doubt, ask before acting.
 
-- **Filesystem deletion** outside regenerable build artifacts. `rm -rf` / `find ... -delete` is forbidden against source, tests, configs, `.env*`, dotfiles, and any path outside common throwaway directories (`.next/`, `node_modules/`, `dist/`, `coverage/`, `/tmp/...`).
+- **Filesystem deletion** outside regenerable build artifacts. `rm -rf` / `find ... -delete` / `git clean -f` / `git clean -fd` is forbidden against source, tests, configs, `.env*`, dotfiles, untracked working files, and any path outside common throwaway directories (`.next/`, `node_modules/`, `dist/`, `coverage/`, `/tmp/...`).
 - **Git history rewriting**: `git reset --hard`, `git push --force` / `--force-with-lease`, `git rebase` against pushed branches, `git commit --amend` after push, `git filter-branch` / `git filter-repo`.
 - **Branch / tag / worktree destruction**: `git branch -D`, deleting remote branches (`git push origin --delete`, `git push origin :ref`), deleting tags, `git worktree remove --force`, `git stash drop` / `git stash clear`.
 - **Direct writes to `main` / `master`**: never push, merge, or rebase directly to the default branch. PRs only.
 - **Process termination beyond your own**: `kill -9`, `pkill`, `killall` against processes you did not start in the current session. Stopping a server you started yourself is fine; killing the user's editor, package manager, or unrelated dev servers is not.
-- **Lockfile / generated-config overwrites you did not intend**: do not commit incidental `package-lock.json` / `yarn.lock` / `pnpm-lock.yaml` / `Cargo.lock` churn produced by routine installs. Either revert the churn or call it out and ask before committing.
+- **Lockfile / generated-config overwrites you did not intend**: do not commit incidental `package-lock.json` / `yarn.lock` / `pnpm-lock.yaml` / `Cargo.lock` churn produced by routine installs. A lockfile-only diff with no accompanying `package.json` (or equivalent manifest) change is almost always incidental — revert it; do not commit lockfile changes unless they are a deliberate, in-scope part of the task. Otherwise call it out and ask before committing.
 - **Dependency surgery**: do not add, remove, or upgrade dependencies, or modify `package.json` scripts, outside the explicit scope of the task. See also CLAUDE.md.
 - **External service destructive calls**: Stripe refunds / subscription cancellations / customer deletion, Resend bulk sends, OpenAI / Gemini billing-relevant batch jobs, any account-deletion or data-purge endpoint. Read-only inspection is fine; writes that move money, send mail to real users, or delete records require confirmation.
 - **Supabase destructive operations** (re-stated from CLAUDE.md): `DROP`, `TRUNCATE`, `DELETE` without `WHERE` against production, migration `rollback` / `down`, Edge Function deletion. Read-only queries, applying forward migrations, and deploying Edge Functions are allowed per CLAUDE.md.
 - **Secrets**: never read `.env*` keys beyond the Supabase-scoped allowlist in CLAUDE.md, never print secret values to chat / commits / files, never paste them into external services.
 
-Regenerable build outputs (`.next/`, `node_modules/`, `coverage/`, build caches) may be removed freely as part of normal work.
+Regenerable build outputs and temporary paths (`.next/`, `node_modules/`, `dist/`, `coverage/`, `/tmp/...`, build caches) may be removed freely as part of normal work.
 
 ## UI Verification Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,23 @@
 - Pull request titles and bodies must always be written in Japanese in this repository.
 - Conventional Commit messages may remain in English, but PR-facing text must include Japanese.
 
+## Destructive Operations
+
+Do **not** perform the following without an explicit user request or confirmation in the current session. When in doubt, ask before acting.
+
+- **Filesystem deletion** outside regenerable build artifacts. `rm -rf` / `find ... -delete` is forbidden against source, tests, configs, `.env*`, dotfiles, and any path outside common throwaway directories (`.next/`, `node_modules/`, `dist/`, `coverage/`, `/tmp/...`).
+- **Git history rewriting**: `git reset --hard`, `git push --force` / `--force-with-lease`, `git rebase` against pushed branches, `git commit --amend` after push, `git filter-branch` / `git filter-repo`.
+- **Branch / tag / worktree destruction**: `git branch -D`, deleting remote branches (`git push origin --delete`, `git push origin :ref`), deleting tags, `git worktree remove --force`, `git stash drop` / `git stash clear`.
+- **Direct writes to `main` / `master`**: never push, merge, or rebase directly to the default branch. PRs only.
+- **Process termination beyond your own**: `kill -9`, `pkill`, `killall` against processes you did not start in the current session. Stopping a server you started yourself is fine; killing the user's editor, package manager, or unrelated dev servers is not.
+- **Lockfile / generated-config overwrites you did not intend**: do not commit incidental `package-lock.json` / `yarn.lock` / `pnpm-lock.yaml` / `Cargo.lock` churn produced by routine installs. Either revert the churn or call it out and ask before committing.
+- **Dependency surgery**: do not add, remove, or upgrade dependencies, or modify `package.json` scripts, outside the explicit scope of the task. See also CLAUDE.md.
+- **External service destructive calls**: Stripe refunds / subscription cancellations / customer deletion, Resend bulk sends, OpenAI / Gemini billing-relevant batch jobs, any account-deletion or data-purge endpoint. Read-only inspection is fine; writes that move money, send mail to real users, or delete records require confirmation.
+- **Supabase destructive operations** (re-stated from CLAUDE.md): `DROP`, `TRUNCATE`, `DELETE` without `WHERE` against production, migration `rollback` / `down`, Edge Function deletion. Read-only queries, applying forward migrations, and deploying Edge Functions are allowed per CLAUDE.md.
+- **Secrets**: never read `.env*` keys beyond the Supabase-scoped allowlist in CLAUDE.md, never print secret values to chat / commits / files, never paste them into external services.
+
+Regenerable build outputs (`.next/`, `node_modules/`, `coverage/`, build caches) may be removed freely as part of normal work.
+
 ## UI Verification Workflow
 
 When verifying UI changes via browser automation (Playwright MCP, Puppeteer, headless browsers, etc.):


### PR DESCRIPTION
## 概要

CLAUDE.md と AGENTS.md には個別の禁止事項（`main`/`master` への直接 push、Supabase 本番 DB の破壊的操作、`.env` の取り扱い、範囲外のリファクタ等）はあったが、エージェントが扱う**破壊的操作全般**に対する明文ルールが無かった。

このギャップを埋めるため、AGENTS.md（行動規範の正典）に `Destructive Operations` 節を追加する。

## なぜ AGENTS.md か

CLAUDE.md の冒頭に「`AGENTS.md` と本ファイルが矛盾した場合、`AGENTS.md` を優先」と明記されており、AGENTS.md がエージェントの行動規範の正典である。Codex / Cursor / Claude Code など複数のエージェントが共通参照するため、特定エージェント専用の CLAUDE.md ではなく AGENTS.md に置く。

## 変更内容

AGENTS.md に以下の節を新設（Pull Requests と UI Verification Workflow の間）：

- **Destructive Operations** — ユーザー承認なしに実行してはいけない不可逆操作を列挙
  - ファイルシステム削除（再生成可能な `.next/` / `node_modules/` 等は対象外と明記）
  - Git 履歴改変（`reset --hard` / `push --force` / amend after push 等）
  - ブランチ・タグ・worktree 削除
  - `main` / `master` への直接 push（既存ルールの再掲）
  - 自分が起動していないプロセスへの強制終了（`kill -9` / `pkill`）
  - 意図しないロックファイル上書き
  - 範囲外の依存更新（既存 CLAUDE.md ルールへの参照）
  - 外部サービスの破壊系 API 呼び出し（Stripe refund、Resend 一斉送信、アカウント削除エンドポイント等）
  - Supabase の破壊的操作（CLAUDE.md からの再掲、参照しやすさのため）
  - シークレット（`.env*` の Supabase 以外、チャット/コミットへの値貼り付け等）

## 検証

- ドキュメントのみの変更のため、lint / typecheck / test / build への影響は無し
- 既存 CLAUDE.md の Supabase 関連ルールと矛盾なし（再掲かつ参照を残している）

## ロールバック

- 不要な記述があれば該当 bullet を削除する変更を別途出すか、本 PR を revert
