### PR TITLE
feat(inspire): プロンプトを短文構造に刷新し 5 ブランチを非対称セマンティクスに変更

### DIFF
--- a/shared/generation/prompt-core.ts
+++ b/shared/generation/prompt-core.ts
@@ -281,135 +281,143 @@ export interface BuildInspirePromptOptions {
 }
 
 /**
- * Inspire 生成で image_0 から保持すべき身体属性の正典リスト（英語の列挙文）。
+ * Inspire 生成で image_0 から保持する身体属性の正典リスト。
+ * face / facial features (identity) はブランチによって扱いが変わる（pose と keep_all は
+ * image_1 の表情を取るので「facial features (identity)」のみ保持、それ以外は face 丸ごと
+ * 保持）ためここには含めない。
  *
- * 「体格・肌色・手足の太さ・胸の大きさが image_1 に寄せられて変わる」という報告への対応で、
- * image_0 の説明 / item 1 の保持指示 / 否定ガード / styleSuffix の補強文を **すべてこの 1 つの
- * 文字列から組み立てる**。こうしてリスト間のドリフト（片方だけ更新し忘れる）を構造的に防ぐ。
- *
- * 注:
- *   - この shared モジュールは Next.js（API/Client）と Supabase Deno Worker の両方から import する。
- *     共有定数はここ（shared/）に置く。lib/ には移さない（Worker から lib/ を import できないため）。
- *   - 安全フィルタ（OpenAI / Gemini）を誘発しやすい `chest size` のような明示は含めず、
- *     `torso proportions` / `overall body silhouette` で胴体全体を中立的に指す。
+ * 注: この shared モジュールは Next.js（API/Client）と Supabase Deno Worker の両方から import する。
+ * 共有定数はここ（shared/）に置く（lib/ には移さない — Worker から import できないため）。
  */
 const INSPIRE_BODY_ATTRIBUTES =
-  "skin tone, body proportions, limb thickness, limb length, shoulder width, waist shape, torso proportions, and overall body silhouette";
+  "hair, skin tone, body type, limb proportions, and head-to-body ratio";
 
 /**
- * 体型を image_1 に引きずられないための否定指示（全ブランチ末尾に付ける）。
+ * 役割宣言（全ブランチ共通の冒頭 1 行）。
  *
- * 最後の一文は「image_0 が上半身のみ × image_1 が全身ポーズ」のケースへの配慮:
- * このとき image_0 には下半身の参照が無いため model は補完するしかないが、
- * 補完元として image_1 を流用しつつ image_0 の頭サイズだけ据え置く → 頭身が崩れる、
- * という典型的なアーティファクトを避けるよう、頭身比の一貫性を明示的に要求する。
- * ソース画像の指定（上半身 / 全身）を制限せず prompt 側で対応する方針。
+ * image_1 側に属性（pose / outfit / background など）を列挙すると、たとえアクション 1 文で
+ * 「pose だけを適用」と指示しても model が他の属性も image_1 から取ってしまう drift が
+ * 観測された。OpenAI のガイド「Reference each input by index and description」を踏襲しつつ、
+ * 属性の列挙はせず「ユーザーキャラ / スタイルテンプレ」だけを名付ける。
  */
