### PR TITLE
fix(style-presets): create/update RPC から削除済み prompt 列の参照を除去

### DIFF
--- a/supabase/migrations/20260601200000_fix_style_preset_rpcs_remove_dropped_prompt_column.sql
+++ b/supabase/migrations/20260601200000_fix_style_preset_rpcs_remove_dropped_prompt_column.sql
@@ -1,0 +1,200 @@
+-- HOTFIX:
+-- 直前のマイグレーション 20260601100100 で書いた create_style_preset / update_style_preset の
+-- INSERT / UPDATE 句が、20260325102000 で既に DROP 済みの `prompt` 列を参照していたため、
+-- 本番で「column "prompt" of relation "style_presets" does not exist (42703)」となり登録不可。
+-- シグネチャ (19 引数 / 18 引数) は変えないため、CREATE OR REPLACE で本体だけ差し替える。
+
+CREATE OR REPLACE FUNCTION public.create_style_preset(
+  p_id UUID,
+  p_slug TEXT,
+  p_title TEXT,
+  p_styling_prompt TEXT,
+  p_background_prompt TEXT DEFAULT NULL,
+  p_thumbnail_image_url TEXT DEFAULT NULL,
+  p_thumbnail_storage_path TEXT DEFAULT NULL,
+  p_thumbnail_width INTEGER DEFAULT 0,
+  p_thumbnail_height INTEGER DEFAULT 0,
+  p_sort_order INTEGER DEFAULT 0,
+  p_status TEXT DEFAULT 'draft',
+  p_created_by UUID DEFAULT NULL,
+  p_category_id UUID DEFAULT NULL,
+  p_image_input_mode TEXT DEFAULT 'single',
+  p_reference_image_url TEXT DEFAULT NULL,
+  p_reference_image_storage_path TEXT DEFAULT NULL,
+  p_reference_image_width INTEGER DEFAULT NULL,
+  p_reference_image_height INTEGER DEFAULT NULL,
+  p_dual_reference_source TEXT DEFAULT 'admin'
+)
+RETURNS public.style_presets
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_created public.style_presets;
+  v_category_id UUID;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtextextended('style_presets_order', 0));
+
+  IF p_category_id IS NULL THEN
+    SELECT id INTO v_category_id FROM public.preset_categories WHERE key = 'coordinate';
+    IF v_category_id IS NULL THEN
+      RAISE EXCEPTION 'default preset_categories row "coordinate" is missing';
+    END IF;
+  ELSE
+    v_category_id := p_category_id;
+  END IF;
+
+  INSERT INTO public.style_presets (
+    id,
+    slug,
+    title,
+    styling_prompt,
+    background_prompt,
+    thumbnail_image_url,
+    thumbnail_storage_path,
+    thumbnail_width,
+    thumbnail_height,
+    sort_order,
+    status,
+    created_by,
+    updated_by,
+    category_id,
+    image_input_mode,
+    reference_image_url,
+    reference_image_storage_path,
+    reference_image_width,
+    reference_image_height,
+    dual_reference_source
+  )
+  VALUES (
+    p_id,
+    p_slug,
+    p_title,
+    p_styling_prompt,
+    NULLIF(p_background_prompt, ''),
+    p_thumbnail_image_url,
+    p_thumbnail_storage_path,
+    p_thumbnail_width,
+    p_thumbnail_height,
+    GREATEST(0, COALESCE(p_sort_order, 0)),
+    p_status,
+    p_created_by,
+    p_created_by,
+    v_category_id,
+    COALESCE(p_image_input_mode, 'single'),
+    p_reference_image_url,
+    p_reference_image_storage_path,
+    p_reference_image_width,
+    p_reference_image_height,
+    COALESCE(p_dual_reference_source, 'admin')
+  )
+  RETURNING * INTO v_created;
+
+  PERFORM public.place_style_preset_at_order(
+    v_created.id,
+    GREATEST(0, COALESCE(p_sort_order, 0)),
+    p_created_by
+  );
+
+  SELECT *
+  INTO v_created
+  FROM public.style_presets
+  WHERE id = v_created.id;
+
+  RETURN v_created;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.update_style_preset(
+  p_id UUID,
+  p_title TEXT,
+  p_styling_prompt TEXT,
+  p_background_prompt TEXT DEFAULT NULL,
+  p_thumbnail_image_url TEXT DEFAULT NULL,
+  p_thumbnail_storage_path TEXT DEFAULT NULL,
+  p_thumbnail_width INTEGER DEFAULT 0,
+  p_thumbnail_height INTEGER DEFAULT 0,
+  p_sort_order INTEGER DEFAULT 0,
+  p_status TEXT DEFAULT 'draft',
+  p_updated_by UUID DEFAULT NULL,
+  p_category_id UUID DEFAULT NULL,
+  p_image_input_mode TEXT DEFAULT 'single',
+  p_reference_image_url TEXT DEFAULT NULL,
+  p_reference_image_storage_path TEXT DEFAULT NULL,
+  p_reference_image_width INTEGER DEFAULT NULL,
+  p_reference_image_height INTEGER DEFAULT NULL,
+  p_dual_reference_source TEXT DEFAULT 'admin'
+)
+RETURNS public.style_presets
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_updated public.style_presets;
+  v_category_id UUID;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtextextended('style_presets_order', 0));
+
+  IF p_category_id IS NULL THEN
+    SELECT category_id INTO v_category_id FROM public.style_presets WHERE id = p_id;
+    IF v_category_id IS NULL THEN
+      RAISE EXCEPTION 'style preset not found';
+    END IF;
+  ELSE
+    v_category_id := p_category_id;
+  END IF;
+
+  UPDATE public.style_presets
+  SET
+    title = p_title,
+    styling_prompt = p_styling_prompt,
+    background_prompt = NULLIF(p_background_prompt, ''),
+    thumbnail_image_url = p_thumbnail_image_url,
+    thumbnail_storage_path = p_thumbnail_storage_path,
+    thumbnail_width = p_thumbnail_width,
+    thumbnail_height = p_thumbnail_height,
+    sort_order = GREATEST(0, COALESCE(p_sort_order, 0)),
+    status = p_status,
+    updated_by = p_updated_by,
+    category_id = v_category_id,
+    image_input_mode = COALESCE(p_image_input_mode, 'single'),
+    reference_image_url = p_reference_image_url,
+    reference_image_storage_path = p_reference_image_storage_path,
+    reference_image_width = p_reference_image_width,
+    reference_image_height = p_reference_image_height,
+    dual_reference_source = COALESCE(p_dual_reference_source, 'admin')
+  WHERE id = p_id
+  RETURNING * INTO v_updated;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'style preset not found';
+  END IF;
+
+  PERFORM public.place_style_preset_at_order(
+    p_id,
+    GREATEST(0, COALESCE(p_sort_order, 0)),
+    p_updated_by
+  );
+
+  SELECT *
+  INTO v_updated
+  FROM public.style_presets
+  WHERE id = p_id;
+
+  RETURN v_updated;
+END;
+$$;
+
+COMMENT ON FUNCTION public.create_style_preset(
+  UUID, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, INTEGER, INTEGER, INTEGER, TEXT, UUID,
+  UUID, TEXT, TEXT, TEXT, INTEGER, INTEGER, TEXT
+) IS
+  'スタイル新規作成 (HOTFIX 20260601200000: 削除済み prompt 列の参照を除去)';
+
+COMMENT ON FUNCTION public.update_style_preset(
+  UUID, TEXT, TEXT, TEXT, TEXT, TEXT, INTEGER, INTEGER, INTEGER, TEXT, UUID,
+  UUID, TEXT, TEXT, TEXT, INTEGER, INTEGER, TEXT
+) IS
+  'スタイル更新 (HOTFIX 20260601200000: 削除済み prompt 列の参照を除去)';


