### PR TITLE
fix(inspire): 生成プロンプトで image_0 の体型・肌色・体格を保持する

### DIFF
--- a/shared/generation/prompt-core.ts
+++ b/shared/generation/prompt-core.ts
@@ -281,14 +281,23 @@ export interface BuildInspirePromptOptions {
 }
 
 /**
- * 体型を image_1 に引きずられないための否定指示（全ブランチ末尾に付ける）。
+ * Inspire 生成で image_0 から保持すべき身体属性の正典リスト（英語の列挙文）。
  *
- * 「体格・肌色・手足の太さ・胸の大きさが image_1 に寄せられて変わる」という報告への対応。
- * 安全フィルタ（OpenAI / Gemini）を誘発しやすい `chest size` のような明示は避け、
- * `torso proportions` / `overall body silhouette` などの中立的な語で胴体全体を指す。
+ * 「体格・肌色・手足の太さ・胸の大きさが image_1 に寄せられて変わる」という報告への対応で、
+ * image_0 の説明 / item 1 の保持指示 / 否定ガード / styleSuffix の補強文を **すべてこの 1 つの
+ * 文字列から組み立てる**。こうしてリスト間のドリフト（片方だけ更新し忘れる）を構造的に防ぐ。
+ *
+ * 注:
+ *   - この shared モジュールは Next.js（API/Client）と Supabase Deno Worker の両方から import する。
+ *     共有定数はここ（shared/）に置く。lib/ には移さない（Worker から lib/ を import できないため）。
+ *   - 安全フィルタ（OpenAI / Gemini）を誘発しやすい `chest size` のような明示は含めず、
+ *     `torso proportions` / `overall body silhouette` で胴体全体を中立的に指す。
  */