-const INSPIRE_BODY_PRESERVATION_GUARD = `Do NOT alter the character's body type to match image_1. Keep image_0's ${INSPIRE_BODY_ATTRIBUTES}. Do NOT change the skin tone. Do NOT slim, enlarge, lengthen, shorten, or otherwise reshape any part of the body to match image_1. If image_0 shows only the upper body but image_1's framing requires the lower body to be drawn, extrapolate the missing parts naturally from image_0's visible proportions (head-to-shoulder ratio, torso width) and keep a realistic, consistent head-to-body ratio across the whole figure; do not leave the head oversized or undersized relative to the generated body.`;
+const INSPIRE_ROLE_DECLARATION =
+  "Two reference images: image_0 = user character; image_1 = style template.";
+
+const INSPIRE_ILLUSTRATION_SUFFIX =
+  "Match the illustration art style of image_1.";
+const INSPIRE_PHOTOREALISTIC_SUFFIX =
+  "Render the result as a photorealistic photograph, with realistic lighting consistent with the scene.";
+
+/**
+ * ブランチごとのアクション文。OpenAI のガイド「change only X + keep everything else
+ * the same」「保持リストは毎回繰り返す」の趣旨に従い、各文に
+ * 「change only X」「Keep Y, Z unchanged. Do not take ...」を明示する。
+ *
+ * セマンティクス:
+ *   - null (keep_all): image_1 の全要素（camera angle / pose / outfit / background /
+ *     facial expression）を採用し、image_0 はキャラ identity のみ
+ *   - angle / pose / outfit / background: image_0 の世界を保ち、image_1 から該当 1 属性
+ *     のみを移植
+ *     - pose だけ追加で image_1 の facial expression も取る（ポーズと表情はセットで
+ *       自然になるため）
+ */
+function getInspireActionSentence(
+  overrideTarget: InspireOverrideTarget | null,
+): string {
+  switch (overrideTarget) {
+    case null:
+      return "Place the character from image_0 into image_1's scene, adopting image_1's camera angle, pose, outfit, background, and facial expression. Replace only the character identity with image_0's.";
+    case "angle":
+      return "Re-render image_0 from image_1's camera angle and perspective. Change only the camera angle. Keep image_0's pose, outfit, and background unchanged. Do not take image_1's pose, outfit, or background.";
+    case "pose":
+      return "Apply image_1's pose and facial expression to the character from image_0. Change only the pose and the facial expression. Keep image_0's outfit, background, and camera angle unchanged. Do not take image_1's outfit, background, or camera angle.";
+    case "outfit":
+      return "Dress the character from image_0 in image_1's outfit. Change only the outfit. Keep image_0's pose, background, and camera angle unchanged. Do not take image_1's pose, background, or camera angle.";
+    case "background":
+      return "Replace the background of image_0 with image_1's background. Change only the background. Keep image_0's character, pose, outfit, and camera angle unchanged. Do not take image_1's pose, outfit, or camera angle.";
+    default:
+      throw new Error(
+        `Unsupported inspire overrideTarget: ${String(overrideTarget)}`,
+      );
+  }
+}
+
+/**
+ * 保持節（OpenAI ガイドの「preserve identity/geometry/...」を踏襲、全ブランチで再掲する）。
+ *
+ * - null / pose: image_1 から facial expression を取るため、image_0 で保持するのは
+ *   「facial features (identity)」のみ（表情は image_1 から差し替え可）
+ * - angle / outfit / background: face 全体（identity + 表情）を image_0 から保持
+ *
+ * またフレーミング保持先もブランチで変わる:
+ * - null (keep_all): image_1 のシーンに移植 → image_1 の aspect ratio / framing / crop を保持
+ * - その他: image_0 を編集 → image_0 の aspect ratio / framing / crop を保持
+ *   出力サイズの起点画像は `resolveInspireTargetSizeBaseIndex` で揃えること。
+ */
+function getInspirePreserveClause(
+  overrideTarget: InspireOverrideTarget | null,
+): string {
+  const facePart =
+    overrideTarget === null || overrideTarget === "pose"
+      ? "facial features (identity)"
+      : "face";
+  const framingSentence =
+    overrideTarget === null
+      ? "Preserve image_1's aspect ratio, framing, and crop."
+      : "Preserve image_0's aspect ratio, framing, and crop.";
+  return `Preserve from image_0: ${facePart}, ${INSPIRE_BODY_ATTRIBUTES}. ${framingSentence} Do not extend the canvas.`;
+}
 
 /**
  * Inspire 生成用のプロンプトを構築する。
  *
- * 入力画像の順序は **必ず以下** とする（Worker 側で揃えること）:
+ * 入力画像の順序は **必ず以下** とする（Worker / Next.js handler 側で揃えること）:
  *   image_0 = ユーザーがアップロードしたキャラ画像
  *   image_1 = 申請されたスタイルテンプレート画像
  *
- * 出力フレームの比率はテンプレ（image_1）に合わせる。これはテンプレートの構図を
- * 完全に維持するために必須。Worker 側の `resolveOpenAITargetSize` も image_1 を起点に算出する。
+ * 出力フレーム比率の起点画像は `resolveInspireTargetSizeBaseIndex(overrideTarget)` で
+ * 決まる（null だけ image_1 基準、他は image_0 基準）。両側を同じ overrideTarget で
+ * 揃えること。
  *
- * 体型保持について:
- *   image_0 の体格・肌色・四肢の太さ・全体シルエットは image_1 に寄せず維持する。
- *   保持指示（image_0 の説明 + item 1）と否定指示（`INSPIRE_BODY_PRESERVATION_GUARD`）と
- *   styleSuffix の補強文を全 5 ブランチ・実写/イラスト両バリアントに共通で入れ、
- *   保持属性のリストはすべて `INSPIRE_BODY_ATTRIBUTES` 1 箇所に集約している。
+ * 構造（OpenAI 推奨「scene → subject → details → constraints」に近い 4 段）:
+ *   1. 役割宣言（属性は列挙しない。drift を抑えるため）
+ *   2. ブランチごとのアクション 1 文（change only X + keep Y, Z）
+ *   3. 保持節（毎回再掲。null / pose は identity のみ、他は face 丸ごと）
+ *   4. スタイル suffix（実写なら photorealistic、それ以外は image_1 のイラスト調）
  *
- * 5 ブランチ:
- *   - keep_all (overrideTarget=null): テンプレのアングル/ポーズ/衣装/背景を維持してキャラだけ差し替える
- *   - angle: テンプレのアングルだけを変えて、ポーズ/衣装/背景は維持
- *   - pose: テンプレのポーズだけを変えて、アングル/衣装/背景は維持
- *   - outfit: テンプレの衣装だけを変えて、アングル/ポーズ/背景は維持
- *   - background: テンプレの背景だけを変えて、アングル/ポーズ/衣装は維持
+ * セマンティクス（5 ブランチ、非対称）:
+ *   - null (keep_all): image_1 の全要素 + facial expression を採用、キャラ identity と
+ *     body は image_0 から。フレーミングは image_1
+ *   - angle: image_1 のカメラアングルのみ採用、image_0 のポーズ/衣装/背景を維持
+ *   - pose: image_1 のポーズ + facial expression のみ採用、image_0 の衣装/背景/アングルを維持
+ *   - outfit: image_1 の衣装のみ採用、image_0 のポーズ/背景/アングルを維持
+ *   - background: image_1 の背景のみ採用、image_0 のキャラ/ポーズ/衣装/アングルを維持
  */
 export function buildInspirePrompt(options: BuildInspirePromptOptions): string {
   const { overrideTarget, sourceImageType = "illustration" } = options;
-
-  const styleBodyReinforcement = ` Even ${
+  const action = getInspireActionSentence(overrideTarget);
+  const preserve = getInspirePreserveClause(overrideTarget);
+  const style =
     sourceImageType === "real"
-      ? "in this photorealistic style"
-      : "when matching the art style"
-  }, keep image_0's ${INSPIRE_BODY_ATTRIBUTES} — do not reshape the body to match image_1.`;
+      ? INSPIRE_PHOTOREALISTIC_SUFFIX
+      : INSPIRE_ILLUSTRATION_SUFFIX;
+  return [INSPIRE_ROLE_DECLARATION, action, preserve, style].join("\n\n");
+}
 
