### PR TITLE
feat(generation): 画像出力アスペクト比を 9:16〜16:9 にクランプ

### DIFF
--- a/app/api/style-templates/preview-generation/handler.ts
+++ b/app/api/style-templates/preview-generation/handler.ts
@@ -33,8 +33,12 @@ import {
   isHeicImage,
 } from "@/features/generation/lib/heic-converter";
 import { getSafeExtensionFromMimeType } from "@/features/generation/lib/schema";
-import { callOpenAIImageEditMultiInput } from "@/features/generation/lib/openai-image";
+import {
+  callOpenAIImageEditMultiInput,
+  parseImageDimensions,
+} from "@/features/generation/lib/openai-image";
 import { createNanobananaClient } from "@/features/generation/lib/nanobanana-client";
+import { resolveGeminiAspectRatio } from "@/shared/generation/gemini-aspect-ratio";
 import { GEMINI_GENERATION_ENABLED } from "@/features/generation/lib/model-config";
 import { buildInspirePrompt } from "@/shared/generation/prompt-core";
 import {
@@ -340,6 +344,14 @@ export async function handlePreviewGeneration(
         };
       }
       const client = createNanobananaClient();
+      // 出力アスペクト比はテンプレ画像 (image_1) 基準で解決する。
+      // preview は「テンプレ適用後の見え方」を確認する用途のため、
+      // テンプレの構図/フレーミングを基準にする (ADR-006)。
+      const templateAspectDims = parseImageDimensions(
+        new Uint8Array(Buffer.from(templateBase64, "base64")),
+        templateMimeType,
+      );
+      const previewAspectRatio = resolveGeminiAspectRatio(templateAspectDims);
       const response = await client.generateContent({
         apiKey: env.GEMINI_API_KEY,
         model: "gemini-3.1-flash-image-preview",
@@ -366,7 +378,10 @@ export async function handlePreviewGeneration(
           generationConfig: {
             candidateCount: 1,
             responseModalities: ["TEXT", "IMAGE"],
-            imageConfig: { imageSize: "512" },
+            imageConfig: {
+              imageSize: "512",
+              aspectRatio: previewAspectRatio,
+            },
           },
         },
       });

--- a/app/i2i/[slug]/generate/route.ts
+++ b/app/i2i/[slug]/generate/route.ts
@@ -13,6 +13,8 @@ import {
   MAX_IMAGE_BYTES,
   MAX_TOTAL_IMAGE_BYTES,
 } from "@/features/i2i-poc/shared/image-constraints";
+import { parseImageDimensions } from "@/features/generation/lib/openai-image";
+import { resolveGeminiAspectRatio } from "@/shared/generation/gemini-aspect-ratio";
 
 const MODEL_NAME = "gemini-3.1-flash-image-preview";
 const OUTPUT_IMAGE_SIZE = "512";
@@ -551,11 +553,26 @@ export async function POST(request: NextRequest, context: GenerateRouteContext) 
     const baseFeedback = trimFeedback(formData.get("baseFeedback"));
     const characterFeedback = trimFeedback(formData.get("characterFeedback"));
 
+    // 出力アスペクト比は baseImage (最初の inline image / image_0 相当) を基準に解決する。
+    // baseImage は背景・衣装・構図・ポーズ等を維持する基準画像であり、出力フレームの
+    // 構図基準と aspect ratio の基準を一致させる (ADR-007)。
+    const baseImageArrayBuffer = await baseImage.arrayBuffer();
+    const baseImageDims = parseImageDimensions(
+      new Uint8Array(baseImageArrayBuffer),
+      baseImage.type,
+    );
+    const i2iAspectRatio = resolveGeminiAspectRatio(baseImageDims);
+
     const parts: GeminiContentPart[] = [
       {
         text: "画像1（base）: 背景・衣装・ポーズ・構図・カメラ・ライティングを維持する基準画像。",
       },
-      await toInlineData(baseImage),
+      {
+        inline_data: {
+          mime_type: baseImage.type,
+          data: Buffer.from(baseImageArrayBuffer).toString("base64"),
+        },
+      },
       {
         text: "画像2（character）: 顔立ち・髪型・表情・体型・骨格バランス・手足比率・キャラクター性を参照する画像。背景・衣装デザイン・ポーズ・構図・描画タッチは参照禁止。",
       },
@@ -592,6 +609,7 @@ export async function POST(request: NextRequest, context: GenerateRouteContext) 
                 responseModalities: ["TEXT", "IMAGE"],
                 imageConfig: {
                   imageSize: OUTPUT_IMAGE_SIZE,
+                  aspectRatio: i2iAspectRatio,
                 },
               },
             }),

--- a/docs/API.md
+++ b/docs/API.md
@@ -173,9 +173,14 @@ curl -X POST "http://localhost:3000/api/internal/account-purge" \
 
 - `sourceImageStockId` か、`sourceImageBase64 + sourceImageMimeType` のどちらかが必須です。
 - GPT Image 2 は `gpt-image-2-{quality}-{sizeTier}` の canonical model を使います。`quality` は `low | medium | high`、`sizeTier` は `1k | 2k | 4k` です。旧 `gpt-image-2-low` は後方互換で `gpt-image-2-low-1k` に正規化されます。
-- GPT Image 2 の出力サイズは入力画像のアスペクト比から自動選択されます。`1k`: `1024x1024` / `1024x1536` / `1536x1024`、`2k`: `2048x2048` / `1664x2496` / `2496x1664`、`4k`: `2880x2880` / `2352x3520` / `3520x2352`。GIF 入力は非対応です。
+- GPT Image 2 の出力サイズは入力画像のアスペクト比から自動選択され、**9:16 〜 16:9 にクランプ** されます (これより極端な縦長/横長の入力は AI 側で再構成されます)。代表例:
+  - `1k`: `1024x1024` (1:1) / `864x1536` (9:16) / `1536x864` (16:9) / `1024x1536` (2:3) / `1536x1024` (3:2)
+  - `2k`: `2048x2048` (1:1) / `1408x2496` (9:16) / `2496x1408` (16:9) / `1664x2496` (2:3) / `2496x1664` (3:2)
+  - `4k`: `2880x2880` (1:1) / `2880x2880` 級にクランプ。長辺 ≤ 3840、総ピクセル ≤ 8,294,400。
+  - GIF 入力は非対応です。
 - GPT Image 2 では `count` を `acceptedImageCount` として受理し、worker が OpenAI Images Edit API に 1 回で `n=acceptedImageCount` を渡します。上限はサブスクプランの生成枚数上限と `1..4` の小さい方です。
 - Gemini 系モデルでは互換性のため、この API 1 回につき 1 job / 1 画像です。複数枚生成はクライアント側が複数 job を投入します。
+- **Gemini 経路は `generationConfig.imageConfig.aspectRatio` を必ず付与** します。入力画像のアスペクトから 9 段階の離散ラベル (`9:16` / `4:5` / `3:4` / `2:3` / `1:1` / `3:2` / `4:3` / `5:4` / `16:9`) のうち最も近いものを選択し、範囲外は `9:16` / `16:9` にクランプします。`gemini-2.5-flash-image` 等 `imageSize` を持たないモデルでも `aspectRatio` だけは送信されます。
 - Base64 元画像は 10MB を超えると `400` になります。
 - HEIC/HEIF はサーバー側で JPEG 変換を試みます。
 - `gemini-2.5-flash-image` と `gemini-2.5-flash-image-preview` は後方互換のため受け付けますが、サーバー側で `gemini-3.1-flash-image-preview-512` に正規化されます。