-const INSPIRE_BODY_PRESERVATION_GUARD =
-  "Do NOT alter the character's body type to match image_1. Do NOT make the arms or legs thinner, thicker, longer, or shorter than image_0. Do NOT change the skin tone. Do NOT change the shoulder width, waist shape, torso proportions, or overall body silhouette from image_0.";
+const INSPIRE_BODY_ATTRIBUTES =
+  "skin tone, body proportions, limb thickness, limb length, shoulder width, waist shape, torso proportions, and overall body silhouette";
+
+/** 体型を image_1 に引きずられないための否定指示（全ブランチ末尾に付ける）。 */
+const INSPIRE_BODY_PRESERVATION_GUARD = `Do NOT alter the character's body type to match image_1. Keep image_0's ${INSPIRE_BODY_ATTRIBUTES}. Do NOT change the skin tone. Do NOT slim, enlarge, lengthen, shorten, or otherwise reshape any part of the body to match image_1.`;
 
 /**
  * Inspire 生成用のプロンプトを構築する。
@@ -303,7 +312,8 @@ const INSPIRE_BODY_PRESERVATION_GUARD =
  * 体型保持について:
  *   image_0 の体格・肌色・四肢の太さ・全体シルエットは image_1 に寄せず維持する。
  *   保持指示（image_0 の説明 + item 1）と否定指示（`INSPIRE_BODY_PRESERVATION_GUARD`）と
- *   styleSuffix の補強文を全 5 ブランチ・実写/イラスト両バリアントに共通で入れる。
+ *   styleSuffix の補強文を全 5 ブランチ・実写/イラスト両バリアントに共通で入れ、
+ *   保持属性のリストはすべて `INSPIRE_BODY_ATTRIBUTES` 1 箇所に集約している。
  *
  * 5 ブランチ:
  *   - keep_all (overrideTarget=null): テンプレのアングル/ポーズ/衣装/背景を維持してキャラだけ差し替える
@@ -315,17 +325,24 @@ const INSPIRE_BODY_PRESERVATION_GUARD =
 export function buildInspirePrompt(options: BuildInspirePromptOptions): string {
   const { overrideTarget, sourceImageType = "illustration" } = options;
 
-  const styleSuffix =
+  const styleBodyReinforcement = ` Even ${
     sourceImageType === "real"
-      ? "Generate a photorealistic result. Captured with an 85mm portrait lens. Use realistic lighting consistent with image_1's environment. Even in this photorealistic style, keep image_0's original body proportions, limb thickness, shoulder width, waist shape, torso proportions, and overall body silhouette — do not reshape the body to match image_1."
-      : "Match the illustration touch and artistic style of image_1 (the style template). Even when matching the art style, keep image_0's original body proportions, limb thickness, shoulder width, waist shape, torso proportions, and overall body silhouette — do not reshape the body to match image_1.";
+      ? "in this photorealistic style"
+      : "when matching the art style"
+  }, keep image_0's ${INSPIRE_BODY_ATTRIBUTES} — do not reshape the body to match image_1.`;
+
+  const styleSuffix =
+    (sourceImageType === "real"
+      ? "Generate a photorealistic result. Captured with an 85mm portrait lens. Use realistic lighting consistent with image_1's environment."
+      : "Match the illustration touch and artistic style of image_1 (the style template).") +
+    styleBodyReinforcement;
 
   const basePrefix = `CRITICAL INSTRUCTION: This is an Image-to-Image task with two reference images:
-- image_0 (User Character): the character identity to render in the output, including face, hair, skin tone, body proportions, limb thickness, arm and leg length, shoulder width, waist shape, and overall body silhouette.
+- image_0 (User Character): the character identity to render in the output, including face, hair, ${INSPIRE_BODY_ATTRIBUTES}.
 - image_1 (Style Template): the visual reference for composition, framing, camera angle, pose, outfit, background, and overall vibe.
 
 You MUST produce a single output image that:
-1. Replaces the character in image_1 with the character from image_0. Preserve image_0's facial features, hair, identity, skin tone, body proportions, arm and leg thickness, limb length, shoulder width, waist shape, torso proportions, and overall body silhouette.
+1. Replaces the character in image_1 with the character from image_0. Preserve image_0's facial features, hair, identity, ${INSPIRE_BODY_ATTRIBUTES}.
 2. Strictly preserves image_1's aspect ratio, framing, and crop. Do NOT extend or change the canvas.`;
 
   if (overrideTarget === null) {

--- a/shared/generation/prompt-core.ts
+++ b/shared/generation/prompt-core.ts
@@ -281,6 +281,16 @@ export interface BuildInspirePromptOptions {
 }
 
 /**
+ * 体型を image_1 に引きずられないための否定指示（全ブランチ末尾に付ける）。
+ *
+ * 「体格・肌色・手足の太さ・胸の大きさが image_1 に寄せられて変わる」という報告への対応。
+ * 安全フィルタ（OpenAI / Gemini）を誘発しやすい `chest size` のような明示は避け、
+ * `torso proportions` / `overall body silhouette` などの中立的な語で胴体全体を指す。
+ */
+const INSPIRE_BODY_PRESERVATION_GUARD =
+  "Do NOT alter the character's body type to match image_1. Do NOT make the arms or legs thinner, thicker, longer, or shorter than image_0. Do NOT change the skin tone. Do NOT change the shoulder width, waist shape, torso proportions, or overall body silhouette from image_0.";
+
+/**
  * Inspire 生成用のプロンプトを構築する。
  *
  * 入力画像の順序は **必ず以下** とする（Worker 側で揃えること）:
@@ -289,6 +299,11 @@ export interface BuildInspirePromptOptions {
  *
  * 出力フレームの比率はテンプレ（image_1）に合わせる。これはテンプレートの構図を
  * 完全に維持するために必須。Worker 側の `resolveOpenAITargetSize` も image_1 を起点に算出する。
+ *
+ * 体型保持について:
+ *   image_0 の体格・肌色・四肢の太さ・全体シルエットは image_1 に寄せず維持する。
+ *   保持指示（image_0 の説明 + item 1）と否定指示（`INSPIRE_BODY_PRESERVATION_GUARD`）と
+ *   styleSuffix の補強文を全 5 ブランチ・実写/イラスト両バリアントに共通で入れる。
  *
  * 5 ブランチ:
  *   - keep_all (overrideTarget=null): テンプレのアングル/ポーズ/衣装/背景を維持してキャラだけ差し替える
@@ -302,22 +317,23 @@ export function buildInspirePrompt(options: BuildInspirePromptOptions): string {
 
   const styleSuffix =
     sourceImageType === "real"
-      ? "Generate a photorealistic result. Captured with an 85mm portrait lens. Use realistic lighting consistent with image_1's environment."
-      : "Match the illustration touch and artistic style of image_1 (the style template).";
+      ? "Generate a photorealistic result. Captured with an 85mm portrait lens. Use realistic lighting consistent with image_1's environment. Even in this photorealistic style, keep image_0's original body proportions, limb thickness, shoulder width, waist shape, torso proportions, and overall body silhouette — do not reshape the body to match image_1."
+      : "Match the illustration touch and artistic style of image_1 (the style template). Even when matching the art style, keep image_0's original body proportions, limb thickness, shoulder width, waist shape, torso proportions, and overall body silhouette — do not reshape the body to match image_1.";
 
   const basePrefix = `CRITICAL INSTRUCTION: This is an Image-to-Image task with two reference images:
-- image_0 (User Character): the character (face, hair, identity) to render in the output.
-- image_1 (Style Template): the visual reference for composition, framing, and overall vibe.
+- image_0 (User Character): the character identity to render in the output, including face, hair, skin tone, body proportions, limb thickness, arm and leg length, shoulder width, waist shape, and overall body silhouette.
+- image_1 (Style Template): the visual reference for composition, framing, camera angle, pose, outfit, background, and overall vibe.
 
 You MUST produce a single output image that:
-1. Replaces the character in image_1 with the character from image_0 (preserve image_0's facial features, hair, and identity).
+1. Replaces the character in image_1 with the character from image_0. Preserve image_0's facial features, hair, identity, skin tone, body proportions, arm and leg thickness, limb length, shoulder width, waist shape, torso proportions, and overall body silhouette.
 2. Strictly preserves image_1's aspect ratio, framing, and crop. Do NOT extend or change the canvas.`;
 
   if (overrideTarget === null) {
     return [
       basePrefix,
-      `3. KEEP ALL of the following from image_1: camera angle, pose, outfit, and background. Only the character identity is taken from image_0.`,
-      `4. The output must look as if the character from image_0 stepped into image_1's exact scene with the same pose, outfit, and background.`,
+      `3. KEEP ALL of the following from image_1: camera angle, pose, outfit, and background. Only the character identity and body come from image_0.`,
+      `4. The output must look as if the character from image_0 stepped into image_1's exact scene with the same camera angle, pose, outfit, and background, while keeping image_0's original body proportions and physical characteristics.`,
+      `5. ${INSPIRE_BODY_PRESERVATION_GUARD}`,
       styleSuffix,
     ].join("\n\n");
   }
@@ -327,7 +343,8 @@ You MUST produce a single output image that:
       basePrefix,
       `3. KEEP from image_1: pose, outfit, and background.`,
       `4. CHANGE: regenerate the camera angle to a natural alternative (e.g., a different viewpoint of the same scene) while keeping the rest faithful to image_1.`,
-      `5. The character identity must come from image_0.`,
+      `5. The character identity and body come from image_0.`,
+      `6. ${INSPIRE_BODY_PRESERVATION_GUARD}`,
       styleSuffix,
     ].join("\n\n");
   }
@@ -337,7 +354,8 @@ You MUST produce a single output image that:
       basePrefix,
       `3. KEEP from image_1: camera angle, outfit, and background.`,
       `4. CHANGE: regenerate the pose to a natural alternative that fits the same scene and outfit.`,
-      `5. The character identity must come from image_0.`,
+      `5. The character identity and body come from image_0.`,
+      `6. ${INSPIRE_BODY_PRESERVATION_GUARD}`,
       styleSuffix,
     ].join("\n\n");
   }
@@ -347,7 +365,8 @@ You MUST produce a single output image that:
       basePrefix,
       `3. KEEP from image_1: camera angle, pose, and background.`,
       `4. CHANGE: regenerate the outfit to a natural alternative that suits the scene and pose.`,
-      `5. The character identity must come from image_0.`,
+      `5. The character identity and body come from image_0.`,
+      `6. ${INSPIRE_BODY_PRESERVATION_GUARD}`,
       styleSuffix,
     ].join("\n\n");
   }
@@ -357,7 +376,8 @@ You MUST produce a single output image that:
       basePrefix,
       `3. KEEP from image_1: camera angle, pose, and outfit.`,
       `4. CHANGE: regenerate the background to a natural alternative that complements the outfit and pose.`,
-      `5. The character identity must come from image_0.`,
+      `5. The character identity and body come from image_0.`,
+      `6. ${INSPIRE_BODY_PRESERVATION_GUARD}`,
       styleSuffix,
     ].join("\n\n");
   }

--- a/tests/unit/shared/inspire-prompt.test.ts
+++ b/tests/unit/shared/inspire-prompt.test.ts
@@ -127,5 +127,24 @@ describe("buildInspirePrompt", () => {
         "Do NOT alter the character's body type to match image_1"
       );
     });
+
+    // 保持属性リストは INSPIRE_BODY_ATTRIBUTES 1 箇所に集約しているので、
+    // image_0 の説明 / item 1 / 否定ガード / styleSuffix 補強文に同じ列挙文が複数回現れる。
+    // ここを変えたらこのテストも更新する（= リストのドリフトに気づける）。
+    test("身体属性の正典リストが全分岐 × 実写/イラストで複数箇所に現れる", () => {
+      const phrase =
+        "skin tone, body proportions, limb thickness, limb length, shoulder width, waist shape, torso proportions, and overall body silhouette";
+      for (const target of targets) {
+        for (const sourceImageType of sources) {
+          const prompt = buildInspirePrompt({
+            overrideTarget: target,
+            sourceImageType,
+          });
+          const occurrences = prompt.split(phrase).length - 1;
+          // image_0 の説明 + item 1 + 否定ガード + styleSuffix 補強文 = 4 箇所以上
+          expect(occurrences).toBeGreaterThanOrEqual(4);
+        }
+      }
+    });
   });
 });

--- a/tests/unit/shared/inspire-prompt.test.ts
+++ b/tests/unit/shared/inspire-prompt.test.ts
@@ -71,4 +71,61 @@ describe("buildInspirePrompt", () => {
       );
     }
   });
+
+  // 「体格・肌色・手足の太さ・胸の大きさが image_1 に寄せられて変わる」報告への対応。
+  // 体型保持の指示が全 5 ブランチ・実写/イラスト両バリアントに入っていることを確認する。
+  describe("body preservation", () => {
+    const targets = [null, "angle", "pose", "outfit", "background"] as const;
+    const sources = ["illustration", "real"] as const;
+
+    test("全分岐 × 実写/イラストで image_0 の体型保持指示と否定指示を含む", () => {
+      for (const target of targets) {
+        for (const sourceImageType of sources) {
+          const prompt = buildInspirePrompt({
+            overrideTarget: target,
+            sourceImageType,
+          });
+          // image_0 の説明 / item 1 の保持指示
+          expect(prompt).toContain("skin tone");
+          expect(prompt).toContain("limb");
+          expect(prompt).toContain("shoulder width");
+          expect(prompt).toContain("overall body silhouette");
+          // 否定指示ブロック
+          expect(prompt).toContain(
+            "Do NOT alter the character's body type to match image_1"
+          );
+          expect(prompt).toContain("Do NOT change the skin tone");
+          // styleSuffix 側の補強文
+          expect(prompt).toContain("do not reshape the body to match image_1");
+        }
+      }
+    });
+
+    test("安全フィルタを誘発しやすい文言（chest / breast）を含まない", () => {
+      for (const target of targets) {
+        for (const sourceImageType of sources) {
+          const prompt = buildInspirePrompt({
+            overrideTarget: target,
+            sourceImageType,
+          }).toLowerCase();
+          expect(prompt).not.toContain("chest");
+          expect(prompt).not.toContain("breast");
+        }
+      }
+    });
+
+    test("override 系でも item 4 の上書き指示と body 専用の否定指示が両立する", () => {
+      const outfit = buildInspirePrompt({ overrideTarget: "outfit" });
+      expect(outfit).toContain("CHANGE: regenerate the outfit");
+      expect(outfit).toContain(
+        "Do NOT alter the character's body type to match image_1"
+      );
+
+      const pose = buildInspirePrompt({ overrideTarget: "pose" });
+      expect(pose).toContain("CHANGE: regenerate the pose");
+      expect(pose).toContain(
+        "Do NOT alter the character's body type to match image_1"
+      );
+    });
+  });
 });


### PR DESCRIPTION
## 概要

inspire（コード内部では `user_style_templates`）の生成で、ユーザーキャラ（`image_0`）をテンプレート（`image_1`）に合成する際、**体格・肌色・手足の太さ・胸まわり（体型シルエット）が `image_1` に寄せられて変わってしまう**という報告への対応。

原因：現行プロンプトの item 1 は `face, hair, identity` しか保持指示しておらず、`image_0` の身体属性をどこから取るか明示していないため、`image_1` の体型シルエットがアイデンティティ参照を上書きしていた。

対応：`buildInspirePrompt()` に **保持すべき身体属性の明示列挙**（positive）と **`image_1` に寄せないための否定指示**（negative）を、**全 5 ブランチ（keep_all / angle / pose / outfit / background）と実写・イラスト両バリアント**に共通で入れる。`basePrefix` 側に寄せたので、`keep_all` 以外のブランチにも漏れなく効く。

## 変更内容

`shared/generation/prompt-core.ts`：

- `basePrefix`（`image_0` の説明 + item 1）に保持属性を列挙：`skin tone / body proportions / limb thickness / arm-leg length / shoulder width / waist shape / torso proportions / overall body silhouette`
- 否定指示の定数 `INSPIRE_BODY_PRESERVATION_GUARD` を新設し、5 ブランチの末尾（item 5 または 6）に付与：「体型を `image_1` に寄せて変えるな／四肢を太く・細く・長く・短くするな／肌色を変えるな／肩幅・ウエスト・胴体プロポーション・全体シルエットを変えるな」
- `styleSuffix` の illustration / real（実写・85mm レンズ）両方に「アートスタイル/写実に合わせても `image_0` の体型は維持しろ」の補強文を追加
- 否定指示は **body 専用**にしたので、`outfit` / `pose` 等の上書きブランチの「衣装/ポーズを変える」指示と矛盾しない
- 安全フィルタ（OpenAI / Gemini）を誘発しやすい `chest size` の明示は使わず、`torso proportions` / `overall body silhouette` など中立的な語に統一

`tests/unit/shared/inspire-prompt.test.ts`：

- 全 5 ブランチ × 実写/イラストで保持指示・否定指示・styleSuffix 補強文が含まれることを検証するケースを追加
- `chest` / `breast` を含まない（安全文言）ことの検証を追加
- 上書きブランチで「衣装/ポーズの上書き指示」と「body 専用の否定指示」が両立することの検証を追加

### 反映範囲

- 審査前のテスト生成（プレビュー、`overrideTarget=null` 固定）— `app/api/style-templates/preview-generation/handler.ts`
- 承認後の `/inspire/[templateId]` 生成 — `supabase/functions/image-gen-worker/index.ts`（同じ `shared/generation/prompt-core.ts` を参照）

### A/B テストについて

現状 inspire は運営（申請ホワイトリスト）しか生成できないため、A/B は実施せず直接置換。問題が出れば revert で戻せる。

## プロンプト比較（keep_all × illustration）

**Before**
```
CRITICAL INSTRUCTION: This is an Image-to-Image task with two reference images:
- image_0 (User Character): the character (face, hair, identity) to render in the output.
- image_1 (Style Template): the visual reference for composition, framing, and overall vibe.

You MUST produce a single output image that:
1. Replaces the character in image_1 with the character from image_0 (preserve image_0's facial features, hair, and identity).
2. Strictly preserves image_1's aspect ratio, framing, and crop. Do NOT extend or change the canvas.

3. KEEP ALL of the following from image_1: camera angle, pose, outfit, and background. Only the character identity is taken from image_0.

4. The output must look as if the character from image_0 stepped into image_1's exact scene with the same pose, outfit, and background.

Match the illustration touch and artistic style of image_1 (the style template).
```

**After**
```
CRITICAL INSTRUCTION: This is an Image-to-Image task with two reference images:
- image_0 (User Character): the character identity to render in the output, including face, hair, skin tone, body proportions, limb thickness, arm and leg length, shoulder width, waist shape, and overall body silhouette.
- image_1 (Style Template): the visual reference for composition, framing, camera angle, pose, outfit, background, and overall vibe.

You MUST produce a single output image that:
1. Replaces the character in image_1 with the character from image_0. Preserve image_0's facial features, hair, identity, skin tone, body proportions, arm and leg thickness, limb length, shoulder width, waist shape, torso proportions, and overall body silhouette.
2. Strictly preserves image_1's aspect ratio, framing, and crop. Do NOT extend or change the canvas.

3. KEEP ALL of the following from image_1: camera angle, pose, outfit, and background. Only the character identity and body come from image_0.

4. The output must look as if the character from image_0 stepped into image_1's exact scene with the same camera angle, pose, outfit, and background, while keeping image_0's original body proportions and physical characteristics.

5. Do NOT alter the character's body type to match image_1. Do NOT make the arms or legs thinner, thicker, longer, or shorter than image_0. Do NOT change the skin tone. Do NOT change the shoulder width, waist shape, torso proportions, or overall body silhouette from image_0.

Match the illustration touch and artistic style of image_1 (the style template). Even when matching the art style, keep image_0's original body proportions, limb thickness, shoulder width, waist shape, torso proportions, and overall body silhouette — do not reshape the body to match image_1.
```

（`angle` / `pose` / `outfit` / `background` ブランチも item 3〜4 はブランチ別のまま、item 5 に「identity と body は image_0 から」、item 6 に上記の否定指示が入る。`sourceImageType=real` のときは末尾が 85mm レンズの写実版 + 体型保持補強文になる。）

## 検証

- `npm run lint` — 変更ファイルにエラー・新規警告なし
- `npm run typecheck` — 本変更起因の新規エラーなし
- `npm run test` — `tests/` 配下全パス（`inspire-prompt.test.ts` の追加ケース含む）
- `npm run build -- --webpack` — 成功

## 注意・フォローアップ

- 否定指示は image 系モデルでは positive 指示より追従が弱いため、効果が薄ければ positive 列挙（item 1 / styleSuffix）側をさらに強化する余地あり
- `chest` 等の明示を外したことで安全ブロック率は下がる方向だが、ロールアウト後に `SAFETY_POLICY_BLOCKED_ERROR` の頻度を一応見ておくとよい

## ロールバック

問題が出た場合はコミット `8f98b9d` を revert すれば旧プロンプトに戻る。
