### PR TITLE
fix(generation): 「生成結果から生成」時に Before 画像が表示されない問題を修正

### DIFF
--- a/features/posts/lib/before-image-storage.ts
+++ b/features/posts/lib/before-image-storage.ts
@@ -40,7 +40,15 @@ export function isAllowedInputImageUrl(rawUrl: string): boolean {
   if (!rawUrl.startsWith(expectedPrefix)) {
     return false;
   }
-  const objectPath = rawUrl.slice(expectedPrefix.length);
+  const rawObjectPath = rawUrl.slice(expectedPrefix.length);
+  // `%2F` などでセグメント検査をすり抜けないよう、デコード後のパスで判定する。
+  // 不正な % エンコーディングは拒否する。
+  let objectPath: string;
+  try {
+    objectPath = decodeURIComponent(rawObjectPath);
+  } catch {
+    return false;
+  }
   if (objectPath.startsWith("temp/")) {
     return true;
   }

--- a/features/posts/lib/before-image-storage.ts
+++ b/features/posts/lib/before-image-storage.ts
@@ -6,8 +6,9 @@
  * `{user_id}/pre-generation/{generated_image_id}_display.webp` に保存する。
  *
  * 入力 URL は `generated-images` バケット配下の公開 URL のうち、
- * `temp/...` または `{uuid}/stocks/...` プレフィックスのみを受理する
- * （`isAllowedInputImageUrl` 参照）。それ以外は SSRF / 任意 URL 注入防止のため拒否。
+ * `temp/...` / `{uuid}/stocks/...` / `{uuid}/{file}`（生成画像本体）のみを受理する
+ * （`isAllowedInputImageUrl` 参照）。`pre-generation/` などの内部ディレクトリは
+ * SSRF / 任意 URL 注入 / ループ防止のため拒否する。
  *
  * 失敗してもログのみで投稿などの上流フローは止めない設計。
  */
@@ -26,7 +27,9 @@ const UUID_RE =
  * 後続パスが以下のいずれかであるものだけ通す:
  *   - `temp/...`（生成リクエスト時のユーザーアップロード）
  *   - `{uuid}/stocks/...`（ストック画像由来）
- * それ以外（生成済み画像本体や pre-generation/ 配下など）は SSRF / 任意 URL 注入防止のため拒否。
+ *   - `{uuid}/{file}`（生成画像本体 = 「生成結果から生成」のソース。
+ *     handler 側で `findGeneratedImage(id, user.id)` により所有確認済み）
+ * `pre-generation/` などの内部ディレクトリは SSRF / 任意 URL 注入 / ループ防止のため拒否。
  */
 export function isAllowedInputImageUrl(rawUrl: string): boolean {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -41,8 +44,16 @@ export function isAllowedInputImageUrl(rawUrl: string): boolean {
   if (objectPath.startsWith("temp/")) {
     return true;
   }
-  // ストック画像: 第 1 階層が UUID（user_id）で第 2 階層が `stocks`
   const segments = objectPath.split("/");
+  // 生成画像本体: `{uuid}/{file}`（uuid 直下のファイル）
+  if (
+    segments.length === 2 &&
+    UUID_RE.test(segments[0]) &&
+    segments[1].length > 0
+  ) {
+    return true;
+  }
+  // ストック画像: 第 1 階層が UUID（user_id）で第 2 階層が `stocks`
   if (segments.length >= 3 && UUID_RE.test(segments[0]) && segments[1] === "stocks") {
     return true;
   }

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,6 +14,7 @@ const customJestConfig = {
     '<rootDir>/.next/',
     '<rootDir>/node_modules/',
     '<rootDir>/tests/e2e/',
+    '<rootDir>/.claude/worktrees/',
   ],
 };
 

--- a/tests/unit/features/posts/before-image-storage.test.ts
+++ b/tests/unit/features/posts/before-image-storage.test.ts
@@ -51,13 +51,23 @@ describe("isAllowedInputImageUrl", () => {
     expect(isAllowedInputImageUrl(STOCK_URL)).toBe(true);
   });
 
-  test("生成済み画像本体パス（uuid 直下のオブジェクト）は拒否する", () => {
+  test("生成済み画像本体パス（uuid 直下のオブジェクト）を受理する（『生成結果から生成』のソース）", () => {
     const url = `${PROJECT_URL}/storage/v1/object/public/generated-images/3f2504e0-4f89-11d3-9a0c-0305e82c3301/job1-0-abc.png`;
+    expect(isAllowedInputImageUrl(url)).toBe(true);
+  });
+
+  test("uuid 直下でもファイル名が空なら拒否する", () => {
+    const url = `${PROJECT_URL}/storage/v1/object/public/generated-images/3f2504e0-4f89-11d3-9a0c-0305e82c3301/`;
     expect(isAllowedInputImageUrl(url)).toBe(false);
   });
 
-  test("pre-generation/ 配下は拒否する", () => {
+  test("pre-generation/ 配下は拒否する（ループ防止）", () => {
     const url = `${PROJECT_URL}/storage/v1/object/public/generated-images/3f2504e0-4f89-11d3-9a0c-0305e82c3301/pre-generation/foo_display.webp`;
+    expect(isAllowedInputImageUrl(url)).toBe(false);
+  });
+
+  test("uuid 配下の未知サブディレクトリは拒否する", () => {
+    const url = `${PROJECT_URL}/storage/v1/object/public/generated-images/3f2504e0-4f89-11d3-9a0c-0305e82c3301/cache/foo.png`;
     expect(isAllowedInputImageUrl(url)).toBe(false);
   });
 

--- a/tests/unit/features/posts/before-image-storage.test.ts
+++ b/tests/unit/features/posts/before-image-storage.test.ts
@@ -71,6 +71,16 @@ describe("isAllowedInputImageUrl", () => {
     expect(isAllowedInputImageUrl(url)).toBe(false);
   });
 
+  test("URL エンコードされたスラッシュ (%2F) による pre-generation バイパスは拒否する", () => {
+    const url = `${PROJECT_URL}/storage/v1/object/public/generated-images/3f2504e0-4f89-11d3-9a0c-0305e82c3301/pre-generation%2Ffoo.webp`;
+    expect(isAllowedInputImageUrl(url)).toBe(false);
+  });
+
+  test("不正な % エンコーディングは拒否する", () => {
+    const url = `${PROJECT_URL}/storage/v1/object/public/generated-images/3f2504e0-4f89-11d3-9a0c-0305e82c3301/foo%ZZ.png`;
+    expect(isAllowedInputImageUrl(url)).toBe(false);
+  });
+
   test("第 1 階層が UUID でない /stocks/ は拒否する", () => {
     const url = `${PROJECT_URL}/storage/v1/object/public/generated-images/not-uuid/stocks/foo.png`;
     expect(isAllowedInputImageUrl(url)).toBe(false);


### PR DESCRIPTION
### 概要

コーディネート / スタイル画面で「**生成結果から選ぶ**」を選んで再生成した場合、生成後のコンテンツ詳細画面で Before / After の **Before 側 (ソース画像) が表示されない** 不具合を修正します。

「ストックから選ぶ」経由では正しく Before が表示されていた一方、「生成結果から選ぶ」では `image_jobs.input_image_url` に保存される URL のパス形式 (`{uuid}/{file}` = 生成画像本体) が、Before 永続化ヘルパー `isAllowedInputImageUrl` のホワイトリスト (`temp/...` と `{uuid}/stocks/...` のみ) で拒否されることが原因でした。

### 変更内容

- `features/posts/lib/before-image-storage.ts` — `isAllowedInputImageUrl` のホワイトリストに **生成画像本体パス (`{uuid}/{file}`)** を追加。`pre-generation/` などの内部サブディレクトリはループ防止のため引き続き拒否。
- `tests/unit/features/posts/before-image-storage.test.ts` — 新ホワイトリスト挙動の検証 (受理: `{uuid}/{file}` / 拒否: 空ファイル名・未知サブディレクトリ) を追加。
- `jest.config.js` — `testPathIgnorePatterns` に `.claude/worktrees/` を追加 (Claude Code worktree 内の重複テスト実行を防止)。

### セキュリティ判断

`sourceImageGeneratedId` は `handler.ts` の `findGeneratedImage(id, user.id)` でユーザー所有が確認済みであり、`image_jobs.input_image_url` への INSERT 経路もサーバー側に閉じています。したがってホワイトリスト緩和によるセキュリティ低下はありません。

### 実機テスト

- [ ] iOS Safari で主要導線を確認
- [ ] Android Chrome で主要導線を確認
- [ ] PC（Chrome）で主要導線を確認
- [ ] レスポンシブ表示崩れがないことを確認
- [ ] エラーメッセージやバリデーション表示を確認

### テスト方法

- `npm run test` — 全 1386 件パス (新規 5 件含む)
- `npm run typecheck` — 修正ファイルに新規エラーなし
- `npm run lint` — 修正ファイルに新規エラーなし
- `npm run build -- --webpack` — 成功
- 手動: コーディネート画面で「生成結果から選ぶ」→ 生成 → コンテンツ詳細で Before が表示されることを確認

### 既存データへの影響

`server-api.ts` の `input_image_url_fallback` ロジックも同じヘルパーを経由するため、過去ジョブ (= 旧ホワイトリスト下で永続化スキップされたもの) もデプロイ後はフォールバック経由で Before が表示されるようになります。バックフィル不要。

### デプロイ範囲

- Vercel (Next.js): マージで自動反映
- Supabase migration: **不要** (DB スキーマ変更なし)
- Edge Function 再デプロイ: **不要** (`supabase/functions/` 配下の変更なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)