### PR TITLE
feat(inspire): スタイルテンプレート申請フローをモーダルから専用ページに変更

### DIFF
--- a/app/(app)/admin/style-templates/AdminStyleTemplatesClient.tsx
+++ b/app/(app)/admin/style-templates/AdminStyleTemplatesClient.tsx
@@ -1,9 +1,13 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { ExternalLink, User as UserIcon } from "lucide-react";
+import {
+  ImageLightboxDialog,
+  type ImageLightboxSlide,
+} from "@/features/inspire/components/ImageLightboxDialog";
 import {
   Tabs,
   TabsContent,
@@ -73,6 +77,8 @@ interface Copy {
   detailTemplate: string;
   detailPreviewOpenAI: string;
   detailPreviewGemini: string;
+  detailEnlargedPrev: string;
+  detailEnlargedNext: string;
 }
 
 interface AdminStyleTemplatesClientProps {
@@ -95,6 +101,43 @@ export function AdminStyleTemplatesClient({
   const [openItem, setOpenItem] = useState<AdminStyleTemplateItem | null>(null);
   const [reason, setReason] = useState("");
   const [submitting, setSubmitting] = useState<DecisionAction | null>(null);
+  const [enlargedIndex, setEnlargedIndex] = useState<number | null>(null);
+
+  // 詳細パネルの 3 つの画像（テンプレ → OpenAI → Gemini）。URL が無いものは除外。
+  const lightboxSlides = useMemo<ImageLightboxSlide[]>(() => {
+    if (!openItem) return [];
+    const slides: ImageLightboxSlide[] = [];
+    if (openItem.image_url) {
+      slides.push({ url: openItem.image_url, label: copy.detailTemplate });
+    }
+    if (openItem.preview_openai_image_url) {
+      slides.push({
+        url: openItem.preview_openai_image_url,
+        label: copy.detailPreviewOpenAI,
+      });
+    }
+    if (openItem.preview_gemini_image_url) {
+      slides.push({
+        url: openItem.preview_gemini_image_url,
+        label: copy.detailPreviewGemini,
+      });
+    }
+    return slides;
+  }, [openItem, copy.detailTemplate, copy.detailPreviewOpenAI, copy.detailPreviewGemini]);
+
+  const openLightbox = useCallback(
+    (url: string) => {
+      const idx = lightboxSlides.findIndex((s) => s.url === url);
+      if (idx >= 0) setEnlargedIndex(idx);
+    },
+    [lightboxSlides]
+  );
+
+  const closeDetail = useCallback(() => {
+    setOpenItem(null);
+    setReason("");
+    setEnlargedIndex(null);
+  }, []);
 
   const handleDecision = useCallback(
     async (action: DecisionAction) => {
@@ -114,14 +157,13 @@ export function AdminStyleTemplatesClient({
           return;
         }
         toast({ title: copy.decisionSuccess });
-        setOpenItem(null);
-        setReason("");
+        closeDetail();
         router.refresh();
       } finally {
         setSubmitting(null);
       }
     },
-    [copy, openItem, reason, router, toast]
+    [closeDetail, copy, openItem, reason, router, toast]
   );
 
   const handleOrderUpdate = useCallback(
@@ -263,10 +305,7 @@ export function AdminStyleTemplatesClient({
       <Sheet
         open={openItem !== null}
         onOpenChange={(next) => {
-          if (!next) {
-            setOpenItem(null);
-            setReason("");
-          }
+          if (!next) closeDetail();
         }}
       >
         <SheetContent
@@ -327,46 +366,71 @@ export function AdminStyleTemplatesClient({
                   <figcaption className="text-xs font-medium">
                     {copy.detailTemplate}
                   </figcaption>
-                  <div className="aspect-square w-full overflow-hidden rounded-md border bg-muted">
-                    {openItem.image_url ? (
-                      /* eslint-disable-next-line @next/next/no-img-element */
+                  {openItem.image_url ? (
+                    <button
+                      type="button"
+                      onClick={() => openLightbox(openItem.image_url!)}
+                      className="block aspect-square w-full overflow-hidden rounded-md border bg-muted cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                      aria-label={copy.detailTemplate}
+                    >
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
                       <img
                         src={openItem.image_url}
                         alt=""
                         className="h-full w-full object-cover"
                       />
-                    ) : null}
-                  </div>
+                    </button>
+                  ) : (
+                    <div className="aspect-square w-full overflow-hidden rounded-md border bg-muted" />
+                  )}
                 </figure>
                 <figure className="space-y-1">
                   <figcaption className="text-xs font-medium">
                     {copy.detailPreviewOpenAI}
                   </figcaption>
-                  <div className="aspect-square w-full overflow-hidden rounded-md border bg-muted">
-                    {openItem.preview_openai_image_url ? (
-                      /* eslint-disable-next-line @next/next/no-img-element */
+                  {openItem.preview_openai_image_url ? (
+                    <button
+                      type="button"
+                      onClick={() =>
+                        openLightbox(openItem.preview_openai_image_url!)
+                      }
+                      className="block aspect-square w-full overflow-hidden rounded-md border bg-muted cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                      aria-label={copy.detailPreviewOpenAI}
+                    >
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
                       <img
                         src={openItem.preview_openai_image_url}
                         alt=""
                         className="h-full w-full object-cover"
                       />
-                    ) : null}
-                  </div>
+                    </button>
+                  ) : (
+                    <div className="aspect-square w-full overflow-hidden rounded-md border bg-muted" />
+                  )}
                 </figure>
                 <figure className="space-y-1">
                   <figcaption className="text-xs font-medium">
                     {copy.detailPreviewGemini}
                   </figcaption>
-                  <div className="aspect-square w-full overflow-hidden rounded-md border bg-muted">
-                    {openItem.preview_gemini_image_url ? (
-                      /* eslint-disable-next-line @next/next/no-img-element */
+                  {openItem.preview_gemini_image_url ? (
+                    <button
+                      type="button"
+                      onClick={() =>
+                        openLightbox(openItem.preview_gemini_image_url!)
+                      }
+                      className="block aspect-square w-full overflow-hidden rounded-md border bg-muted cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                      aria-label={copy.detailPreviewGemini}
+                    >
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
                       <img
                         src={openItem.preview_gemini_image_url}
                         alt=""
                         className="h-full w-full object-cover"
                       />
-                    ) : null}
-                  </div>
+                    </button>
+                  ) : (
+                    <div className="aspect-square w-full overflow-hidden rounded-md border bg-muted" />
+                  )}
                 </figure>
               </div>
 
@@ -410,7 +474,7 @@ export function AdminStyleTemplatesClient({
                 )}
                 <Button
                   variant="ghost"
-                  onClick={() => setOpenItem(null)}
+                  onClick={closeDetail}
                   disabled={submitting !== null}
                 >
                   {copy.detailClose}
@@ -420,6 +484,14 @@ export function AdminStyleTemplatesClient({
           )}
         </SheetContent>
       </Sheet>
+
+      <ImageLightboxDialog
+        slides={lightboxSlides}
+        index={enlargedIndex}
+        onIndexChange={setEnlargedIndex}
+        prevLabel={copy.detailEnlargedPrev}
+        nextLabel={copy.detailEnlargedNext}
+      />
     </>
   );
 }

--- a/app/(app)/admin/style-templates/page.tsx
+++ b/app/(app)/admin/style-templates/page.tsx
@@ -158,6 +158,8 @@ export default async function AdminStyleTemplatesPage() {
           detailTemplate: t("detailTemplate"),
           detailPreviewOpenAI: t("detailPreviewOpenAI"),
           detailPreviewGemini: t("detailPreviewGemini"),
+          detailEnlargedPrev: t("detailEnlargedPrev"),
+          detailEnlargedNext: t("detailEnlargedNext"),
         }}
       />
     </div>

--- a/app/(app)/inspire/[templateId]/page.tsx
+++ b/app/(app)/inspire/[templateId]/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import { getLocale, getTranslations } from "next-intl/server";
@@ -9,6 +10,9 @@ import {
   getStyleTemplateById,
 } from "@/features/inspire/lib/repository";
 import { InspirePageClient } from "@/features/inspire/components/InspirePageClient";
+import { CachedGeneratedImageGallery } from "@/features/generation/components/CachedGeneratedImageGallery";
+import { GeneratedImageGallerySkeleton } from "@/features/generation/components/GeneratedImageGallerySkeleton";
+import { GenerationStateProvider } from "@/features/generation/context/GenerationStateContext";
 import { DEFAULT_LOCALE, isLocale } from "@/i18n/config";
 import { createMarketingPageMetadata } from "@/lib/metadata";
 
@@ -40,7 +44,7 @@ export default async function InspirePage({ params }: InspirePageProps) {
   }
 
   const { templateId } = await params;
-  await requireAuth();
+  const user = await requireAuth();
 
   const adminClient = createAdminClient();
   const { data: template, error } = await getStyleTemplateById(
@@ -88,18 +92,19 @@ export default async function InspirePage({ params }: InspirePageProps) {
             </p>
           </div>
 
-          <InspirePageClient
-            template={{
-              id: template.id,
-              alt: template.alt,
-              image_url: templateImageUrl,
-              submitted_by_user_id: template.submitted_by_user_id,
-            }}
-            submitter={{
-              nickname: profile?.nickname ?? null,
-              avatar_url: profile?.avatar_url ?? null,
-            }}
-            copy={{
+          <GenerationStateProvider>
+            <InspirePageClient
+              template={{
+                id: template.id,
+                alt: template.alt,
+                image_url: templateImageUrl,
+                submitted_by_user_id: template.submitted_by_user_id,
+              }}
+              submitter={{
+                nickname: profile?.nickname ?? null,
+                avatar_url: profile?.avatar_url ?? null,
+              }}
+              copy={{
               formTitle: t("formTitle"),
               formDescription: t("formDescription"),
               formImageLabel: t("formImageLabel"),
@@ -130,7 +135,22 @@ export default async function InspirePage({ params }: InspirePageProps) {
               resultsPlaceholder: t("resultsPlaceholder"),
               resultImageAlt: t("resultImageAlt"),
             }}
-          />
+            />
+
+            <div className="mt-8">
+              <Suspense fallback={<GeneratedImageGallerySkeleton />}>
+                <CachedGeneratedImageGallery
+                  userId={user.id}
+                  generationType="inspire"
+                  cacheTag={`inspire-${user.id}`}
+                  title={t("resultsTitle")}
+                  detailFromParam="coordinate"
+                  returnToImageIdKey="persta-ai:inspire-return-to-image-id"
+                  applyActionMode="navigate-coordinate"
+                />
+              </Suspense>
+            </div>
+          </GenerationStateProvider>
         </div>
       </div>
     </div>

--- a/app/(app)/inspire/submit/page.tsx
+++ b/app/(app)/inspire/submit/page.tsx
@@ -1,0 +1,68 @@
+import { notFound, redirect } from "next/navigation";
+import type { Metadata } from "next";
+import { getLocale, getTranslations } from "next-intl/server";
+import { env, isInspireFeatureEnabled } from "@/lib/env";
+import { isInspireSubmitterAllowed, requireAuth } from "@/lib/auth";
+import { DEFAULT_LOCALE, isLocale } from "@/i18n/config";
+import { createMarketingPageMetadata } from "@/lib/metadata";
+import { UserStyleTemplateSubmissionForm } from "@/features/inspire/components/UserStyleTemplateSubmissionForm";
+
+interface InspireSubmitPageProps {
+  searchParams: Promise<{ replace?: string }>;
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  const localeValue = await getLocale();
+  const locale = isLocale(localeValue) ? localeValue : DEFAULT_LOCALE;
+  const t = await getTranslations("inspireSubmission");
+
+  return createMarketingPageMetadata({
+    title: t("dialogTitle"),
+    description: t("dialogDescription"),
+    path: "/inspire/submit",
+    locale,
+  });
+}
+
+/**
+ * inspire 申請ページ。旧 `UserStyleTemplateSubmissionDialog`（モーダル）を 1 画面に置き換え。
+ *
+ * ゲート:
+ *   - 機能フラグ (`NEXT_PUBLIC_INSPIRE_ENABLED`) → 無効なら 404
+ *   - 認証必須（`requireAuth()` が未認証時に /login へリダイレクト）
+ *   - 申請ホワイトリスト（`isInspireSubmitterAllowed`）→ 不許可なら /my-page へリダイレクト
+ *     （マイページ側で「新しいテンプレートを申請」ボタンが表示されない人がレシピを叩いた場合のフォールバック）
+ *
+ * 「再申請」フローでは `?replace=<old-template-id>` を渡すと submit 成功時に古い行を上書き削除する
+ * （マイページのカードの「再申請」ボタンから渡される）。
+ */
+export default async function InspireSubmitPage({
+  searchParams,
+}: InspireSubmitPageProps) {
+  if (!isInspireFeatureEnabled()) {
+    notFound();
+  }
+
+  const user = await requireAuth();
+
+  if (!isInspireSubmitterAllowed(user.id)) {
+    redirect("/my-page");
+  }
+
+  const { replace } = await searchParams;
+  const replaceTemplateId =
+    typeof replace === "string" && replace.length > 0 ? replace : null;
+
+  const testCharacterImageUrl = env.INSPIRE_TEST_CHARACTER_IMAGE_URL || null;
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="px-4 pb-8 pt-6 md:pb-10 md:pt-8">
+        <UserStyleTemplateSubmissionForm
+          testCharacterImageUrl={testCharacterImageUrl}
+          replaceTemplateId={replaceTemplateId}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/inspire/submit/page.tsx
+++ b/app/(app)/inspire/submit/page.tsx
@@ -50,8 +50,12 @@ export default async function InspireSubmitPage({
   }
 
   const { replace } = await searchParams;
+  // 後続で /api/style-templates/submissions/{id} 等の path に直接埋め込むので
+  // UUID v1-v5 の形に合致するときのみ採用する（不正値は null に丸めて pass-through）。
+  const UUID_RE =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
   const replaceTemplateId =
-    typeof replace === "string" && replace.length > 0 ? replace : null;
+    typeof replace === "string" && UUID_RE.test(replace) ? replace : null;
 
   const testCharacterImageUrl = env.INSPIRE_TEST_CHARACTER_IMAGE_URL || null;
 

--- a/app/api/style-templates/preview-generation/handler.ts
+++ b/app/api/style-templates/preview-generation/handler.ts
@@ -294,9 +294,7 @@ export async function handlePreviewGeneration(
         targetSizeBaseIndex: 1,
         timeoutMs: OPENAI_TIMEOUT_MS,
         n: 1,
-        // inspire はキャラ識別 × テンプレ構図の合成で難度が高いため
-        // OpenAI の品質ティアを medium に引き上げる（既定の low は細部が崩れやすい）。
-        quality: "medium",
+        quality: "low",
       });
       const result = results[0];
       const previewPath = `${user.id}/preview/${draftId}-openai.png`;
@@ -446,6 +444,23 @@ export async function handlePreviewGeneration(
 
   // 全失敗 → draft + Storage オブジェクトを削除して 500
   if (successes.length === 0) {
+    console.error("[preview-generation] all providers failed", {
+      draftId,
+      userId: user.id,
+      openai: !isSuccess(openaiOutcome)
+        ? {
+            errorMessage: openaiOutcome.errorMessage,
+            isSafetyBlocked: openaiOutcome.isSafetyBlocked,
+          }
+        : null,
+      gemini: !isSuccess(geminiOutcome)
+        ? {
+            errorMessage: geminiOutcome.errorMessage,
+            isSafetyBlocked: geminiOutcome.isSafetyBlocked,
+          }
+        : null,
+    });
+
     await adminClient.storage
       .from("style-templates")
       .remove([templateStoragePath]);
@@ -463,6 +478,27 @@ export async function handlePreviewGeneration(
       isSafety ? "INSPIRE_SAFETY_BLOCKED" : "INSPIRE_PREVIEW_FAILED",
       isSafety ? 400 : 500
     );
+  }
+
+  // partial（片方失敗）でも失敗側の詳細をログに残す。
+  // 全失敗はこのブロックの手前で return 済みのため、ここに来た時点で 1 つ以上は成功している。
+  if (successes.length < 2) {
+    if (!isSuccess(openaiOutcome)) {
+      console.warn("[preview-generation] openai failed (partial)", {
+        draftId,
+        userId: user.id,
+        errorMessage: openaiOutcome.errorMessage,
+        isSafetyBlocked: openaiOutcome.isSafetyBlocked,
+      });
+    }
+    if (!isSuccess(geminiOutcome)) {
+      console.warn("[preview-generation] gemini failed (partial)", {
+        draftId,
+        userId: user.id,
+        errorMessage: geminiOutcome.errorMessage,
+        isSafetyBlocked: geminiOutcome.isSafetyBlocked,
+      });
+    }
   }
 
   // draft 行に preview URL を設定

--- a/features/generation/components/CachedGeneratedImageGallery.tsx
+++ b/features/generation/components/CachedGeneratedImageGallery.tsx
@@ -18,7 +18,8 @@ export type GalleryGenerationType =
   | "specified_coordinate"
   | "full_body"
   | "chibi"
-  | "one_tap_style";
+  | "one_tap_style"
+  | "inspire";
 
 interface CachedGeneratedImageGalleryProps {
   userId: string;

--- a/features/generation/components/GeneratedImageList.tsx
+++ b/features/generation/components/GeneratedImageList.tsx
@@ -94,6 +94,9 @@ export function GeneratedImageList({
   generationType,
 }: GeneratedImageListProps) {
   const isOneTapStyle = generationType === "one_tap_style";
+  // inspire はテンプレ提供者のプロンプト保護のため、one_tap_style と同様に
+  // 使用プロンプトを非表示・コピー不可とする。
+  const isPromptHidden = isOneTapStyle || generationType === "inspire";
   const router = useRouter();
   const t = useTranslations("coordinate");
   const { toast } = useToast();
@@ -302,13 +305,14 @@ export function GeneratedImageList({
           </div>
         );
 
-        // one_tap_style はプリセット保護のため prompt が常に redact される。
-        // 「One-Tap Styleで生成した為、ありません」と専用文言を表示し、
-        // コピーボタンも表示しない（コピー対象が無いだけでなく方針として隠す）。
-        const promptText = isOneTapStyle
-          ? t("listPromptOneTapStyleEmpty")
+        // one_tap_style / inspire はプリセット or テンプレ提供者保護のため prompt を非表示にする。
+        // 専用文言を表示し、コピーボタンも出さない。
+        const promptText = isPromptHidden
+          ? isOneTapStyle
+            ? t("listPromptOneTapStyleEmpty")
+            : t("listPromptInspireEmpty")
           : image.prompt || t("listPromptEmpty");
-        const showCopyButton = !isOneTapStyle && Boolean(image.prompt);
+        const showCopyButton = !isPromptHidden && Boolean(image.prompt);
 
         const promptBlock = (
           <div className="rounded-lg bg-gray-50 p-2.5">

--- a/features/generation/lib/database.ts
+++ b/features/generation/lib/database.ts
@@ -25,6 +25,7 @@ export interface GeneratedImageRecord {
     | 'full_body'
     | 'chibi'
     | 'one_tap_style'
+    | 'inspire'
     | null;
   input_images?: Record<string, unknown> | null;
   generation_metadata?: Record<string, unknown> | null;
@@ -124,6 +125,7 @@ export async function getGeneratedImages(
     | "full_body"
     | "chibi"
     | "one_tap_style"
+    | "inspire"
 ): Promise<GeneratedImageRecord[]> {
   const supabase = createBrowserClient();
 

--- a/features/generation/lib/server-database.ts
+++ b/features/generation/lib/server-database.ts
@@ -82,7 +82,8 @@ export const getGeneratedImagesServer = cache(async (
     | "specified_coordinate"
     | "full_body"
     | "chibi"
-    | "one_tap_style",
+    | "one_tap_style"
+    | "inspire",
   supabaseOverride?: SupabaseClient
 ): Promise<GeneratedImageRecord[]> => {
   const supabase = supabaseOverride ?? (await createClient());

--- a/features/inspire/components/ImageLightboxDialog.tsx
+++ b/features/inspire/components/ImageLightboxDialog.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useEffect } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+
+export interface ImageLightboxSlide {
+  url: string;
+  label: string;
+}
+
+interface ImageLightboxDialogProps {
+  slides: ImageLightboxSlide[];
+  index: number | null;
+  onIndexChange: (next: number | null) => void;
+  prevLabel: string;
+  nextLabel: string;
+}
+
+export function ImageLightboxDialog({
+  slides,
+  index,
+  onIndexChange,
+  prevLabel,
+  nextLabel,
+}: ImageLightboxDialogProps) {
+  useEffect(() => {
+    if (index === null) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        onIndexChange(
+          ((index - 1) + slides.length) % slides.length
+        );
+      } else if (e.key === "ArrowRight") {
+        e.preventDefault();
+        onIndexChange((index + 1) % slides.length);
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [index, slides.length, onIndexChange]);
+
+  const goPrev = () => {
+    if (index === null || slides.length === 0) return;
+    onIndexChange(((index - 1) + slides.length) % slides.length);
+  };
+  const goNext = () => {
+    if (index === null || slides.length === 0) return;
+    onIndexChange((index + 1) % slides.length);
+  };
+
+  return (
+    <Dialog
+      open={index !== null}
+      onOpenChange={(next) => {
+        if (!next) onIndexChange(null);
+      }}
+    >
+      <DialogContent className="max-w-4xl bg-black/95 p-2 sm:p-4">
+        {index !== null && slides[index] && (
+          <div className="relative flex max-h-[85vh] flex-col items-center justify-center">
+            {slides.length > 1 && (
+              <>
+                <button
+                  type="button"
+                  onClick={goPrev}
+                  aria-label={prevLabel}
+                  className="absolute left-2 top-1/2 z-10 -translate-y-1/2 cursor-pointer rounded-full bg-white/10 p-2 text-white shadow-md transition hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black sm:p-3"
+                >
+                  <ChevronLeft aria-hidden="true" className="size-6 sm:size-8" />
+                </button>
+                <button
+                  type="button"
+                  onClick={goNext}
+                  aria-label={nextLabel}
+                  className="absolute right-2 top-1/2 z-10 -translate-y-1/2 cursor-pointer rounded-full bg-white/10 p-2 text-white shadow-md transition hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black sm:p-3"
+                >
+                  <ChevronRight aria-hidden="true" className="size-6 sm:size-8" />
+                </button>
+              </>
+            )}
+
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={slides[index].url}
+              alt={slides[index].label}
+              className="max-h-[80vh] w-auto max-w-full object-contain"
+            />
+
+            <div className="mt-2 flex items-center justify-center gap-3 text-xs text-white/80">
+              <span className="font-medium">{slides[index].label}</span>
+              {slides.length > 1 && <span aria-hidden="true">·</span>}
+              {slides.length > 1 && (
+                <span className="tabular-nums">
+                  {index + 1} / {slides.length}
+                </span>
+              )}
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/features/inspire/components/InspireGenerationFlow.tsx
+++ b/features/inspire/components/InspireGenerationFlow.tsx
@@ -74,6 +74,12 @@ interface InspireGenerationFlowProps {
   aspectRatio: number;
   copy: InspireGenerationFlowCopy;
   onComplete?: (status: AsyncGenerationStatus) => void;
+  /**
+   * 完了後の結果セクションを表示するか。
+   * 下に CachedGeneratedImageGallery を別途置く構成では false にする
+   * （二重表示の回避用）。
+   */
+  showResultPanel?: boolean;
 }
 
 // /inspire 用の生成中ステータスカード + 結果表示。
@@ -85,6 +91,7 @@ export function InspireGenerationFlow({
   aspectRatio,
   copy,
   onComplete,
+  showResultPanel = true,
 }: InspireGenerationFlowProps) {
   const t = useTranslations("coordinate");
   const [status, setStatus] = useState<AsyncGenerationStatus | null>(null);
@@ -258,7 +265,7 @@ export function InspireGenerationFlow({
       )}
 
       {/* 結果セクション（completing の 5 秒祝福ステートを抜けて idle になってから表示） */}
-      {isRevealed && (
+      {showResultPanel && isRevealed && (
         <section className="space-y-3">
           <h2 className="text-xl font-semibold text-gray-900">
             {copy.resultsTitle}

--- a/features/inspire/components/InspireGenerationFlow.tsx
+++ b/features/inspire/components/InspireGenerationFlow.tsx
@@ -69,7 +69,11 @@ interface InspireGenerationFlowCopy {
 }
 
 interface InspireGenerationFlowProps {
-  jobId: string;
+  /**
+   * 非同期ジョブの ID。fetch 中はまだ jobId が無いので null を渡すと
+   * polling せずに「準備中」のステータスバーだけが表示される（/style と同等）。
+   */
+  jobId: string | null;
   /** テンプレ画像のアスペクト比（結果カードのサイズ計算用） */
   aspectRatio: number;
   copy: InspireGenerationFlowCopy;
@@ -179,8 +183,17 @@ export function InspireGenerationFlow({
     };
   }, [phase]);
 
+  // /style と同じく祝福フェーズ (completing → idle) を抜けてからコンテナへ通知する。
+  // これによりステータスバーが 5 秒残り、その後 setActiveJobId(null) 等で unmount される。
+  useEffect(() => {
+    if (phase === "idle" && status?.status === "succeeded") {
+      onCompleteRef.current?.(status);
+    }
+  }, [phase, status]);
+
   // job poll（adaptive interval は /style と同じ）
   useEffect(() => {
+    if (!jobId) return;
     let isMounted = true;
     const { promise, stop } = pollGenerationStatus(jobId, {
       interval: getStatusPollingIntervalMs,
@@ -199,9 +212,13 @@ export function InspireGenerationFlow({
         if (!isMounted) return;
         setStatus(finalStatus);
         if (finalStatus.status === "succeeded") {
+          // 成功時の onComplete は completing → idle 遷移後の useEffect で呼ぶ
+          // （祝福フェーズの 5 秒を待ってから unmount するため）。
           setPhase((prev) => (prev === "running" ? "completing" : prev));
+        } else {
+          // 失敗時は即座にコンテナへ通知（祝福フェーズには入らない）。
+          onCompleteRef.current?.(finalStatus);
         }
-        onCompleteRef.current?.(finalStatus);
       })
       .catch((err: unknown) => {
         if (!isMounted) return;

--- a/features/inspire/components/InspirePageClient.tsx
+++ b/features/inspire/components/InspirePageClient.tsx
@@ -297,6 +297,9 @@ export function InspirePageClient({
           jobId={activeJobId}
           aspectRatio={templateAspectRatio}
           onComplete={() => router.refresh()}
+          // 結果は下の CachedGeneratedImageGallery 側で表示するため、
+          // ここでは進捗カード／失敗カードのみ描画して二重表示を避ける。
+          showResultPanel={false}
           copy={{
             statusFailed: copy.statusFailed,
             statusFailedDescription: copy.statusFailedDescription,

--- a/features/inspire/components/InspirePageClient.tsx
+++ b/features/inspire/components/InspirePageClient.tsx
@@ -95,11 +95,15 @@ export function InspirePageClient({
   const { toast } = useToast();
   const [activeJobId, setActiveJobId] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  // 生成中（fetch 中 + ジョブ進行中）はフォームを操作不可にする。
+  // /style と同じく単一ジョブ運用なので polling 終了 (onComplete) で activeJobId を null に戻し再生成可能とする。
+  const isGenerating = submitting || activeJobId !== null;
   const [uploadedImage, setUploadedImage] = useState<UploadedImage | null>(null);
   const [selectedModel, setSelectedModel] = useState<GeminiModel>(
     DEFAULT_GENERATION_MODEL
   );
-  const [count, setCount] = useState<number>(1);
+  // /style と同じく生成枚数は常に 1 固定（UI なし）。
+  const COUNT = 1;
   const [overrideTarget, setOverrideTarget] =
     useState<InspireOverrideValue>("keep_all");
   const [error, setError] = useState<string | null>(null);
@@ -125,7 +129,7 @@ export function InspirePageClient({
           sourceImageMimeType: uploadedImage.file.type,
           generationType: "inspire",
           model: selectedModel,
-          count,
+          count: COUNT,
           styleTemplateId: template.id,
           overrideTarget: toApiOverrideTarget(overrideTarget),
         }),
@@ -161,7 +165,7 @@ export function InspirePageClient({
             value={uploadedImage}
             label={copy.formUploadLabel}
             addImageLabel={copy.formAddImageAction}
-            disabled={submitting}
+            disabled={isGenerating}
             aspectRatio={templateAspectRatio}
             filledPreviewMode="natural"
           />
@@ -251,27 +255,17 @@ export function InspirePageClient({
       {/* モデル + 枚数 + 生成ボタン */}
       <Card className="p-6">
         <div className="space-y-6">
-          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
-            <div className="space-y-3">
-              <p className="text-base font-medium">{copy.formModelLabel}</p>
-              <LockableModelSelect
-                value={selectedModel}
-                onChange={setSelectedModel}
-                onLockedClick={() => {
-                  /* 認証必須ページなのでロックは発火しない（guard 用 placeholder） */
-                }}
-                authState="authenticated"
-                disabled={submitting}
-              />
-            </div>
-            <div className="space-y-3">
-              <p className="text-base font-medium">{copy.formCountLabel}</p>
-              <CountSelector
-                value={count}
-                onChange={setCount}
-                disabled={submitting}
-              />
-            </div>
+          <div className="space-y-3">
+            <p className="text-base font-medium">{copy.formModelLabel}</p>
+            <LockableModelSelect
+              value={selectedModel}
+              onChange={setSelectedModel}
+              onLockedClick={() => {
+                /* 認証必須ページなのでロックは発火しない（guard 用 placeholder） */
+              }}
+              authState="authenticated"
+              disabled={isGenerating}
+            />
           </div>
 
           {error ? (
@@ -282,21 +276,30 @@ export function InspirePageClient({
             type="button"
             className="w-full"
             size="lg"
-            disabled={!uploadedImage || submitting}
+            disabled={!uploadedImage || isGenerating}
             onClick={handleGenerate}
             aria-label={copy.formGenerateAria}
           >
             <Sparkles className="mr-2 h-5 w-5" aria-hidden="true" />
-            {submitting ? copy.formGenerating : copy.formGenerateButton}
+            {isGenerating ? copy.formGenerating : copy.formGenerateButton}
           </Button>
         </div>
       </Card>
 
-      {activeJobId && (
+      {/*
+        /style と同じく「生成する」ボタン押下直後（fetch 中で jobId 未取得）から
+        ステータスバーを表示するため、isGenerating の間ずっとマウントする。
+        jobId が null の間は polling せず「準備中」表示のみになる。
+      */}
+      {isGenerating && (
         <InspireGenerationFlow
           jobId={activeJobId}
           aspectRatio={templateAspectRatio}
-          onComplete={() => router.refresh()}
+          onComplete={() => {
+            // ジョブ完了で再度フォーム操作可能にし、router.refresh() で Gallery を更新。
+            setActiveJobId(null);
+            router.refresh();
+          }}
           // 結果は下の CachedGeneratedImageGallery 側で表示するため、
           // ここでは進捗カード／失敗カードのみ描画して二重表示を避ける。
           showResultPanel={false}
@@ -313,36 +316,3 @@ export function InspirePageClient({
   );
 }
 
-function CountSelector({
-  value,
-  onChange,
-  disabled,
-}: {
-  value: number;
-  onChange: (next: number) => void;
-  disabled?: boolean;
-}) {
-  return (
-    <div className="grid grid-cols-4 gap-2">
-      {[1, 2, 3, 4].map((n) => {
-        const isSelected = value === n;
-        return (
-          <button
-            key={n}
-            type="button"
-            onClick={() => onChange(n)}
-            disabled={disabled}
-            aria-pressed={isSelected}
-            className={`rounded-lg border px-3 py-2 text-sm font-medium transition cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 ${
-              isSelected
-                ? "border-primary bg-primary text-primary-foreground"
-                : "border-input bg-background hover:bg-accent"
-            }`}
-          >
-            {n}
-          </button>
-        );
-      })}
-    </div>
-  );
-}

--- a/features/inspire/components/MySubmittedTemplatesCard.tsx
+++ b/features/inspire/components/MySubmittedTemplatesCard.tsx
@@ -1,8 +1,5 @@
 import { getTranslations } from "next-intl/server";
-import {
-  env,
-  isInspireFeatureEnabled,
-} from "@/lib/env";
+import { isInspireFeatureEnabled } from "@/lib/env";
 import { isInspireSubmitterAllowed } from "@/lib/auth";
 import { createAdminClient } from "@/lib/supabase/admin";
 import {
@@ -74,14 +71,13 @@ export async function MySubmittedTemplatesCard({
       : null,
   }));
 
-  // Step 2 のテストキャラ画像表示用に env URL を Client へ渡す。
-  // env は長期 signed URL を想定（運営側で設定、Method A）。
-  const testCharacterImageUrl = env.INSPIRE_TEST_CHARACTER_IMAGE_URL || null;
+  // テストキャラ画像 URL は申請ページ（app/(app)/inspire/submit/page.tsx）側で env から
+  // 読み出すため、ここからは渡さない。マイページ Card 自体は申請モーダルを持たない構成に
+  // 変更（モーダル廃止、申請は専用ページへ遷移）。
 
   return (
     <MySubmittedTemplatesCardClient
       items={items}
-      testCharacterImageUrl={testCharacterImageUrl}
       copy={{
         title: t("inspireSectionTitle"),
         description: t("inspireSectionDescription"),

--- a/features/inspire/components/MySubmittedTemplatesCard.tsx
+++ b/features/inspire/components/MySubmittedTemplatesCard.tsx
@@ -107,6 +107,7 @@ export async function MySubmittedTemplatesCard({
         deleteConfirmAction: t("inspireDeleteConfirmAction"),
         deleteSuccess: t("inspireDeleteSuccess"),
         deleteFailed: t("inspireDeleteFailed"),
+        openForGenerationAria: t("inspireOpenForGenerationAria"),
       }}
     />
   );

--- a/features/inspire/components/MySubmittedTemplatesCardClient.tsx
+++ b/features/inspire/components/MySubmittedTemplatesCardClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import {
   AlertDialog,
@@ -15,7 +16,6 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/components/ui/use-toast";
-import { UserStyleTemplateSubmissionDialog } from "./UserStyleTemplateSubmissionDialog";
 
 type ModerationStatus =
   | "draft"
@@ -63,23 +63,15 @@ interface Copy {
 
 interface MySubmittedTemplatesCardClientProps {
   items: MySubmittedTemplate[];
-  testCharacterImageUrl: string | null;
   copy: Copy;
 }
 
 export function MySubmittedTemplatesCardClient({
   items,
-  testCharacterImageUrl,
   copy,
 }: MySubmittedTemplatesCardClientProps) {
   const router = useRouter();
   const { toast } = useToast();
-  const [dialogOpen, setDialogOpen] = useState(false);
-  // 「再申請」で開かれたとき、上書き対象となる古い rejected/withdrawn 行の ID。
-  // submit 成功時にこの ID の行が自動削除される（上書き挙動）。
-  const [replaceTemplateId, setReplaceTemplateId] = useState<string | null>(
-    null
-  );
   const [pendingWithdraw, setPendingWithdraw] =
     useState<MySubmittedTemplate | null>(null);
   const [withdrawing, setWithdrawing] = useState(false);
@@ -180,7 +172,9 @@ export function MySubmittedTemplatesCardClient({
             {copy.description}
           </p>
         </div>
-        <Button onClick={() => setDialogOpen(true)}>{copy.submitButton}</Button>
+        <Button asChild>
+          <Link href="/inspire/submit">{copy.submitButton}</Link>
+        </Button>
       </div>
 
       {items.length === 0 ? (
@@ -241,16 +235,14 @@ export function MySubmittedTemplatesCardClient({
                 )}
                 {canResubmitOrDelete(item.moderation_status) && (
                   <div className="grid grid-cols-2 gap-2">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => {
-                        // 再申請: submit 成功時にこの行（古い rejected/withdrawn）を上書き削除する
-                        setReplaceTemplateId(item.id);
-                        setDialogOpen(true);
-                      }}
-                    >
-                      {copy.resubmitAction}
+                    <Button asChild variant="outline" size="sm">
+                      {/* 再申請: submit 成功時にこの行（古い rejected/withdrawn）を
+                          上書き削除するため、`?replace=<id>` でページに渡す */}
+                      <Link
+                        href={`/inspire/submit?replace=${encodeURIComponent(item.id)}`}
+                      >
+                        {copy.resubmitAction}
+                      </Link>
                     </Button>
                     <Button
                       variant="ghost"
@@ -267,18 +259,6 @@ export function MySubmittedTemplatesCardClient({
           ))}
         </ul>
       )}
-
-      <UserStyleTemplateSubmissionDialog
-        open={dialogOpen}
-        onOpenChange={(next) => {
-          setDialogOpen(next);
-          // dialog が閉じたら replace 対象もリセット（cancel 時は上書きしない）
-          if (!next) setReplaceTemplateId(null);
-        }}
-        onSubmissionSucceeded={() => router.refresh()}
-        testCharacterImageUrl={testCharacterImageUrl}
-        replaceTemplateId={replaceTemplateId}
-      />
 
       <AlertDialog
         open={pendingWithdraw !== null}

--- a/features/inspire/components/MySubmittedTemplatesCardClient.tsx
+++ b/features/inspire/components/MySubmittedTemplatesCardClient.tsx
@@ -59,6 +59,7 @@ interface Copy {
   deleteConfirmAction: string;
   deleteSuccess: string;
   deleteFailed: string;
+  openForGenerationAria: string;
 }
 
 interface MySubmittedTemplatesCardClientProps {
@@ -188,20 +189,35 @@ export function MySubmittedTemplatesCardClient({
               key={item.id}
               className="overflow-hidden rounded-md border bg-card"
             >
-              <div className="flex aspect-square items-center justify-center bg-muted">
-                {item.image_url ? (
-                  /* eslint-disable-next-line @next/next/no-img-element */
+              {item.moderation_status === "visible" && item.image_url ? (
+                <Link
+                  href={`/inspire/${item.id}`}
+                  aria-label={copy.openForGenerationAria}
+                  className="flex aspect-square items-center justify-center bg-muted transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                >
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
                   <img
                     src={item.image_url}
                     alt={item.alt ?? ""}
                     className="h-full w-full object-cover"
                   />
-                ) : (
-                  <span className="text-xs text-muted-foreground">
-                    no image
-                  </span>
-                )}
-              </div>
+                </Link>
+              ) : (
+                <div className="flex aspect-square items-center justify-center bg-muted">
+                  {item.image_url ? (
+                    /* eslint-disable-next-line @next/next/no-img-element */
+                    <img
+                      src={item.image_url}
+                      alt={item.alt ?? ""}
+                      className="h-full w-full object-cover"
+                    />
+                  ) : (
+                    <span className="text-xs text-muted-foreground">
+                      no image
+                    </span>
+                  )}
+                </div>
+              )}
               <div className="space-y-2 p-3">
                 <div className="flex items-center justify-between gap-2">
                   <Badge variant={statusVariant(item.moderation_status)}>

--- a/features/inspire/components/UserStyleTemplateSubmissionForm.tsx
+++ b/features/inspire/components/UserStyleTemplateSubmissionForm.tsx
@@ -530,10 +530,14 @@ export function UserStyleTemplateSubmissionForm({
             )}
 
             <div className="flex flex-col gap-2 sm:flex-row sm:justify-between">
-              <Button variant="ghost" onClick={requestLeave}>
+              <Button type="button" variant="ghost" onClick={requestLeave}>
                 {t("cancelButton")}
               </Button>
-              <Button onClick={() => setStep(2)} disabled={!file || !consent}>
+              <Button
+                type="button"
+                onClick={() => setStep(2)}
+                disabled={!file || !consent}
+              >
                 {t("step1NextButton")}
               </Button>
             </div>
@@ -588,6 +592,7 @@ export function UserStyleTemplateSubmissionForm({
 
             <div className="flex flex-col gap-2 sm:flex-row sm:justify-between">
               <Button
+                type="button"
                 variant="ghost"
                 onClick={() => setStep(1)}
                 disabled={generating}
@@ -595,6 +600,7 @@ export function UserStyleTemplateSubmissionForm({
                 {t("step2BackButton")}
               </Button>
               <Button
+                type="button"
                 onClick={handleGeneratePreview}
                 disabled={!file || generating}
                 className="cursor-pointer"
@@ -680,13 +686,18 @@ export function UserStyleTemplateSubmissionForm({
 
             <div className="flex flex-col gap-2 sm:flex-row sm:justify-between">
               <Button
+                type="button"
                 variant="ghost"
                 onClick={() => setStep(2)}
                 disabled={submitting}
               >
                 {t("step3BackButton")}
               </Button>
-              <Button onClick={handleSubmit} disabled={!consent || submitting}>
+              <Button
+                type="button"
+                onClick={handleSubmit}
+                disabled={!consent || submitting}
+              >
                 {submitting ? t("submitting") : t("step3SubmitButton")}
               </Button>
             </div>
@@ -706,6 +717,7 @@ export function UserStyleTemplateSubmissionForm({
           <AlertDialogFooter>
             <AlertDialogCancel>{t("closeConfirmCancel")}</AlertDialogCancel>
             <AlertDialogAction
+              type="button"
               onClick={() => {
                 setCloseConfirmOpen(false);
                 leaveNow();

--- a/features/inspire/components/UserStyleTemplateSubmissionForm.tsx
+++ b/features/inspire/components/UserStyleTemplateSubmissionForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { ChevronLeft, ChevronRight, Loader2, Plus } from "lucide-react";
 import {
@@ -15,14 +16,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -40,10 +34,7 @@ interface PreviewGenerationResponse {
   previews: PreviewSummary[];
 }
 
-interface UserStyleTemplateSubmissionDialogProps {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  onSubmissionSucceeded?: () => void;
+interface UserStyleTemplateSubmissionFormProps {
   /**
    * Step 2 で「試着するキャラ」として表示する画像 URL。
    * 運営が env (INSPIRE_TEST_CHARACTER_IMAGE_URL) で設定した長期 signed URL。
@@ -84,7 +75,7 @@ async function readFileAsBase64(file: File): Promise<string> {
 }
 
 /**
- * 上部の Step indicator (1 / 2 / 3 ドット + 接続線 + ラベル)
+ * 上部の Step indicator (1 / 2 / 3 ドット + 接続線)
  */
 function StepIndicator({ current }: { current: Step }) {
   const steps: Step[] = [1, 2, 3];
@@ -183,15 +174,22 @@ function MediaCell({
   );
 }
 
-export function UserStyleTemplateSubmissionDialog({
-  open,
-  onOpenChange,
-  onSubmissionSucceeded,
+/**
+ * 申請フォーム（旧 `UserStyleTemplateSubmissionDialog` の中身を専用ページに移植したもの）。
+ *
+ * モーダルから 1 画面構成に変更したのに伴い、
+ * - 外側の `<Dialog>` は削除し、`<section>` ベースの page layout に
+ * - 旧「× / 背景クリック / Esc で閉じる」は「キャンセル / 戻るボタンで /my-page へ戻る」に
+ * - dirty な状態で離脱しようとしたら AlertDialog で確認（draft の cleanup は変わらず）
+ * - 申請成功後は `router.push("/my-page")` で戻る
+ */
+export function UserStyleTemplateSubmissionForm({
   testCharacterImageUrl,
   replaceTemplateId,
-}: UserStyleTemplateSubmissionDialogProps) {
+}: UserStyleTemplateSubmissionFormProps) {
   const t = useTranslations("inspireSubmission");
   const { toast } = useToast();
+  const router = useRouter();
 
   const [step, setStep] = useState<Step>(1);
   const [file, setFile] = useState<File | null>(null);
@@ -211,21 +209,6 @@ export function UserStyleTemplateSubmissionDialog({
   // 拡大表示している画像のインデックス（null = 表示なし）。
   // インデックスは下記 enlargeableSlides 配列上の位置を指す。
   const [enlargedIndex, setEnlargedIndex] = useState<number | null>(null);
-
-  const reset = useCallback(() => {
-    setStep(1);
-    setFile(null);
-    if (filePreviewUrl) URL.revokeObjectURL(filePreviewUrl);
-    setFilePreviewUrl(null);
-    setAlt("");
-    setGenerating(false);
-    setSubmitting(false);
-    setPreviewResult(null);
-    setPreviewSignedUrls({});
-    setConsent(false);
-    setErrorMessage(null);
-    setEnlargedIndex(null);
-  }, [filePreviewUrl]);
 
   // Step 3 で拡大可能な画像の集合（左右ナビ用）。
   // テンプレ → OpenAI → Gemini の順。URL が存在しないものは除外する。
@@ -289,13 +272,20 @@ export function UserStyleTemplateSubmissionDialog({
     return () => window.removeEventListener("keydown", handler);
   }, [enlargedIndex, goPrev, goNext]);
 
+  // ObjectURL を unmount 時にも掃除する（旧 Dialog では reset() で掃除していた）。
+  useEffect(() => {
+    return () => {
+      if (filePreviewUrl) URL.revokeObjectURL(filePreviewUrl);
+    };
+  }, [filePreviewUrl]);
+
   /**
-   * ダイアログを閉じる。
+   * 画面を閉じる（= マイページに戻る）。
    * @param options.deleteDraft - true の場合、draft 行が DB にあればバックグラウンドで削除する。
-   *   ユーザーが取り消した場合（× / キャンセル / ESC / 背景クリック）= true
+   *   ユーザーが取り消した場合（キャンセル / 戻る）= true
    *   申請が成功して閉じる場合 = false（既に pending に昇格済みなので消さない）
    */
-  const closeNow = useCallback(
+  const leaveNow = useCallback(
     (options: { deleteDraft: boolean } = { deleteDraft: true }) => {
       const draftId = previewResult?.template_id;
       if (options.deleteDraft && draftId) {
@@ -306,24 +296,20 @@ export function UserStyleTemplateSubmissionDialog({
           console.warn("[submission] background draft delete failed", err);
         });
       }
-      reset();
-      onOpenChange(false);
+      router.push("/my-page");
     },
-    [onOpenChange, previewResult, reset]
+    [previewResult, router]
   );
 
-  const requestClose = useCallback(() => {
+  const requestLeave = useCallback(() => {
     const hasInput =
-      file !== null ||
-      alt.length > 0 ||
-      previewResult !== null ||
-      consent;
+      file !== null || alt.length > 0 || previewResult !== null || consent;
     if (!hasInput) {
-      closeNow();
+      leaveNow();
       return;
     }
     setCloseConfirmOpen(true);
-  }, [alt, closeNow, consent, file, previewResult]);
+  }, [alt, consent, file, leaveNow, previewResult]);
 
   const handleFileChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -462,296 +448,249 @@ export function UserStyleTemplateSubmissionDialog({
           console.warn("[submission] replace target delete failed", err);
         });
       }
-      onSubmissionSucceeded?.();
       // 申請成功時は新しい draft → pending へ昇格済み。新しい行を DELETE してはいけない。
-      closeNow({ deleteDraft: false });
+      leaveNow({ deleteDraft: false });
     } catch (err) {
       console.error("[submission] submit failed", err);
       setErrorMessage(t("submitFailedGeneric"));
     } finally {
       setSubmitting(false);
     }
-  }, [
-    closeNow,
-    consent,
-    onSubmissionSucceeded,
-    previewResult,
-    replaceTemplateId,
-    t,
-    toast,
-  ]);
+  }, [consent, leaveNow, previewResult, replaceTemplateId, t, toast]);
 
   return (
     <>
-      <Dialog
-        open={open}
-        onOpenChange={(next) => {
-          if (!next) {
-            requestClose();
-            return;
-          }
-          onOpenChange(next);
-        }}
-      >
-        <DialogContent
-          className="max-w-2xl max-h-[90vh] overflow-y-auto"
-          onPointerDownOutside={(e) => {
-            e.preventDefault();
-            requestClose();
-          }}
-          onEscapeKeyDown={(e) => {
-            e.preventDefault();
-            requestClose();
-          }}
-        >
-          <DialogHeader>
-            <DialogTitle>{t("dialogTitle")}</DialogTitle>
-            <DialogDescription>{t("dialogDescription")}</DialogDescription>
-          </DialogHeader>
+      <section className="mx-auto max-w-2xl space-y-6">
+        <header className="space-y-2">
+          <h1 className="text-2xl font-bold text-gray-900">{t("dialogTitle")}</h1>
+          <p className="text-sm text-muted-foreground">{t("dialogDescription")}</p>
+        </header>
 
-          <StepIndicator current={step} />
+        <StepIndicator current={step} />
 
-          {step === 1 && (
-            <div className="space-y-4">
-              <h3 className="text-base font-semibold">{t("step1Title")}</h3>
-              <p className="text-sm text-muted-foreground">
-                {t("step1Description")}
-              </p>
+        {step === 1 && (
+          <div className="space-y-4">
+            <h2 className="text-base font-semibold">{t("step1Title")}</h2>
+            <p className="text-sm text-muted-foreground">{t("step1Description")}</p>
 
-              <div className="space-y-2">
-                <Label htmlFor="inspire-file">{t("step1FileLabel")}</Label>
-                <Input
-                  id="inspire-file"
-                  type="file"
-                  accept={ACCEPTED_MIME.join(",")}
-                  onChange={handleFileChange}
-                  className="cursor-pointer"
-                />
-                <p className="text-xs text-muted-foreground">
-                  {t("step1FileHint")}
-                </p>
-              </div>
-
-              {filePreviewUrl && (
-                <div className="overflow-hidden rounded-lg border bg-muted shadow-sm">
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
-                    src={filePreviewUrl}
-                    alt="upload preview"
-                    className="max-h-64 w-full object-contain"
-                  />
-                </div>
-              )}
-
-              <div className="space-y-2">
-                <Label htmlFor="inspire-alt">{t("step1AltLabel")}</Label>
-                <Textarea
-                  id="inspire-alt"
-                  value={alt}
-                  onChange={(e) => setAlt(e.target.value)}
-                  placeholder={t("step1AltPlaceholder")}
-                  maxLength={200}
-                  rows={2}
-                />
-              </div>
-
-              <div className="flex items-start gap-2 rounded-lg border bg-muted/30 p-3">
-                <Checkbox
-                  id="inspire-consent"
-                  checked={consent}
-                  onCheckedChange={(v) => setConsent(v === true)}
-                  className="mt-0.5 cursor-pointer"
-                />
-                <Label
-                  htmlFor="inspire-consent"
-                  className="cursor-pointer text-xs leading-snug"
-                >
-                  {t("step3ConsentLabel")}
-                </Label>
-              </div>
-
-              {errorMessage && (
-                <p className="text-sm text-destructive">{errorMessage}</p>
-              )}
-
-              <DialogFooter className="flex flex-col gap-2 sm:flex-row sm:justify-between">
-                <Button variant="ghost" onClick={requestClose}>
-                  {t("cancelButton")}
-                </Button>
-                <Button
-                  onClick={() => setStep(2)}
-                  disabled={!file || !consent}
-                >
-                  {t("step1NextButton")}
-                </Button>
-              </DialogFooter>
+            <div className="space-y-2">
+              <Label htmlFor="inspire-file">{t("step1FileLabel")}</Label>
+              <Input
+                id="inspire-file"
+                type="file"
+                accept={ACCEPTED_MIME.join(",")}
+                onChange={handleFileChange}
+                className="cursor-pointer"
+              />
+              <p className="text-xs text-muted-foreground">{t("step1FileHint")}</p>
             </div>
-          )}
 
-          {step === 2 && (
-            <div className="space-y-4">
-              <h3 className="text-base font-semibold">{t("step2Title")}</h3>
-              <p className="text-sm text-muted-foreground">
-                {t("step2Description")}
-              </p>
-
-              {/*
-                「あなたのテンプレ + テストキャラ」の Before 構造。
-                生成中は中央/下部に「生成中…」を別途表示し、placeholder の 3 枚目は出さない。
-              */}
-              <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-3">
-                <MediaCell
+            {filePreviewUrl && (
+              <div className="overflow-hidden rounded-lg border bg-muted shadow-sm">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
                   src={filePreviewUrl}
-                  alt="your template"
-                  label={t("step2YourTemplateLabel")}
+                  alt="upload preview"
+                  className="max-h-64 w-full object-contain"
                 />
-                <div
+              </div>
+            )}
+
+            <div className="space-y-2">
+              <Label htmlFor="inspire-alt">{t("step1AltLabel")}</Label>
+              <Textarea
+                id="inspire-alt"
+                value={alt}
+                onChange={(e) => setAlt(e.target.value)}
+                placeholder={t("step1AltPlaceholder")}
+                maxLength={200}
+                rows={2}
+              />
+            </div>
+
+            <div className="flex items-start gap-2 rounded-lg border bg-muted/30 p-3">
+              <Checkbox
+                id="inspire-consent"
+                checked={consent}
+                onCheckedChange={(v) => setConsent(v === true)}
+                className="mt-0.5 cursor-pointer"
+              />
+              <Label
+                htmlFor="inspire-consent"
+                className="cursor-pointer text-xs leading-snug"
+              >
+                {t("step3ConsentLabel")}
+              </Label>
+            </div>
+
+            {errorMessage && (
+              <p className="text-sm text-destructive">{errorMessage}</p>
+            )}
+
+            <div className="flex flex-col gap-2 sm:flex-row sm:justify-between">
+              <Button variant="ghost" onClick={requestLeave}>
+                {t("cancelButton")}
+              </Button>
+              <Button onClick={() => setStep(2)} disabled={!file || !consent}>
+                {t("step1NextButton")}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {step === 2 && (
+          <div className="space-y-4">
+            <h2 className="text-base font-semibold">{t("step2Title")}</h2>
+            <p className="text-sm text-muted-foreground">{t("step2Description")}</p>
+
+            {/*
+              「あなたのテンプレ + テストキャラ」の Before 構造。
+              生成中は中央/下部に「生成中…」を別途表示し、placeholder の 3 枚目は出さない。
+            */}
+            <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-3">
+              <MediaCell
+                src={filePreviewUrl}
+                alt="your template"
+                label={t("step2YourTemplateLabel")}
+              />
+              <div
+                aria-hidden="true"
+                className="flex size-9 items-center justify-center rounded-full bg-muted text-muted-foreground"
+              >
+                <Plus className="size-5" />
+              </div>
+              <MediaCell
+                src={testCharacterImageUrl}
+                alt="test character"
+                label={t("step2TestCharacterLabel")}
+                placeholderText="—"
+              />
+            </div>
+
+            {generating && (
+              <div className="flex items-center justify-center gap-2 rounded-lg bg-muted/50 py-3 text-sm text-muted-foreground">
+                <Loader2
+                  className="size-4 motion-safe:animate-spin"
                   aria-hidden="true"
-                  className="flex size-9 items-center justify-center rounded-full bg-muted text-muted-foreground"
-                >
-                  <Plus className="size-5" />
-                </div>
-                <MediaCell
-                  src={testCharacterImageUrl}
-                  alt="test character"
-                  label={t("step2TestCharacterLabel")}
-                  placeholderText="—"
                 />
+                <span>{t("step2GeneratingMessage")}</span>
               </div>
+            )}
 
-              {generating && (
-                <div className="flex items-center justify-center gap-2 rounded-lg bg-muted/50 py-3 text-sm text-muted-foreground">
-                  <Loader2
-                    className="size-4 motion-safe:animate-spin"
-                    aria-hidden="true"
-                  />
-                  <span>{t("step2GeneratingMessage")}</span>
-                </div>
-              )}
+            {errorMessage && (
+              <p className="text-sm text-destructive">{errorMessage}</p>
+            )}
 
-              {errorMessage && (
-                <p className="text-sm text-destructive">{errorMessage}</p>
-              )}
-
-              <DialogFooter className="flex flex-col gap-2 sm:flex-row sm:justify-between">
-                <Button
-                  variant="ghost"
-                  onClick={() => setStep(1)}
-                  disabled={generating}
-                >
-                  {t("step2BackButton")}
-                </Button>
-                <Button
-                  onClick={handleGeneratePreview}
-                  disabled={!file || generating}
-                  className="cursor-pointer"
-                >
-                  {generating ? (
-                    <>
-                      <Loader2
-                        className="mr-1.5 size-4 motion-safe:animate-spin"
-                        aria-hidden="true"
-                      />
-                      {t("step2GeneratingInline")}
-                    </>
-                  ) : (
-                    t("step2NextButton")
-                  )}
-                </Button>
-              </DialogFooter>
+            <div className="flex flex-col gap-2 sm:flex-row sm:justify-between">
+              <Button
+                variant="ghost"
+                onClick={() => setStep(1)}
+                disabled={generating}
+              >
+                {t("step2BackButton")}
+              </Button>
+              <Button
+                onClick={handleGeneratePreview}
+                disabled={!file || generating}
+                className="cursor-pointer"
+              >
+                {generating ? (
+                  <>
+                    <Loader2
+                      className="mr-1.5 size-4 motion-safe:animate-spin"
+                      aria-hidden="true"
+                    />
+                    {t("step2GeneratingInline")}
+                  </>
+                ) : (
+                  t("step2NextButton")
+                )}
+              </Button>
             </div>
-          )}
+          </div>
+        )}
 
-          {step === 3 && previewResult && (
-            <div className="space-y-4">
-              <h3 className="text-base font-semibold">{t("step3Title")}</h3>
-              <p className="text-sm text-muted-foreground">
-                {t("step3Description")}
+        {step === 3 && previewResult && (
+          <div className="space-y-4">
+            <h2 className="text-base font-semibold">{t("step3Title")}</h2>
+            <p className="text-sm text-muted-foreground">{t("step3Description")}</p>
+
+            {previewResult.outcome === "partial" && (
+              <p
+                role="status"
+                className="rounded-lg border border-yellow-300 bg-yellow-50 p-2 text-xs text-yellow-900"
+              >
+                {t("step2PartialNotice")}
               </p>
+            )}
 
-              {previewResult.outcome === "partial" && (
-                <p
-                  role="status"
-                  className="rounded-lg border border-yellow-300 bg-yellow-50 p-2 text-xs text-yellow-900"
-                >
-                  {t("step2PartialNotice")}
-                </p>
-              )}
-
-              {/* 3-up grid: あなたのテンプレ + OpenAI + Gemini （すべてクリックで拡大） */}
-              <div className="grid grid-cols-3 gap-3">
-                <MediaCell
-                  src={filePreviewUrl}
-                  alt="your template"
-                  label={t("step3TemplateLabel")}
-                  onClick={
-                    filePreviewUrl ? () => openEnlarged(filePreviewUrl) : undefined
-                  }
-                  ariaLabel={t("enlargeImageAriaLabel")}
-                />
-                <MediaCell
-                  src={previewSignedUrls.openai ?? null}
-                  alt="openai preview"
-                  label={t("step3PreviewLabel")}
-                  onClick={
-                    previewSignedUrls.openai
-                      ? () => openEnlarged(previewSignedUrls.openai!)
-                      : undefined
-                  }
-                  ariaLabel={t("enlargeImageAriaLabel")}
-                  placeholderText={
-                    previewResult.previews.find((p) => p.provider === "openai")
-                      ? "(preview saved)"
-                      : t("step3PreviewMissing")
-                  }
-                />
-                <MediaCell
-                  src={previewSignedUrls.gemini ?? null}
-                  alt="gemini preview"
-                  label={t("step3PreviewLabelGemini")}
-                  onClick={
-                    previewSignedUrls.gemini
-                      ? () => openEnlarged(previewSignedUrls.gemini!)
-                      : undefined
-                  }
-                  ariaLabel={t("enlargeImageAriaLabel")}
-                  placeholderText={
-                    previewResult.previews.find((p) => p.provider === "gemini")
-                      ? "(preview saved)"
-                      : t("step3PreviewMissing")
-                  }
-                />
-              </div>
-
-              {errorMessage && (
-                <p className="text-sm text-destructive">{errorMessage}</p>
-              )}
-
-              <DialogFooter className="flex flex-col gap-2 sm:flex-row sm:justify-between">
-                <Button
-                  variant="ghost"
-                  onClick={() => setStep(2)}
-                  disabled={submitting}
-                >
-                  {t("step3BackButton")}
-                </Button>
-                <Button
-                  onClick={handleSubmit}
-                  disabled={!consent || submitting}
-                >
-                  {submitting ? t("submitting") : t("step3SubmitButton")}
-                </Button>
-              </DialogFooter>
+            {/* 3-up grid: あなたのテンプレ + OpenAI + Gemini （すべてクリックで拡大） */}
+            <div className="grid grid-cols-3 gap-3">
+              <MediaCell
+                src={filePreviewUrl}
+                alt="your template"
+                label={t("step3TemplateLabel")}
+                onClick={
+                  filePreviewUrl ? () => openEnlarged(filePreviewUrl) : undefined
+                }
+                ariaLabel={t("enlargeImageAriaLabel")}
+              />
+              <MediaCell
+                src={previewSignedUrls.openai ?? null}
+                alt="openai preview"
+                label={t("step3PreviewLabel")}
+                onClick={
+                  previewSignedUrls.openai
+                    ? () => openEnlarged(previewSignedUrls.openai!)
+                    : undefined
+                }
+                ariaLabel={t("enlargeImageAriaLabel")}
+                placeholderText={
+                  previewResult.previews.find((p) => p.provider === "openai")
+                    ? "(preview saved)"
+                    : t("step3PreviewMissing")
+                }
+              />
+              <MediaCell
+                src={previewSignedUrls.gemini ?? null}
+                alt="gemini preview"
+                label={t("step3PreviewLabelGemini")}
+                onClick={
+                  previewSignedUrls.gemini
+                    ? () => openEnlarged(previewSignedUrls.gemini!)
+                    : undefined
+                }
+                ariaLabel={t("enlargeImageAriaLabel")}
+                placeholderText={
+                  previewResult.previews.find((p) => p.provider === "gemini")
+                    ? "(preview saved)"
+                    : t("step3PreviewMissing")
+                }
+              />
             </div>
-          )}
-        </DialogContent>
-      </Dialog>
 
-      {/* 閉じる確認ダイアログ */}
-      <AlertDialog
-        open={closeConfirmOpen}
-        onOpenChange={setCloseConfirmOpen}
-      >
+            {errorMessage && (
+              <p className="text-sm text-destructive">{errorMessage}</p>
+            )}
+
+            <div className="flex flex-col gap-2 sm:flex-row sm:justify-between">
+              <Button
+                variant="ghost"
+                onClick={() => setStep(2)}
+                disabled={submitting}
+              >
+                {t("step3BackButton")}
+              </Button>
+              <Button onClick={handleSubmit} disabled={!consent || submitting}>
+                {submitting ? t("submitting") : t("step3SubmitButton")}
+              </Button>
+            </div>
+          </div>
+        )}
+      </section>
+
+      {/* 離脱確認（dirty な状態でキャンセル/戻るしたとき） */}
+      <AlertDialog open={closeConfirmOpen} onOpenChange={setCloseConfirmOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>{t("closeConfirmTitle")}</AlertDialogTitle>
@@ -764,7 +703,7 @@ export function UserStyleTemplateSubmissionDialog({
             <AlertDialogAction
               onClick={() => {
                 setCloseConfirmOpen(false);
-                closeNow();
+                leaveNow();
               }}
             >
               {t("closeConfirmAction")}
@@ -792,10 +731,7 @@ export function UserStyleTemplateSubmissionDialog({
                     aria-label={t("enlargedPrev")}
                     className="absolute left-2 top-1/2 z-10 -translate-y-1/2 rounded-full bg-white/10 p-2 text-white shadow-md transition hover:bg-white/20 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black sm:p-3"
                   >
-                    <ChevronLeft
-                      aria-hidden="true"
-                      className="size-6 sm:size-8"
-                    />
+                    <ChevronLeft aria-hidden="true" className="size-6 sm:size-8" />
                   </button>
                   <button
                     type="button"

--- a/features/inspire/components/UserStyleTemplateSubmissionForm.tsx
+++ b/features/inspire/components/UserStyleTemplateSubmissionForm.tsx
@@ -3,12 +3,13 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { ChevronLeft, ChevronRight, Loader2, Plus } from "lucide-react";
+import { Loader2, Plus } from "lucide-react";
 import { GenerationStatusCard } from "@/features/generation/components/GenerationStatusCard";
 import {
   PSEUDO_INITIAL_PROGRESS,
   calculatePseudoProgress,
 } from "@/features/generation/lib/pseudo-progress";
+import { ImageLightboxDialog } from "@/features/inspire/components/ImageLightboxDialog";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -21,7 +22,6 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -246,38 +246,6 @@ export function UserStyleTemplateSubmissionForm({
     },
     [enlargeableSlides]
   );
-
-  const goPrev = useCallback(() => {
-    setEnlargedIndex((current) => {
-      if (current === null) return null;
-      if (enlargeableSlides.length === 0) return null;
-      return (current - 1 + enlargeableSlides.length) % enlargeableSlides.length;
-    });
-  }, [enlargeableSlides.length]);
-
-  const goNext = useCallback(() => {
-    setEnlargedIndex((current) => {
-      if (current === null) return null;
-      if (enlargeableSlides.length === 0) return null;
-      return (current + 1) % enlargeableSlides.length;
-    });
-  }, [enlargeableSlides.length]);
-
-  // キーボードナビ: 拡大表示中の ← / →
-  useEffect(() => {
-    if (enlargedIndex === null) return;
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "ArrowLeft") {
-        e.preventDefault();
-        goPrev();
-      } else if (e.key === "ArrowRight") {
-        e.preventDefault();
-        goNext();
-      }
-    };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, [enlargedIndex, goPrev, goNext]);
 
   // ObjectURL を unmount 時にも掃除する（旧 Dialog では reset() で掃除していた）。
   useEffect(() => {
@@ -750,66 +718,13 @@ export function UserStyleTemplateSubmissionForm({
       </AlertDialog>
 
       {/* 画像拡大表示（lightbox、prev/next ナビ付き） */}
-      <Dialog
-        open={enlargedIndex !== null}
-        onOpenChange={(next) => {
-          if (!next) setEnlargedIndex(null);
-        }}
-      >
-        <DialogContent className="max-w-4xl bg-black/95 p-2 sm:p-4">
-          {enlargedIndex !== null && enlargeableSlides[enlargedIndex] && (
-            <div className="relative flex max-h-[85vh] flex-col items-center justify-center">
-              {/* prev/next ボタン（slide が 2 枚以上のときだけ表示） */}
-              {enlargeableSlides.length > 1 && (
-                <>
-                  <button
-                    type="button"
-                    onClick={goPrev}
-                    aria-label={t("enlargedPrev")}
-                    className="absolute left-2 top-1/2 z-10 -translate-y-1/2 rounded-full bg-white/10 p-2 text-white shadow-md transition hover:bg-white/20 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black sm:p-3"
-                  >
-                    <ChevronLeft aria-hidden="true" className="size-6 sm:size-8" />
-                  </button>
-                  <button
-                    type="button"
-                    onClick={goNext}
-                    aria-label={t("enlargedNext")}
-                    className="absolute right-2 top-1/2 z-10 -translate-y-1/2 rounded-full bg-white/10 p-2 text-white shadow-md transition hover:bg-white/20 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black sm:p-3"
-                  >
-                    <ChevronRight
-                      aria-hidden="true"
-                      className="size-6 sm:size-8"
-                    />
-                  </button>
-                </>
-              )}
-
-              {/* 画像本体 */}
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                src={enlargeableSlides[enlargedIndex].url}
-                alt={enlargeableSlides[enlargedIndex].label}
-                className="max-h-[80vh] w-auto max-w-full object-contain"
-              />
-
-              {/* 下部にラベル + ページ番号 */}
-              <div className="mt-2 flex items-center justify-center gap-3 text-xs text-white/80">
-                <span className="font-medium">
-                  {enlargeableSlides[enlargedIndex].label}
-                </span>
-                {enlargeableSlides.length > 1 && (
-                  <span aria-hidden="true">·</span>
-                )}
-                {enlargeableSlides.length > 1 && (
-                  <span className="tabular-nums">
-                    {enlargedIndex + 1} / {enlargeableSlides.length}
-                  </span>
-                )}
-              </div>
-            </div>
-          )}
-        </DialogContent>
-      </Dialog>
+      <ImageLightboxDialog
+        slides={enlargeableSlides}
+        index={enlargedIndex}
+        onIndexChange={setEnlargedIndex}
+        prevLabel={t("enlargedPrev")}
+        nextLabel={t("enlargedNext")}
+      />
     </>
   );
 }

--- a/features/inspire/components/UserStyleTemplateSubmissionForm.tsx
+++ b/features/inspire/components/UserStyleTemplateSubmissionForm.tsx
@@ -4,6 +4,11 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { ChevronLeft, ChevronRight, Loader2, Plus } from "lucide-react";
+import { GenerationStatusCard } from "@/features/generation/components/GenerationStatusCard";
+import {
+  PSEUDO_INITIAL_PROGRESS,
+  calculatePseudoProgress,
+} from "@/features/generation/lib/pseudo-progress";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -196,6 +201,8 @@ export function UserStyleTemplateSubmissionForm({
   const [filePreviewUrl, setFilePreviewUrl] = useState<string | null>(null);
   const [alt, setAlt] = useState("");
   const [generating, setGenerating] = useState(false);
+  const [pseudoProgress, setPseudoProgress] = useState(0);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [previewResult, setPreviewResult] =
     useState<PreviewGenerationResponse | null>(null);
@@ -278,6 +285,33 @@ export function UserStyleTemplateSubmissionForm({
       if (filePreviewUrl) URL.revokeObjectURL(filePreviewUrl);
     };
   }, [filePreviewUrl]);
+
+  // prefers-reduced-motion を検知（StatusCard のアニメ抑制用）。
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mql = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setPrefersReducedMotion(mql.matches);
+    const onChange = (e: MediaQueryListEvent) => setPrefersReducedMotion(e.matches);
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
+
+  // 生成中は経過時間ベースで擬似プログレスを進める。idle 時は 0 に戻す。
+  useEffect(() => {
+    if (!generating) {
+      setPseudoProgress(0);
+      return;
+    }
+    setPseudoProgress(PSEUDO_INITIAL_PROGRESS);
+    const startTime = Date.now();
+    const intervalId = window.setInterval(() => {
+      const elapsedMs = Date.now() - startTime;
+      setPseudoProgress((previous) =>
+        Math.max(previous, calculatePseudoProgress(elapsedMs))
+      );
+    }, 160);
+    return () => window.clearInterval(intervalId);
+  }, [generating]);
 
   /**
    * 画面を閉じる（= マイページに戻る）。
@@ -568,13 +602,16 @@ export function UserStyleTemplateSubmissionForm({
             </div>
 
             {generating && (
-              <div className="flex items-center justify-center gap-2 rounded-lg bg-muted/50 py-3 text-sm text-muted-foreground">
-                <Loader2
-                  className="size-4 motion-safe:animate-spin"
-                  aria-hidden="true"
-                />
-                <span>{t("step2GeneratingMessage")}</span>
-              </div>
+              <GenerationStatusCard
+                title={t("step2GeneratingCardTitle")}
+                message={t("step2GeneratingInline")}
+                liveMessage={t("step2GeneratingMessage")}
+                footerText={t("step2GeneratingCardFooter")}
+                progress={pseudoProgress}
+                animateFromZeroOnMount
+                isComplete={false}
+                prefersReducedMotion={prefersReducedMotion}
+              />
             )}
 
             {errorMessage && (

--- a/messages/ar.ts
+++ b/messages/ar.ts
@@ -395,6 +395,9 @@ export const arMessages = {
     step2TestCharacterLabel: "شخصية الاختبار",
     step2GeneratingMessage: "جارٍ التوليد... يُرجى عدم إغلاق هذه التبويبة.",
     step2GeneratingInline: "جارٍ التوليد…",
+    step2GeneratingCardTitle: "جارٍ توليد محاكاة التجربة",
+    step2GeneratingCardFooter:
+      "يُرجى عدم إغلاق هذه التبويبة. ينتهي خلال 60 إلى 90 ثانية تقريبًا.",
     step2PartialNotice:
       "نجحت معاينة واحدة فقط من الاثنتين. يمكنك مع ذلك إرسالها إذا كانت النتيجة مقبولة.",
     step2BackButton: "رجوع",

--- a/messages/ar.ts
+++ b/messages/ar.ts
@@ -375,6 +375,7 @@ export const arMessages = {
     inspireDeleteConfirmAction: "حذف",
     inspireDeleteSuccess: "تم الحذف.",
     inspireDeleteFailed: "فشل الحذف.",
+    inspireOpenForGenerationAria: "افتح صفحة التوليد بهذا القالب",
   },
   inspireSubmission: {
     dialogTitle: "إرسال قالب تنسيق",

--- a/messages/ar.ts
+++ b/messages/ar.ts
@@ -1086,6 +1086,8 @@ export const arMessages = {
     listPromptCopyFailed: "فشل نسخ النص الموجِّه.",
     listPromptEmpty: "لا توجد معلومات عن النص الموجِّه.",
     listPromptOneTapStyleEmpty: "غير متاح لأن هذه الصورة أُنشئت بـ One-Tap Style.",
+    listPromptInspireEmpty:
+      "غير متاح لأن هذه الصورة أُنشئت بقالب نمط من مساهمات المجتمع.",
     listApplyForNext: "توليد من هذه الصورة",
     listApplyForNextSuccess: "تم تعيين الصورة في حقل الرفع.",
     listApplyForNextConfirmTitle: "الانتقال إلى صفحة التنسيق",

--- a/messages/ar.ts
+++ b/messages/ar.ts
@@ -1599,6 +1599,8 @@ export const arMessages = {
     detailTemplate: "صورة القالب",
     detailPreviewOpenAI: "معاينة (OpenAI)",
     detailPreviewGemini: "معاينة (Gemini)",
+    detailEnlargedPrev: "الصورة السابقة",
+    detailEnlargedNext: "الصورة التالية",
   },
   inspirePage: {
     pageTitle: "توليد بهذا الأسلوب",

--- a/messages/de.ts
+++ b/messages/de.ts
@@ -1087,6 +1087,8 @@ export const deMessages = {
     listPromptCopyFailed: "Prompt konnte nicht kopiert werden.",
     listPromptEmpty: "Keine Prompt-Informationen verfügbar.",
     listPromptOneTapStyleEmpty: "Nicht verfügbar, da dieses Bild mit One-Tap Style generiert wurde.",
+    listPromptInspireEmpty:
+      "Nicht verfügbar, da dieses Bild mit einer Community-Stilvorlage generiert wurde.",
     listApplyForNext: "Aus diesem Bild generieren",
     listApplyForNextSuccess: "Bild wurde im Upload-Feld eingestellt.",
     listApplyForNextConfirmTitle: "Zur Koordinieren-Seite gehen",

--- a/messages/de.ts
+++ b/messages/de.ts
@@ -375,6 +375,8 @@ export const deMessages = {
     inspireDeleteConfirmAction: "Löschen",
     inspireDeleteSuccess: "Gelöscht.",
     inspireDeleteFailed: "Löschen fehlgeschlagen.",
+    inspireOpenForGenerationAria:
+      "Generierungsseite mit dieser Vorlage öffnen",
   },
   inspireSubmission: {
     dialogTitle: "Stilvorlage einreichen",

--- a/messages/de.ts
+++ b/messages/de.ts
@@ -395,6 +395,9 @@ export const deMessages = {
     step2TestCharacterLabel: "Test-Charakter",
     step2GeneratingMessage: "Generierung läuft... bitte diesen Tab nicht schließen.",
     step2GeneratingInline: "Wird generiert…",
+    step2GeneratingCardTitle: "Anprobe-Simulation wird erstellt",
+    step2GeneratingCardFooter:
+      "Bitte diesen Tab nicht schließen. Dauert etwa 60–90 Sekunden.",
     step2PartialNotice:
       "Nur eine der beiden Vorschauen war erfolgreich. Du kannst trotzdem einreichen, wenn das Ergebnis akzeptabel ist.",
     step2BackButton: "Zurück",

--- a/messages/de.ts
+++ b/messages/de.ts
@@ -1599,6 +1599,8 @@ export const deMessages = {
     detailTemplate: "Vorlagenbild",
     detailPreviewOpenAI: "Vorschau (OpenAI)",
     detailPreviewGemini: "Vorschau (Gemini)",
+    detailEnlargedPrev: "Vorheriges Bild",
+    detailEnlargedNext: "Nächstes Bild",
   },
   inspirePage: {
     pageTitle: "Mit diesem Stil generieren",

--- a/messages/en.ts
+++ b/messages/en.ts
@@ -375,6 +375,7 @@ export const enMessages = {
     inspireDeleteConfirmAction: "Delete",
     inspireDeleteSuccess: "Deleted.",
     inspireDeleteFailed: "Failed to delete.",
+    inspireOpenForGenerationAria: "Open the generation page with this template",
   },
   inspireSubmission: {
     dialogTitle: "Submit a style template",

--- a/messages/en.ts
+++ b/messages/en.ts
@@ -395,6 +395,9 @@ export const enMessages = {
     step2TestCharacterLabel: "Test character",
     step2GeneratingMessage: "Generating... please don't close this tab.",
     step2GeneratingInline: "Generating…",
+    step2GeneratingCardTitle: "Generating the try-on simulation",
+    step2GeneratingCardFooter:
+      "Please keep this tab open. Finishes in about 60–90 seconds.",
     step2PartialNotice:
       "Only one of the two previews succeeded. You can still submit if the result looks acceptable.",
     step2BackButton: "Back",

--- a/messages/en.ts
+++ b/messages/en.ts
@@ -1086,6 +1086,7 @@ export const enMessages = {
     listPromptCopyFailed: "Failed to copy the prompt.",
     listPromptEmpty: "No prompt information available.",
     listPromptOneTapStyleEmpty: "Not available because this image was generated with One-Tap Style.",
+    listPromptInspireEmpty: "Not available because this image was generated with a community style template.",
     listApplyForNext: "Generate from this image",
     listApplyForNextSuccess: "Image has been set to the upload field.",
     listApplyForNextConfirmTitle: "Going to the coordinate page",

--- a/messages/en.ts
+++ b/messages/en.ts
@@ -1599,6 +1599,8 @@ export const enMessages = {
     detailTemplate: "Template image",
     detailPreviewOpenAI: "Preview (OpenAI)",
     detailPreviewGemini: "Preview (Gemini)",
+    detailEnlargedPrev: "Previous image",
+    detailEnlargedNext: "Next image",
   },
   inspirePage: {
     pageTitle: "Generate with this style",

--- a/messages/es.ts
+++ b/messages/es.ts
@@ -1599,6 +1599,8 @@ export const esMessages = {
     detailTemplate: "Imagen de la plantilla",
     detailPreviewOpenAI: "Vista previa (OpenAI)",
     detailPreviewGemini: "Vista previa (Gemini)",
+    detailEnlargedPrev: "Imagen anterior",
+    detailEnlargedNext: "Imagen siguiente",
   },
   inspirePage: {
     pageTitle: "Generar con este estilo",

--- a/messages/es.ts
+++ b/messages/es.ts
@@ -395,6 +395,9 @@ export const esMessages = {
     step2TestCharacterLabel: "Personaje de prueba",
     step2GeneratingMessage: "Generando... no cierres esta pestaña.",
     step2GeneratingInline: "Generando…",
+    step2GeneratingCardTitle: "Generando la simulación de prueba",
+    step2GeneratingCardFooter:
+      "No cierres esta pestaña. Termina en unos 60–90 segundos.",
     step2PartialNotice:
       "Solo una de las dos previsualizaciones se generó correctamente. Aun así puedes enviarla si el resultado te parece aceptable.",
     step2BackButton: "Atrás",

--- a/messages/es.ts
+++ b/messages/es.ts
@@ -375,6 +375,8 @@ export const esMessages = {
     inspireDeleteConfirmAction: "Eliminar",
     inspireDeleteSuccess: "Eliminada.",
     inspireDeleteFailed: "No se pudo eliminar.",
+    inspireOpenForGenerationAria:
+      "Abrir la página de generación con esta plantilla",
   },
   inspireSubmission: {
     dialogTitle: "Enviar plantilla de estilo",

--- a/messages/es.ts
+++ b/messages/es.ts
@@ -1087,6 +1087,8 @@ export const esMessages = {
     listPromptCopyFailed: "No se pudo copiar el prompt.",
     listPromptEmpty: "No hay información del prompt.",
     listPromptOneTapStyleEmpty: "No disponible porque esta imagen se generó con One-Tap Style.",
+    listPromptInspireEmpty:
+      "No disponible porque esta imagen se generó con una plantilla de estilo comunitaria.",
     listApplyForNext: "Generar a partir de esta imagen",
     listApplyForNextSuccess: "La imagen se ha establecido en el campo de subida.",
     listApplyForNextConfirmTitle: "Yendo a la página Coordinar",

--- a/messages/fr.ts
+++ b/messages/fr.ts
@@ -395,6 +395,9 @@ export const frMessages = {
     step2TestCharacterLabel: "Personnage de test",
     step2GeneratingMessage: "Génération en cours... ne fermez pas cet onglet.",
     step2GeneratingInline: "Génération…",
+    step2GeneratingCardTitle: "Génération de la simulation d'essayage",
+    step2GeneratingCardFooter:
+      "Veuillez ne pas fermer cet onglet. Termine en 60 à 90 secondes environ.",
     step2PartialNotice:
       "Un seul des deux aperçus a abouti. Vous pouvez quand même soumettre si le résultat vous convient.",
     step2BackButton: "Retour",

--- a/messages/fr.ts
+++ b/messages/fr.ts
@@ -1599,6 +1599,8 @@ export const frMessages = {
     detailTemplate: "Image du modèle",
     detailPreviewOpenAI: "Aperçu (OpenAI)",
     detailPreviewGemini: "Aperçu (Gemini)",
+    detailEnlargedPrev: "Image précédente",
+    detailEnlargedNext: "Image suivante",
   },
   inspirePage: {
     pageTitle: "Générer avec ce style",

--- a/messages/fr.ts
+++ b/messages/fr.ts
@@ -1087,6 +1087,8 @@ export const frMessages = {
     listPromptCopyFailed: "Impossible de copier le prompt.",
     listPromptEmpty: "Aucune information de prompt.",
     listPromptOneTapStyleEmpty: "Indisponible : cette image a été générée avec One-Tap Style.",
+    listPromptInspireEmpty:
+      "Indisponible : cette image a été générée avec un modèle de style communautaire.",
     listApplyForNext: "Générer à partir de cette image",
     listApplyForNextSuccess: "L'image a été placée dans le champ d'envoi.",
     listApplyForNextConfirmTitle: "Aller à la page Coordonner",

--- a/messages/fr.ts
+++ b/messages/fr.ts
@@ -375,6 +375,8 @@ export const frMessages = {
     inspireDeleteConfirmAction: "Supprimer",
     inspireDeleteSuccess: "Supprimée.",
     inspireDeleteFailed: "Impossible de supprimer.",
+    inspireOpenForGenerationAria:
+      "Ouvrir la page de génération avec ce modèle",
   },
   inspireSubmission: {
     dialogTitle: "Soumettre un modèle de style",

--- a/messages/hi.ts
+++ b/messages/hi.ts
@@ -375,6 +375,7 @@ export const hiMessages = {
     inspireDeleteConfirmAction: "हटाएँ",
     inspireDeleteSuccess: "हटा दिया गया।",
     inspireDeleteFailed: "हटाने में विफल।",
+    inspireOpenForGenerationAria: "इस टेम्पलेट से जनरेशन पेज खोलें",
   },
   inspireSubmission: {
     dialogTitle: "स्टाइल टेम्पलेट जमा करें",

--- a/messages/hi.ts
+++ b/messages/hi.ts
@@ -1599,6 +1599,8 @@ export const hiMessages = {
     detailTemplate: "टेम्पलेट छवि",
     detailPreviewOpenAI: "पूर्वावलोकन (OpenAI)",
     detailPreviewGemini: "पूर्वावलोकन (Gemini)",
+    detailEnlargedPrev: "पिछली छवि",
+    detailEnlargedNext: "अगली छवि",
   },
   inspirePage: {
     pageTitle: "इस स्टाइल से उत्पन्न करें",

--- a/messages/hi.ts
+++ b/messages/hi.ts
@@ -395,6 +395,9 @@ export const hiMessages = {
     step2TestCharacterLabel: "टेस्ट कैरेक्टर",
     step2GeneratingMessage: "उत्पन्न हो रहा है... कृपया यह टैब बंद न करें।",
     step2GeneratingInline: "उत्पन्न हो रहा है…",
+    step2GeneratingCardTitle: "ट्राई-ऑन सिमुलेशन बनाया जा रहा है",
+    step2GeneratingCardFooter:
+      "कृपया यह टैब बंद न करें। लगभग 60–90 सेकंड में पूरा होगा।",
     step2PartialNotice:
       "दो में से केवल एक पूर्वावलोकन सफल रहा। अगर परिणाम स्वीकार्य है तो आप फिर भी जमा कर सकते हैं।",
     step2BackButton: "वापस",

--- a/messages/hi.ts
+++ b/messages/hi.ts
@@ -1086,6 +1086,8 @@ export const hiMessages = {
     listPromptCopyFailed: "प्रॉम्प्ट कॉपी करने में विफल।",
     listPromptEmpty: "कोई प्रॉम्प्ट जानकारी उपलब्ध नहीं है।",
     listPromptOneTapStyleEmpty: "उपलब्ध नहीं क्योंकि यह छवि One-Tap Style से उत्पन्न की गई थी।",
+    listPromptInspireEmpty:
+      "उपलब्ध नहीं क्योंकि यह छवि कम्युनिटी स्टाइल टेम्पलेट से उत्पन्न की गई थी।",
     listApplyForNext: "इस छवि से उत्पन्न करें",
     listApplyForNextSuccess: "अपलोड फ़ील्ड में छवि सेट कर दी गई है।",
     listApplyForNextConfirmTitle: "कोऑर्डिनेट पेज पर जा रहे हैं",

--- a/messages/id.ts
+++ b/messages/id.ts
@@ -395,6 +395,9 @@ export const idMessages = {
     step2TestCharacterLabel: "Karakter uji",
     step2GeneratingMessage: "Menghasilkan... jangan tutup tab ini.",
     step2GeneratingInline: "Menghasilkan…",
+    step2GeneratingCardTitle: "Membuat simulasi coba pakai",
+    step2GeneratingCardFooter:
+      "Mohon jangan tutup tab ini. Selesai dalam sekitar 60–90 detik.",
     step2PartialNotice:
       "Hanya satu dari dua pratinjau berhasil. Kamu tetap bisa mengirim jika hasilnya bisa diterima.",
     step2BackButton: "Kembali",

--- a/messages/id.ts
+++ b/messages/id.ts
@@ -1087,6 +1087,8 @@ export const idMessages = {
     listPromptCopyFailed: "Gagal menyalin prompt.",
     listPromptEmpty: "Tidak ada informasi prompt.",
     listPromptOneTapStyleEmpty: "Tidak tersedia karena gambar ini dibuat dengan One-Tap Style.",
+    listPromptInspireEmpty:
+      "Tidak tersedia karena gambar ini dibuat dengan template gaya kiriman komunitas.",
     listApplyForNext: "Hasilkan dari gambar ini",
     listApplyForNextSuccess: "Gambar telah disetel ke kolom unggah.",
     listApplyForNextConfirmTitle: "Menuju halaman Koordinat",

--- a/messages/id.ts
+++ b/messages/id.ts
@@ -375,6 +375,8 @@ export const idMessages = {
     inspireDeleteConfirmAction: "Hapus",
     inspireDeleteSuccess: "Terhapus.",
     inspireDeleteFailed: "Gagal menghapus.",
+    inspireOpenForGenerationAria:
+      "Buka halaman pembuatan dengan template ini",
   },
   inspireSubmission: {
     dialogTitle: "Kirim template gaya",

--- a/messages/id.ts
+++ b/messages/id.ts
@@ -1599,6 +1599,8 @@ export const idMessages = {
     detailTemplate: "Gambar template",
     detailPreviewOpenAI: "Pratinjau (OpenAI)",
     detailPreviewGemini: "Pratinjau (Gemini)",
+    detailEnlargedPrev: "Gambar sebelumnya",
+    detailEnlargedNext: "Gambar berikutnya",
   },
   inspirePage: {
     pageTitle: "Hasilkan dengan gaya ini",

--- a/messages/it.ts
+++ b/messages/it.ts
@@ -1599,6 +1599,8 @@ export const itMessages = {
     detailTemplate: "Immagine del modello",
     detailPreviewOpenAI: "Anteprima (OpenAI)",
     detailPreviewGemini: "Anteprima (Gemini)",
+    detailEnlargedPrev: "Immagine precedente",
+    detailEnlargedNext: "Immagine successiva",
   },
   inspirePage: {
     pageTitle: "Genera con questo stile",

--- a/messages/it.ts
+++ b/messages/it.ts
@@ -1087,6 +1087,8 @@ export const itMessages = {
     listPromptCopyFailed: "Impossibile copiare il prompt.",
     listPromptEmpty: "Nessuna informazione sul prompt disponibile.",
     listPromptOneTapStyleEmpty: "Non disponibile perché questa immagine è stata generata con One-Tap Style.",
+    listPromptInspireEmpty:
+      "Non disponibile perché questa immagine è stata generata con un modello di stile della community.",
     listApplyForNext: "Genera a partire da questa immagine",
     listApplyForNextSuccess: "L'immagine è stata impostata nel campo di caricamento.",
     listApplyForNextConfirmTitle: "Sto andando alla pagina Coordina",

--- a/messages/it.ts
+++ b/messages/it.ts
@@ -395,6 +395,9 @@ export const itMessages = {
     step2TestCharacterLabel: "Personaggio di prova",
     step2GeneratingMessage: "Generazione in corso... non chiudere questa scheda.",
     step2GeneratingInline: "Generazione…",
+    step2GeneratingCardTitle: "Generazione della simulazione di prova",
+    step2GeneratingCardFooter:
+      "Non chiudere questa scheda. Termina in circa 60–90 secondi.",
     step2PartialNotice:
       "Solo una delle due anteprime è andata a buon fine. Puoi comunque inviare se il risultato ti sembra accettabile.",
     step2BackButton: "Indietro",

--- a/messages/it.ts
+++ b/messages/it.ts
@@ -375,6 +375,8 @@ export const itMessages = {
     inspireDeleteConfirmAction: "Elimina",
     inspireDeleteSuccess: "Eliminato.",
     inspireDeleteFailed: "Impossibile eliminare.",
+    inspireOpenForGenerationAria:
+      "Apri la pagina di generazione con questo modello",
   },
   inspireSubmission: {
     dialogTitle: "Invia un modello di stile",

--- a/messages/ja.ts
+++ b/messages/ja.ts
@@ -1531,6 +1531,8 @@ export const jaMessages = {
     detailTemplate: "テンプレート画像",
     detailPreviewOpenAI: "プレビュー（OpenAI）",
     detailPreviewGemini: "プレビュー（Gemini）",
+    detailEnlargedPrev: "前の画像",
+    detailEnlargedNext: "次の画像",
   },
   inspirePage: {
     pageTitle: "投稿スタイルで生成",

--- a/messages/ja.ts
+++ b/messages/ja.ts
@@ -371,6 +371,7 @@ export const jaMessages = {
     inspireDeleteConfirmAction: "削除する",
     inspireDeleteSuccess: "削除しました。",
     inspireDeleteFailed: "削除に失敗しました。",
+    inspireOpenForGenerationAria: "このテンプレートで生成画面を開く",
   },
   inspireSubmission: {
     dialogTitle: "スタイルテンプレートを申請",

--- a/messages/ja.ts
+++ b/messages/ja.ts
@@ -1032,6 +1032,7 @@ export const jaMessages = {
     listPromptCopyFailed: "プロンプトのコピーに失敗しました",
     listPromptEmpty: "プロンプト情報がありません",
     listPromptOneTapStyleEmpty: "One-Tap Styleで生成した為、ありません",
+    listPromptInspireEmpty: "投稿スタイルで生成した為、ありません",
     listApplyForNext: "このイラストで生成",
     listApplyForNextSuccess: "アップロード欄に画像をセットしました",
     listApplyForNextConfirmTitle: "コーディネートに移動します",

--- a/messages/ja.ts
+++ b/messages/ja.ts
@@ -391,6 +391,9 @@ export const jaMessages = {
     step2TestCharacterLabel: "試着するキャラ",
     step2GeneratingMessage: "生成中... 別タブを閉じないでください。",
     step2GeneratingInline: "生成中…",
+    step2GeneratingCardTitle: "試着シミュレーションを生成中",
+    step2GeneratingCardFooter:
+      "別タブを閉じずにお待ちください。完了まで約 60〜90 秒です。",
     step2PartialNotice:
       "片方の生成のみ成功しました。問題なければそのまま申請できます。",
     step2BackButton: "戻る",

--- a/messages/ko.ts
+++ b/messages/ko.ts
@@ -1086,6 +1086,7 @@ export const koMessages = {
     listPromptCopyFailed: "프롬프트 복사에 실패했습니다.",
     listPromptEmpty: "프롬프트 정보가 없습니다.",
     listPromptOneTapStyleEmpty: "원탭 스타일로 생성된 이미지라 표시할 수 없습니다.",
+    listPromptInspireEmpty: "투고 스타일 템플릿으로 생성된 이미지라 표시할 수 없습니다.",
     listApplyForNext: "이 이미지로 다시 생성",
     listApplyForNextSuccess: "업로드 칸에 이미지를 설정했습니다.",
     listApplyForNextConfirmTitle: "코디 페이지로 이동합니다",

--- a/messages/ko.ts
+++ b/messages/ko.ts
@@ -395,6 +395,9 @@ export const koMessages = {
     step2TestCharacterLabel: "테스트 캐릭터",
     step2GeneratingMessage: "생성 중입니다... 탭을 닫지 말아 주세요.",
     step2GeneratingInline: "생성 중…",
+    step2GeneratingCardTitle: "트라이온 시뮬레이션 생성 중",
+    step2GeneratingCardFooter:
+      "이 탭을 닫지 말아 주세요. 약 60~90초 후 완료됩니다.",
     step2PartialNotice:
       "두 미리보기 중 하나만 성공했습니다. 결과가 만족스럽다면 그대로 투고할 수 있습니다.",
     step2BackButton: "뒤로",

--- a/messages/ko.ts
+++ b/messages/ko.ts
@@ -375,6 +375,7 @@ export const koMessages = {
     inspireDeleteConfirmAction: "삭제",
     inspireDeleteSuccess: "삭제했습니다.",
     inspireDeleteFailed: "삭제에 실패했습니다.",
+    inspireOpenForGenerationAria: "이 템플릿으로 생성 화면 열기",
   },
   inspireSubmission: {
     dialogTitle: "스타일 템플릿 투고",

--- a/messages/ko.ts
+++ b/messages/ko.ts
@@ -1599,6 +1599,8 @@ export const koMessages = {
     detailTemplate: "템플릿 이미지",
     detailPreviewOpenAI: "미리보기 (OpenAI)",
     detailPreviewGemini: "미리보기 (Gemini)",
+    detailEnlargedPrev: "이전 이미지",
+    detailEnlargedNext: "다음 이미지",
   },
   inspirePage: {
     pageTitle: "이 스타일로 생성",

--- a/messages/pt.ts
+++ b/messages/pt.ts
@@ -1087,6 +1087,8 @@ export const ptMessages = {
     listPromptCopyFailed: "Não foi possível copiar o prompt.",
     listPromptEmpty: "Sem informações de prompt.",
     listPromptOneTapStyleEmpty: "Indisponível porque esta imagem foi gerada com One-Tap Style.",
+    listPromptInspireEmpty:
+      "Indisponível porque esta imagem foi gerada com um template de estilo da comunidade.",
     listApplyForNext: "Gerar a partir desta imagem",
     listApplyForNextSuccess: "A imagem foi colocada no campo de upload.",
     listApplyForNextConfirmTitle: "Indo para a página Coordenar",

--- a/messages/pt.ts
+++ b/messages/pt.ts
@@ -1599,6 +1599,8 @@ export const ptMessages = {
     detailTemplate: "Imagem do modelo",
     detailPreviewOpenAI: "Preview (OpenAI)",
     detailPreviewGemini: "Preview (Gemini)",
+    detailEnlargedPrev: "Imagem anterior",
+    detailEnlargedNext: "Próxima imagem",
   },
   inspirePage: {
     pageTitle: "Gerar com este estilo",

--- a/messages/pt.ts
+++ b/messages/pt.ts
@@ -375,6 +375,8 @@ export const ptMessages = {
     inspireDeleteConfirmAction: "Excluir",
     inspireDeleteSuccess: "Excluído.",
     inspireDeleteFailed: "Não foi possível excluir.",
+    inspireOpenForGenerationAria:
+      "Abrir a página de geração com este template",
   },
   inspireSubmission: {
     dialogTitle: "Enviar modelo de estilo",

--- a/messages/pt.ts
+++ b/messages/pt.ts
@@ -395,6 +395,9 @@ export const ptMessages = {
     step2TestCharacterLabel: "Personagem de teste",
     step2GeneratingMessage: "Gerando... não feche esta aba.",
     step2GeneratingInline: "Gerando…",
+    step2GeneratingCardTitle: "Gerando a simulação de prova",
+    step2GeneratingCardFooter:
+      "Por favor, não feche esta aba. Termina em cerca de 60–90 segundos.",
     step2PartialNotice:
       "Apenas um dos dois previews foi gerado com sucesso. Você ainda pode enviar se o resultado estiver aceitável.",
     step2BackButton: "Voltar",

--- a/messages/th.ts
+++ b/messages/th.ts
@@ -1086,6 +1086,7 @@ export const thMessages = {
     listPromptCopyFailed: "คัดลอกพรอมป์ไม่สำเร็จ",
     listPromptEmpty: "ไม่มีข้อมูลพรอมป์",
     listPromptOneTapStyleEmpty: "ไม่สามารถแสดงได้เพราะรูปนี้ถูกสร้างด้วย One-Tap Style",
+    listPromptInspireEmpty: "ไม่สามารถแสดงได้เพราะรูปนี้ถูกสร้างด้วยเทมเพลตสไตล์ที่ผู้ใช้ส่งเข้ามา",
     listApplyForNext: "สร้างจากรูปนี้",
     listApplyForNextSuccess: "ตั้งรูปไว้ในช่องอัปโหลดแล้ว",
     listApplyForNextConfirmTitle: "กำลังไปหน้าจัดเซ็ต",

--- a/messages/th.ts
+++ b/messages/th.ts
@@ -1599,6 +1599,8 @@ export const thMessages = {
     detailTemplate: "รูปเทมเพลต",
     detailPreviewOpenAI: "ตัวอย่าง (OpenAI)",
     detailPreviewGemini: "ตัวอย่าง (Gemini)",
+    detailEnlargedPrev: "ภาพก่อนหน้า",
+    detailEnlargedNext: "ภาพถัดไป",
   },
   inspirePage: {
     pageTitle: "สร้างด้วยสไตล์นี้",

--- a/messages/th.ts
+++ b/messages/th.ts
@@ -375,6 +375,7 @@ export const thMessages = {
     inspireDeleteConfirmAction: "ลบ",
     inspireDeleteSuccess: "ลบแล้ว",
     inspireDeleteFailed: "ลบไม่สำเร็จ",
+    inspireOpenForGenerationAria: "เปิดหน้าสร้างด้วยเทมเพลตนี้",
   },
   inspireSubmission: {
     dialogTitle: "ส่งเทมเพลตสไตล์",

--- a/messages/th.ts
+++ b/messages/th.ts
@@ -395,6 +395,9 @@ export const thMessages = {
     step2TestCharacterLabel: "ตัวละครทดสอบ",
     step2GeneratingMessage: "กำลังสร้าง... โปรดอย่าปิดแท็บนี้",
     step2GeneratingInline: "กำลังสร้าง…",
+    step2GeneratingCardTitle: "กำลังสร้างการจำลองการลอง",
+    step2GeneratingCardFooter:
+      "โปรดอย่าปิดแท็บนี้ ใช้เวลาประมาณ 60–90 วินาที",
     step2PartialNotice:
       "ตัวอย่างหนึ่งในสองรายการสำเร็จเท่านั้น คุณยังส่งได้หากผลลัพธ์ดูพอใช้ได้",
     step2BackButton: "ย้อนกลับ",

--- a/messages/vi.ts
+++ b/messages/vi.ts
@@ -375,6 +375,7 @@ export const viMessages = {
     inspireDeleteConfirmAction: "Xóa",
     inspireDeleteSuccess: "Đã xóa.",
     inspireDeleteFailed: "Xóa thất bại.",
+    inspireOpenForGenerationAria: "Mở trang tạo với mẫu này",
   },
   inspireSubmission: {
     dialogTitle: "Gửi mẫu phong cách",

--- a/messages/vi.ts
+++ b/messages/vi.ts
@@ -1086,6 +1086,8 @@ export const viMessages = {
     listPromptCopyFailed: "Sao chép prompt thất bại.",
     listPromptEmpty: "Không có thông tin prompt.",
     listPromptOneTapStyleEmpty: "Không khả dụng vì hình này được tạo bằng One-Tap Style.",
+    listPromptInspireEmpty:
+      "Không khả dụng vì hình này được tạo bằng mẫu phong cách do người dùng đóng góp.",
     listApplyForNext: "Tạo từ hình này",
     listApplyForNextSuccess: "Đã đặt hình vào ô tải lên.",
     listApplyForNextConfirmTitle: "Đang đến trang Phối đồ",

--- a/messages/vi.ts
+++ b/messages/vi.ts
@@ -1599,6 +1599,8 @@ export const viMessages = {
     detailTemplate: "Hình mẫu",
     detailPreviewOpenAI: "Xem trước (OpenAI)",
     detailPreviewGemini: "Xem trước (Gemini)",
+    detailEnlargedPrev: "Ảnh trước",
+    detailEnlargedNext: "Ảnh tiếp theo",
   },
   inspirePage: {
     pageTitle: "Tạo bằng phong cách này",

--- a/messages/vi.ts
+++ b/messages/vi.ts
@@ -395,6 +395,9 @@ export const viMessages = {
     step2TestCharacterLabel: "Nhân vật thử nghiệm",
     step2GeneratingMessage: "Đang tạo... vui lòng không đóng tab này.",
     step2GeneratingInline: "Đang tạo…",
+    step2GeneratingCardTitle: "Đang tạo mô phỏng thử đồ",
+    step2GeneratingCardFooter:
+      "Vui lòng không đóng tab này. Hoàn tất trong khoảng 60–90 giây.",
     step2PartialNotice:
       "Chỉ một trong hai bản xem trước thành công. Bạn vẫn có thể gửi nếu kết quả chấp nhận được.",
     step2BackButton: "Quay lại",

--- a/messages/zh-CN.ts
+++ b/messages/zh-CN.ts
@@ -1597,6 +1597,8 @@ export const zhCnMessages = {
     detailTemplate: "模板图片",
     detailPreviewOpenAI: "预览 (OpenAI)",
     detailPreviewGemini: "预览 (Gemini)",
+    detailEnlargedPrev: "上一张",
+    detailEnlargedNext: "下一张",
   },
   inspirePage: {
     pageTitle: "用此造型生成",

--- a/messages/zh-CN.ts
+++ b/messages/zh-CN.ts
@@ -395,6 +395,8 @@ export const zhCnMessages = {
     step2TestCharacterLabel: "测试角色",
     step2GeneratingMessage: "生成中...请不要关闭此页面。",
     step2GeneratingInline: "生成中…",
+    step2GeneratingCardTitle: "正在生成试穿模拟",
+    step2GeneratingCardFooter: "请不要关闭此页面。约 60〜90 秒后完成。",
     step2PartialNotice:
       "两个预览中只有一个生成成功。如果结果可以接受，仍然可以投稿。",
     step2BackButton: "返回",

--- a/messages/zh-CN.ts
+++ b/messages/zh-CN.ts
@@ -1085,6 +1085,7 @@ export const zhCnMessages = {
     listPromptCopyFailed: "复制提示词失败。",
     listPromptEmpty: "暂无提示词信息。",
     listPromptOneTapStyleEmpty: "由于此图片是通过一键造型生成的，无法显示。",
+    listPromptInspireEmpty: "由于此图片是通过投稿样式模板生成的，无法显示。",
     listApplyForNext: "用此图片再次生成",
     listApplyForNextSuccess: "已将图片设置到上传栏。",
     listApplyForNextConfirmTitle: "前往搭配页面",

--- a/messages/zh-CN.ts
+++ b/messages/zh-CN.ts
@@ -375,6 +375,7 @@ export const zhCnMessages = {
     inspireDeleteConfirmAction: "删除",
     inspireDeleteSuccess: "已删除。",
     inspireDeleteFailed: "删除失败。",
+    inspireOpenForGenerationAria: "用此模板打开生成页面",
   },
   inspireSubmission: {
     dialogTitle: "投稿造型模板",

--- a/messages/zh-TW.ts
+++ b/messages/zh-TW.ts
@@ -1085,6 +1085,7 @@ export const zhTwMessages = {
     listPromptCopyFailed: "複製提示詞失敗。",
     listPromptEmpty: "沒有提示詞資訊。",
     listPromptOneTapStyleEmpty: "因此圖片是以一鍵造型生成，無法顯示。",
+    listPromptInspireEmpty: "因此圖片是以投稿樣式範本生成，無法顯示。",
     listApplyForNext: "用此圖片再次生成",
     listApplyForNextSuccess: "已將圖片設定到上傳欄。",
     listApplyForNextConfirmTitle: "前往穿搭頁面",

--- a/messages/zh-TW.ts
+++ b/messages/zh-TW.ts
@@ -395,6 +395,8 @@ export const zhTwMessages = {
     step2TestCharacterLabel: "測試角色",
     step2GeneratingMessage: "生成中...請不要關閉此分頁。",
     step2GeneratingInline: "生成中…",
+    step2GeneratingCardTitle: "正在生成試穿模擬",
+    step2GeneratingCardFooter: "請不要關閉此分頁。約 60〜90 秒後完成。",
     step2PartialNotice:
       "兩個預覽中只有一個成功。如果結果可接受，仍可投稿。",
     step2BackButton: "返回",

--- a/messages/zh-TW.ts
+++ b/messages/zh-TW.ts
@@ -1597,6 +1597,8 @@ export const zhTwMessages = {
     detailTemplate: "範本圖片",
     detailPreviewOpenAI: "預覽 (OpenAI)",
     detailPreviewGemini: "預覽 (Gemini)",
+    detailEnlargedPrev: "上一張",
+    detailEnlargedNext: "下一張",
   },
   inspirePage: {
     pageTitle: "用此造型生成",

--- a/messages/zh-TW.ts
+++ b/messages/zh-TW.ts
@@ -375,6 +375,7 @@ export const zhTwMessages = {
     inspireDeleteConfirmAction: "刪除",
     inspireDeleteSuccess: "已刪除。",
     inspireDeleteFailed: "刪除失敗。",
+    inspireOpenForGenerationAria: "用此範本開啟生成頁面",
   },
   inspireSubmission: {
     dialogTitle: "投稿造型範本",

--- a/supabase/functions/image-gen-worker/index.ts
+++ b/supabase/functions/image-gen-worker/index.ts
@@ -1744,9 +1744,7 @@ Deno.serve(async () => {
                               ),
                             timeoutMs: OPENAI_REQUEST_TIMEOUT_MS,
                             n: requestedImageCount,
-                            // inspire はキャラ識別 × テンプレ構図の合成で難度が高いため
-                            // OpenAI の品質ティアを medium に引き上げる（既定の low は細部が崩れやすい）。
-                            quality: "medium",
+                            quality: "low",
                           })
                         : callOpenAIImageEditBatch({
                             prompt: basePromptText,

--- a/supabase/functions/image-gen-worker/openai-image.ts
+++ b/supabase/functions/image-gen-worker/openai-image.ts
@@ -1,7 +1,7 @@
 // OpenAI gpt-image-2 クライアント
 // - POST https://api.openai.com/v1/images/edits を multipart/form-data で叩く
 // - 入力画像のアスペクト比から 1024x1024 / 1024x1536 / 1536x1024 を選択
-// - `quality` は呼び出し側から指定可能（省略時は "low"）。inspire 経路では "medium" を使う。
+// - `quality` は呼び出し側から指定可能（省略時は "low"）。
 // - moderation/safety 系のエラーは SAFETY_POLICY_BLOCKED_ERROR に統一
 // - GIF 入力は OpenAI 経路では非対応（呼び出し側で再試行不可エラーとして扱う）
 


### PR DESCRIPTION
## 概要

マイページの **「新しいテンプレートを申請」「再申請」ボタンで開いていた `UserStyleTemplateSubmissionDialog`（モーダル、842 行、3 ステップを内包）を廃止し、専用ページ `/inspire/submit` に置き換える**。スマホでの操作性を優先した UX 変更。

## 動作

| アクション | 旧 | 新 |
|---|---|---|
| 「新しいテンプレートを申請」 | モーダル `setDialogOpen(true)` | `<Link href="/inspire/submit">` でページ遷移 |
| 「再申請」 | モーダル + `setReplaceTemplateId(id)` state | `<Link href="/inspire/submit?replace=<id>">` で query 引き継ぎ |
| キャンセル / 戻る | モーダルを閉じる | dirty 確認後 `router.push("/my-page")` |
| 申請成功 | モーダルを閉じる + `router.refresh()` | `router.push("/my-page")` で自動遷移 |
| ESC / 背景クリック | モーダル閉じ確認 | ブラウザ標準のナビゲーション（ページなので適用不可） |

3 ステップ（画像アップロード → 試着シミュレーション → 申請確定）、draft 行の cleanup、画像 lightbox、ConfirmDialog による離脱確認、はすべて引き続き動きます。

## 主な変更

### 新規ファイル

- **`app/(app)/inspire/submit/page.tsx`**（Server Component）
  - 機能フラグ（`NEXT_PUBLIC_INSPIRE_ENABLED`）→ 404
  - 認証必須（`requireAuth()`）→ 未認証は `/login`
  - 申請ホワイトリスト（`isInspireSubmitterAllowed`）→ 不許可は `/my-page`
  - `?replace=<id>` query を読んで再申請フローを伝達
  - `env.INSPIRE_TEST_CHARACTER_IMAGE_URL` を Server 側で読んで Client に props 渡し
  - `generateMetadata` で OG タイトル / canonical も設定

- **`features/inspire/components/UserStyleTemplateSubmissionForm.tsx`**
  - 旧 Dialog の body をそのまま 1 画面の `<section>` 構造に移植
  - 3 ステップのステート切替、file upload、preview、submit、AlertDialog 離脱確認、lightbox を維持
  - キャンセル / 戻る → AlertDialog 確認（dirty 時のみ）→ `router.push("/my-page")`
  - 申請成功時も同様に `/my-page` へ自動遷移（成功時は draft DELETE しない）
  - `useEffect` で unmount 時の ObjectURL クリーンアップを追加（旧 Dialog では `reset()` で掃除していたぶん）

### 修正ファイル

- **`features/inspire/components/MySubmittedTemplatesCardClient.tsx`**
  - `useState<dialogOpen>` / `useState<replaceTemplateId>` / `<UserStyleTemplateSubmissionDialog>` を撤去
  - `<Button asChild><Link href="/inspire/submit">` 形式に
  - 「再申請」は `?replace=` query で id を伝達
- **`features/inspire/components/MySubmittedTemplatesCard.tsx`**
  - `testCharacterImageUrl` の受け渡し配管を削除（環境変数 read は新ページが担当）

### 削除ファイル

- **`features/inspire/components/UserStyleTemplateSubmissionDialog.tsx`**（842 行）

## i18n

`messages/ja.ts` 等の翻訳キー（`inspireSubmission.dialogTitle` 等）は新ページからそのまま使い回しているため、**i18n 側は変更なし**。キー名 `dialogTitle` が若干 misnomer になりますが、将来的にリネームしたければ別 PR で。

## ルーティング

`/inspire/submit` は `app/(app)/inspire/submit/page.tsx` で静的セグメント。同階層の `/inspire/[templateId]` は dynamic で、Next.js のルート優先順位により static が dynamic より先にマッチするため衝突なし（`/inspire/submit` は確実に新しいページに行く、`/inspire/<UUID>` は既存の承認後生成画面に行く）。

`(app)` ルートグループ配下なのでロケール接頭辞は付かず、proxy のロケールリダイレクトの対象外（`/inspire/[templateId]` と同じ扱い）。

## 検証

- `npm run lint` — エラーなし
- `npm run typecheck` — 新規エラーなし（baseline 38 を維持）
- `npm run test` — `tests/` 配下全パス（0 回帰）。inspire 専用のユニットテストは元々なし
- `npm run build -- --webpack` — 成功、`/inspire/submit` が `◐ (Partial Prerender)` として出力されることを確認

## 影響範囲

- API ルート（`/api/style-templates/...`）は **無変更**。フォーム → API の通信仕様は完全に同じ
- DB スキーマ、Edge Function、Worker：**無変更**
- 旧モーダルの外部参照箇所は `MySubmittedTemplatesCardClient` のみ。grep で確認済み

## ロールバック

コミット `4920bdc` を revert で旧モーダル方式に戻ります。