--- a/docs/planning/image-output-aspect-ratio-clamp-plan.md
+++ b/docs/planning/image-output-aspect-ratio-clamp-plan.md
@@ -1,0 +1,364 @@
+# 画像出力アスペクト比の上限クランプ（9:16〜16:9）
+
+## 背景
+
+`generated_images` テーブルに `width=512, height=1536`（= 1:3）という極端な縦長画像が生成された事例が発生した。原因は以下の2点：
+
+1. **OpenAI gpt-image-2 経路**: [shared/generation/openai-image-model.ts:118](../../shared/generation/openai-image-model.ts#L118) の `MAX_ASPECT_RATIO = 3` により、入力画像が極端に縦長/横長の場合、出力サイズもそのまま 1:3 / 3:1 まで許容されていた。
+2. **Gemini 経路**: [supabase/functions/image-gen-worker/index.ts:1715-1734](../../supabase/functions/image-gen-worker/index.ts#L1715-L1734) で `aspectRatio` を **未指定**。Gemini API のデフォルト挙動「入力画像のアスペクトに追従 or 1:1」により、極端な縦長入力がそのまま出力に反映されていた。
+
+## 目的
+
+両プロバイダーの出力アスペクト比を **9:16 〜 16:9** の範囲に収める。**入力画像のトリミングは行わず、出力サイズ側で丸める** 方針とする（入力画像のアスペクトと出力アスペクトが乖離する場合、AI 側で再構成される挙動を許容）。
+
+## やらないこと
+
+- クライアント [features/generation/lib/normalize-source-image.ts](../../features/generation/lib/normalize-source-image.ts) の変更（入力画像のアスペクトには触らない）
+- プロンプト [shared/generation/style-prompts.ts](../../shared/generation/style-prompts.ts) の文言変更（Strict Framing の表現はそのまま）
+- 入力画像バリデーション（早期拒否）の追加
+- 過去に生成された 1:3 等の画像のマイグレーション（DB はそのまま）
+
+---
+
+## コードベース調査結果（Phase B）
+
+### B-1: Supabase 接続確認
+DB 変更なし。スキップ。
+
+### B-2: 既存類似機能の調査
+
+| 関心事 | 該当箇所 | 備考 |
+|--------|---------|------|
+| OpenAI 出力サイズ算出 | [shared/generation/openai-image-model.ts:127-189](../../shared/generation/openai-image-model.ts#L127-L189) `computeGptImage2OptimalSize` | アスペクト比クランプ `MAX_ASPECT_RATIO=3` がここに集約 |
+| OpenAI 呼び出し時のサイズ解決 | [supabase/functions/image-gen-worker/openai-image.ts:208-220](../../supabase/functions/image-gen-worker/openai-image.ts#L208-L220) `resolveOpenAITargetSize` | base64 ヘッダから入力 dims を抽出して `getGptImage2TargetSize` に渡す |
+| 入力画像 dims 抽出 | [supabase/functions/image-gen-worker/openai-image.ts](../../supabase/functions/image-gen-worker/openai-image.ts) `parseImageDimensions` | PNG/JPEG/WebP ヘッダパーサー。Gemini 経路からも再利用可能 |
+| Gemini 呼び出しの request body 組み立て（非同期 worker） | [supabase/functions/image-gen-worker/index.ts:1680-1737](../../supabase/functions/image-gen-worker/index.ts#L1680-L1737) | `imageConfig.imageSize` のみ送信、`aspectRatio` 未指定 |
+| Gemini legacy worker 経路 | [supabase/functions/image-gen-worker/index.ts:1715-1734](../../supabase/functions/image-gen-worker/index.ts#L1715-L1734) | `apiModel === "gemini-3.1-flash-image-preview"` / `gemini-3-pro-image-preview` 以外では `generationConfig.imageConfig` 自体を作らない。`gemini-2.5-flash-image` でも `aspectRatio` を送る設計が必要 |
+| Gemini 直叩き経路 | [features/generation/lib/guest-generate.ts:320-326](../../features/generation/lib/guest-generate.ts#L320-L326), [app/api/style-templates/preview-generation/handler.ts:366-370](../../app/api/style-templates/preview-generation/handler.ts#L366-L370), [app/i2i/[slug]/generate/route.ts:588-597](../../app/i2i/%5Bslug%5D/generate/route.ts#L588-L597) | 「画像出力全体」が対象のため、worker 以外の Gemini 直叩き経路にも `aspectRatio` 指定が必要 |
+| I2I PoC の画像順序 | [app/i2i/[slug]/generate/route.ts:554-562](../../app/i2i/%5Bslug%5D/generate/route.ts#L554-L562) | `baseImage` が最初の inline image、`characterImage` が2番目。出力フレームは base image（最初の inline image / image_0 相当）基準にする |
+| 既存ユニットテスト | [tests/unit/features/generation/openai-image.test.ts:161-233](../../tests/unit/features/generation/openai-image.test.ts#L161-L233) | `resolveOpenAITargetSize` の挙動テストあり、新上限超えのケースが2件存在 |
+| Gemini request body テスト | [tests/integration/app/style-generate-route.test.ts:315-374](../../tests/integration/app/style-generate-route.test.ts#L315-L374), [tests/unit/features/generation/guest-generate.test.ts:182-226](../../tests/unit/features/generation/guest-generate.test.ts#L182-L226) | style guest / guest 共通ヘルパには既存検証あり。worker / style-template preview / I2I PoC の request body 専用テストは現状見当たらないため新規追加が必要 |
+
+### B-3: 影響範囲
+
+- **必須変更**: 5ファイル（`shared/generation/openai-image-model.ts`, `supabase/functions/image-gen-worker/index.ts`, `features/generation/lib/guest-generate.ts`, `app/api/style-templates/preview-generation/handler.ts`, `app/i2i/[slug]/generate/route.ts`）
+- **新規ファイル**: 2ファイル（Gemini 用アスペクト比マッピング関数、worker 用 request config helper）
+- **型更新**: 1ファイル（`features/generation/lib/nanobanana-client.ts` の `imageConfig.aspectRatio` 型追加）
+- **ドキュメント更新**: 1ファイル（`docs/API.md` の GPT Image 2 サイズ説明と Gemini aspectRatio 指定の追記）
+- **テスト更新**: 既存テストの期待値修正 + 新規テスト + worker / Gemini 直叩き経路の request body 検証追加
+- **DB 変更なし / RLS 変更なし / UI 変更なし**
+
+### B-4: 参照ドキュメント
+
+- Gemini API 仕様: <https://ai.google.dev/gemini-api/docs/image-generation>
+- OpenAI gpt-image-2 仕様: 既存コードのコメント参照
+- [.cursor/rules/database-design.mdc](../../.cursor/rules/database-design.mdc): 今回スキーマ無関係のため参照不要
+
+---
+
+## 1. 概要図
+
+### 入力アスペクト → 出力アスペクトのクランプフロー
+
+```mermaid
+graph TD
+    A[Input image] --> B[Parse dimensions]
+    B --> C[OpenAI path]
+    B --> D[Gemini path]
+    C --> E[Compute optimal size]
+    E --> F[Clamp to 9 to 16 through 16 to 9]
+    F --> G[Send size parameter]
+    D --> H[Resolve Gemini aspect ratio]
+    H --> I[Choose closest supported ratio]
+    I --> J[Send aspectRatio parameter]
+    G --> K[Generated image within target range]
+    J --> K
+```
+
+| 経路 | 処理 | 送信パラメータ |
+|------|------|----------------|
+| OpenAI gpt-image-2 | 入力画像の width / height から出力サイズを計算し、9:16〜16:9 にクランプ | `size` |
+| Gemini | 入力画像の width / height から Gemini 対応比率の最近傍を選択 | `generationConfig.imageConfig.aspectRatio` |
+
+### Gemini 側アスペクト比マッピング（離散値）
+
+```mermaid
+graph LR
+    A[Input aspect] --> B[Below lower bound]
+    A --> C[Within range]
+    A --> D[Above upper bound]
+    B --> E[Clamp to 9 to 16]
+    C --> F[Choose closest of 9 ratios]
+    D --> G[Clamp to 16 to 9]
+```
+
+| 入力アスペクト | 解決方法 | 出力候補 |
+|----------------|----------|----------|
+| 9:16 より縦長 | 9:16 にクランプ | `9:16` |
+| 9:16〜16:9 の範囲内 | 9段階から `log(aspect)` 距離が最小の比率を選択 | `9:16`, `4:5`, `3:4`, `2:3`, `1:1`, `3:2`, `4:3`, `5:4`, `16:9` |
+| 16:9 より横長 | 16:9 にクランプ | `16:9` |
+
+---
+
+## 2. EARS（要件定義）
+
+| ID | 要件 |
+|----|------|
+| REQ-1 | When OpenAI gpt-image-2 でサイズ算出する時, the system shall アスペクト比を 9/16 ≤ aspect ≤ 16/9 の範囲にクランプする。<br>**EN**: When computing OpenAI gpt-image-2 output size, the system shall clamp the aspect ratio to the range 9/16 ≤ aspect ≤ 16/9. |
+| REQ-2 | When Gemini API を呼び出す時, the system shall 入力画像のアスペクト比から 9段階の離散比率（9:16, 4:5, 3:4, 2:3, 1:1, 3:2, 4:3, 5:4, 16:9）の中で最も近いものを `generationConfig.imageConfig.aspectRatio` として送信する。`imageSize` を持たない `gemini-2.5-flash-image` 経路でも `imageConfig.aspectRatio` は送信する。<br>**EN**: When invoking the Gemini API, the system shall send the closest discrete aspect ratio from a 9-tier set as `generationConfig.imageConfig.aspectRatio`, including Gemini paths without `imageSize` such as `gemini-2.5-flash-image`. |
+| REQ-3 | If 入力画像から dimensions を抽出できない場合, then the system shall 1:1 として扱う（既存フォールバックを継承）。<br>**EN**: If image dimensions cannot be extracted, then the system shall treat it as 1:1 (inherits existing fallback). |
+| REQ-4 | Where Gemini モデルが指定されている場合, the system shall モデルごとのサポート対象比率内に限定する（共通サポート対象の 9段階で十分）。<br>**EN**: Where a Gemini model is specified, the system shall restrict to ratios supported by the model. |
+| REQ-5 | While 既存 OpenAI 単体テストが存在する間, the system shall 新上限を反映したテスト期待値で全テストを通過させる。<br>**EN**: While existing OpenAI unit tests exist, the system shall update expected values to reflect the new upper bound. |
+| REQ-6 | When Gemini API を直接呼び出す worker 以外の経路がある場合, the system shall 同じ `resolveGeminiAspectRatio` ロジックで `aspectRatio` を送信する。<br>**EN**: When a non-worker path invokes the Gemini API directly, the system shall send `aspectRatio` using the same `resolveGeminiAspectRatio` logic. |
+| REQ-7 | When Inspire の Gemini 複数入力で aspectRatio を解決する時, the system shall OpenAI と同じ基準画像選択（すべて維持=image_1、部分上書き=image_0）を使用する。<br>**EN**: When resolving aspectRatio for multi-input Inspire Gemini generation, the system shall use the same base-image selection as OpenAI. |
+| REQ-8 | When I2I PoC の Gemini aspectRatio を解決する時, the system shall `baseImage`（最初の inline image / image_0 相当）を基準画像として使用する。<br>**EN**: When resolving Gemini aspectRatio for I2I PoC, the system shall use `baseImage` (the first inline image, equivalent to image_0) as the base image. |
+
+---
+
+## 3. ADR（設計判断記録）
+
+### ADR-001: クランプ上限を 9:16 / 16:9 にする
+
+- **Context**: 過去に 1:3 の極端な縦長画像が生成された事例があり、UX 上不自然な構図になる。
+- **Decision**: OpenAI/Gemini 両プロバイダーで出力アスペクト比を 9:16 〜 16:9 にクランプする。
+- **Reason**: 9:16 / 16:9 はスマホ縦・横写真の事実上の標準。これより極端な比率はコーディネート画像という用途で意味がない。
+- **Consequence**: 入力が 9:16 より縦長の場合、出力アスペクトが入力と異なるため、AI が再構成する（被写体が画面内に再配置される）。ユーザーはこの挙動を許容済み。
+
+### ADR-002: 入力画像のトリミングは行わない
+
+- **Context**: 出力アスペクトを制限する手段として「入力をクロップしてアスペクトを合わせる」案もあった。
+- **Decision**: 入力には一切手を加えず、出力 `size` / `aspectRatio` パラメータのみで制御する。
+- **Reason**: ユーザー要件「入力画像はトリミングしたくない」を尊重。AI 側の再構成に委ねる方針。
+- **Consequence**: AI が指定アスペクトに収めるための被写体配置を判断する。プロンプト内の `Strict Framing` 指示と矛盾する可能性があるが、稼働観察で問題が顕在化した場合に再検討する。
+
+### ADR-003: Gemini はモデル別ではなく共通の 9段階セットを採用
+
+- **Context**: Gemini モデルによってサポートする離散比率が異なる（`gemini-3.1-flash` のみ 1:4, 4:1, 8:1, 1:8 など追加サポート）。
+- **Decision**: 全モデル共通でサポートされている **9段階**（9:16, 4:5, 3:4, 2:3, 1:1, 3:2, 4:3, 5:4, 16:9）のみ使用する。
+- **Reason**: ロジック分岐を増やさず、本目的（9:16〜16:9 クランプ）にも十分。全 Gemini モデルでサポート保証あり。
+- **Consequence**: モデル追加時にマッピング関数の改修不要。1:4 等は最初からクランプ対象なので除外で問題なし。
+
+### ADR-004: マッピング関数を新規ファイルとして分離
+
+- **Context**: Gemini の aspectRatio 解決ロジックを `index.ts`（既に 2000+ 行）に直接書くか、別ファイルにするか。
+- **Decision**: `shared/generation/gemini-aspect-ratio.ts` として新規作成し、worker から import する。
+- **Reason**: 単体テストが容易、既存 `shared/generation/openai-image-model.ts` と同じ分離パターン、Edge Function / Next.js 双方から再利用可能。
+- **Consequence**: ファイル数は増えるが、責務が明確になる。
+
+### ADR-005: Gemini 直叩き経路も対象に含める
+
+- **Context**: 非同期 worker 以外にも、ゲスト同期生成、Inspire プレビュー、I2I PoC で Gemini API を直接呼び出す経路が存在する。
+- **Decision**: 「画像出力全体」を 9:16〜16:9 に収めるため、全 Gemini 呼び出しの `imageConfig` に `aspectRatio` を追加する。
+- **Reason**: worker のみ対応すると、同期生成やプレビュー経路では極端な参照画像比率がそのまま出力される余地が残る。
+- **Consequence**: 共通マッピング関数を Next.js 側と Edge Function 側の両方から利用する。既存の request body テストがある style guest / guest 共通ヘルパは期待値を更新し、worker / style-template preview / I2I PoC は専用テストを新規追加する。
+
+### ADR-006: Inspire 複数入力の基準画像を OpenAI と揃える
+
+- **Context**: Inspire はユーザー画像（image_0）とテンプレ画像（image_1）の複数入力を使う。OpenAI 経路は `resolveInspireTargetSizeBaseIndex` で出力フレームの基準画像を切り替えている。
+- **Decision**: Gemini 経路も同じ基準を使う。すべて維持（4 つ true）の場合はテンプレ画像（image_1）基準、部分上書きの場合はユーザー画像（image_0）基準で `aspectRatio` を解決する。
+- **Reason**: プロンプト上の「どちらのシーン/構図へ寄せるか」と出力フレーム比率を一致させるため。
+- **Consequence**: Inspire の Gemini worker と preview-generation の両方で、複数入力から基準画像を明示的に選ぶ実装が必要になる。
+
+### ADR-007: I2I PoC は baseImage を出力フレーム基準にする
+
+- **Context**: I2I PoC の request body は [app/i2i/[slug]/generate/route.ts:554-562](../../app/i2i/%5Bslug%5D/generate/route.ts#L554-L562) で `baseImage` を最初の inline image、`characterImage` を2番目の inline image として送信している。テキスト指示でも base image は背景・衣装・ポーズ・構図・カメラ・ライティングを維持する基準画像と定義されている。
+- **Decision**: I2I PoC の `aspectRatio` は `baseImage`（最初の inline image / image_0 相当）から解決する。
+- **Reason**: 出力フレームの構図基準と aspect ratio の基準を一致させるため。`characterImage` は人物参照であり、出力フレーム比率の基準ではない。
+- **Consequence**: I2I PoC の TODO では「image_1」ではなく「baseImage / 最初の inline image」と明記する。
+
+---
+
+## 4. 実装計画（フェーズ＋TODO）
+
+### フェーズ間の依存関係
+
+```mermaid
+flowchart LR
+    P1["Phase 1: OpenAI 側クランプ更新"] --> P3["Phase 3: 統合検証"]
+    P2["Phase 2: Gemini 側 aspectRatio 追加"] --> P3
+```
+
+Phase 1 と Phase 2 は独立しており並行実装可能。コミットも分割推奨。
+
+### Phase 1: OpenAI 側クランプ更新
+
+**目的**: `MAX_ASPECT_RATIO` を 16/9 に変更し、既存テストを更新する。
+**ビルド確認**: `npm run lint && npm run typecheck && npm run test -- openai-image`
+
+- [ ] [shared/generation/openai-image-model.ts:118](../../shared/generation/openai-image-model.ts#L118) の定数 `MAX_ASPECT_RATIO = 3` を `MAX_ASPECT_RATIO = 16 / 9` に変更
+- [ ] 同ファイルのコメント（123行付近 `長:短 ≤ 3:1`, 125行付近 `3:1 を超える極端なアスペクト` 等）を `16:9` に更新
+- [ ] [tests/unit/features/generation/openai-image.test.ts:175-182](../../tests/unit/features/generation/openai-image.test.ts#L175-L182) `1:2 縦長は 1K で 768x1536` の期待値を新クランプ後の値に更新
+  - 入力 512x1024 (=1:2) → aspect クランプで 9/16 → 1536 × 9/16 = 864 → 16の倍数丸めで **864x1536**
+- [ ] [tests/unit/features/generation/openai-image.test.ts:211-221](../../tests/unit/features/generation/openai-image.test.ts#L211-L221) `2k は ... 1:2 を保ったまま 1248x2496` の期待値を新クランプ後の値に更新
+  - 入力 512x1024 (=1:2), 2k tier (maxEdge=2496) → クランプで 9/16 → 2496 × 9/16 = 1404 → 16の倍数丸めで **1408x2496**（pixel budget 2048×2048 内のため再スケール不要）
+- [ ] 新規テスト追加（推奨）: 「入力 1:3 でも出力は 9:16 にクランプされる」「入力 3:1 でも出力は 16:9 にクランプされる」
+
+### Phase 2: Gemini 側 aspectRatio 送信
+
+**目的**: 入力画像のアスペクトから 9段階の離散比率を選び、すべての Gemini API 呼び出しに送信する。
+**ビルド確認**: `npm run lint && npm run typecheck && npm run test -- gemini`
+
+- [ ] **新規ファイル** [shared/generation/gemini-aspect-ratio.ts](../../shared/generation/gemini-aspect-ratio.ts) を作成
+  - エクスポート: 型 `GeminiAspectRatio = "9:16" | "4:5" | "3:4" | "2:3" | "1:1" | "3:2" | "4:3" | "5:4" | "16:9"`
+  - エクスポート: 配列 `GEMINI_SUPPORTED_ASPECT_RATIOS`（9段階の `{label, value}`）
+  - エクスポート: 関数 `resolveGeminiAspectRatio(dimensions: {width, height} | null | undefined): GeminiAspectRatio`
+    - dimensions が null/無効 → `"1:1"` フォールバック
+    - aspect を 9/16 ≤ aspect ≤ 16/9 でクランプ
+    - 9段階の中で `log(aspect)` 距離が最小のものを選択（幾何平均的に最近傍）
+- [ ] **新規ファイル** [supabase/functions/image-gen-worker/gemini-request-config.ts](../../supabase/functions/image-gen-worker/gemini-request-config.ts) を作成
+  - 目的: worker 本体を起動せずに `generationConfig.imageConfig` の組み立てを単体テストできるようにする
+  - 入力: `imageSize: GeminiImageSize | null`, `aspectRatio: GeminiAspectRatio`, `requiresResponseModalities: boolean`
+  - 出力: `generationConfig` 断片。`imageSize` が null でも `imageConfig.aspectRatio` は必ず含める
+  - Deno / Jest 双方で import しやすいよう、Deno runtime API や Supabase client へ依存しない pure TypeScript にする
+- [ ] **新規ファイル** [tests/unit/shared/generation/gemini-aspect-ratio.test.ts](../../tests/unit/shared/generation/gemini-aspect-ratio.test.ts) を作成
+  - 各離散値が選ばれる典型ケース（1:1, 9:16, 16:9, 3:4, 4:3 等）
+  - 範囲外（1:3, 3:1）が 9:16 / 16:9 にクランプされる
+  - null / 0 / 不正値が 1:1 にフォールバック
+- [ ] [supabase/functions/image-gen-worker/index.ts:1680-1737](../../supabase/functions/image-gen-worker/index.ts#L1680-L1737) の Gemini request body 組み立て箇所を修正
+  - 入力画像があるケースで `parseImageDimensions` を呼び出して dims を取得
+  - Inspire 複数入力では `resolveInspireTargetSizeBaseIndex` と同じ基準画像（すべて維持は image_1、部分上書きは image_0）から dims を取得
+  - `resolveGeminiAspectRatio(dims)` で aspect ratio を解決
+  - `imageConfig` に `aspectRatio` を追加して送信
+  - `apiModel === "gemini-2.5-flash-image"` のように `imageSize` を持たない経路でも `generationConfig: { imageConfig: { aspectRatio } }` を作成する
+  - `gemini-3.1-flash-image-preview` / `gemini-3-pro-image-preview` では既存の `imageSize` を維持し、同じ `imageConfig` に `aspectRatio` を併置する
+  - 型定義（1695-1697 行付近）に `aspectRatio?: GeminiAspectRatio` を追加
+  - `generationConfig.imageConfig` の生成は `gemini-request-config.ts` helper に寄せ、worker 本体を起動せずに単体テストできる形にする
+- [ ] Edge Function は Deno なので、`shared/generation/gemini-aspect-ratio.ts` を import するパス・拡張子を Deno 互換にする（既存パターンに合わせる: [supabase/functions/image-gen-worker/openai-image.ts:14](../../supabase/functions/image-gen-worker/openai-image.ts#L14) で `shared/` から import している実例あり）
+- [ ] [features/generation/lib/guest-generate.ts:320-326](../../features/generation/lib/guest-generate.ts#L320-L326) のゲスト同期 Gemini 経路にも `aspectRatio` を追加
+  - `File` から取得したアップロード画像を基準に `resolveGeminiAspectRatio` を適用
+- [ ] [app/api/style-templates/preview-generation/handler.ts:366-370](../../app/api/style-templates/preview-generation/handler.ts#L366-L370) の Inspire プレビュー Gemini 経路にも `aspectRatio` を追加
+  - preview は「テンプレ適用後の見え方」を確認する用途のため、テンプレ画像（image_1）基準で解決
+- [ ] [app/i2i/[slug]/generate/route.ts:588-597](../../app/i2i/%5Bslug%5D/generate/route.ts#L588-L597) の I2I PoC Gemini 経路にも `aspectRatio` を追加
+  - [app/i2i/[slug]/generate/route.ts:554-562](../../app/i2i/%5Bslug%5D/generate/route.ts#L554-L562) では `baseImage` が最初の inline image、`characterImage` が2番目なので、`baseImage`（最初の inline image / image_0 相当）を基準に解決する
+- [ ] [features/generation/lib/nanobanana-client.ts:18-20](../../features/generation/lib/nanobanana-client.ts#L18-L20) の `GeminiGenerateContentRequestBody` 型に `aspectRatio?: GeminiAspectRatio` を追加
+- [ ] 既存の Gemini request body テストを更新
+  - [tests/integration/app/style-generate-route.test.ts](../../tests/integration/app/style-generate-route.test.ts) の `imageConfig` 期待値に `aspectRatio` を追加
+  - [tests/unit/features/generation/guest-generate.test.ts](../../tests/unit/features/generation/guest-generate.test.ts) の fetch body 検証に `aspectRatio` を追加
+- [ ] 現状 request body 専用テストがない経路は新規テストを追加
+  - [tests/unit/supabase/functions/image-gen-worker/gemini-request-config.test.ts](../../tests/unit/supabase/functions/image-gen-worker/gemini-request-config.test.ts): `gemini-2.5-flash-image` 相当でも `aspectRatio` が送られること、`imageSize` ありモデルでは `imageSize` と `aspectRatio` が共存すること
+  - worker の request body helper 呼び出しテスト: Inspire の基準画像選択が OpenAI と一致すること
+  - [tests/integration/api/style-template-preview-generation-route.test.ts](../../tests/integration/api/style-template-preview-generation-route.test.ts): テンプレ画像（image_1）基準の `aspectRatio` が `imageConfig` に入ること
+  - [tests/integration/app/i2i-generate-route.test.ts](../../tests/integration/app/i2i-generate-route.test.ts): `baseImage`（最初の inline image / image_0 相当）基準の `aspectRatio` が `imageConfig` に入ること
+
+### Phase 3: 統合検証
+
+**目的**: 全テスト通過 + 実環境での動作確認。
+**ビルド確認**: `npm run lint && npm run typecheck && npm run test && npm run build -- --webpack`
+
+- [ ] `npm run lint`
+- [ ] `npm run typecheck`
+- [ ] `npm run test`（全テスト）
+- [ ] `npm run build -- --webpack`（[.agents/skills/codex-webpack-build/](../../.agents/skills/codex-webpack-build/) 参照、Turbopack は禁止）
+- [ ] Edge Function のローカル動作確認（任意、`supabase functions serve image-gen-worker`）
+- [ ] ステージング環境で OpenAI / Gemini 経路それぞれで縦長入力を試し、出力が想定範囲内に収まることを確認
+- [ ] [docs/API.md](../API.md) の GPT Image 2 出力サイズ説明を新クランプ後の代表値に更新し、Gemini も `aspectRatio` を明示指定することを追記
+
+---
+
+## 5. 修正対象ファイル一覧
+
+| ファイル | 操作 | 変更内容 |
+|----------|------|----------|
+| [shared/generation/openai-image-model.ts](../../shared/generation/openai-image-model.ts) | 修正 | `MAX_ASPECT_RATIO` を 3 → 16/9、コメント更新 |
+| [shared/generation/gemini-aspect-ratio.ts](../../shared/generation/gemini-aspect-ratio.ts) | 新規 | Gemini 向け aspect ratio 解決ロジック |
+| [supabase/functions/image-gen-worker/gemini-request-config.ts](../../supabase/functions/image-gen-worker/gemini-request-config.ts) | 新規 | worker Gemini `generationConfig.imageConfig` の pure helper |
+| [supabase/functions/image-gen-worker/index.ts](../../supabase/functions/image-gen-worker/index.ts) | 修正 | Gemini request body に `aspectRatio` を追加、入力 dims 取得 |
+| [features/generation/lib/guest-generate.ts](../../features/generation/lib/guest-generate.ts) | 修正 | ゲスト同期 Gemini 経路の request body に `aspectRatio` を追加 |
+| [app/api/style-templates/preview-generation/handler.ts](../../app/api/style-templates/preview-generation/handler.ts) | 修正 | Inspire プレビュー Gemini 経路の request body に `aspectRatio` を追加 |
+| [app/i2i/[slug]/generate/route.ts](../../app/i2i/%5Bslug%5D/generate/route.ts) | 修正 | I2I PoC Gemini 経路の request body に `aspectRatio` を追加 |
+| [features/generation/lib/nanobanana-client.ts](../../features/generation/lib/nanobanana-client.ts) | 修正 | Gemini request body 型に `aspectRatio` を追加 |
+| [tests/unit/features/generation/openai-image.test.ts](../../tests/unit/features/generation/openai-image.test.ts) | 修正 | 1:2 / 2k 1:2 の期待値更新、新クランプの境界テスト追加 |
+| [tests/unit/shared/generation/gemini-aspect-ratio.test.ts](../../tests/unit/shared/generation/gemini-aspect-ratio.test.ts) | 新規 | マッピング関数のユニットテスト |
+| [tests/unit/supabase/functions/image-gen-worker/gemini-request-config.test.ts](../../tests/unit/supabase/functions/image-gen-worker/gemini-request-config.test.ts) | 新規 | `gemini-2.5-flash-image` 相当を含む worker Gemini request config の `aspectRatio` 検証 |
+| [tests/integration/app/style-generate-route.test.ts](../../tests/integration/app/style-generate-route.test.ts) | 修正 | 既存 Gemini request body 期待値に `aspectRatio` を追加 |
+| [tests/unit/features/generation/guest-generate.test.ts](../../tests/unit/features/generation/guest-generate.test.ts) | 修正 | ゲスト共通 Gemini fetch body の `aspectRatio` 検証を追加 |
+| [tests/integration/api/style-template-preview-generation-route.test.ts](../../tests/integration/api/style-template-preview-generation-route.test.ts) | 新規 | テンプレ画像（image_1）基準の `aspectRatio` 検証 |
+| [tests/integration/app/i2i-generate-route.test.ts](../../tests/integration/app/i2i-generate-route.test.ts) | 新規 | `baseImage`（最初の inline image / image_0 相当）基準の `aspectRatio` 検証 |
+| [docs/API.md](../API.md) | 修正 | GPT Image 2 の代表サイズを新クランプ後に更新し、Gemini の `aspectRatio` 指定を追記 |
+
+**変更行数の概算**: 本体 ~190 行追加 / ~45 行修正、テスト ~260 行追加 / ~40 行修正
+
+---
+
+## 6. 品質・テスト観点
+
+### 品質チェックリスト
+
+- [ ] **エラーハンドリング**: dimensions 抽出失敗時に 1:1 フォールバックが効く（既存挙動と同じ）
+- [ ] **境界値**: 9:16 ちょうど、16:9 ちょうど、それを 1 ピクセル超える/下回るケース
+- [ ] **後方互換**: 1:1 や 4:3 等、新上限内のアスペクトでは挙動変化なし
+- [ ] **全経路適用**: worker / guest sync / Inspire preview / I2I PoC の Gemini request body がすべて `aspectRatio` を送る。`imageSize` を持たない `gemini-2.5-flash-image` worker 経路も対象
+- [ ] **Inspire 複数入力**: Gemini でも OpenAI と同じ基準画像選択（すべて維持=image_1、部分上書き=image_0）になる
+- [ ] **I2I 基準画像**: I2I PoC では `characterImage` ではなく `baseImage`（最初の inline image / image_0 相当）から `aspectRatio` を解決する
+- [ ] **Edge Function ビルド**: Deno での型解決と import path が通る
+- [ ] **i18n**: UI 文言変更なしのため対象外
+
+### テスト観点
+
+| カテゴリ | テスト内容 |
+|----------|-----------|
+| **正常系（OpenAI）** | 1:1, 4:5, 9:16, 16:9 の入力でそれぞれ期待サイズが返る |
+| **正常系（Gemini）** | 1:1, 9:16, 16:9 の入力でそれぞれ完全一致するラベルが返る |
+| **境界（OpenAI）** | 入力 1:3 → 出力 864x1536（9:16 クランプ後の最大）、入力 3:1 → 出力 1536x864 |
+| **境界（Gemini）** | 入力 1:3 → "9:16"、入力 3:1 → "16:9"、入力 1.0 → "1:1"、入力 0.7 → "2:3"（`log(aspect)` 距離では 0.7 は 2:3 側。2:3 / 3:4 の境界は `sqrt(2/3*3/4) ≒ 0.7071`）|
+| **異常系** | dims が null / width=0 / height=0 → 1:1 |
+| **回帰** | 既存 `resolveOpenAITargetSize` のテストが新期待値で通る。worker / Gemini 直叩き経路の request body テストで `imageConfig.aspectRatio` を検証する |
+| **worker legacy** | `gemini-2.5-flash-image` でも `generationConfig.imageConfig.aspectRatio` が送られる。`gemini-3.1-flash-image-preview` / `gemini-3-pro-image-preview` では `imageSize` と `aspectRatio` が共存する |
+| **I2I** | `baseImage` と `characterImage` のアスペクトが異なるテストデータで、`baseImage` 側の比率が選ばれる |
+
+### テスト実装手順
+
+実装完了後、`/test-flow` スキルに沿ってテストを実施：
+
+1. `/test-flow gemini-aspect-ratio` — 状態確認
+2. `/spec-extract gemini-aspect-ratio` — EARS スペック抽出
+3. `/test-generate gemini-aspect-ratio` — テスト生成
+4. `/test-reviewing gemini-aspect-ratio` — レビュー
+5. `/spec-verify gemini-aspect-ratio` — カバレッジ確認
+
+---
+
+## 7. ロールバック方針
+
+- **Git**: Phase 1 / Phase 2 を別コミットにし、`git revert` で個別ロールバック可能にする
+- **DB**: スキーマ変更なし → ロールバック不要
+- **Edge Function**: 旧バージョンに `supabase functions deploy image-gen-worker --no-verify-jwt` で再デプロイ可能
+- **機能フラグ不要**: 出力サイズの上限変更は破壊的ではなく、過去画像にも影響しない
+- **段階リリース**: もし慎重に行きたい場合、Phase 1（OpenAI 側）のみ先行リリースし、Gemini 側は1週間ほど様子を見てから出す手も可
+
+---
+
+## 8. 使用スキル
+
+| スキル | 用途 | フェーズ |
+|--------|------|----------|
+| `/git-create-branch` | 作業ブランチ作成 | 実装開始時 |
+| `/spec-extract` | EARS 仕様の抽出 | Phase 2 のマッピング関数で活用 |
+| `/test-generate` | テスト生成 | Phase 1 / Phase 2 |
+| `/codex-webpack-build` | ビルド検証 | Phase 3 |
+| `/git-create-pr` | PR 作成 | 実装完了時 |
+
+---
+
+## 9. 補足: Gemini モデル別サポート比率（参考）
+
+リポジトリ内では Gemini 系モデルを **NanoBanana / NanoBanana 2 / NanoBanana Pro** の3系統で扱っている（UIラベル: [features/generation/components/LockableModelSelect.tsx:55-78](../../features/generation/components/LockableModelSelect.tsx#L55-L78), 命名由来コメント: [features/generation/lib/nanobanana.ts:2](../../features/generation/lib/nanobanana.ts#L2)）。
+
+| リポジトリ呼称 | API モデル | API がサポートする比率 | 本計画の9段階を含むか |
+|--------------|-----------|--------------------|------------------|
+| **NanoBanana** | `gemini-2.5-flash-image` | 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9 | ✓ すべて含む |
+| **NanoBanana 2** | `gemini-3.1-flash-image-preview` (-512 / -1024) | 1:1, 1:4, 1:8, 2:3, 3:2, 3:4, 4:1, 4:3, 4:5, 5:4, 8:1, 9:16, 16:9, 21:9 | ✓ すべて含む（追加で 1:4, 1:8, 4:1, 8:1 もあるが本計画では使用しない） |
+| **NanoBanana Pro** | `gemini-3-pro-image-preview` (-1k / -2k / -4k) | 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9 | ✓ すべて含む |
+
+**結論**: 9段階セット（9:16, 4:5, 3:4, 2:3, 1:1, 3:2, 4:3, 5:4, 16:9）は **NanoBanana / NanoBanana 2 / NanoBanana Pro の全 Gemini 系モデルで共通サポート** されるため、モデル判定不要・単一マッピング関数で対応可能（ADR-003 のとおり）。
+
+---
+
+## 10. 整合性チェック結果
+
+- [x] **図とスキーマの整合性**: スキーマ変更なし、対象外
+- [x] **認証モデルの一貫性**: 認証境界に変更なし、対象外
+- [x] **データフェッチの整合性**: データ取得経路に変更なし、対象外
+- [x] **イベント網羅性**: イベント追跡なし、対象外
+- [x] **APIパラメータのソース安全性**: 入力画像は既存の認証済み経路から取得、変更なし
+- [x] **ビジネスルールのDB層での強制**: DB制約不要（純粋に画像生成パラメータの制限）

--- a/features/generation/lib/guest-generate.ts
+++ b/features/generation/lib/guest-generate.ts
@@ -2,8 +2,10 @@ import "server-only";
 
 import {
   callOpenAIImageEdit,
+  parseImageDimensions,
   type OpenAIImageEditResult,
 } from "@/features/generation/lib/openai-image";
+import { resolveGeminiAspectRatio } from "@/shared/generation/gemini-aspect-ratio";
 import {
   GUEST_ALLOWED_MODELS,
   parseGuestRequestedModel,
@@ -189,16 +191,28 @@ interface GeminiContentTextPart {
 }
 type GeminiContentPart = GeminiContentTextPart | GeminiContentInlineDataPart;
 
-async function fileToInlineDataPart(
+/**
+ * File から base64 inline data part と aspect ratio 解決用 dimensions を一度の I/O で取得する。
+ * Gemini API へ送る `generationConfig.imageConfig.aspectRatio` の決定に使う。
+ */
+async function fileToInlineDataPartWithDimensions(
   file: File
-): Promise<GeminiContentInlineDataPart> {
+): Promise<{
+  part: GeminiContentInlineDataPart;
+  dimensions: { width: number; height: number } | null;
+}> {
   const arrayBuffer = await file.arrayBuffer();
+  const bytes = new Uint8Array(arrayBuffer);
   const data = Buffer.from(arrayBuffer).toString("base64");
+  const dimensions = parseImageDimensions(bytes, file.type);
   return {
-    inline_data: {
-      mime_type: file.type,
-      data,
+    part: {
+      inline_data: {
+        mime_type: file.type,
+        data,
+      },
     },
+    dimensions,
   };
 }
 
@@ -299,7 +313,9 @@ async function dispatchGemini(
   const fetchImpl = input.fetchFn ?? fetch;
   const apiModel = toApiModelName(input.model as GeminiOnlyModel);
   const imageSize = extractImageSize(input.model as GeminiOnlyModel);
-  const imagePart = await fileToInlineDataPart(input.uploadImage);
+  const { part: imagePart, dimensions: inputDimensions } =
+    await fileToInlineDataPartWithDimensions(input.uploadImage);
+  const aspectRatio = resolveGeminiAspectRatio(inputDimensions);
   const parts: GeminiContentPart[] = [
     { text: input.promptText },
     imagePart,
@@ -322,7 +338,9 @@ async function dispatchGemini(
         generationConfig: {
           candidateCount: 1,
           responseModalities: ["TEXT", "IMAGE"],
-          imageConfig: imageSize ? { imageSize } : undefined,
+          // 出力アスペクトを 9:16 〜 16:9 にクランプするため、imageSize 有無に関わらず
+          // aspectRatio を必ず付与する。
+          imageConfig: imageSize ? { imageSize, aspectRatio } : { aspectRatio },
         },
       }),
       signal: abortController.signal,

--- a/features/generation/lib/nanobanana-client.ts
+++ b/features/generation/lib/nanobanana-client.ts
@@ -17,6 +17,21 @@ export interface GeminiGenerateContentRequestBody {
     responseModalities?: Array<"TEXT" | "IMAGE">;
     imageConfig?: {
       imageSize?: "512" | "1K" | "2K" | "4K";
+      /**
+       * 出力アスペクト比 (Gemini 全モデル共通の 9 段階)。
+       * `shared/generation/gemini-aspect-ratio.ts` の `GeminiAspectRatio` 型と一致。
+       * 9:16 〜 16:9 のクランプは `resolveGeminiAspectRatio()` で行う。
+       */
+      aspectRatio?:
+        | "9:16"
+        | "4:5"
+        | "3:4"
+        | "2:3"
+        | "1:1"
+        | "3:2"
+        | "4:3"
+        | "5:4"
+        | "16:9";
     };
   };
 }

--- a/shared/generation/gemini-aspect-ratio.ts
+++ b/shared/generation/gemini-aspect-ratio.ts
@@ -1,0 +1,84 @@
+/**
+ * Gemini 画像生成 API 向け aspect ratio 解決ユーティリティ。
+ *
+ * 入力画像のアスペクト比を 9 段階の離散値 (9:16 〜 16:9) のうち最も近いものに丸める。
+ * 範囲外 (1:3 や 3:1 等の極端な縦長/横長) は 9:16 / 16:9 にクランプする。
+ *
+ * Edge Function (Deno) と Next.js (Node) の双方から import するため、ランタイム
+ * 依存を持たない pure TypeScript として実装する。
+ *
+ * 計画書: docs/planning/image-output-aspect-ratio-clamp-plan.md (ADR-001/003)
+ */
+
+export type GeminiAspectRatio =
+  | "9:16"
+  | "4:5"
+  | "3:4"
+  | "2:3"
+  | "1:1"
+  | "3:2"
+  | "4:3"
+  | "5:4"
+  | "16:9";
+
+interface GeminiAspectRatioEntry {
+  label: GeminiAspectRatio;
+  value: number; // width / height
+}
+
+/**
+ * 全 Gemini モデル (NanoBanana / NanoBanana 2 / NanoBanana Pro) で共通サポートされる
+ * 9 段階のアスペクト比 (ADR-003)。1:4, 4:1, 8:1 等は本目的のクランプ範囲外のため除外。
+ */
+export const GEMINI_SUPPORTED_ASPECT_RATIOS: readonly GeminiAspectRatioEntry[] =
+  [
+    { label: "9:16", value: 9 / 16 },
+    { label: "4:5", value: 4 / 5 },
+    { label: "3:4", value: 3 / 4 },
+    { label: "2:3", value: 2 / 3 },
+    { label: "1:1", value: 1 },
+    { label: "3:2", value: 3 / 2 },
+    { label: "4:3", value: 4 / 3 },
+    { label: "5:4", value: 5 / 4 },
+    { label: "16:9", value: 16 / 9 },
+  ];
+
+const MIN_RATIO = 9 / 16;
+const MAX_RATIO = 16 / 9;
+const FALLBACK_RATIO: GeminiAspectRatio = "1:1";
+
+/**
+ * 入力画像の dimensions から Gemini 用 aspectRatio ラベルを解決する。
+ *
+ * - dimensions が null / 無効値 (width<=0 / height<=0) → "1:1" にフォールバック
+ * - 9/16 ≤ aspect ≤ 16/9 の範囲にクランプ
+ * - 9 段階の中で log(aspect) 距離が最小のラベルを選択 (幾何平均的に最近傍)
+ */
+export function resolveGeminiAspectRatio(
+  dimensions: { width: number; height: number } | null | undefined,
+): GeminiAspectRatio {
+  if (
+    dimensions == null ||
+    !Number.isFinite(dimensions.width) ||
+    !Number.isFinite(dimensions.height) ||
+    dimensions.width <= 0 ||
+    dimensions.height <= 0
+  ) {
+    return FALLBACK_RATIO;
+  }
+
+  const rawAspect = dimensions.width / dimensions.height;
+  const clampedAspect = Math.max(MIN_RATIO, Math.min(MAX_RATIO, rawAspect));
+  const targetLog = Math.log(clampedAspect);
+
+  let bestLabel: GeminiAspectRatio = FALLBACK_RATIO;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  for (const entry of GEMINI_SUPPORTED_ASPECT_RATIOS) {
+    const distance = Math.abs(Math.log(entry.value) - targetLog);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestLabel = entry.label;
+    }
+  }
+  return bestLabel;
+}

--- a/shared/generation/openai-image-model.ts
+++ b/shared/generation/openai-image-model.ts
@@ -115,14 +115,16 @@ export const GPT_IMAGE_2_TIER_LIMITS: Record<
 export type GptImage2TargetSize = `${number}x${number}`;
 
 const SIZE_MULTIPLE = 16;
-const MAX_ASPECT_RATIO = 3;
+// 出力アスペクト比の上限。1:3 等の極端な縦長/横長を抑え、スマホ標準の 9:16 / 16:9 に揃える。
+// 入力画像はクロップせず、出力サイズ側で丸める方針 (AI が再構成)。
+const MAX_ASPECT_RATIO = 16 / 9;
 
 /**
  * 入力画像のアスペクト比を保ったまま、tier の上限内で最大の出力サイズを計算する。
  *
- * - OpenAI gpt-image-2 制約: 長辺 ≤ 3840 / 総ピクセル ≤ 8,294,400 / 16 の倍数 / 長:短 ≤ 3:1
+ * - OpenAI gpt-image-2 制約: 長辺 ≤ 3840 / 総ピクセル ≤ 8,294,400 / 16 の倍数
+ * - 出力アスペクトは 9:16 ≤ aspect ≤ 16/9 にクランプ (これより極端な入力は再構成される)
  * - 入力 dimensions が null / 無効値のときは正方形扱い（1:1）
- * - 3:1 を超える極端なアスペクトは 3:1 にクランプする
  */
 export function computeGptImage2OptimalSize(
   sizeTier: GptImage2SizeTier,
@@ -139,7 +141,7 @@ export function computeGptImage2OptimalSize(
   ) {
     aspect = dimensions.width / dimensions.height;
   }
-  // OpenAI の長:短 ≤ 3:1 制約に合わせてクランプ
+  // 出力アスペクト比を 9:16 ≤ aspect ≤ 16:9 にクランプ
   aspect = Math.max(1 / MAX_ASPECT_RATIO, Math.min(MAX_ASPECT_RATIO, aspect));
 
   // 長辺を maxEdge 起点で算出

--- a/supabase/functions/image-gen-worker/gemini-request-config.ts
+++ b/supabase/functions/image-gen-worker/gemini-request-config.ts
@@ -1,0 +1,62 @@
+/**
+ * Gemini API の `generationConfig` 断片を組み立てる pure helper。
+ *
+ * worker 本体 (Deno) から呼び出して request body の `generationConfig` を構築する。
+ * worker 本体は 2500+ 行で起動コストが大きいため、この helper を分離して Jest
+ * からも単体テストできるようにする。
+ *
+ * Deno / Jest 双方で動くよう、ランタイム依存 (Deno API / supabase client) は持たない。
+ *
+ * 計画書: docs/planning/image-output-aspect-ratio-clamp-plan.md (ADR-004)
+ */
+
+import type { GeminiAspectRatio } from "../../../shared/generation/gemini-aspect-ratio.ts";
+
+export type GeminiImageSize = "512" | "1K" | "2K" | "4K";
+
+export interface BuildGeminiGenerationConfigInput {
+  /** API モデルが対応する離散サイズラベル。`gemini-2.5-flash-image` 等では null */
+  imageSize: GeminiImageSize | null;
+  /** `resolveGeminiAspectRatio()` で解決した出力アスペクト比 */
+  aspectRatio: GeminiAspectRatio;
+  /**
+   * `gemini-3.1-flash-image-preview` 系は `candidateCount: 1` と
+   * `responseModalities: ["TEXT", "IMAGE"]` も必要。それ以外のモデルでは不要。
+   */
+  requiresResponseModalities?: boolean;
+}
+
+export interface GeminiGenerationConfigPiece {
+  candidateCount?: number;
+  responseModalities?: Array<"TEXT" | "IMAGE">;
+  imageConfig: {
+    imageSize?: GeminiImageSize;
+    aspectRatio: GeminiAspectRatio;
+  };
+}
+
+/**
+ * Gemini request body の `generationConfig` 断片を組み立てる。
+ *
+ * - `imageSize` が null でも `imageConfig.aspectRatio` は必ず含める。
+ *   (`gemini-2.5-flash-image` のように imageSize を持たないモデルでも aspectRatio 指定が必要)
+ * - `requiresResponseModalities=true` のときは `candidateCount` と `responseModalities` も付与。
+ *   (`gemini-3.1-flash-image-preview` 系のみ true)
+ */
+export function buildGeminiGenerationConfig(
+  input: BuildGeminiGenerationConfigInput,
+): GeminiGenerationConfigPiece {
+  const imageConfig: GeminiGenerationConfigPiece["imageConfig"] = {
+    aspectRatio: input.aspectRatio,
+  };
+  if (input.imageSize != null) {
+    imageConfig.imageSize = input.imageSize;
+  }
+
+  const piece: GeminiGenerationConfigPiece = { imageConfig };
+  if (input.requiresResponseModalities) {
+    piece.candidateCount = 1;
+    piece.responseModalities = ["TEXT", "IMAGE"];
+  }
+  return piece;
+}

--- a/supabase/functions/image-gen-worker/index.ts
+++ b/supabase/functions/image-gen-worker/index.ts
@@ -36,10 +36,15 @@ import {
 } from "../../../shared/generation/openai-image-model.ts";
 import type { GptImage2CanonicalModel } from "../../../shared/generation/openai-image-model.ts";
 import {
+  resolveGeminiAspectRatio,
+  type GeminiAspectRatio,
+} from "../../../shared/generation/gemini-aspect-ratio.ts";
+import {
   callOpenAIImageEditBatch,
   callOpenAIImageEditMultiInputBatch,
   parseImageDimensions,
 } from "./openai-image.ts";
+import { buildGeminiGenerationConfig } from "./gemini-request-config.ts";
 
 /**
  * 画像生成ワーカー Edge Function
@@ -1694,6 +1699,7 @@ Deno.serve(async () => {
                       responseModalities?: Array<"TEXT" | "IMAGE">;
                       imageConfig?: {
                         imageSize?: GeminiImageSize;
+                        aspectRatio?: GeminiAspectRatio;
                       };
                     };
                   } = {
@@ -1712,26 +1718,59 @@ Deno.serve(async () => {
 
                   const imageSize = extractImageSize(dbModel);
 
-                  if (apiModel === "gemini-3.1-flash-image-preview") {
-                    if (!imageSize) {
-                      throw new Error(`Unsupported image size for model: ${dbModel}`);
-                    }
-                    nextRequestBody.generationConfig = {
-                      ...nextRequestBody.generationConfig,
-                      candidateCount: 1,
-                      responseModalities: ["TEXT", "IMAGE"],
-                      imageConfig: {
-                        imageSize,
-                      },
-                    };
-                  } else if (apiModel === "gemini-3-pro-image-preview" && imageSize) {
-                    nextRequestBody.generationConfig = {
-                      ...nextRequestBody.generationConfig,
-                      imageConfig: {
-                        imageSize,
-                      },
-                    };
+                  // `gemini-3.1-flash-image-preview` は imageSize 必須 (既存仕様)。
+                  if (apiModel === "gemini-3.1-flash-image-preview" && !imageSize) {
+                    throw new Error(`Unsupported image size for model: ${dbModel}`);
                   }
+
+                  // === 出力アスペクト比の決定 ===
+                  // Inspire (複数入力) のときは OpenAI と同じ基準画像選択を使う:
+                  // - すべて維持 (4 つ true) → image_1 (スタイルテンプレ) 基準
+                  // - 部分上書き                  → image_0 (ユーザーキャラ) 基準
+                  // 単一入力経路では image_0 (= resolvedInputImageData) を使う。
+                  const isInspireGemini =
+                    job.generation_type === "inspire" &&
+                    resolvedInspireTemplateImage !== null;
+                  const aspectBaseImage = isInspireGemini
+                    ? resolveInspireTargetSizeBaseIndex({
+                        outfit: job.override_outfit ?? true,
+                        angle: job.override_angle ?? true,
+                        pose: job.override_pose ?? true,
+                        background: job.override_background ?? true,
+                      }) === 1
+                      ? resolvedInspireTemplateImage
+                      : resolvedInputImageData
+                    : resolvedInputImageData;
+                  const aspectDims = aspectBaseImage
+                    ? parseImageDimensions(
+                        decodeBase64(aspectBaseImage.base64),
+                        aspectBaseImage.mimeType,
+                      )
+                    : null;
+                  const aspectRatio = resolveGeminiAspectRatio(aspectDims);
+
+                  // gemini-3.1-flash-image-preview のみ candidateCount / responseModalities を追加。
+                  // gemini-3-pro-image-preview / gemini-2.5-flash-image 等は不要。
+                  const requiresResponseModalities =
+                    apiModel === "gemini-3.1-flash-image-preview";
+
+                  // gemini-3-pro-image-preview は imageSize がある場合のみ送信 (既存仕様維持)。
+                  // それ以外のモデル (gemini-2.5-flash-image 等) でも `imageConfig.aspectRatio`
+                  // は必ず付与し、出力アスペクトをクランプ範囲に収める。
+                  const finalImageSize: GeminiImageSize | null =
+                    apiModel === "gemini-3.1-flash-image-preview" ||
+                    apiModel === "gemini-3-pro-image-preview"
+                      ? imageSize
+                      : null;
+
+                  nextRequestBody.generationConfig = {
+                    ...nextRequestBody.generationConfig,
+                    ...buildGeminiGenerationConfig({
+                      imageSize: finalImageSize,
+                      aspectRatio,
+                      requiresResponseModalities,
+                    }),
+                  };
 
                   return nextRequestBody;
                 }

--- a/supabase/functions/image-gen-worker/index.ts
+++ b/supabase/functions/image-gen-worker/index.ts
@@ -1731,16 +1731,19 @@ Deno.serve(async () => {
                   const isInspireGemini =
                     job.generation_type === "inspire" &&
                     resolvedInspireTemplateImage !== null;
-                  const aspectBaseImage = isInspireGemini
-                    ? resolveInspireTargetSizeBaseIndex({
-                        outfit: job.override_outfit ?? true,
-                        angle: job.override_angle ?? true,
-                        pose: job.override_pose ?? true,
-                        background: job.override_background ?? true,
-                      }) === 1
-                      ? resolvedInspireTemplateImage
-                      : resolvedInputImageData
-                    : resolvedInputImageData;
+                  let aspectBaseImage: InputImageData | null =
+                    resolvedInputImageData;
+                  if (isInspireGemini) {
+                    const inspireBaseIndex = resolveInspireTargetSizeBaseIndex({
+                      outfit: job.override_outfit ?? true,
+                      angle: job.override_angle ?? true,
+                      pose: job.override_pose ?? true,
+                      background: job.override_background ?? true,
+                    });
+                    if (inspireBaseIndex === 1) {
+                      aspectBaseImage = resolvedInspireTemplateImage;
+                    }
+                  }
                   const aspectDims = aspectBaseImage
                     ? parseImageDimensions(
                         decodeBase64(aspectBaseImage.base64),

--- a/tests/integration/app/style-generate-route.test.ts
+++ b/tests/integration/app/style-generate-route.test.ts
@@ -342,7 +342,7 @@ describe("StyleGenerateRoute integration tests", () => {
       generationConfig: {
         candidateCount: number;
         responseModalities: string[];
-        imageConfig: { imageSize: string };
+        imageConfig: { imageSize: string; aspectRatio: string };
       };
     };
 
@@ -367,6 +367,9 @@ describe("StyleGenerateRoute integration tests", () => {
       responseModalities: ["TEXT", "IMAGE"],
       imageConfig: {
         imageSize: "512",
+        // 16 byte の zero buffer は parseImageDimensions が null を返すため、
+        // resolveGeminiAspectRatio フォールバックで "1:1" になる。
+        aspectRatio: "1:1",
       },
     });
     expect(checkAndConsumeRateLimitFn).toHaveBeenCalledWith({

--- a/tests/unit/features/generation/guest-generate.test.ts
+++ b/tests/unit/features/generation/guest-generate.test.ts
@@ -235,6 +235,52 @@ describe("guest-generate", () => {
       });
     });
 
+    test("imageSize を持たない Gemini モデル (gemini-2.5-flash-image) でも aspectRatio は送られる", async () => {
+      const fetchFn = jest.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            candidates: [
+              {
+                content: {
+                  parts: [
+                    {
+                      inline_data: {
+                        mime_type: "image/png",
+                        data: "BASE64_OK",
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      );
+      await dispatchGuestImageGeneration({
+        // GUEST_ALLOWED_MODELS には含まれないが extractImageSize が null を返す
+        // 経路の network request body 検証用 (本番では別の guard で弾かれる想定)。
+        model: "gemini-2.5-flash-image" as unknown as Parameters<
+          typeof dispatchGuestImageGeneration
+        >[0]["model"],
+        promptText: "hello",
+        uploadImage: createPngFile(),
+        geminiApiKey: "key",
+        fetchFn: fetchFn as unknown as typeof fetch,
+      });
+      const requestBody = JSON.parse(
+        String(fetchFn.mock.calls[0][1].body),
+      ) as {
+        generationConfig: {
+          imageConfig?: { imageSize?: string; aspectRatio?: string };
+        };
+      };
+      // imageSize は含まれず、aspectRatio のみが送られること
+      expect(requestBody.generationConfig.imageConfig).toEqual({
+        aspectRatio: "1:1",
+      });
+    });
+
     test("safety/policy エラーレスポンスは safety_blocked", async () => {
       const fetchFn = jest.fn().mockResolvedValue(
         new Response(

--- a/tests/unit/features/generation/guest-generate.test.ts
+++ b/tests/unit/features/generation/guest-generate.test.ts
@@ -218,6 +218,21 @@ describe("guest-generate", () => {
         "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-image-preview:generateContent",
         expect.objectContaining({ method: "POST" })
       );
+
+      // Gemini request body の imageConfig には imageSize と aspectRatio が併置される。
+      // 16 byte の zero buffer は parseImageDimensions が null を返すため、
+      // resolveGeminiAspectRatio フォールバックで "1:1" になる。
+      const requestBody = JSON.parse(
+        String(fetchFn.mock.calls[0][1].body),
+      ) as {
+        generationConfig: {
+          imageConfig?: { imageSize?: string; aspectRatio?: string };
+        };
+      };
+      expect(requestBody.generationConfig.imageConfig).toEqual({
+        imageSize: "512",
+        aspectRatio: "1:1",
+      });
     });
 
     test("safety/policy エラーレスポンスは safety_blocked", async () => {

--- a/tests/unit/features/generation/openai-image.test.ts
+++ b/tests/unit/features/generation/openai-image.test.ts
@@ -172,13 +172,13 @@ describe("openai-image (Node port)", () => {
       ).toBe("1248x1248");
     });
 
-    test("1:2 縦長は 1K で 768x1536（入力アスペクトを保持）", () => {
+    test("1:2 縦長は 1K で 9:16 にクランプされ 864x1536 を返す", () => {
       expect(
         resolveOpenAITargetSize({
           base64: createPngHeader(512, 1024).toString("base64"),
           mimeType: "image/png",
         })
-      ).toBe("768x1536");
+      ).toBe("864x1536");
     });
 
     test("3:2 横長は 1K で 1536x1024", () => {
@@ -208,7 +208,7 @@ describe("openai-image (Node port)", () => {
       ).toBe("1248x1248");
     });
 
-    test("2k は入力アスペクト比 1:2 を保ったまま 1248x2496 を返す", () => {
+    test("2k で 1:2 縦長は 9:16 にクランプされ 1408x2496 を返す", () => {
       expect(
         resolveOpenAITargetSize(
           {
@@ -217,7 +217,7 @@ describe("openai-image (Node port)", () => {
           },
           "2k"
         )
-      ).toBe("1248x2496");
+      ).toBe("1408x2496");
     });
 
     test("4k 正方形は pixel budget 内の 2880x2880 にクランプする", () => {
@@ -230,6 +230,24 @@ describe("openai-image (Node port)", () => {
           "4k"
         )
       ).toBe("2880x2880");
+    });
+
+    test("1:3 の極端な縦長でも 9:16 にクランプされ 864x1536 を返す", () => {
+      expect(
+        resolveOpenAITargetSize({
+          base64: createPngHeader(512, 1536).toString("base64"),
+          mimeType: "image/png",
+        })
+      ).toBe("864x1536");
+    });
+
+    test("3:1 の極端な横長でも 16:9 にクランプされ 1536x864 を返す", () => {
+      expect(
+        resolveOpenAITargetSize({
+          base64: createPngHeader(1536, 512).toString("base64"),
+          mimeType: "image/png",
+        })
+      ).toBe("1536x864");
     });
   });
 
@@ -549,8 +567,9 @@ describe("openai-image (Node port)", () => {
         fetchFn.mock.calls[0][1] as RequestInit
       ).body as FormData;
       expect(requestBody.get("quality")).toBe("high");
-      // 動的サイジング: targetSizeBaseIndex=1 の画像 (512x1024 = 1:2) で 2k → 1248x2496
-      expect(requestBody.get("size")).toBe("1248x2496");
+      // 動的サイジング: targetSizeBaseIndex=1 の画像 (512x1024 = 1:2) で 2k
+      // → 出力アスペクト 9:16 にクランプされ 1408x2496
+      expect(requestBody.get("size")).toBe("1408x2496");
       expect(requestBody.getAll("image[]")).toHaveLength(2);
       expect(requestBody.get("n")).toBe("2");
     });

--- a/tests/unit/shared/generation/gemini-aspect-ratio.test.ts
+++ b/tests/unit/shared/generation/gemini-aspect-ratio.test.ts
@@ -1,0 +1,147 @@
+/** @jest-environment node */
+
+import {
+  GEMINI_SUPPORTED_ASPECT_RATIOS,
+  resolveGeminiAspectRatio,
+} from "@/shared/generation/gemini-aspect-ratio";
+
+describe("resolveGeminiAspectRatio", () => {
+  describe("典型的なアスペクト比は完全一致するラベルを返す", () => {
+    test("1:1 → '1:1'", () => {
+      expect(resolveGeminiAspectRatio({ width: 1000, height: 1000 })).toBe(
+        "1:1",
+      );
+    });
+
+    test("9:16 (縦長スマホ写真) → '9:16'", () => {
+      expect(resolveGeminiAspectRatio({ width: 900, height: 1600 })).toBe(
+        "9:16",
+      );
+    });
+
+    test("16:9 (横長スマホ写真) → '16:9'", () => {
+      expect(resolveGeminiAspectRatio({ width: 1600, height: 900 })).toBe(
+        "16:9",
+      );
+    });
+
+    test("3:4 → '3:4'", () => {
+      expect(resolveGeminiAspectRatio({ width: 600, height: 800 })).toBe("3:4");
+    });
+
+    test("4:3 → '4:3'", () => {
+      expect(resolveGeminiAspectRatio({ width: 800, height: 600 })).toBe("4:3");
+    });
+
+    test("2:3 → '2:3'", () => {
+      expect(resolveGeminiAspectRatio({ width: 400, height: 600 })).toBe("2:3");
+    });
+
+    test("3:2 → '3:2'", () => {
+      expect(resolveGeminiAspectRatio({ width: 600, height: 400 })).toBe("3:2");
+    });
+
+    test("4:5 → '4:5'", () => {
+      expect(resolveGeminiAspectRatio({ width: 400, height: 500 })).toBe("4:5");
+    });
+
+    test("5:4 → '5:4'", () => {
+      expect(resolveGeminiAspectRatio({ width: 500, height: 400 })).toBe("5:4");
+    });
+  });
+
+  describe("クランプ動作", () => {
+    test("9:16 より縦長 (1:3) は '9:16' にクランプ", () => {
+      expect(resolveGeminiAspectRatio({ width: 500, height: 1500 })).toBe(
+        "9:16",
+      );
+    });
+
+    test("16:9 より横長 (3:1) は '16:9' にクランプ", () => {
+      expect(resolveGeminiAspectRatio({ width: 1500, height: 500 })).toBe(
+        "16:9",
+      );
+    });
+
+    test("非常に極端な縦長 (1:10) も '9:16' にクランプ", () => {
+      expect(resolveGeminiAspectRatio({ width: 100, height: 1000 })).toBe(
+        "9:16",
+      );
+    });
+  });
+
+  describe("最近傍ロジック (log 距離)", () => {
+    test("0.7 (2:3 と 3:4 の間) は log 距離が短い 2:3 寄り", () => {
+      // 2:3 = 0.6667, 3:4 = 0.75。幾何平均 = sqrt(0.6667 * 0.75) ≒ 0.707
+      // 入力 0.7 は幾何平均より小さいため 2:3 が選ばれる
+      expect(resolveGeminiAspectRatio({ width: 700, height: 1000 })).toBe(
+        "2:3",
+      );
+    });
+
+    test("0.72 (2:3 と 3:4 の境界より上) は '3:4'", () => {
+      expect(resolveGeminiAspectRatio({ width: 720, height: 1000 })).toBe(
+        "3:4",
+      );
+    });
+
+    test("1.1 (1:1 と 5:4 の境界) は 1:1 寄り", () => {
+      // 1:1 = 1.0, 5:4 = 1.25。幾何平均 = sqrt(1.0 * 1.25) ≒ 1.118
+      expect(resolveGeminiAspectRatio({ width: 1100, height: 1000 })).toBe(
+        "1:1",
+      );
+    });
+  });
+
+  describe("フォールバック (1:1)", () => {
+    test("null は 1:1", () => {
+      expect(resolveGeminiAspectRatio(null)).toBe("1:1");
+    });
+
+    test("undefined は 1:1", () => {
+      expect(resolveGeminiAspectRatio(undefined)).toBe("1:1");
+    });
+
+    test("width=0 は 1:1", () => {
+      expect(resolveGeminiAspectRatio({ width: 0, height: 100 })).toBe("1:1");
+    });
+
+    test("height=0 は 1:1", () => {
+      expect(resolveGeminiAspectRatio({ width: 100, height: 0 })).toBe("1:1");
+    });
+
+    test("負の値は 1:1", () => {
+      expect(resolveGeminiAspectRatio({ width: -100, height: 200 })).toBe(
+        "1:1",
+      );
+    });
+
+    test("NaN は 1:1", () => {
+      expect(resolveGeminiAspectRatio({ width: NaN, height: 100 })).toBe("1:1");
+    });
+
+    test("Infinity は 1:1", () => {
+      expect(
+        resolveGeminiAspectRatio({ width: Infinity, height: 100 }),
+      ).toBe("1:1");
+    });
+  });
+
+  describe("サポート対象アスペクト比一覧", () => {
+    test("9 段階すべて含まれる", () => {
+      expect(GEMINI_SUPPORTED_ASPECT_RATIOS).toHaveLength(9);
+      const labels = GEMINI_SUPPORTED_ASPECT_RATIOS.map((e) => e.label);
+      expect(labels).toEqual([
+        "9:16",
+        "4:5",
+        "3:4",
+        "2:3",
+        "1:1",
+        "3:2",
+        "4:3",
+        "5:4",
+        "16:9",
+      ]);
+    });
+  });
+});

--- a/tests/unit/supabase/functions/image-gen-worker/gemini-request-config.test.ts
+++ b/tests/unit/supabase/functions/image-gen-worker/gemini-request-config.test.ts
@@ -1,0 +1,72 @@
+/** @jest-environment node */
+
+import { buildGeminiGenerationConfig } from "@/supabase/functions/image-gen-worker/gemini-request-config";
+
+describe("buildGeminiGenerationConfig", () => {
+  test("imageSize がある場合は imageConfig に imageSize と aspectRatio を併置", () => {
+    const result = buildGeminiGenerationConfig({
+      imageSize: "1K",
+      aspectRatio: "9:16",
+    });
+    expect(result).toEqual({
+      imageConfig: {
+        imageSize: "1K",
+        aspectRatio: "9:16",
+      },
+    });
+  });
+
+  test("imageSize が null でも aspectRatio は必ず送られる (gemini-2.5-flash-image 等)", () => {
+    const result = buildGeminiGenerationConfig({
+      imageSize: null,
+      aspectRatio: "1:1",
+    });
+    expect(result).toEqual({
+      imageConfig: {
+        aspectRatio: "1:1",
+      },
+    });
+    expect(result.imageConfig.imageSize).toBeUndefined();
+  });
+
+  test("requiresResponseModalities=true で candidateCount と responseModalities を追加", () => {
+    const result = buildGeminiGenerationConfig({
+      imageSize: "2K",
+      aspectRatio: "16:9",
+      requiresResponseModalities: true,
+    });
+    expect(result).toEqual({
+      candidateCount: 1,
+      responseModalities: ["TEXT", "IMAGE"],
+      imageConfig: {
+        imageSize: "2K",
+        aspectRatio: "16:9",
+      },
+    });
+  });
+
+  test("requiresResponseModalities=false (default) では candidateCount を含めない", () => {
+    const result = buildGeminiGenerationConfig({
+      imageSize: "1K",
+      aspectRatio: "4:3",
+      requiresResponseModalities: false,
+    });
+    expect(result.candidateCount).toBeUndefined();
+    expect(result.responseModalities).toBeUndefined();
+  });
+
+  test("imageSize=null + requiresResponseModalities=true の組み合わせ", () => {
+    const result = buildGeminiGenerationConfig({
+      imageSize: null,
+      aspectRatio: "3:4",
+      requiresResponseModalities: true,
+    });
+    expect(result).toEqual({
+      candidateCount: 1,
+      responseModalities: ["TEXT", "IMAGE"],
+      imageConfig: {
+        aspectRatio: "3:4",
+      },
+    });
+  });
+});


### PR DESCRIPTION
## 概要

過去に `width=512, height=1536` (1:3) という極端な縦長画像が生成された事例への対応。OpenAI gpt-image-2 と Gemini の両プロバイダーの出力アスペクト比を **9:16 〜 16:9** にクランプします。入力画像はトリミングせず、出力サイズ側で丸める方針 (AI 側で再構成される挙動を許容)。

計画書: [docs/planning/image-output-aspect-ratio-clamp-plan.md](https://github.com/3balljugglerYu/ai_coordinate/blob/feature/clamp-image-output-aspect-ratio/docs/planning/image-output-aspect-ratio-clamp-plan.md)

## 変更内容

### Phase 1: OpenAI 側クランプ更新 (`fe2c8ee`)

- `shared/generation/openai-image-model.ts` の `MAX_ASPECT_RATIO` を `3` → `16/9` に変更
- 既存テスト 3 件の期待値更新 + 境界テスト 2 件 (1:3 / 3:1) 新規追加

### Phase 2: Gemini 全 4 経路で `aspectRatio` 必須化 (`79421b4`)

- **共通関数を新規作成**
  - `shared/generation/gemini-aspect-ratio.ts` — Deno / Node 両対応 pure TS。9 段階の離散ラベル (\`9:16/4:5/3:4/2:3/1:1/3:2/4:3/5:4/16:9\`) から log 距離が最小のものを選択
  - `supabase/functions/image-gen-worker/gemini-request-config.ts` — worker 用の `generationConfig` ビルダ (本体起動なしでテスト可能)
- **API 呼び出し 4 経路すべてに反映**
  - `supabase/functions/image-gen-worker/index.ts` (非同期 worker、Inspire 複数入力では `resolveInspireTargetSizeBaseIndex` で基準画像選択)
  - `features/generation/lib/guest-generate.ts` (ゲスト sync)
  - `app/api/style-templates/preview-generation/handler.ts` (Inspire プレビュー、テンプレ画像 / image_1 基準)
  - `app/i2i/[slug]/generate/route.ts` (I2I PoC、baseImage / image_0 相当を基準)
- `features/generation/lib/nanobanana-client.ts` の `GeminiGenerateContentRequestBody` 型に `aspectRatio?` を追加
- `imageSize` を持たない `gemini-2.5-flash-image` 経路でも `aspectRatio` だけは送信する

### Phase 3: ドキュメント更新 (`96e25f0`)

- `docs/API.md` の GPT Image 2 代表サイズ表を新クランプ後の値に更新
- Gemini API に `aspectRatio` を必ず付与する旨を追記

## やらないこと (計画書より)

- 入力画像のトリミング (\`features/generation/lib/normalize-source-image.ts\` は変更なし)
- プロンプト (\`shared/generation/style-prompts.ts\`) の文言変更
- 過去に生成された 1:3 等の画像のマイグレーション
- DB / RLS / UI / i18n の変更なし

## テスト

- 新規 28 件:
  - \`resolveGeminiAspectRatio\` 23 件 (典型値 / クランプ / 最近傍 / フォールバック)
  - \`buildGeminiGenerationConfig\` 5 件 (imageSize 有無 / requiresResponseModalities)
- 既存テスト更新 2 件:
  - \`tests/integration/app/style-generate-route.test.ts\` — \`imageConfig.aspectRatio\` assertion 追加
  - \`tests/unit/features/generation/guest-generate.test.ts\` — Gemini 成功テストに body 検証追加
- 既存 \`openai-image.test.ts\` の 1:2 縦長期待値更新 + 1:3 / 3:1 境界ケース追加

## Test plan

- [x] \`npm run lint\` — 変更ファイルにエラーゼロ (既存 138 problems は pre-existing)
- [x] \`npm run typecheck\` — 変更ファイルにエラーゼロ (既存 38 errors は pre-existing テスト)
- [x] \`npm test\` — Phase 1/2 関連テストすべてパス
- [x] \`npm run build -- --webpack\` — exit 0 で成功
- [ ] ステージング環境で OpenAI / Gemini 各経路で縦長入力 → 出力が 9:16〜16:9 内に収まることを確認
- [ ] Edge Function デプロイ (\`supabase functions deploy image-gen-worker\`) — 別途承認のうえ実施

## ロールバック

- Phase 1 / Phase 2 はファイル disjoint で個別 \`git revert\` 可能
- DB / スキーマ変更なし
- Edge Function は前バージョンに再デプロイで戻せる

🤖 Generated with [Claude Code](https://claude.com/claude-code)