### PR TITLE
chore(generation): Gemini kill switch のコメント整理と enabled 状態テスト追加

### DIFF
--- a/features/generation/lib/model-config.ts
+++ b/features/generation/lib/model-config.ts
@@ -13,11 +13,21 @@ import {
 export { DEFAULT_GENERATION_MODEL };
 
 /**
- * Google Cloud プロジェクト停止中の一時的な kill switch。
+ * Gemini 画像生成の kill switch。
  *
- * Gemini を再開するときは Next.js 側で `NEXT_PUBLIC_GEMINI_GENERATION_ENABLED=true`
- * を設定して再デプロイし、Supabase Edge Function 側も `GEMINI_GENERATION_ENABLED=true`
- * に揃える。
+ * 何らかの理由で Gemini を全画面で一時停止したいとき（Google Cloud プロジェクト停止・
+ * モデル不調・コスト問題など）に env を未設定 / `false` にして、全画面の Gemini 系
+ * モデルを `isModelAvailableForGeneration()` でフィルタアウトする。
+ *
+ * 切替手順（必ず両方を揃えること）:
+ *   - Next.js 側: Vercel の env に `NEXT_PUBLIC_GEMINI_GENERATION_ENABLED=true` を
+ *     設定して再デプロイ（`NEXT_PUBLIC_*` はビルド時に bake-in される）。
+ *   - Supabase Edge Function 側: `supabase secrets set GEMINI_GENERATION_ENABLED=true`
+ *     のあと `supabase functions deploy image-gen-worker` を実行。
+ *
+ * テスト: kill ON / OFF 双方の挙動は `tests/unit/features/generation/inspire-model-config.test.ts`
+ * で担保している。integration テストでも `jest.mock` で `GEMINI_GENERATION_ENABLED: true`
+ * を上書きして enabled 経路を検証している。
  */
 export const GEMINI_GENERATION_ENABLED =
   process.env.NEXT_PUBLIC_GEMINI_GENERATION_ENABLED === "true";

--- a/tests/helpers/load-config-with-gemini.ts
+++ b/tests/helpers/load-config-with-gemini.ts
@@ -1,0 +1,34 @@
+/**
+ * `process.env.NEXT_PUBLIC_GEMINI_GENERATION_ENABLED` を一時的に切り替えて
+ * `@/features/generation/lib/model-config` を fresh に再ロードするテストヘルパー。
+ *
+ * `GEMINI_GENERATION_ENABLED` 定数は `process.env` をモジュール load 時に 1 回だけ
+ * 読むため、env 切替後の挙動を検証するにはモジュール自体を再ロードする必要がある。
+ * このヘルパーは `jest.isolateModules` でモジュールを fresh に評価し、評価後は
+ * env を元の値に戻す（取り回しを各テストに分散させない）。
+ *
+ * 主な利用先:
+ *   - tests/unit/features/generation/inspire-model-config.test.ts
+ *   - tests/unit/features/generation/model-config.test.ts
+ */
+export function loadConfigWithGemini(
+  enabled: boolean
+): typeof import("@/features/generation/lib/model-config") {
+  const KEY = "NEXT_PUBLIC_GEMINI_GENERATION_ENABLED";
+  const original = process.env[KEY];
+  process.env[KEY] = enabled ? "true" : "false";
+  let mod!: typeof import("@/features/generation/lib/model-config");
+  jest.isolateModules(() => {
+    // `jest.requireActual` を使うと @typescript-eslint/no-require-imports に引っかからない。
+    // isolateModules 内で呼ぶことで env 切替後のモジュールを fresh に load する。
+    mod = jest.requireActual<
+      typeof import("@/features/generation/lib/model-config")
+    >("@/features/generation/lib/model-config");
+  });
+  if (original === undefined) {
+    delete process.env[KEY];
+  } else {
+    process.env[KEY] = original;
+  }
+  return mod;
+}

--- a/tests/unit/features/generation/inspire-model-config.test.ts
+++ b/tests/unit/features/generation/inspire-model-config.test.ts
@@ -1,52 +1,132 @@
 import {
   INSPIRE_ALLOWED_MODELS,
-  INSPIRE_PREVIEW_MODELS,
   isInspireAllowedModel,
 } from "@/features/generation/lib/model-config";
 
+/**
+ * `process.env.NEXT_PUBLIC_GEMINI_GENERATION_ENABLED` を一時的に切り替えて
+ * `model-config` を再評価するヘルパー。
+ *
+ * `GEMINI_GENERATION_ENABLED` は `process.env` をモジュール load 時に 1 回だけ
+ * 読むため、env 切替後の挙動を検証するにはモジュール自体を再ロードする必要がある。
+ */
+function loadConfigWithGemini(
+  enabled: boolean
+): typeof import("@/features/generation/lib/model-config") {
+  const KEY = "NEXT_PUBLIC_GEMINI_GENERATION_ENABLED";
+  const original = process.env[KEY];
+  process.env[KEY] = enabled ? "true" : "false";
+  let mod!: typeof import("@/features/generation/lib/model-config");
+  jest.isolateModules(() => {
+    // `jest.requireActual` を使うと @typescript-eslint/no-require-imports に引っかからない。
+    // isolateModules 内で呼ぶことで env 切替後のモジュールを fresh に load する。
+    mod = jest.requireActual<
+      typeof import("@/features/generation/lib/model-config")
+    >("@/features/generation/lib/model-config");
+  });
+  if (original === undefined) {
+    delete process.env[KEY];
+  } else {
+    process.env[KEY] = original;
+  }
+  return mod;
+}
+
 describe("Inspire model config", () => {
-  describe("INSPIRE_ALLOWED_MODELS", () => {
-    test("低解像度の gemini-3.1-flash-image-preview-512 を含まない", () => {
+  // kill switch の ON / OFF に関係なく成り立つ構造的性質。
+  describe("構造（kill switch 状態に依存しない）", () => {
+    test("INSPIRE_ALLOWED_MODELS は低解像度の gemini-3.1-flash-image-preview-512 を含まない", () => {
+      // preview-512 は申請プレビュー専用（INSPIRE_PREVIEW_MODELS にのみ載る）。
+      // 利用者向け INSPIRE_ALLOWED_MODELS にはどちらの kill 状態でも入れない。
       expect(
         (INSPIRE_ALLOWED_MODELS as ReadonlyArray<string>).includes(
           "gemini-3.1-flash-image-preview-512"
         )
       ).toBe(false);
+      const enabled = loadConfigWithGemini(true);
+      expect(
+        (enabled.INSPIRE_ALLOWED_MODELS as ReadonlyArray<string>).includes(
+          "gemini-3.1-flash-image-preview-512"
+        )
+      ).toBe(false);
     });
 
-    test("Gemini 停止中は OpenAI のみを含む", () => {
+    test("isInspireAllowedModel: 低解像度プレビュー専用モデル (preview-512) は inspire 利用者には不許可（両状態）", () => {
+      expect(isInspireAllowedModel("gemini-3.1-flash-image-preview-512")).toBe(
+        false
+      );
+      const enabled = loadConfigWithGemini(true);
+      expect(
+        enabled.isInspireAllowedModel("gemini-3.1-flash-image-preview-512")
+      ).toBe(false);
+    });
+
+    test("isInspireAllowedModel: 未知のモデル文字列は false", () => {
+      expect(isInspireAllowedModel("unknown-model")).toBe(false);
+    });
+
+    test("isInspireAllowedModel: null / undefined / 空文字は false", () => {
+      expect(isInspireAllowedModel(null)).toBe(false);
+      expect(isInspireAllowedModel(undefined)).toBe(false);
+      expect(isInspireAllowedModel("")).toBe(false);
+    });
+  });
+
+  // kill switch ON: Gemini 系を全部フィルタアウトし OpenAI のみが残る（停止中のリグレッション担保）。
+  describe("kill switch ON (Gemini 停止) 時", () => {
+    test("INSPIRE_ALLOWED_MODELS は OpenAI のみ", () => {
+      const { INSPIRE_ALLOWED_MODELS } = loadConfigWithGemini(false);
       expect(INSPIRE_ALLOWED_MODELS).toEqual(["gpt-image-2-low"]);
     });
-  });
 
-  describe("INSPIRE_PREVIEW_MODELS", () => {
-    test("Gemini 停止中は OpenAI low のみ", () => {
+    test("INSPIRE_PREVIEW_MODELS は OpenAI のみ", () => {
+      const { INSPIRE_PREVIEW_MODELS } = loadConfigWithGemini(false);
       expect(INSPIRE_PREVIEW_MODELS).toEqual(["gpt-image-2-low"]);
     });
-  });
 
-  describe("isInspireAllowedModel", () => {
-    test("許可リスト内のモデルで true を返す", () => {
+    test("isInspireAllowedModel は OpenAI low のみ true、Gemini 系は false", () => {
+      const { isInspireAllowedModel } = loadConfigWithGemini(false);
       expect(isInspireAllowedModel("gpt-image-2-low")).toBe(true);
       expect(isInspireAllowedModel("gemini-3.1-flash-image-preview-1024")).toBe(
         false
       );
+      expect(isInspireAllowedModel("gemini-3-pro-image-1k")).toBe(false);
+      expect(isInspireAllowedModel("gemini-2.5-flash-image")).toBe(false);
+    });
+  });
+
+  // kill switch OFF: 本番再開時の状態。Gemini 系も全部入る。
+  describe("kill switch OFF (Gemini 有効) 時", () => {
+    test("INSPIRE_ALLOWED_MODELS は nanobanana 1 / nanobanana 2 (1024) / nanobanana pro (1K/2K/4K) / OpenAI を含む", () => {
+      const { INSPIRE_ALLOWED_MODELS } = loadConfigWithGemini(true);
+      expect(INSPIRE_ALLOWED_MODELS).toEqual([
+        "gemini-2.5-flash-image",
+        "gemini-3.1-flash-image-preview-1024",
+        "gemini-3-pro-image-1k",
+        "gemini-3-pro-image-2k",
+        "gemini-3-pro-image-4k",
+        "gpt-image-2-low",
+      ]);
     });
 
-    test("低解像度プレビュー専用モデルは inspire 利用者には不許可", () => {
-      expect(isInspireAllowedModel("gemini-3.1-flash-image-preview-512")).toBe(
-        false
+    test("INSPIRE_PREVIEW_MODELS は OpenAI low と Gemini preview-512 のみ（運営コスト最小化のため低解像度固定）", () => {
+      const { INSPIRE_PREVIEW_MODELS } = loadConfigWithGemini(true);
+      expect(INSPIRE_PREVIEW_MODELS).toEqual([
+        "gpt-image-2-low",
+        "gemini-3.1-flash-image-preview-512",
+      ]);
+    });
+
+    test("isInspireAllowedModel: 許可リストにある Gemini モデルと OpenAI は true", () => {
+      const { isInspireAllowedModel } = loadConfigWithGemini(true);
+      expect(isInspireAllowedModel("gemini-2.5-flash-image")).toBe(true);
+      expect(isInspireAllowedModel("gemini-3.1-flash-image-preview-1024")).toBe(
+        true
       );
-    });
-
-    test("未知のモデル文字列は false", () => {
-      expect(isInspireAllowedModel("unknown-model")).toBe(false);
-    });
-
-    test("null / undefined / 空文字は false", () => {
-      expect(isInspireAllowedModel(null)).toBe(false);
-      expect(isInspireAllowedModel(undefined)).toBe(false);
-      expect(isInspireAllowedModel("")).toBe(false);
+      expect(isInspireAllowedModel("gemini-3-pro-image-1k")).toBe(true);
+      expect(isInspireAllowedModel("gemini-3-pro-image-2k")).toBe(true);
+      expect(isInspireAllowedModel("gemini-3-pro-image-4k")).toBe(true);
+      expect(isInspireAllowedModel("gpt-image-2-low")).toBe(true);
     });
   });
 });

--- a/tests/unit/features/generation/inspire-model-config.test.ts
+++ b/tests/unit/features/generation/inspire-model-config.test.ts
@@ -2,35 +2,7 @@ import {
   INSPIRE_ALLOWED_MODELS,
   isInspireAllowedModel,
 } from "@/features/generation/lib/model-config";
-
-/**
- * `process.env.NEXT_PUBLIC_GEMINI_GENERATION_ENABLED` を一時的に切り替えて
- * `model-config` を再評価するヘルパー。
- *
- * `GEMINI_GENERATION_ENABLED` は `process.env` をモジュール load 時に 1 回だけ
- * 読むため、env 切替後の挙動を検証するにはモジュール自体を再ロードする必要がある。
- */
-function loadConfigWithGemini(
-  enabled: boolean
-): typeof import("@/features/generation/lib/model-config") {
-  const KEY = "NEXT_PUBLIC_GEMINI_GENERATION_ENABLED";
-  const original = process.env[KEY];
-  process.env[KEY] = enabled ? "true" : "false";
-  let mod!: typeof import("@/features/generation/lib/model-config");
-  jest.isolateModules(() => {
-    // `jest.requireActual` を使うと @typescript-eslint/no-require-imports に引っかからない。
-    // isolateModules 内で呼ぶことで env 切替後のモジュールを fresh に load する。
-    mod = jest.requireActual<
-      typeof import("@/features/generation/lib/model-config")
-    >("@/features/generation/lib/model-config");
-  });
-  if (original === undefined) {
-    delete process.env[KEY];
-  } else {
-    process.env[KEY] = original;
-  }
-  return mod;
-}
+import { loadConfigWithGemini } from "@/tests/helpers/load-config-with-gemini";
 
 describe("Inspire model config", () => {
   // kill switch の ON / OFF に関係なく成り立つ構造的性質。

--- a/tests/unit/features/generation/model-config.test.ts
+++ b/tests/unit/features/generation/model-config.test.ts
@@ -10,6 +10,7 @@ import {
   isOpenAIImageModel,
   normalizeModelName,
 } from "@/features/generation/types";
+import { loadConfigWithGemini } from "@/tests/helpers/load-config-with-gemini";
 
 describe("model-config / model identification helpers", () => {
   describe("getPercoinCost", () => {
@@ -156,6 +157,90 @@ describe("model-config / model identification helpers", () => {
         isModelAvailableForGeneration("gemini-3.1-flash-image-preview-512")
       ).toBe(false);
       expect(isModelAvailableForGeneration("unknown-model")).toBe(false);
+    });
+  });
+
+  // 以下は kill switch を ON にしたときの挙動を回帰テストする。
+  // 上の既存ブロックは OFF（停止中）状態の本番デフォルトを担保し、
+  // 下のブロックは将来 Gemini を再開した時のリグレッションを担保する。
+  describe("kill switch ON (Gemini 有効) 時", () => {
+    it("GUEST_ALLOWED_MODELS にはゲスト用 Gemini preview-512 も含まれる", () => {
+      const { GUEST_ALLOWED_MODELS } = loadConfigWithGemini(true);
+      expect(GUEST_ALLOWED_MODELS).toEqual([
+        "gpt-image-2-low",
+        "gemini-3.1-flash-image-preview-512",
+      ]);
+    });
+
+    it("isCanonicalGuestAllowedModel: 許可リストの Gemini も true、許可外 Gemini は false", () => {
+      const { isCanonicalGuestAllowedModel } = loadConfigWithGemini(true);
+      expect(isCanonicalGuestAllowedModel("gpt-image-2-low")).toBe(true);
+      expect(
+        isCanonicalGuestAllowedModel("gemini-3.1-flash-image-preview-512")
+      ).toBe(true);
+      expect(
+        isCanonicalGuestAllowedModel("gemini-3.1-flash-image-preview-1024")
+      ).toBe(false);
+      expect(isCanonicalGuestAllowedModel("gemini-3-pro-image-1k")).toBe(false);
+    });
+
+    it("parseGuestRequestedModel: ゲスト許可 Gemini はそのまま返り、許可外は null", () => {
+      const { parseGuestRequestedModel } = loadConfigWithGemini(true);
+      expect(parseGuestRequestedModel("gpt-image-2-low")).toBe("gpt-image-2-low");
+      expect(
+        parseGuestRequestedModel("gemini-3.1-flash-image-preview-512")
+      ).toBe("gemini-3.1-flash-image-preview-512");
+      // エイリアス（preview, 2.5-flash-image）は normalize 後に preview-512 へ正規化される
+      expect(parseGuestRequestedModel("gemini-3.1-flash-image-preview")).toBe(
+        "gemini-3.1-flash-image-preview-512"
+      );
+      expect(parseGuestRequestedModel("gemini-2.5-flash-image")).toBe(
+        "gemini-3.1-flash-image-preview-512"
+      );
+      // 許可外 Gemini は null
+      expect(
+        parseGuestRequestedModel("gemini-3.1-flash-image-preview-1024")
+      ).toBeNull();
+      expect(parseGuestRequestedModel("gemini-3-pro-image-4k")).toBeNull();
+    });
+
+    it("isModelAvailableForGeneration: Gemini 系も全部利用可能（未知モデルは引き続き不許可）", () => {
+      const { isModelAvailableForGeneration } = loadConfigWithGemini(true);
+      expect(isModelAvailableForGeneration("gpt-image-2-low")).toBe(true);
+      expect(
+        isModelAvailableForGeneration("gemini-3.1-flash-image-preview-512")
+      ).toBe(true);
+      expect(
+        isModelAvailableForGeneration("gemini-3.1-flash-image-preview-1024")
+      ).toBe(true);
+      expect(isModelAvailableForGeneration("gemini-3-pro-image-1k")).toBe(true);
+      expect(isModelAvailableForGeneration("gemini-3-pro-image-4k")).toBe(true);
+      expect(isModelAvailableForGeneration("gemini-2.5-flash-image")).toBe(true);
+      expect(isModelAvailableForGeneration("unknown-model")).toBe(false);
+    });
+
+    it("resolveEffectiveModelForAuthState: 認証ユーザーの Gemini はそのまま、ゲストは許可リストに照らして丸める", () => {
+      const { resolveEffectiveModelForAuthState } = loadConfigWithGemini(true);
+      // 認証ユーザーはどの Gemini もそのまま使える
+      expect(
+        resolveEffectiveModelForAuthState("gemini-3-pro-image-4k", "authenticated")
+      ).toBe("gemini-3-pro-image-4k");
+      expect(
+        resolveEffectiveModelForAuthState(
+          "gemini-3.1-flash-image-preview-1024",
+          "authenticated"
+        )
+      ).toBe("gemini-3.1-flash-image-preview-1024");
+      // ゲストは preview-512 のみ許可、それ以外の Gemini は default (gpt-image-2-low) に丸める
+      expect(
+        resolveEffectiveModelForAuthState(
+          "gemini-3.1-flash-image-preview-512",
+          "guest"
+        )
+      ).toBe("gemini-3.1-flash-image-preview-512");
+      expect(
+        resolveEffectiveModelForAuthState("gemini-3-pro-image-4k", "guest")
+      ).toBe("gpt-image-2-low");
     });
   });
 });


### PR DESCRIPTION
## 概要

PR #270 で導入した `GEMINI_GENERATION_ENABLED` kill switch のドキュメントとテストを整理する。本番側で env を `true` に切替えて Gemini 画像生成を再開する運用に備えて、

- コメントを「Google Cloud プロジェクト停止中の一時的な kill switch」という特定インシデント前提の文言から、**汎用的な kill switch の説明**に書き換え
- テストを `kill switch ON / OFF の両状態`を検証する形に再編

する。本 PR ではコード挙動は変えない（テスト・コメントのみ）。実際の本番再開は本 PR のマージとは独立に、Vercel / Supabase Edge Function の env 切替＋再デプロイで行う。

## 背景

`GEMINI_GENERATION_ENABLED` は `model-config.ts` の単一 env フラグで、Next.js（`NEXT_PUBLIC_GEMINI_GENERATION_ENABLED`）と Supabase Edge Function（`GEMINI_GENERATION_ENABLED`）の双方で参照される。`isModelAvailableForGeneration()` のフィルタ経由で `GUEST_ALLOWED_MODELS` / `INSPIRE_ALLOWED_MODELS` / `INSPIRE_PREVIEW_MODELS` 等の許可リストから Gemini 系モデルを一括除外する設計で、**全画面（/style / /coordinate / /i2i / /inspire / 申請プレビュー）に効く一括 kill switch** になっている。

現状（kill ON）と再開後（kill OFF）の挙動は対称ではない：

| | kill ON（現在） | kill OFF（再開後） |
|---|---|---|
| `INSPIRE_ALLOWED_MODELS` | `["gpt-image-2-low"]` | nanobanana 1 / nanobanana 2 (1024) / nanobanana pro (1K/2K/4K) / OpenAI |
| `INSPIRE_PREVIEW_MODELS` | `["gpt-image-2-low"]` | `["gpt-image-2-low", "gemini-3.1-flash-image-preview-512"]` |
| `isInspireAllowedModel("gemini-3-pro-image-2k")` | `false` | `true` |

既存テスト（再編前）は kill ON の状態だけを assert していて、本番再開後にテスト記述が乖離していた（再開しても CI は `process.env` 未設定なので機械的には pass し続けるが、ドキュメント的に misleading だった）。本 PR で両状態を明示的にカバーする。

## 変更内容

### `features/generation/lib/model-config.ts`
`GEMINI_GENERATION_ENABLED` のドキュメントコメントを書き換え：

- 「Google Cloud プロジェクト停止中の一時的な kill switch」（インシデント前提）→ 「Gemini 画像生成の kill switch」（汎用説明）
- 一時停止する動機の例（Google Cloud 停止・モデル不調・コスト問題）を追記
- 再開時に必ず両方の env を揃えること、および手順を明記
- 両状態のテスト所在（本 PR で整理する `inspire-model-config.test.ts` と integration テスト）を明記

### `tests/unit/features/generation/inspire-model-config.test.ts`
3 つの `describe` ブロックに再編：

1. **構造（kill switch 状態に依存しない）** — `preview-512` が常に `INSPIRE_ALLOWED_MODELS` に含まれない、未知・null・空文字に対する `isInspireAllowedModel` の挙動など。kill ON / OFF 両方で同じ結果を assert
2. **kill switch ON (Gemini 停止) 時** — `INSPIRE_ALLOWED_MODELS` / `INSPIRE_PREVIEW_MODELS` / `isInspireAllowedModel` が OpenAI のみを許可することのリグレッション担保
3. **kill switch OFF (Gemini 有効) 時** — 本番再開後の状態。nanobanana 系・OpenAI が許可リストに並び、`isInspireAllowedModel` が Gemini モデルにも `true` を返す

env 切替の仕組み：`loadConfigWithGemini(boolean)` ヘルパーを追加。`process.env.NEXT_PUBLIC_GEMINI_GENERATION_ENABLED` を一時的に上書き → `jest.isolateModules` + `jest.requireActual` でモジュールを fresh load → 元に戻す、という流れ（`GEMINI_GENERATION_ENABLED` は module load 時に 1 回だけ評価されるため、後から env を変えても constant は更新されないことへの対処）。

## 検証

- `npm run lint` — エラーなし
- `npm run typecheck` — 新規エラーなし（baseline 維持）
- `npm run test` — `inspire-model-config.test.ts` は 10/10 pass（kill ON: 3、kill OFF: 3、構造: 4）。リポジトリ全体のテストにも回帰なし
- `npm run build -- --webpack` — 成功

## 本 PR とは独立に運用側で行うこと

本 PR は **テスト・コメントのみ**。実際の Gemini 再開は別途：

1. Google Cloud プロジェクトが利用可能な状態であることを確認
2. Vercel: `NEXT_PUBLIC_GEMINI_GENERATION_ENABLED=true` を Production / Preview に設定 → **再デプロイ**（`NEXT_PUBLIC_*` はビルド時 bake-in のため）
3. Supabase Function: `supabase secrets set GEMINI_GENERATION_ENABLED=true` の後 `supabase functions deploy image-gen-worker`

両方の env を揃えないと「UI で選べるのにサーバーで弾く」または逆の不整合が出る。

## ロールバック

問題が出た場合はコミット `30917d0` を revert すれば、コメントとテストは元の kill ON 前提の記述に戻る。kill switch のロジック自体には触れていないので、機能挙動の rollback は env 側で行う。
