### PR TITLE
fix(inspire): 上半身ソースの頭身崩れに対応・OpenAI 品質を medium に引き上げ

### DIFF
--- a/app/api/style-templates/preview-generation/handler.ts
+++ b/app/api/style-templates/preview-generation/handler.ts
@@ -294,6 +294,9 @@ export async function handlePreviewGeneration(
         targetSizeBaseIndex: 1,
         timeoutMs: OPENAI_TIMEOUT_MS,
         n: 1,
+        // inspire はキャラ識別 × テンプレ構図の合成で難度が高いため
+        // OpenAI の品質ティアを medium に引き上げる（既定の low は細部が崩れやすい）。
+        quality: "medium",
       });
       const result = results[0];
       const previewPath = `${user.id}/preview/${draftId}-openai.png`;

--- a/features/generation/lib/openai-image.ts
+++ b/features/generation/lib/openai-image.ts
@@ -21,17 +21,11 @@ import {
   OPENAI_PROVIDER_ERROR,
   SAFETY_POLICY_BLOCKED_ERROR,
 } from "@/shared/generation/errors";
+import type { OpenAIImageQuality } from "@/shared/generation/openai-types";
 
 const OPENAI_IMAGES_EDITS_URL = "https://api.openai.com/v1/images/edits";
 
 export type OpenAITargetSize = "1024x1024" | "1024x1536" | "1536x1024";
