### PR TITLE
feat(my-page): 累計生成数・累計ビュー数を RPC 化し PostgREST 1000 行制限を解消

### DIFF
--- a/features/my-page/lib/server-api.ts
+++ b/features/my-page/lib/server-api.ts
@@ -140,25 +140,15 @@ export const getUserStatsServer = cache(async (
     generatedCount = 0; // UIでは generatedCountPublic=false のとき "-" を表示
   }
 
-  // いいね総数の集計（likesテーブルとgenerated_imagesテーブルをJOIN）
-  // まず、ユーザーの投稿済み画像IDを取得
-  const { data: postedImages } = await supabase
-    .from("generated_images")
-    .select("id")
-    .eq("user_id", userId)
-    .eq("is_posted", true);
-
-  const postedImageIds = postedImages?.map((img) => img.id) || [];
-
+  // いいね総数の集計: PostgREST の 1000 行返却上限を避けるため
+  // Postgres 側の RPC で likes と generated_images を JOIN して集計済みの値を取得する。
+  const { data: likeCountData, error: likeCountError } = await supabase
+    .rpc("get_user_like_count", { p_user_id: userId });
   let likeCount = 0;
-  if (postedImageIds.length > 0) {
-    // 投稿済み画像に対するいいね数を集計
-    // likesテーブルはimage_idカラムを使用（post_idではない）
-    const { count } = await supabase
-      .from("likes")
-      .select("*", { count: "exact", head: true })
-      .in("image_id", postedImageIds);
-    likeCount = count || 0;
+  if (likeCountError) {
+    console.error("Like count fetch error:", likeCountError);
+  } else {
+    likeCount = Number(likeCountData) || 0;
   }
 
   // ビュー総数の集計: PostgREST の 1000 行返却上限を避けるため

--- a/features/my-page/lib/server-api.ts
+++ b/features/my-page/lib/server-api.ts
@@ -121,26 +121,19 @@ export const getUserStatsServer = cache(async (
     : (await supabase.auth.getUser()).data.user?.id === userId;
 
   // 累計生成数: 削除に左右されないよう image_jobs（生成ジョブログ）から集計する。
-  // - 1 ジョブが requested_image_count 枚を生成する（OpenAI バッチ等で N>1）
+  // PostgREST の 1000 行返却上限を避けるため Postgres 側の RPC で合計済みの値を取得する。
   // - 成功したジョブのみを対象（失敗は数えない）
-  // - generated_images.image_job_id → image_jobs は ON DELETE SET NULL なので、画像削除しても
-  //   image_jobs は残る → 削除しても累計は減らない
+  // - requested_image_count NULL の旧ジョブは 1 として加算（RPC 側で coalesce）
   // - image_jobs 導入（2026-01-15）以前の生成は count されない既知の制約あり
   let generatedCount: number;
   if (isOwnProfile) {
-    const { data: jobs, error: jobsError } = await supabase
-      .from("image_jobs")
-      .select("requested_image_count")
-      .eq("user_id", userId)
-      .eq("status", "succeeded");
+    const { data: generatedCountData, error: jobsError } = await supabase
+      .rpc("get_user_generated_count", { p_user_id: userId });
     if (jobsError) {
       console.error("Generated count fetch error:", jobsError);
       generatedCount = 0;
     } else {
-      generatedCount = (jobs ?? []).reduce(
-        (sum, row) => sum + (Number(row.requested_image_count) || 1),
-        0,
-      );
+      generatedCount = Number(generatedCountData) || 0;
     }
   } else {
     // 他ユーザー: 生成数はRLSで非公開（未投稿画像は参照不可）
@@ -168,18 +161,16 @@ export const getUserStatsServer = cache(async (
     likeCount = count || 0;
   }
 
-  // ビュー総数の集計（generated_imagesテーブルのview_countを合計）
-  const { data: postedImagesWithViews } = await supabase
-    .from("generated_images")
-    .select("view_count")
-    .eq("user_id", userId)
-    .eq("is_posted", true);
-
-  const viewCount =
-    postedImagesWithViews?.reduce(
-      (sum, img) => sum + (img.view_count || 0),
-      0
-    ) || 0;
+  // ビュー総数の集計: PostgREST の 1000 行返却上限を避けるため
+  // Postgres 側の RPC で合計済みの値を取得する（投稿済み generated_images.view_count の合計）。
+  const { data: viewCountData, error: viewCountError } = await supabase
+    .rpc("get_user_view_count", { p_user_id: userId });
+  let viewCount = 0;
+  if (viewCountError) {
+    console.error("View count fetch error:", viewCountError);
+  } else {
+    viewCount = Number(viewCountData) || 0;
+  }
 
   // フォロー数・フォロワー数を1回のRPCコールで取得
   const { data: followCounts, error: followCountsError } = await supabase

--- a/supabase/migrations/20260518130000_add_my_page_stats_rpcs.sql
+++ b/supabase/migrations/20260518130000_add_my_page_stats_rpcs.sql
@@ -1,0 +1,49 @@
+-- ===============================================
+-- Add my page stats RPCs
+-- マイページの累計生成数・累計ビュー数を Postgres 側で集計するための関数
+--
+-- PostgREST のデフォルト返却上限（1000 行）により、ヘビーユーザーで
+-- 累計値が頭打ちになる既知の問題（image_jobs/view_count 行 > 1000）に対処する。
+-- ===============================================
+
+-- 累計生成数: 成功した image_jobs.requested_image_count の合計
+-- requested_image_count が NULL の旧ジョブも最低 1 枚として加算する
+create or replace function public.get_user_generated_count(p_user_id uuid)
+returns bigint
+language sql
+security definer
+stable
+set search_path = public
+as $$
+  select coalesce(sum(coalesce(requested_image_count, 1)), 0)::bigint
+  from public.image_jobs
+  where user_id = p_user_id
+    and status = 'succeeded';
+$$;
+
+comment on function public.get_user_generated_count(uuid) is
+  '指定ユーザーの累計生成数（成功 image_jobs の requested_image_count 合計）を返す。NULL の行は 1 として加算。';
+
+-- 累計ビュー数: 投稿済み generated_images.view_count の合計
+create or replace function public.get_user_view_count(p_user_id uuid)
+returns bigint
+language sql
+security definer
+stable
+set search_path = public
+as $$
+  select coalesce(sum(view_count), 0)::bigint
+  from public.generated_images
+  where user_id = p_user_id
+    and is_posted = true;
+$$;
+
+comment on function public.get_user_view_count(uuid) is
+  '指定ユーザーの累計ビュー数（投稿済み generated_images.view_count の合計）を返す。';
+
+-- 権限: 認証済みユーザーのみ実行可能
+revoke all on function public.get_user_generated_count(uuid) from public;
+grant execute on function public.get_user_generated_count(uuid) to authenticated;
+
+revoke all on function public.get_user_view_count(uuid) from public;
+grant execute on function public.get_user_view_count(uuid) to authenticated;

--- a/supabase/migrations/20260518140000_add_user_like_count_rpc.sql
+++ b/supabase/migrations/20260518140000_add_user_like_count_rpc.sql
@@ -1,0 +1,31 @@
+-- ===============================================
+-- Add get_user_like_count RPC
+-- マイページの累計いいね数を Postgres 側で集計するための関数
+--
+-- 既存実装は generated_images から投稿済み画像 ID を全件取得してから
+-- likes を WHERE image_id IN (...) で集計していたが、PostgREST のデフォルト
+-- 返却上限（1000 行）により投稿数が 1000 を超えると ID 配列が打ち切られ、
+-- 一部の投稿に対するいいねが likeCount に含まれない問題があった。
+--
+-- 20260518130000_add_my_page_stats_rpcs と同じ方針で集計を Postgres 側に寄せる。
+-- ===============================================
+
+create or replace function public.get_user_like_count(p_user_id uuid)
+returns bigint
+language sql
+security definer
+stable
+set search_path = public
+as $$
+  select count(*)::bigint
+  from public.likes as l
+  join public.generated_images as gi on gi.id = l.image_id
+  where gi.user_id = p_user_id
+    and gi.is_posted = true;
+$$;
+
+comment on function public.get_user_like_count(uuid) is
+  '指定ユーザーの累計いいね数（投稿済み generated_images に紐づく likes の件数）を返す。';
+
+revoke all on function public.get_user_like_count(uuid) from public;
+grant execute on function public.get_user_like_count(uuid) to authenticated;

--- a/tests/unit/lib/my-page-server-api.test.ts
+++ b/tests/unit/lib/my-page-server-api.test.ts
@@ -426,23 +426,17 @@ describe("MyPageServerApi unit tests from EARS specs", () => {
   describe("MPSAPI-004 getUserStatsServer", () => {
     test("getUserStatsServer_authで自分のプロフィールの場合_全カウンタを集計してgeneratedCountを公開する", async () => {
       // Spec: MPSAPI-004
-      // 累計生成数は get_user_generated_count RPC が返した値をそのまま使う（PostgREST 1000 行制限回避）
+      // 累計生成数・累計いいね数・累計ビュー数はすべて RPC が返した値をそのまま使う（PostgREST 1000 行制限回避）
       const supabase = createSupabaseMock({
         authUser: { id: "user-1" },
         from: {
           generated_images: [
             { result: { data: null, error: null, count: 4 } },
-            {
-              result: {
-                data: [{ id: "img-1" }, { id: "img-2" }],
-                error: null,
-              },
-            },
           ],
-          likes: [{ result: { data: null, error: null, count: 6 } }],
         },
         rpc: {
           get_user_generated_count: [{ result: { data: 9, error: null } }],
+          get_user_like_count: [{ result: { data: 6, error: null } }],
           get_user_view_count: [{ result: { data: 10, error: null } }],
           get_follow_counts: [
             {
@@ -468,52 +462,46 @@ describe("MyPageServerApi unit tests from EARS specs", () => {
         followingCount: 5,
       });
       expect(supabase.getUser).toHaveBeenCalledTimes(1);
-      expect(supabase.fromCalls.generated_images).toHaveLength(2);
+      expect(supabase.fromCalls.generated_images).toHaveLength(1);
       expect(supabase.fromCalls.generated_images[0].calls.eq).toEqual([
         ["user_id", "user-1"],
         ["is_posted", true],
       ]);
       expect(supabase.fromCalls.image_jobs).toBeUndefined();
-      expect(supabase.fromCalls.likes[0].calls.in).toEqual([
-        ["image_id", ["img-1", "img-2"]],
-      ]);
+      expect(supabase.fromCalls.likes).toBeUndefined();
       const rpcNames = supabase.rpcCalls.map((c) => c.name);
       expect(rpcNames).toEqual(
         expect.arrayContaining([
           "get_user_generated_count",
+          "get_user_like_count",
           "get_user_view_count",
           "get_follow_counts",
         ]),
       );
-      expect(
-        supabase.rpcCalls.find((c) => c.name === "get_user_generated_count"),
-      ).toMatchObject({ params: { p_user_id: "user-1" } });
-      expect(
-        supabase.rpcCalls.find((c) => c.name === "get_user_view_count"),
-      ).toMatchObject({ params: { p_user_id: "user-1" } });
-      expect(
-        supabase.rpcCalls.find((c) => c.name === "get_follow_counts"),
-      ).toMatchObject({ params: { p_user_id: "user-1" } });
+      for (const name of [
+        "get_user_generated_count",
+        "get_user_like_count",
+        "get_user_view_count",
+        "get_follow_counts",
+      ]) {
+        expect(supabase.rpcCalls.find((c) => c.name === name)).toMatchObject({
+          params: { p_user_id: "user-1" },
+        });
+      }
     });
 
     test("getUserStatsServer_supabaseOverrideで自分のプロフィールの場合_auth参照なしで集計する", async () => {
       // Spec: MPSAPI-004
-      // 累計生成数・累計ビュー数は RPC が合計済みの値を返す
+      // 累計生成数・累計いいね数・累計ビュー数は RPC が合計済みの値を返す
       const supabase = createSupabaseMock({
         from: {
           generated_images: [
             { result: { data: null, error: null, count: 2 } },
-            {
-              result: {
-                data: [{ id: "img-10" }],
-                error: null,
-              },
-            },
           ],
-          likes: [{ result: { data: null, error: null, count: 3 } }],
         },
         rpc: {
           get_user_generated_count: [{ result: { data: 5, error: null } }],
+          get_user_like_count: [{ result: { data: 3, error: null } }],
           get_user_view_count: [{ result: { data: 4, error: null } }],
           get_follow_counts: [
             {
@@ -546,14 +534,13 @@ describe("MyPageServerApi unit tests from EARS specs", () => {
         from: {
           generated_images: [
             { result: { data: null, error: null, count: 1 } },
-            { result: { data: [{ id: "img-50" }], error: null } },
           ],
-          likes: [{ result: { data: null, error: null, count: 0 } }],
         },
         rpc: {
           get_user_generated_count: [
             { result: { data: null, error: rpcError } },
           ],
+          get_user_like_count: [{ result: { data: 0, error: null } }],
           get_user_view_count: [{ result: { data: 9, error: null } }],
           get_follow_counts: [
             {
@@ -580,6 +567,45 @@ describe("MyPageServerApi unit tests from EARS specs", () => {
       );
     });
 
+    test("getUserStatsServer_likeCountRpcエラー時_likeCountを0にフォールバックしconsole.errorに出力する", async () => {
+      // Spec: MPSAPI-004
+      // get_user_like_count RPC がエラーを返した場合の安全側挙動を担保する。
+      const rpcError = { message: "like rpc unreachable" };
+      const supabase = createSupabaseMock({
+        from: {
+          generated_images: [
+            { result: { data: null, error: null, count: 1 } },
+          ],
+        },
+        rpc: {
+          get_user_generated_count: [{ result: { data: 3, error: null } }],
+          get_user_like_count: [{ result: { data: null, error: rpcError } }],
+          get_user_view_count: [{ result: { data: 0, error: null } }],
+          get_follow_counts: [
+            {
+              singleResult: {
+                data: { following_count: 0, follower_count: 0 },
+                error: null,
+              },
+            },
+          ],
+        },
+      });
+
+      const result = await getUserStatsServer(
+        "user-1",
+        supabase.client as never,
+        { isOwnProfile: true },
+      );
+
+      expect(result.likeCount).toBe(0);
+      expect(result.generatedCount).toBe(3);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Like count fetch error:",
+        rpcError,
+      );
+    });
+
     test("getUserStatsServer_viewCountRpcエラー時_viewCountを0にフォールバックしconsole.errorに出力する", async () => {
       // Spec: MPSAPI-004
       // get_user_view_count RPC がエラーを返した場合の安全側挙動を担保する。
@@ -588,12 +614,11 @@ describe("MyPageServerApi unit tests from EARS specs", () => {
         from: {
           generated_images: [
             { result: { data: null, error: null, count: 1 } },
-            { result: { data: [{ id: "img-60" }], error: null } },
           ],
-          likes: [{ result: { data: null, error: null, count: 0 } }],
         },
         rpc: {
           get_user_generated_count: [{ result: { data: 3, error: null } }],
+          get_user_like_count: [{ result: { data: 0, error: null } }],
           get_user_view_count: [{ result: { data: null, error: rpcError } }],
           get_follow_counts: [
             {
@@ -627,11 +652,11 @@ describe("MyPageServerApi unit tests from EARS specs", () => {
         from: {
           generated_images: [
             { result: { data: null, error: null, count: 0 } },
-            { result: { data: [], error: null } },
           ],
         },
         rpc: {
           get_user_generated_count: [{ result: { data: null, error: null } }],
+          get_user_like_count: [{ result: { data: null, error: null } }],
           get_user_view_count: [{ result: { data: null, error: null } }],
           get_follow_counts: [
             {
@@ -660,22 +685,16 @@ describe("MyPageServerApi unit tests from EARS specs", () => {
     test("getUserStatsServer_他人のプロフィールの場合_generatedCountを隠しつつ公開集計を返す", async () => {
       // Spec: MPSAPI-005
       // 他人プロフィール時は get_user_generated_count を呼ばずに 0 を返すが、
-      // viewCount は公開情報なので RPC が返す合計値を使う。
+      // likeCount / viewCount は公開情報なので RPC が返す合計値を使う。
       const supabase = createSupabaseMock({
         authUser: { id: "viewer-1" },
         from: {
           generated_images: [
             { result: { data: null, error: null, count: 2 } },
-            {
-              result: {
-                data: [{ id: "img-20" }, { id: "img-21" }],
-                error: null,
-              },
-            },
           ],
-          likes: [{ result: { data: null, error: null, count: 4 } }],
         },
         rpc: {
+          get_user_like_count: [{ result: { data: 4, error: null } }],
           get_user_view_count: [{ result: { data: 4, error: null } }],
           get_follow_counts: [
             {
@@ -700,29 +719,30 @@ describe("MyPageServerApi unit tests from EARS specs", () => {
         followerCount: 7,
         followingCount: 9,
       });
-      expect(supabase.fromCalls.generated_images).toHaveLength(2);
-      expect(supabase.fromCalls.likes).toHaveLength(1);
+      expect(supabase.fromCalls.generated_images).toHaveLength(1);
+      expect(supabase.fromCalls.likes).toBeUndefined();
       // get_user_generated_count は他人プロフィールでは呼ばれない
       expect(
         supabase.rpcCalls.find((c) => c.name === "get_user_generated_count"),
       ).toBeUndefined();
+      // likeCount / viewCount は他人プロフィールでも RPC で取得される
+      expect(
+        supabase.rpcCalls.find((c) => c.name === "get_user_like_count"),
+      ).toMatchObject({ params: { p_user_id: "user-2" } });
     });
 
     test("getUserStatsServer_他人のプロフィールで投稿済み画像なしの場合_likeCountを0に保つ", async () => {
       // Spec: MPSAPI-005
+      // 投稿が 0 件のとき RPC は 0 を返す。client 側で短絡せず RPC が値を返す前提に変わったため、
+      // likes テーブルへの from() 呼び出しは発生しないことを担保する。
       const supabase = createSupabaseMock({
         from: {
           generated_images: [
             { result: { data: null, error: null, count: 0 } },
-            {
-              result: {
-                data: [],
-                error: null,
-              },
-            },
           ],
         },
         rpc: {
+          get_user_like_count: [{ result: { data: 0, error: null } }],
           get_user_view_count: [{ result: { data: 0, error: null } }],
           get_follow_counts: [
             {
@@ -757,17 +777,11 @@ describe("MyPageServerApi unit tests from EARS specs", () => {
         from: {
           generated_images: [
             { result: { data: null, error: null, count: 1 } },
-            {
-              result: {
-                data: [{ id: "img-30" }],
-                error: null,
-              },
-            },
           ],
-          likes: [{ result: { data: null, error: null, count: 5 } }],
         },
         rpc: {
           get_user_generated_count: [{ result: { data: 2, error: null } }],
+          get_user_like_count: [{ result: { data: 5, error: null } }],
           get_user_view_count: [{ result: { data: 11, error: null } }],
           get_follow_counts: [
             {

--- a/tests/unit/lib/my-page-server-api.test.ts
+++ b/tests/unit/lib/my-page-server-api.test.ts
@@ -426,7 +426,7 @@ describe("MyPageServerApi unit tests from EARS specs", () => {
   describe("MPSAPI-004 getUserStatsServer", () => {
     test("getUserStatsServer_authで自分のプロフィールの場合_全カウンタを集計してgeneratedCountを公開する", async () => {
       // Spec: MPSAPI-004
-      // 累計生成数は image_jobs.requested_image_count の合計から算出される（4 + 5 = 9）
+      // 累計生成数は get_user_generated_count RPC が返した値をそのまま使う（PostgREST 1000 行制限回避）
       const supabase = createSupabaseMock({
         authUser: { id: "user-1" },
         from: {
@@ -438,27 +438,12 @@ describe("MyPageServerApi unit tests from EARS specs", () => {
                 error: null,
               },
             },
-            {
-              result: {
-                data: [{ view_count: 3 }, { view_count: null }, { view_count: 7 }],
-                error: null,
-              },
-            },
-          ],
-          image_jobs: [
-            {
-              result: {
-                data: [
-                  { requested_image_count: 4 },
-                  { requested_image_count: 5 },
-                ],
-                error: null,
-              },
-            },
           ],
           likes: [{ result: { data: null, error: null, count: 6 } }],
         },
         rpc: {
+          get_user_generated_count: [{ result: { data: 9, error: null } }],
+          get_user_view_count: [{ result: { data: 10, error: null } }],
           get_follow_counts: [
             {
               singleResult: {
@@ -483,28 +468,37 @@ describe("MyPageServerApi unit tests from EARS specs", () => {
         followingCount: 5,
       });
       expect(supabase.getUser).toHaveBeenCalledTimes(1);
-      expect(supabase.fromCalls.generated_images).toHaveLength(3);
+      expect(supabase.fromCalls.generated_images).toHaveLength(2);
       expect(supabase.fromCalls.generated_images[0].calls.eq).toEqual([
         ["user_id", "user-1"],
         ["is_posted", true],
       ]);
-      expect(supabase.fromCalls.image_jobs).toHaveLength(1);
-      expect(supabase.fromCalls.image_jobs[0].calls.eq).toEqual([
-        ["user_id", "user-1"],
-        ["status", "succeeded"],
-      ]);
+      expect(supabase.fromCalls.image_jobs).toBeUndefined();
       expect(supabase.fromCalls.likes[0].calls.in).toEqual([
         ["image_id", ["img-1", "img-2"]],
       ]);
-      expect(supabase.rpcCalls[0]).toMatchObject({
-        name: "get_follow_counts",
-        params: { p_user_id: "user-1" },
-      });
+      const rpcNames = supabase.rpcCalls.map((c) => c.name);
+      expect(rpcNames).toEqual(
+        expect.arrayContaining([
+          "get_user_generated_count",
+          "get_user_view_count",
+          "get_follow_counts",
+        ]),
+      );
+      expect(
+        supabase.rpcCalls.find((c) => c.name === "get_user_generated_count"),
+      ).toMatchObject({ params: { p_user_id: "user-1" } });
+      expect(
+        supabase.rpcCalls.find((c) => c.name === "get_user_view_count"),
+      ).toMatchObject({ params: { p_user_id: "user-1" } });
+      expect(
+        supabase.rpcCalls.find((c) => c.name === "get_follow_counts"),
+      ).toMatchObject({ params: { p_user_id: "user-1" } });
     });
 
     test("getUserStatsServer_supabaseOverrideで自分のプロフィールの場合_auth参照なしで集計する", async () => {
       // Spec: MPSAPI-004
-      // 累計生成数は image_jobs.requested_image_count の合計（2 + 3 = 5）
+      // 累計生成数・累計ビュー数は RPC が合計済みの値を返す
       const supabase = createSupabaseMock({
         from: {
           generated_images: [
@@ -515,27 +509,12 @@ describe("MyPageServerApi unit tests from EARS specs", () => {
                 error: null,
               },
             },
-            {
-              result: {
-                data: [{ view_count: 4 }],
-                error: null,
-              },
-            },
-          ],
-          image_jobs: [
-            {
-              result: {
-                data: [
-                  { requested_image_count: 2 },
-                  { requested_image_count: 3 },
-                ],
-                error: null,
-              },
-            },
           ],
           likes: [{ result: { data: null, error: null, count: 3 } }],
         },
         rpc: {
+          get_user_generated_count: [{ result: { data: 5, error: null } }],
+          get_user_view_count: [{ result: { data: 4, error: null } }],
           get_follow_counts: [
             {
               singleResult: {
@@ -559,21 +538,23 @@ describe("MyPageServerApi unit tests from EARS specs", () => {
       expect(result.viewCount).toBe(4);
     });
 
-    test("getUserStatsServer_image_jobs取得エラー時_generatedCountを0にフォールバックしconsole.errorに出力する", async () => {
+    test("getUserStatsServer_generatedCountRpcエラー時_generatedCountを0にフォールバックしconsole.errorに出力する", async () => {
       // Spec: MPSAPI-004
-      // 累計生成数の集計クエリ（image_jobs）がエラーを返した場合の安全側挙動を担保する。
-      const jobsError = { message: "image_jobs unreachable" };
+      // get_user_generated_count RPC がエラーを返した場合の安全側挙動を担保する。
+      const rpcError = { message: "rpc unreachable" };
       const supabase = createSupabaseMock({
         from: {
           generated_images: [
             { result: { data: null, error: null, count: 1 } },
             { result: { data: [{ id: "img-50" }], error: null } },
-            { result: { data: [{ view_count: 9 }], error: null } },
           ],
-          image_jobs: [{ result: { data: null, error: jobsError } }],
           likes: [{ result: { data: null, error: null, count: 0 } }],
         },
         rpc: {
+          get_user_generated_count: [
+            { result: { data: null, error: rpcError } },
+          ],
+          get_user_view_count: [{ result: { data: 9, error: null } }],
           get_follow_counts: [
             {
               singleResult: {
@@ -595,23 +576,63 @@ describe("MyPageServerApi unit tests from EARS specs", () => {
       expect(result.generatedCountPublic).toBe(true);
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         "Generated count fetch error:",
-        jobsError,
+        rpcError,
       );
     });
 
-    test("getUserStatsServer_image_jobsがnullを返した場合_generatedCountは0になる", async () => {
+    test("getUserStatsServer_viewCountRpcエラー時_viewCountを0にフォールバックしconsole.errorに出力する", async () => {
       // Spec: MPSAPI-004
-      // PostgREST は通常 [] を返すが、安全策の `jobs ?? []` フォールバックが効くことを確認する。
+      // get_user_view_count RPC がエラーを返した場合の安全側挙動を担保する。
+      const rpcError = { message: "view rpc unreachable" };
+      const supabase = createSupabaseMock({
+        from: {
+          generated_images: [
+            { result: { data: null, error: null, count: 1 } },
+            { result: { data: [{ id: "img-60" }], error: null } },
+          ],
+          likes: [{ result: { data: null, error: null, count: 0 } }],
+        },
+        rpc: {
+          get_user_generated_count: [{ result: { data: 3, error: null } }],
+          get_user_view_count: [{ result: { data: null, error: rpcError } }],
+          get_follow_counts: [
+            {
+              singleResult: {
+                data: { following_count: 0, follower_count: 0 },
+                error: null,
+              },
+            },
+          ],
+        },
+      });
+
+      const result = await getUserStatsServer(
+        "user-1",
+        supabase.client as never,
+        { isOwnProfile: true },
+      );
+
+      expect(result.viewCount).toBe(0);
+      expect(result.generatedCount).toBe(3);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "View count fetch error:",
+        rpcError,
+      );
+    });
+
+    test("getUserStatsServer_generatedCountRpcがnullを返した場合_generatedCountは0になる", async () => {
+      // Spec: MPSAPI-004
+      // RPC が data: null を返した場合の Number() フォールバックが効くことを確認する。
       const supabase = createSupabaseMock({
         from: {
           generated_images: [
             { result: { data: null, error: null, count: 0 } },
             { result: { data: [], error: null } },
-            { result: { data: [], error: null } },
           ],
-          image_jobs: [{ result: { data: null, error: null } }],
         },
         rpc: {
+          get_user_generated_count: [{ result: { data: null, error: null } }],
+          get_user_view_count: [{ result: { data: null, error: null } }],
           get_follow_counts: [
             {
               singleResult: {
@@ -631,58 +652,15 @@ describe("MyPageServerApi unit tests from EARS specs", () => {
 
       expect(result.generatedCount).toBe(0);
       expect(result.generatedCountPublic).toBe(true);
-    });
-
-    test("getUserStatsServer_requested_image_countがnullの行は1枚としてカウントする", async () => {
-      // Spec: MPSAPI-004
-      // 古い行や旧スキーマで requested_image_count が NULL のジョブも、
-      // 最低 1 枚生成された前提で人生通算カウントに含める。
-      const supabase = createSupabaseMock({
-        from: {
-          generated_images: [
-            { result: { data: null, error: null, count: 0 } },
-            { result: { data: [], error: null } },
-            { result: { data: [], error: null } },
-          ],
-          image_jobs: [
-            {
-              result: {
-                data: [
-                  { requested_image_count: null },
-                  { requested_image_count: 2 },
-                  { requested_image_count: undefined },
-                ],
-                error: null,
-              },
-            },
-          ],
-        },
-        rpc: {
-          get_follow_counts: [
-            {
-              singleResult: {
-                data: { following_count: 0, follower_count: 0 },
-                error: null,
-              },
-            },
-          ],
-        },
-      });
-
-      const result = await getUserStatsServer(
-        "user-2",
-        supabase.client as never,
-        { isOwnProfile: true },
-      );
-
-      // null → 1, 2 → 2, undefined → 1。合計 4。
-      expect(result.generatedCount).toBe(4);
+      expect(result.viewCount).toBe(0);
     });
   });
 
   describe("MPSAPI-005 getUserStatsServer", () => {
     test("getUserStatsServer_他人のプロフィールの場合_generatedCountを隠しつつ公開集計を返す", async () => {
       // Spec: MPSAPI-005
+      // 他人プロフィール時は get_user_generated_count を呼ばずに 0 を返すが、
+      // viewCount は公開情報なので RPC が返す合計値を使う。
       const supabase = createSupabaseMock({
         authUser: { id: "viewer-1" },
         from: {
@@ -694,16 +672,11 @@ describe("MyPageServerApi unit tests from EARS specs", () => {
                 error: null,
               },
             },
-            {
-              result: {
-                data: [{ view_count: 1 }, { view_count: 3 }],
-                error: null,
-              },
-            },
           ],
           likes: [{ result: { data: null, error: null, count: 4 } }],
         },
         rpc: {
+          get_user_view_count: [{ result: { data: 4, error: null } }],
           get_follow_counts: [
             {
               singleResult: {
@@ -727,8 +700,12 @@ describe("MyPageServerApi unit tests from EARS specs", () => {
         followerCount: 7,
         followingCount: 9,
       });
-      expect(supabase.fromCalls.generated_images).toHaveLength(3);
+      expect(supabase.fromCalls.generated_images).toHaveLength(2);
       expect(supabase.fromCalls.likes).toHaveLength(1);
+      // get_user_generated_count は他人プロフィールでは呼ばれない
+      expect(
+        supabase.rpcCalls.find((c) => c.name === "get_user_generated_count"),
+      ).toBeUndefined();
     });
 
     test("getUserStatsServer_他人のプロフィールで投稿済み画像なしの場合_likeCountを0に保つ", async () => {
@@ -743,15 +720,10 @@ describe("MyPageServerApi unit tests from EARS specs", () => {
                 error: null,
               },
             },
-            {
-              result: {
-                data: [],
-                error: null,
-              },
-            },
           ],
         },
         rpc: {
+          get_user_view_count: [{ result: { data: 0, error: null } }],
           get_follow_counts: [
             {
               singleResult: {
@@ -779,7 +751,6 @@ describe("MyPageServerApi unit tests from EARS specs", () => {
   describe("MPSAPI-006 getUserStatsServer", () => {
     test("getUserStatsServer_followCountRpcエラーの場合_ログしてfollow数を0にフォールバックする", async () => {
       // Spec: MPSAPI-006
-      // 累計生成数は image_jobs.requested_image_count の合計（2）
       const followError = { message: "rpc failed" };
       const supabase = createSupabaseMock({
         authUser: { id: "user-1" },
@@ -792,24 +763,12 @@ describe("MyPageServerApi unit tests from EARS specs", () => {
                 error: null,
               },
             },
-            {
-              result: {
-                data: [{ view_count: 11 }],
-                error: null,
-              },
-            },
-          ],
-          image_jobs: [
-            {
-              result: {
-                data: [{ requested_image_count: 2 }],
-                error: null,
-              },
-            },
           ],
           likes: [{ result: { data: null, error: null, count: 5 } }],
         },
         rpc: {
+          get_user_generated_count: [{ result: { data: 2, error: null } }],
+          get_user_view_count: [{ result: { data: 11, error: null } }],
           get_follow_counts: [
             {
               singleResult: {


### PR DESCRIPTION
### 概要

マイページの「累計生成数」と「累計ビュー数」は、PostgREST のデフォルト返却上限（1000 行）に阻まれ、ヘビーユーザーで頭打ちになる既知の問題があった。Supabase RPC で Postgres 側に集計を寄せることで、行数に依存しない正確な合計値を返すように修正する。

PR #283 の Gemini レビュー #1 で指摘された follow-up に該当する。

### 変更内容

- **migration `20260518130000_add_my_page_stats_rpcs.sql`**: 2 つの RPC を追加（リモート Supabase 適用済み）
  - `get_user_generated_count(p_user_id uuid) returns bigint`: 成功 `image_jobs.requested_image_count` の合計を返す。NULL 行は 1 として加算（旧スキーマ互換）
  - `get_user_view_count(p_user_id uuid) returns bigint`: 投稿済み `generated_images.view_count` の合計を返す
  - 両関数とも `security definer` / `stable` / `search_path = public`、`authenticated` ロールに execute 権限付与
- **[features/my-page/lib/server-api.ts](features/my-page/lib/server-api.ts) `getUserStatsServer`**: `image_jobs` / `generated_images.view_count` の全行取得 + JS 側 reduce を RPC 呼び出しに置換
  - `viewCount` にもエラー時 `console.error` フォールバックを追加（既存の generatedCount と同じパターン）
- **[tests/unit/lib/my-page-server-api.test.ts](tests/unit/lib/my-page-server-api.test.ts)**: 行レベルのモック（`image_jobs:[{...}]` / `generated_images` 3 回目）を RPC モック（`get_user_generated_count` / `get_user_view_count`）に書き換え

### 体感ベース影響

- アクティブユーザーが約 1〜2 ヶ月で 1000 ジョブに達した時点で発症する時限バグの解消
- 1000 行近いデータをワイヤー転送していたのが 1 数値だけになるため、マイページ初回ロードもやや軽くなる

### 実機テスト

- [ ] PC（Chrome）でマイページを開き、累計生成数・累計ビュー数が正しく表示されることを確認
- [ ] 自分のプロフィール: 累計生成数が公開される
- [ ] 他人のプロフィール: 累計生成数が \"-\" 表示（generatedCountPublic=false）
- [ ] iOS Safari で主要導線を確認
- [ ] Android Chrome で主要導線を確認

### テスト方法

- `npm run test` 全 1169 件パス（うち `MPSAPI-004/005/006` 系 11 ケースを RPC ベースに刷新）
- `npm run lint` / `npm run typecheck`: 既存のエラー件数と完全一致（新規エラーゼロ）
- `npm run build -- --webpack`: ビルド成功

### マージ方式

short-lived な feature ブランチなので **Squash and merge** で OK。

🤖 Generated with [Claude Code](https://claude.com/claude-code)