### PR DESCRIPTION
## 概要

PR #293 で追加したマイグレーション `20260601100100_update_style_preset_rpcs_for_dual_source.sql` の `create_style_preset` / `update_style_preset` 本体が、すでに `20260325102000_drop_legacy_style_preset_prompt.sql` で DROP されていた `style_presets.prompt` 列を INSERT / UPDATE していたため、本番管理画面からのスタイル登録・更新時に下記の PostgreSQL エラーが発生していました。

\`\`\`
code: 42703
message: column "prompt" of relation "style_presets" does not exist
\`\`\`

本番への RPC 適用は既に完了しており、登録が再び成功することを動作確認済み。

## 変更内容

- 新規マイグレーション `20260601200000_fix_style_preset_rpcs_remove_dropped_prompt_column.sql` を追加
- `create_style_preset` / `update_style_preset` を `CREATE OR REPLACE` で本体のみ差し替え
  - INSERT / UPDATE 句から `prompt` 列の参照を削除
  - シグネチャ (19/18 引数) は据え置きのため、呼び出し側のコード変更は不要
- COMMENT を HOTFIX 適用済みである旨に更新

## Test plan

- [x] 本番 DB に `supabase db push --linked` で適用 (済)
- [x] 本番 `/admin/style-presets` で新規登録が成功することを確認 (済)
- [ ] CI (lint / typecheck / test / build) パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)