-
-/**
- * OpenAI gpt-image-2 の `quality` パラメータ。
- * "low" は最も高速・低コスト、"high" は最も高品質・高コスト。
- * 既定は "low"。
- */
-export type OpenAIImageQuality = "low" | "medium" | "high" | "auto";
 
 export interface OpenAIImageInput {
   base64: string;

--- a/features/generation/lib/openai-image.ts
+++ b/features/generation/lib/openai-image.ts
@@ -1,7 +1,10 @@
 import "server-only";
 
 /**
- * OpenAI gpt-image-2 (quality=low) の Node ランタイム向けクライアント。
+ * OpenAI gpt-image-2 の Node ランタイム向けクライアント。
+ *
+ * `quality` は呼び出し側から渡せる（既定 "low"）。inspire のように難度の高い
+ * 合成タスクは "medium" を指定して品質を引き上げる。
  *
  * 同等の Deno 実装が `supabase/functions/image-gen-worker/openai-image.ts` にあり、
  * Edge Function ワーカーで使われている。本ファイルは新設の guest sync ルート
@@ -23,6 +26,13 @@ const OPENAI_IMAGES_EDITS_URL = "https://api.openai.com/v1/images/edits";
 
 export type OpenAITargetSize = "1024x1024" | "1024x1536" | "1536x1024";
 
+/**
+ * OpenAI gpt-image-2 の `quality` パラメータ。
+ * "low" は最も高速・低コスト、"high" は最も高品質・高コスト。
+ * 既定は "low"。
+ */
+export type OpenAIImageQuality = "low" | "medium" | "high" | "auto";
+
 export interface OpenAIImageInput {
   base64: string;
   mimeType: string;
@@ -41,6 +51,10 @@ export interface CallOpenAIImageEditParams {
    * API キーの差し替え用。既定では `process.env.OPENAI_API_KEY` を読む。
    */
   apiKey?: string;
+  /**
+   * 生成品質。省略時は "low"。inspire のように合成難度が高い経路では "medium" を指定する。
+   */
+  quality?: OpenAIImageQuality;
 }
 
 /**
@@ -63,6 +77,10 @@ export interface CallOpenAIImageEditMultiInputParams {
   fetchFn?: typeof fetch;
   apiKey?: string;
   n?: number;
+  /**
+   * 生成品質。省略時は "low"。inspire のように合成難度が高い経路では "medium" を指定する。
+   */
+  quality?: OpenAIImageQuality;
 }
 
 export interface OpenAIImageEditResult {
@@ -193,7 +211,8 @@ export function resolveOpenAITargetSize(
 }
 
 /**
- * OpenAI gpt-image-2 (quality=low) を呼び出して画像編集を実行する Node 版。
+ * OpenAI gpt-image-2 を呼び出して画像編集を実行する Node 版。
+ * `quality` は呼び出し側から指定可能（省略時は "low"）。
  *
  * Deno 版と同じ振る舞い:
  * - GIF 入力は再試行不可エラーで早期失敗（OPENAI_PROVIDER_ERROR プレフィックス付き）
@@ -240,7 +259,7 @@ export async function callOpenAIImageEditBatch(
   form.append("prompt", params.prompt);
   form.append("image[]", file);
   form.append("size", targetSize);
-  form.append("quality", "low");
+  form.append("quality", params.quality ?? "low");
   form.append("moderation", "low");
   form.append("output_format", "png");
   form.append("n", String(requestedImageCount));
@@ -368,7 +387,7 @@ export async function callOpenAIImageEditMultiInput(
     form.append("image[]", file);
   }
   form.append("size", targetSize);
-  form.append("quality", "low");
+  form.append("quality", params.quality ?? "low");
   form.append("moderation", "low");
   form.append("output_format", "png");
   form.append("n", String(requestedImageCount));

--- a/shared/generation/openai-types.ts
+++ b/shared/generation/openai-types.ts
@@ -1,0 +1,19 @@
+/**
+ * OpenAI gpt-image-2 関連の共有型。
+ *
+ * Next.js（`features/generation/lib/openai-image.ts`）と Supabase Deno Worker
+ * （`supabase/functions/image-gen-worker/openai-image.ts`）の両方から import する。
+ * 既存パターン: `shared/generation/errors.ts` と同じく、新しい OpenAI 共有型は
+ * ここに集約する（既存の重複型 `OpenAITargetSize` / `OpenAIImageInput` 等の整理は
+ * スコープ別 PR で扱う）。
+ */
+
+/**
+ * OpenAI gpt-image-2 の `quality` パラメータ。
+ *
+ * - "low": 最も高速・低コスト（既定）
+ * - "medium": 中品質（inspire のように合成難度が高い経路で指定）
+ * - "high": 最高品質・高コスト
+ * - "auto": OpenAI に自動選択させる
+ */
+export type OpenAIImageQuality = "low" | "medium" | "high" | "auto";

--- a/shared/generation/prompt-core.ts
+++ b/shared/generation/prompt-core.ts
@@ -296,8 +296,16 @@ export interface BuildInspirePromptOptions {
 const INSPIRE_BODY_ATTRIBUTES =
   "skin tone, body proportions, limb thickness, limb length, shoulder width, waist shape, torso proportions, and overall body silhouette";
 
-/** 体型を image_1 に引きずられないための否定指示（全ブランチ末尾に付ける）。 */
-const INSPIRE_BODY_PRESERVATION_GUARD = `Do NOT alter the character's body type to match image_1. Keep image_0's ${INSPIRE_BODY_ATTRIBUTES}. Do NOT change the skin tone. Do NOT slim, enlarge, lengthen, shorten, or otherwise reshape any part of the body to match image_1.`;
+/**
+ * 体型を image_1 に引きずられないための否定指示（全ブランチ末尾に付ける）。
+ *
+ * 最後の一文は「image_0 が上半身のみ × image_1 が全身ポーズ」のケースへの配慮:
+ * このとき image_0 には下半身の参照が無いため model は補完するしかないが、
+ * 補完元として image_1 を流用しつつ image_0 の頭サイズだけ据え置く → 頭身が崩れる、
+ * という典型的なアーティファクトを避けるよう、頭身比の一貫性を明示的に要求する。
+ * ソース画像の指定（上半身 / 全身）を制限せず prompt 側で対応する方針。
+ */
+const INSPIRE_BODY_PRESERVATION_GUARD = `Do NOT alter the character's body type to match image_1. Keep image_0's ${INSPIRE_BODY_ATTRIBUTES}. Do NOT change the skin tone. Do NOT slim, enlarge, lengthen, shorten, or otherwise reshape any part of the body to match image_1. If image_0 shows only the upper body but image_1's framing requires the lower body to be drawn, extrapolate the missing parts naturally from image_0's visible proportions (head-to-shoulder ratio, torso width) and keep a realistic, consistent head-to-body ratio across the whole figure; do not leave the head oversized or undersized relative to the generated body.`;
 
 /**
  * Inspire 生成用のプロンプトを構築する。

--- a/supabase/functions/image-gen-worker/index.ts
+++ b/supabase/functions/image-gen-worker/index.ts
@@ -1730,6 +1730,9 @@ Deno.serve(async () => {
                             targetSizeBaseIndex: 1,
                             timeoutMs: OPENAI_REQUEST_TIMEOUT_MS,
                             n: requestedImageCount,
+                            // inspire はキャラ識別 × テンプレ構図の合成で難度が高いため
+                            // OpenAI の品質ティアを medium に引き上げる（既定の low は細部が崩れやすい）。
+                            quality: "medium",
                           })
                         : callOpenAIImageEditBatch({
                             prompt: basePromptText,

--- a/supabase/functions/image-gen-worker/openai-image.ts
+++ b/supabase/functions/image-gen-worker/openai-image.ts
@@ -1,6 +1,7 @@
-// OpenAI gpt-image-2 (quality=low) クライアント
+// OpenAI gpt-image-2 クライアント
 // - POST https://api.openai.com/v1/images/edits を multipart/form-data で叩く
 // - 入力画像のアスペクト比から 1024x1024 / 1024x1536 / 1536x1024 を選択
+// - `quality` は呼び出し側から指定可能（省略時は "low"）。inspire 経路では "medium" を使う。
 // - moderation/safety 系のエラーは SAFETY_POLICY_BLOCKED_ERROR に統一
 // - GIF 入力は OpenAI 経路では非対応（呼び出し側で再試行不可エラーとして扱う）
 
@@ -14,6 +15,12 @@ const OPENAI_IMAGES_EDITS_URL = "https://api.openai.com/v1/images/edits";
 
 export type OpenAITargetSize = "1024x1024" | "1024x1536" | "1536x1024";
 
+/**
+ * OpenAI gpt-image-2 の `quality` パラメータ。省略時は "low"。
+ * inspire のように合成難度が高い経路では "medium" を指定する。
+ */
+export type OpenAIImageQuality = "low" | "medium" | "high" | "auto";
+
 export interface OpenAIImageInput {
   base64: string;
   mimeType: string;
@@ -23,6 +30,7 @@ export interface CallOpenAIImageEditParams {
   prompt: string;
   inputImage: OpenAIImageInput;
   timeoutMs: number;
+  quality?: OpenAIImageQuality;
 }
 
 export interface OpenAIImageEditResult {
@@ -148,7 +156,7 @@ export function resolveOpenAITargetSize(
 }
 
 /**
- * OpenAI gpt-image-2 (quality=low) を呼び出して画像編集を実行。
+ * OpenAI gpt-image-2 を呼び出して画像編集を実行（`quality` は呼び出し側指定、省略時 "low"）。
  *
  * - GIF 入力は再試行不可エラーで早期失敗
  * - HTTP 400 + content_policy_violation または message に moderation/safety を含む
@@ -199,7 +207,7 @@ export async function callOpenAIImageEditBatch(
   form.append("prompt", params.prompt);
   form.append("image[]", file);
   form.append("size", targetSize);
-  form.append("quality", "low");
+  form.append("quality", params.quality ?? "low");
   form.append("moderation", "low");
   form.append("output_format", "png");
   form.append("n", String(requestedImageCount));
@@ -289,6 +297,7 @@ export interface CallOpenAIImageEditMultiInputParams {
   timeoutMs: number;
   targetSizeBaseIndex?: number;
   n?: number;
+  quality?: OpenAIImageQuality;
 }
 
 export async function callOpenAIImageEditMultiInputBatch(
@@ -329,7 +338,7 @@ export async function callOpenAIImageEditMultiInputBatch(
     form.append("image[]", file);
   }
   form.append("size", targetSize);
-  form.append("quality", "low");
+  form.append("quality", params.quality ?? "low");
   form.append("moderation", "low");
   form.append("output_format", "png");
   form.append("n", String(requestedImageCount));

--- a/supabase/functions/image-gen-worker/openai-image.ts
+++ b/supabase/functions/image-gen-worker/openai-image.ts
@@ -10,16 +10,11 @@ import {
   OPENAI_PROVIDER_ERROR,
   SAFETY_POLICY_BLOCKED_ERROR,
 } from "../../../shared/generation/errors.ts";
+import type { OpenAIImageQuality } from "../../../shared/generation/openai-types.ts";
 
 const OPENAI_IMAGES_EDITS_URL = "https://api.openai.com/v1/images/edits";
 
 export type OpenAITargetSize = "1024x1024" | "1024x1536" | "1536x1024";
-
-/**
- * OpenAI gpt-image-2 の `quality` パラメータ。省略時は "low"。
- * inspire のように合成難度が高い経路では "medium" を指定する。
- */
-export type OpenAIImageQuality = "low" | "medium" | "high" | "auto";
 
 export interface OpenAIImageInput {
   base64: string;

--- a/tests/unit/shared/inspire-prompt.test.ts
+++ b/tests/unit/shared/inspire-prompt.test.ts
@@ -146,5 +146,22 @@ describe("buildInspirePrompt", () => {
         }
       }
     });
+
+    // 「image_0 が上半身のみ × image_1 が全身」のときに頭でっかちになる
+    // アーティファクトを抑えるための頭身比保持指示が含まれること。
+    test("頭身比を一貫させる指示が全分岐 × 実写/イラストに含まれる", () => {
+      for (const target of targets) {
+        for (const sourceImageType of sources) {
+          const prompt = buildInspirePrompt({
+            overrideTarget: target,
+            sourceImageType,
+          });
+          expect(prompt).toContain(
+            "If image_0 shows only the upper body but image_1's framing requires the lower body to be drawn"
+          );
+          expect(prompt).toContain("head-to-body ratio");
+        }
+      }
+    });
   });
 });