-  const styleSuffix =
-    (sourceImageType === "real"
-      ? "Generate a photorealistic result. Captured with an 85mm portrait lens. Use realistic lighting consistent with image_1's environment."
-      : "Match the illustration touch and artistic style of image_1 (the style template).") +
-    styleBodyReinforcement;
-
-  const basePrefix = `CRITICAL INSTRUCTION: This is an Image-to-Image task with two reference images:
-- image_0 (User Character): the character identity to render in the output, including face, hair, ${INSPIRE_BODY_ATTRIBUTES}.
-- image_1 (Style Template): the visual reference for composition, framing, camera angle, pose, outfit, background, and overall vibe.
-
-You MUST produce a single output image that:
-1. Replaces the character in image_1 with the character from image_0. Preserve image_0's facial features, hair, identity, ${INSPIRE_BODY_ATTRIBUTES}.
-2. Strictly preserves image_1's aspect ratio, framing, and crop. Do NOT extend or change the canvas.`;
-
-  if (overrideTarget === null) {
-    return [
-      basePrefix,
-      `3. KEEP ALL of the following from image_1: camera angle, pose, outfit, and background. Only the character identity and body come from image_0.`,
-      `4. The output must look as if the character from image_0 stepped into image_1's exact scene with the same camera angle, pose, outfit, and background, while keeping image_0's original body proportions and physical characteristics.`,
-      `5. ${INSPIRE_BODY_PRESERVATION_GUARD}`,
-      styleSuffix,
-    ].join("\n\n");
-  }
-
-  if (overrideTarget === "angle") {
-    return [
-      basePrefix,
-      `3. KEEP from image_1: pose, outfit, and background.`,
-      `4. CHANGE: regenerate the camera angle to a natural alternative (e.g., a different viewpoint of the same scene) while keeping the rest faithful to image_1.`,
-      `5. The character identity and body come from image_0.`,
-      `6. ${INSPIRE_BODY_PRESERVATION_GUARD}`,
-      styleSuffix,
-    ].join("\n\n");
-  }
-
-  if (overrideTarget === "pose") {
-    return [
-      basePrefix,
-      `3. KEEP from image_1: camera angle, outfit, and background.`,
-      `4. CHANGE: regenerate the pose to a natural alternative that fits the same scene and outfit.`,
-      `5. The character identity and body come from image_0.`,
-      `6. ${INSPIRE_BODY_PRESERVATION_GUARD}`,
-      styleSuffix,
-    ].join("\n\n");
-  }
-
-  if (overrideTarget === "outfit") {
-    return [
-      basePrefix,
-      `3. KEEP from image_1: camera angle, pose, and background.`,
-      `4. CHANGE: regenerate the outfit to a natural alternative that suits the scene and pose.`,
-      `5. The character identity and body come from image_0.`,
-      `6. ${INSPIRE_BODY_PRESERVATION_GUARD}`,
-      styleSuffix,
-    ].join("\n\n");
-  }
-
-  if (overrideTarget === "background") {
-    return [
-      basePrefix,
-      `3. KEEP from image_1: camera angle, pose, and outfit.`,
-      `4. CHANGE: regenerate the background to a natural alternative that complements the outfit and pose.`,
-      `5. The character identity and body come from image_0.`,
-      `6. ${INSPIRE_BODY_PRESERVATION_GUARD}`,
-      styleSuffix,
-    ].join("\n\n");
-  }
-
-  throw new Error(
-    `Unsupported inspire overrideTarget: ${String(overrideTarget)}`
-  );
+/**
+ * Inspire 生成で OpenAI helper に渡す `targetSizeBaseIndex` を解決する。
+ *
+ * - null (keep_all): image_1 のシーンに置き換える → image_1 のアスペクト比を起点（→ 1）
+ * - その他: image_0 を編集する（1 属性だけ image_1 から移植）→ image_0 のアスペクト比を起点（→ 0）
+ *
+ * caller（preview-generation handler / image-gen-worker）は `callOpenAIImageEditMultiInput*`
+ * の `targetSizeBaseIndex` にこの値を渡すこと。プロンプト側の保持節（image_0 / image_1 の
+ * どちらのフレーミングを保つか）と一致させる必要がある。
+ */
+export function resolveInspireTargetSizeBaseIndex(
+  overrideTarget: InspireOverrideTarget | null,
+): 0 | 1 {
+  return overrideTarget === null ? 1 : 0;
 }
 
 /**

--- a/supabase/functions/image-gen-worker/index.ts
+++ b/supabase/functions/image-gen-worker/index.ts
@@ -8,6 +8,7 @@ import {
   buildCoordinateAttemptReinforcementPrefix,
   buildInspirePrompt,
   resolveBackgroundMode,
+  resolveInspireTargetSizeBaseIndex,
 } from "../../../shared/generation/prompt-core.ts";
 import type {
   GenerationType,
@@ -1726,8 +1727,18 @@ Deno.serve(async () => {
                               openAIInputImage,
                               resolvedInspireTemplateImage,
                             ],
-                            // 出力フレームはテンプレ（image_1）の比率に合わせる（ADR-006）
-                            targetSizeBaseIndex: 1,
+                            // 出力フレームの起点画像はブランチ依存（resolveInspireTargetSizeBaseIndex）。
+                            // null (keep_all): image_1 のシーンへ置換 → image_1 基準
+                            // angle / pose / outfit / background: image_0 を編集 → image_0 基準
+                            // プロンプト側の保持節（image_0 / image_1 のどちらのフレーミングを
+                            // 保つか）と一致させる。
+                            targetSizeBaseIndex:
+                              resolveInspireTargetSizeBaseIndex(
+                                (job.override_target as
+                                  | InspireOverrideTarget
+                                  | null
+                                  | undefined) ?? null,
+                              ),
                             timeoutMs: OPENAI_REQUEST_TIMEOUT_MS,
                             n: requestedImageCount,
                             // inspire はキャラ識別 × テンプレ構図の合成で難度が高いため

--- a/supabase/functions/image-gen-worker/index.ts
+++ b/supabase/functions/image-gen-worker/index.ts
@@ -1607,10 +1607,12 @@ Deno.serve(async () => {
                       : job.generation_type === "inspire"
                         ? buildInspirePrompt({
                             overrideTarget:
+                              // `||` を使って空文字列も null に丸める。`??` だと "" のときに
+                              // 「未知のオーバーライド対象」として default 節で throw する。
                               (job.override_target as
                                 | InspireOverrideTarget
                                 | null
-                                | undefined) ?? null,
+                                | undefined) || null,
                             sourceImageType:
                               job.source_image_type === "real"
                                 ? "real"
@@ -1732,12 +1734,13 @@ Deno.serve(async () => {
                             // angle / pose / outfit / background: image_0 を編集 → image_0 基準
                             // プロンプト側の保持節（image_0 / image_1 のどちらのフレーミングを
                             // 保つか）と一致させる。
+                            // `||` で空文字列も null に丸める（上の buildInspirePrompt 呼び出しと統一）。
                             targetSizeBaseIndex:
                               resolveInspireTargetSizeBaseIndex(
                                 (job.override_target as
                                   | InspireOverrideTarget
                                   | null
-                                  | undefined) ?? null,
+                                  | undefined) || null,
                               ),
                             timeoutMs: OPENAI_REQUEST_TIMEOUT_MS,
                             n: requestedImageCount,

--- a/tests/unit/shared/inspire-prompt.test.ts
+++ b/tests/unit/shared/inspire-prompt.test.ts
@@ -1,109 +1,178 @@
-import { buildInspirePrompt } from "@/shared/generation/prompt-core";
+import {
+  buildInspirePrompt,
+  resolveInspireTargetSizeBaseIndex,
+} from "@/shared/generation/prompt-core";
+
+const ALL_TARGETS = [null, "angle", "pose", "outfit", "background"] as const;
+const ALL_SOURCES = ["illustration", "real"] as const;
 
 describe("buildInspirePrompt", () => {
-  test("keep_all (overrideTarget=null) はテンプレ全要素維持を指示する", () => {
-    const prompt = buildInspirePrompt({ overrideTarget: null });
-    expect(prompt).toContain("KEEP ALL of the following from image_1");
-    expect(prompt).toContain("camera angle, pose, outfit, and background");
-  });
-
-  test("angle はカメラアングルだけを変更", () => {
-    const prompt = buildInspirePrompt({ overrideTarget: "angle" });
-    expect(prompt).toContain("KEEP from image_1: pose, outfit, and background");
-    expect(prompt).toContain("CHANGE: regenerate the camera angle");
-  });
-
-  test("pose はポーズだけを変更", () => {
-    const prompt = buildInspirePrompt({ overrideTarget: "pose" });
-    expect(prompt).toContain(
-      "KEEP from image_1: camera angle, outfit, and background"
-    );
-    expect(prompt).toContain("CHANGE: regenerate the pose");
-  });
-
-  test("outfit は衣装だけを変更", () => {
-    const prompt = buildInspirePrompt({ overrideTarget: "outfit" });
-    expect(prompt).toContain(
-      "KEEP from image_1: camera angle, pose, and background"
-    );
-    expect(prompt).toContain("CHANGE: regenerate the outfit");
-  });
-
-  test("background は背景だけを変更", () => {
-    const prompt = buildInspirePrompt({ overrideTarget: "background" });
-    expect(prompt).toContain(
-      "KEEP from image_1: camera angle, pose, and outfit"
-    );
-    expect(prompt).toContain("CHANGE: regenerate the background");
-  });
-
-  test("デフォルトは illustration スタイル指示", () => {
-    const prompt = buildInspirePrompt({ overrideTarget: null });
-    expect(prompt).toContain("Match the illustration touch");
-  });
-
-  test('sourceImageType="real" のときは photorealistic 指示', () => {
-    const prompt = buildInspirePrompt({
-      overrideTarget: null,
-      sourceImageType: "real",
-    });
-    expect(prompt).toContain("photorealistic");
-    expect(prompt).toContain("85mm portrait lens");
-  });
-
-  test("不明な overrideTarget は throw する", () => {
-    expect(() =>
-      buildInspirePrompt({
-        // 型を意図的にバイパスして runtime エラーパスを検証
-        overrideTarget: "unknown" as never,
-      })
-    ).toThrow(/Unsupported inspire overrideTarget/);
-  });
-
-  test("全分岐に共通の image_0/image_1 指示を含む", () => {
-    const targets = [null, "angle", "pose", "outfit", "background"] as const;
-    for (const target of targets) {
-      const prompt = buildInspirePrompt({ overrideTarget: target });
-      expect(prompt).toContain("image_0 (User Character)");
-      expect(prompt).toContain("image_1 (Style Template)");
-      expect(prompt).toContain(
-        "Strictly preserves image_1's aspect ratio, framing, and crop"
-      );
-    }
-  });
-
-  // 「体格・肌色・手足の太さ・胸の大きさが image_1 に寄せられて変わる」報告への対応。
-  // 体型保持の指示が全 5 ブランチ・実写/イラスト両バリアントに入っていることを確認する。
-  describe("body preservation", () => {
-    const targets = [null, "angle", "pose", "outfit", "background"] as const;
-    const sources = ["illustration", "real"] as const;
-
-    test("全分岐 × 実写/イラストで image_0 の体型保持指示と否定指示を含む", () => {
-      for (const target of targets) {
-        for (const sourceImageType of sources) {
+  // 役割宣言は属性を列挙しない（属性列挙すると、たとえ「pose だけ」と指示しても model が
+  // image_1 の他属性も取ってしまう drift が観測されたため）。
+  describe("役割宣言（属性を列挙しない最小形）", () => {
+    test("全分岐 × 実写/イラストで `image_0 = user character; image_1 = style template.` を含む", () => {
+      for (const target of ALL_TARGETS) {
+        for (const sourceImageType of ALL_SOURCES) {
           const prompt = buildInspirePrompt({
             overrideTarget: target,
             sourceImageType,
           });
-          // image_0 の説明 / item 1 の保持指示
-          expect(prompt).toContain("skin tone");
-          expect(prompt).toContain("limb");
-          expect(prompt).toContain("shoulder width");
-          expect(prompt).toContain("overall body silhouette");
-          // 否定指示ブロック
           expect(prompt).toContain(
-            "Do NOT alter the character's body type to match image_1"
+            "Two reference images: image_0 = user character; image_1 = style template."
           );
-          expect(prompt).toContain("Do NOT change the skin tone");
-          // styleSuffix 側の補強文
-          expect(prompt).toContain("do not reshape the body to match image_1");
         }
       }
     });
 
+    test("役割宣言の image_1 側に属性（pose / outfit / background 等）を列挙していない", () => {
+      // 旧プロンプトでは `image_1 = style template (composition, camera angle, pose, outfit, background)`
+      // のように列挙していて drift の原因になっていた。これを除去できているかをチェックする。
+      const prompt = buildInspirePrompt({ overrideTarget: "pose" });
+      expect(prompt).not.toMatch(
+        /image_1 = style template \([^)]*pose[^)]*\)/i
+      );
+    });
+  });
+
+  describe("ブランチごとのアクション文", () => {
+    test("null (keep_all): image_1 のシーン全体 + facial expression を適用、image_0 から identity を取る", () => {
+      const prompt = buildInspirePrompt({ overrideTarget: null });
+      expect(prompt).toContain(
+        "Place the character from image_0 into image_1's scene"
+      );
+      expect(prompt).toContain(
+        "image_1's camera angle, pose, outfit, background, and facial expression"
+      );
+      expect(prompt).toContain(
+        "Replace only the character identity with image_0's"
+      );
+    });
+
+    test("angle: image_1 のカメラアングルのみ適用、image_0 のポーズ/衣装/背景を維持", () => {
+      const prompt = buildInspirePrompt({ overrideTarget: "angle" });
+      expect(prompt).toContain(
+        "Re-render image_0 from image_1's camera angle and perspective"
+      );
+      expect(prompt).toContain("Change only the camera angle.");
+      expect(prompt).toContain(
+        "Keep image_0's pose, outfit, and background unchanged."
+      );
+      expect(prompt).toContain(
+        "Do not take image_1's pose, outfit, or background."
+      );
+    });
+
+    test("pose: image_1 のポーズ + facial expression のみ適用、image_0 の衣装/背景/アングルを維持", () => {
+      const prompt = buildInspirePrompt({ overrideTarget: "pose" });
+      expect(prompt).toContain(
+        "Apply image_1's pose and facial expression to the character from image_0."
+      );
+      expect(prompt).toContain("Change only the pose and the facial expression.");
+      expect(prompt).toContain(
+        "Keep image_0's outfit, background, and camera angle unchanged."
+      );
+      expect(prompt).toContain(
+        "Do not take image_1's outfit, background, or camera angle."
+      );
+    });
+
+    test("outfit: image_1 の衣装のみ適用、image_0 のポーズ/背景/アングルを維持", () => {
+      const prompt = buildInspirePrompt({ overrideTarget: "outfit" });
+      expect(prompt).toContain(
+        "Dress the character from image_0 in image_1's outfit."
+      );
+      expect(prompt).toContain("Change only the outfit.");
+      expect(prompt).toContain(
+        "Keep image_0's pose, background, and camera angle unchanged."
+      );
+      expect(prompt).toContain(
+        "Do not take image_1's pose, background, or camera angle."
+      );
+    });
+
+    test("background: image_1 の背景のみ適用、image_0 のキャラ/ポーズ/衣装/アングルを維持", () => {
+      const prompt = buildInspirePrompt({ overrideTarget: "background" });
+      expect(prompt).toContain(
+        "Replace the background of image_0 with image_1's background."
+      );
+      expect(prompt).toContain("Change only the background.");
+      expect(prompt).toContain(
+        "Keep image_0's character, pose, outfit, and camera angle unchanged."
+      );
+      expect(prompt).toContain(
+        "Do not take image_1's pose, outfit, or camera angle."
+      );
+    });
+
+    test("不明な overrideTarget は throw する", () => {
+      expect(() =>
+        buildInspirePrompt({
+          // 型を意図的にバイパスして runtime エラーパスを検証
+          overrideTarget: "unknown" as never,
+        })
+      ).toThrow(/Unsupported inspire overrideTarget/);
+    });
+  });
+
+  // OpenAI ガイド「preserve identity/geometry」を全ブランチで再掲する。
+  // 顔の扱いは pose / null だけ image_1 の表情を取るため「facial features (identity)」のみ保持、
+  // それ以外は face 丸ごと保持。フレーミングは null だけ image_1、他は image_0 を保持。
+  describe("保持節", () => {
+    test("全分岐 × 実写/イラストで body 属性（hair / skin tone / body type / limb proportions / head-to-body ratio）を保持", () => {
+      for (const target of ALL_TARGETS) {
+        for (const sourceImageType of ALL_SOURCES) {
+          const prompt = buildInspirePrompt({
+            overrideTarget: target,
+            sourceImageType,
+          });
+          expect(prompt).toContain(
+            "hair, skin tone, body type, limb proportions, and head-to-body ratio"
+          );
+          expect(prompt).toContain("Do not extend the canvas.");
+        }
+      }
+    });
+
+    test("null / pose は facial features (identity) を保持（表情は image_1 から差し替え可）", () => {
+      for (const target of [null, "pose"] as const) {
+        const prompt = buildInspirePrompt({ overrideTarget: target });
+        expect(prompt).toContain(
+          "Preserve from image_0: facial features (identity),"
+        );
+      }
+    });
+
+    test("angle / outfit / background は face 丸ごと（identity + 表情）を image_0 から保持", () => {
+      for (const target of ["angle", "outfit", "background"] as const) {
+        const prompt = buildInspirePrompt({ overrideTarget: target });
+        expect(prompt).toContain("Preserve from image_0: face,");
+      }
+    });
+
+    test("null (keep_all) は image_1 のフレーミングを保持", () => {
+      const prompt = buildInspirePrompt({ overrideTarget: null });
+      expect(prompt).toContain(
+        "Preserve image_1's aspect ratio, framing, and crop."
+      );
+    });
+
+    test("null 以外は image_0 のフレーミングを保持", () => {
+      for (const target of [
+        "angle",
+        "pose",
+        "outfit",
+        "background",
+      ] as const) {
+        const prompt = buildInspirePrompt({ overrideTarget: target });
+        expect(prompt).toContain(
+          "Preserve image_0's aspect ratio, framing, and crop."
+        );
+      }
+    });
+
     test("安全フィルタを誘発しやすい文言（chest / breast）を含まない", () => {
-      for (const target of targets) {
-        for (const sourceImageType of sources) {
+      for (const target of ALL_TARGETS) {
+        for (const sourceImageType of ALL_SOURCES) {
           const prompt = buildInspirePrompt({
             overrideTarget: target,
             sourceImageType,
@@ -113,55 +182,38 @@ describe("buildInspirePrompt", () => {
         }
       }
     });
+  });
 
-    test("override 系でも item 4 の上書き指示と body 専用の否定指示が両立する", () => {
-      const outfit = buildInspirePrompt({ overrideTarget: "outfit" });
-      expect(outfit).toContain("CHANGE: regenerate the outfit");
-      expect(outfit).toContain(
-        "Do NOT alter the character's body type to match image_1"
-      );
-
-      const pose = buildInspirePrompt({ overrideTarget: "pose" });
-      expect(pose).toContain("CHANGE: regenerate the pose");
-      expect(pose).toContain(
-        "Do NOT alter the character's body type to match image_1"
-      );
+  describe("スタイル suffix", () => {
+    test("既定（illustration）は image_1 のイラスト調を一致させる", () => {
+      const prompt = buildInspirePrompt({ overrideTarget: null });
+      expect(prompt).toContain("Match the illustration art style of image_1.");
     });
 
-    // 保持属性リストは INSPIRE_BODY_ATTRIBUTES 1 箇所に集約しているので、
-    // image_0 の説明 / item 1 / 否定ガード / styleSuffix 補強文に同じ列挙文が複数回現れる。
-    // ここを変えたらこのテストも更新する（= リストのドリフトに気づける）。
-    test("身体属性の正典リストが全分岐 × 実写/イラストで複数箇所に現れる", () => {
-      const phrase =
-        "skin tone, body proportions, limb thickness, limb length, shoulder width, waist shape, torso proportions, and overall body silhouette";
-      for (const target of targets) {
-        for (const sourceImageType of sources) {
-          const prompt = buildInspirePrompt({
-            overrideTarget: target,
-            sourceImageType,
-          });
-          const occurrences = prompt.split(phrase).length - 1;
-          // image_0 の説明 + item 1 + 否定ガード + styleSuffix 補強文 = 4 箇所以上
-          expect(occurrences).toBeGreaterThanOrEqual(4);
-        }
-      }
+    test('sourceImageType="real" は photorealistic 指示', () => {
+      const prompt = buildInspirePrompt({
+        overrideTarget: null,
+        sourceImageType: "real",
+      });
+      // OpenAI のガイド「include the word 'photorealistic' directly」を踏襲
+      expect(prompt).toContain("photorealistic photograph");
     });
+  });
+});
 
-    // 「image_0 が上半身のみ × image_1 が全身」のときに頭でっかちになる
-    // アーティファクトを抑えるための頭身比保持指示が含まれること。
-    test("頭身比を一貫させる指示が全分岐 × 実写/イラストに含まれる", () => {
-      for (const target of targets) {
-        for (const sourceImageType of sources) {
-          const prompt = buildInspirePrompt({
-            overrideTarget: target,
-            sourceImageType,
-          });
-          expect(prompt).toContain(
-            "If image_0 shows only the upper body but image_1's framing requires the lower body to be drawn"
-          );
-          expect(prompt).toContain("head-to-body ratio");
-        }
-      }
-    });
+describe("resolveInspireTargetSizeBaseIndex", () => {
+  test("null (keep_all) は image_1 基準（1）", () => {
+    expect(resolveInspireTargetSizeBaseIndex(null)).toBe(1);
+  });
+
+  test("angle / pose / outfit / background は image_0 基準（0）", () => {
+    for (const target of [
+      "angle",
+      "pose",
+      "outfit",
+      "background",
+    ] as const) {
+      expect(resolveInspireTargetSizeBaseIndex(target)).toBe(0);
+    }
   });
 });


### PR DESCRIPTION
## 概要

OpenAI 公式の [Prompting Fundamentals](https://platform.openai.com/docs/guides/image-generation) に沿って inspire のプロンプトを短文構造に再構築し、加えて 5 ブランチのセマンティクスを **非対称**（`null` は全要素入れ替え、それ以外は image_0 を編集して 1 属性だけ image_1 から移植）に変更する。

合わせて「pose ブランチで衣装や背景まで一緒に変わる」報告への対応も含む。原因は役割宣言で `image_1 = style template (composition, camera angle, pose, outfit, background)` のように属性を列挙していたため、たとえアクション 1 文で `pose だけ` と指示しても model が他属性も image_1 から取ってしまう drift。新プロンプトでは属性列挙をやめて最小化 + `change only X + keep Y, Z unchanged. Do not take ...` を毎回明示する。

## セマンティクス変更（非対称、5 ブランチ）

| ブランチ | 取る（from image_1） | 保つ（from image_0） |
|---|---|---|
| `null`（keep_all） | カメラアングル・ポーズ・衣装・背景・**facial expression** | キャラ identity・body |
| `angle` | カメラアングルのみ | キャラ identity・body・**ポーズ・衣装・背景** |
| `pose` | ポーズ + **facial expression** | キャラ identity・body・**衣装・背景・カメラアングル** |
| `outfit` | 衣装のみ | キャラ identity・body・**ポーズ・背景・カメラアングル** |
| `background` | 背景のみ | キャラ identity・body・**ポーズ・衣装・カメラアングル** |

- `null` のみ「テンプレ全部入れ替え」、他は「image_0 を編集して 1 属性だけ移植」
- `null` と `pose` だけ image_1 の facial expression を採用するため、保持節は `facial features (identity)` のみ（表情は image_1 から差し替え可）
- それ以外（`angle` / `outfit` / `background`）は face 丸ごと（identity + 表情）を image_0 から保持

## `targetSizeBaseIndex` のブランチ依存化

これまで全ブランチで `targetSizeBaseIndex: 1`（image_1 基準）にハードコードしていたが、新セマンティクスでは `null` 以外は image_0 を編集する性質に合わせて image_0 基準（0）にする必要がある。`resolveInspireTargetSizeBaseIndex(overrideTarget)` を新規 export し、worker の OpenAI 呼び出しで使うよう変更。

Next.js 側の preview-generation handler は `overrideTarget: null` 固定なので影響なし（明示的に変更しないままで OK）。

## プロンプト構造（OpenAI 推奨「scene → subject → details → constraints」の 4 段）

```
[1. 役割宣言]   Two reference images: image_0 = user character; image_1 = style template.

[2. アクション] <ブランチ別、1 文。change only X + keep Y, Z unchanged. Do not take ...>

[3. 保持節]    Preserve from image_0: <face or facial features (identity)>, hair, skin tone,
              body type, limb proportions, and head-to-body ratio.
              Preserve <image_0 or image_1>'s aspect ratio, framing, and crop.
              Do not extend the canvas.

[4. スタイル]  Match the illustration art style of image_1. (or photorealistic 版)
```

文字数：~1700 文字（旧）→ ~520 文字（新）、約 1/3。

### 例：`outfit` × `illustration`

```
Two reference images: image_0 = user character; image_1 = style template.

Dress the character from image_0 in image_1's outfit. Change only the outfit. Keep image_0's pose, background, and camera angle unchanged. Do not take image_1's pose, background, or camera angle.

Preserve from image_0: face, hair, skin tone, body type, limb proportions, and head-to-body ratio. Preserve image_0's aspect ratio, framing, and crop. Do not extend the canvas.

Match the illustration art style of image_1.
```

## 変更ファイル

- `shared/generation/prompt-core.ts`
  - `buildInspirePrompt()` を全面書き換え（4 段構造 + ブランチ別アクション）
  - `resolveInspireTargetSizeBaseIndex(overrideTarget)` を新規 export
  - 旧 `INSPIRE_BODY_PRESERVATION_GUARD` と長い `INSPIRE_BODY_ATTRIBUTES`（chest size 等を含む 8 項目列挙）を削除し、簡潔な 5 項目（hair, skin tone, body type, limb proportions, head-to-body ratio）に変更
- `supabase/functions/image-gen-worker/index.ts`
  - inspire 経路の OpenAI 呼び出しで `targetSizeBaseIndex: resolveInspireTargetSizeBaseIndex(job.override_target)` を使うよう変更
- `tests/unit/shared/inspire-prompt.test.ts`
  - 役割宣言（属性列挙なし）・アクション文・保持節（identity vs face / image_0 vs image_1 framing）・スタイル suffix・`resolveInspireTargetSizeBaseIndex` を網羅するテストに再編
  - `chest` / `breast` を含まないチェックは継続

## 検証

- `npm run lint` — エラーなし
- `npm run typecheck` — 新規エラーなし（baseline 38 を維持）
- `npm run test` — `inspire-prompt.test.ts` 18/18 pass、`tests/` 配下全体で 0 回帰
- `npm run build -- --webpack` — 成功（exit 0）
- 5 ブランチ × 2 sourceImageType の出力を実際に dump して確認済み

## ロールバック

コミット `a7b9444` を revert すれば旧プロンプトとセマンティクスに戻る。
