### PR TITLE
docs(agents): 長命ブランチ同期・大規模リリース PR は merge commit 必須

### DIFF
--- a/.agents/skills/git-create-pr/SKILL.md
+++ b/.agents/skills/git-create-pr/SKILL.md
@@ -55,3 +55,22 @@ description: Execute commit -> push -> PR creation safely in this repository. Us
 - `main` / `master` へ直接 push しない
 - 認証情報は追跡ファイルに書かない
 - リポジトリ不一致時は停止する
+
+## マージ方式（merge strategy）
+
+PR を **作成する**段階での既定は変わらず draft の有無のみ。**マージ時の方式**は PR の性質に応じて使い分け、ユーザーには本文末尾にどの方式を推奨するか明記する。
+
+| PR 種別 | 推奨マージ方式 | 理由 |
+|---|---|---|
+| 短命の feature / fix → `main` | Squash and merge | 履歴がシンプルになる |
+| **長命ブランチ同期**（`main` → `feature-model` などの sync PR） | **Create a merge commit（Squash 禁止）** | Squash すると merge commit の 2 親リンクが失われ、main の祖先関係が認識されなくなる。次回の sync で同じコンフリクトが再発する |
+| **長命ブランチ → `main` の大規模リリース PR** | **Create a merge commit（Squash 禁止）** | 長命ブランチ内の merge commit ・履歴・blame が保たれる |
+
+CLI で merge するときは `gh pr merge --merge` を使う（`--squash` ではなく）。GitHub UI からマージするときは「**Create a merge commit**」ボタンを選ぶ。
+
+sync / リリース系 PR を作る場合は PR 本文末尾に以下のフッターを必ず付ける：
+
+```
+> ⚠️ このPRは Squash ではなく **Create a merge commit** でマージしてください。
+> Squash すると親リンクが失われ、次回 `main` を取り込むときに同じファイルが再衝突します。
+```

--- a/.agents/skills/git-create-pr/SKILL.md
+++ b/.agents/skills/git-create-pr/SKILL.md
@@ -58,12 +58,12 @@ description: Execute commit -> push -> PR creation safely in this repository. Us
 
 ## マージ方式（merge strategy）
 
-PR を **作成する**段階での既定は変わらず draft の有無のみ。**マージ時の方式**は PR の性質に応じて使い分け、ユーザーには本文末尾にどの方式を推奨するか明記する。
+PR を **作成する**段階での既定は変わらず draft の有無のみ。**マージ時の方式**は PR の性質に応じて使い分け、ユーザーには本文末尾にどの方式を指定するか明記する。
 
-| PR 種別 | 推奨マージ方式 | 理由 |
+| PR 種別 | 指定マージ方式 | 理由 |
 |---|---|---|
 | 短命の feature / fix → `main` | Squash and merge | 履歴がシンプルになる |
-| **長命ブランチ同期**（`main` → `feature-model` などの sync PR） | **Create a merge commit（Squash 禁止）** | Squash すると merge commit の 2 親リンクが失われ、main の祖先関係が認識されなくなる。次回の sync で同じコンフリクトが再発する |
+| **長命ブランチ同期**（`main` → `feature-model` などの sync PR） | **Create a merge commit（Squash 禁止）** | Squash するとマージコミットが持つべき 2 つの親（parent）へのリンクが作成されず、main の祖先関係が認識されなくなる。次回の sync で同じコンフリクトが再発する |
 | **長命ブランチ → `main` の大規模リリース PR** | **Create a merge commit（Squash 禁止）** | 長命ブランチ内の merge commit ・履歴・blame が保たれる |
 
 CLI で merge するときは `gh pr merge --merge` を使う（`--squash` ではなく）。GitHub UI からマージするときは「**Create a merge commit**」ボタンを選ぶ。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,8 @@ Why: Squash merge produces a single commit with one parent, so Git cannot see th
 incoming branch's commits as ancestors. For sync / release PRs that bridge two
 long-lived branches, this destroys the merge-base linkage and forces the same
 conflicts to recur on every subsequent main update. Use `gh pr merge --merge`
-(not `--squash`) or click **Create a merge commit** in the GitHub UI when in
-doubt.
+(not `--squash`) or click **Create a merge commit** in the GitHub UI for these
+PR types.
 
 ## Destructive Operations
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,23 @@
 - Pull request titles and bodies must always be written in Japanese in this repository.
 - Conventional Commit messages may remain in English, but PR-facing text must include Japanese.
 
+### Merge strategy
+
+Choose the merge method based on what the PR represents. **Do not default to Squash.**
+
+| PR type | Required merge strategy |
+| --- | --- |
+| Short-lived feature / fix branch into `main` | Squash and merge OK |
+| Long-lived branch ↔ `main` sync (e.g. `main` → `feature-model`) | **Create a merge commit** (Squash forbidden) |
+| Large release PR from a long-lived branch (e.g. `feature-model` → `main`) | **Create a merge commit** (Squash forbidden) |
+
+Why: Squash merge produces a single commit with one parent, so Git cannot see the
+incoming branch's commits as ancestors. For sync / release PRs that bridge two
+long-lived branches, this destroys the merge-base linkage and forces the same
+conflicts to recur on every subsequent main update. Use `gh pr merge --merge`
+(not `--squash`) or click **Create a merge commit** in the GitHub UI when in
+doubt.
+
 ## Destructive Operations
 
 Do **not** perform the following without an explicit user request or confirmation in the current session. When in doubt, ask before acting.


### PR DESCRIPTION
## 概要

PR #281 と PR #283 はいずれも \`main → feature-model\` の同期 PR だったが、Squash でマージされた結果、merge commit が持つべき 2 親リンクが失われた。これにより `main` 側の `#278 / #280 / #282` のコミットが feature-model の祖先として認識されず、`main` が動くたびに同じ 8〜10 ファイルが再衝突する状態になっている。

Squash は短命の feature ブランチ向けで、長命ブランチ間の同期や大規模リリース PR には適さない。次回以降の事故を防ぐためにルールを明文化する。

## 変更

- [AGENTS.md](AGENTS.md) の `Pull Requests` セクションに **Merge strategy** 表を追加
- [.agents/skills/git-create-pr/SKILL.md](.agents/skills/git-create-pr/SKILL.md) に同じ表 + sync / リリース PR 用フッターテンプレートを追加

## ルール本体

| PR 種別 | 推奨マージ方式 |
|---|---|
| 短命の feature / fix → `main` | Squash and merge OK |
| **長命ブランチ同期**（`main` → `feature-model` 等）| **Create a merge commit（Squash 禁止）** |
| **長命ブランチ → `main` の大規模リリース PR** | **Create a merge commit（Squash 禁止）** |

CLI: `gh pr merge --merge`（`--squash` ではなく）
UI: 「**Create a merge commit**」を選択

## このPRのマージ方式

このPR自体は **短命なドキュメント変更**なので Squash でも問題ありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)