### PR DESCRIPTION
## 概要

inspire の生成で、**「上半身のみのマイキャラ画像 × 全身ポーズのテンプレート」のとき、生成された全身の下半身が image_1（テンプレ）から補完され、image_0 の頭サイズだけが据え置かれて頭身がちぐはぐ**になる、という報告への対応。

ユーザーにソース画像の指定（上半身 / 全身）を強制したくない（上半身のみだからこそ良いポーズというテンプレートもあるため）方針なので、prompt 側で対応する。あわせて OpenAI の品質ティアを引き上げて細部の整合を底上げする。

## 変更内容

### prompt の補強（`shared/generation/prompt-core.ts`）

`INSPIRE_BODY_PRESERVATION_GUARD` の末尾に「image_0 が上半身のみ × image_1 が全身要求」ケース向けの一文を追記：

> If image_0 shows only the upper body but image_1's framing requires the lower body to be drawn, extrapolate the missing parts naturally from image_0's visible proportions (head-to-shoulder ratio, torso width) and keep a realistic, consistent head-to-body ratio across the whole figure; do not leave the head oversized or undersized relative to the generated body.

- 下半身を image_0 の見えている比率（頭・肩・胴の比率）から自然に外挿する
- 頭身比の一貫性を保つ（頭だけ大きく/小さくしない）

### OpenAI 品質ティアを medium に（inspire 経路のみ）

- `OpenAIImageQuality` 型（`"low" | "medium" | "high" | "auto"`）と `quality?` パラメータを Next.js / Worker 両方のクライアントに追加。既定は `"low"` で既存呼び出しに影響なし
- inspire 関連の 2 経路で `quality: "medium"` を指定：
  - 審査前プレビュー：`app/api/style-templates/preview-generation/handler.ts`（`callOpenAIImageEditMultiInput`）
  - 公開後の `/inspire/[templateId]` 生成：`supabase/functions/image-gen-worker/index.ts`（`callOpenAIImageEditMultiInputBatch`、`isInspireOpenAI` 分岐）
- 非 inspire 経路（coordinate / full_body / chibi 等の `callOpenAIImageEditBatch` 呼び出し）は **既定の `"low"` のまま**で何も変わらない

### タイムアウト

`OPENAI_TIMEOUT_MS` / `OPENAI_REQUEST_TIMEOUT_MS` ともに 90 秒。medium でも経験的に十分余裕がある想定で据え置き。実運用で逼迫するようなら別途引き上げる。

### テスト

`tests/unit/shared/inspire-prompt.test.ts` に、頭身比保持指示が全 5 ブランチ × 実写/イラストに含まれることを検証するケースを追加。

## 期待される効果

- 「上半身ソース + 全身テンプレ」での頭身崩れアーティファクトを抑制（完全解消ではなく緩和）
- 全体的に細部の描き込みが向上（手・顔・服のディテール、構図の整合）

## 限界・注意

- 根本的には「ソース画像に下半身の情報が無い」情報欠落の問題なので、prompt と quality 引き上げで**緩和**はできても**完全解消は不可能**（補完元は image_1 のみのため、ある程度はテンプレに引っ張られる）。違和感が強い場合は、申請モーダル等で「全身画像を推奨」のソフトな案内を出すのが補完策（本 PR には含めない）
- `medium` は `low` より生成コスト・レイテンシが上がる（経験的に ~2x）。inspire は審査前プレビュー（1日10回制限・運営負担）と公開後生成（ペルコイン課金）のみで使われるため、影響範囲は限定的
- 非 inspire 経路（coordinate 等）は変更なし

## 検証

- `npm run lint` — 変更ファイルにエラー・新規警告なし
- `npm run typecheck` — 本変更起因の新規エラーなし
- `npm run test` — `tests/` 配下全パス（`inspire-prompt.test.ts` 23 ケース）
- `npm run build -- --webpack` — 成功（exit 0）

## ロールバック

コミット `88d346a` を revert すれば prompt の追加文・`quality: "medium"` 指定の両方が元に戻る（型と `quality?` パラメータは残るが既定 `"low"` のため挙動は変わらない）。
