### PR TITLE
feat(creator-looks): 投稿フォームを Step 1 完結に変更 (preview 生成スキップ)

### DIFF
--- a/app/api/style-templates/preview-generation/handler.ts
+++ b/app/api/style-templates/preview-generation/handler.ts
@@ -394,6 +394,18 @@ export async function handlePreviewGeneration(
     );
   }
 
+  // Creator Looks モードは preview 生成を行わず即時 draft 完了で返す。
+  // 投稿者向け試着シミュレーションは UX 上不要 (消費者が利用時に生成する) ため、
+  // OpenAI / Gemini への課金・90 秒待ち時間を省略する。
+  // hidden_prompt 抽出は submissions API での pending 昇格時に Trigger 経由で発火する。
+  if (isCreatorLooksMode) {
+    return NextResponse.json({
+      template_id: draftId,
+      outcome: "skipped",
+      previews: [],
+    });
+  }
+
   // OpenAI と Gemini を並列起動。
   // Step 2 プレビューは「すべて維持」相当（テンプレ全体を image_0 に適用）のプロンプトで生成する。
   const promptTemplates = await resolveAllPromptTemplates();

--- a/features/inspire/components/UserStyleTemplateSubmissionForm.tsx
+++ b/features/inspire/components/UserStyleTemplateSubmissionForm.tsx
@@ -565,6 +565,15 @@ export function UserStyleTemplateSubmissionForm({
         return;
       }
 
+      // submissions 失敗 + ユーザー離脱で draft が孤立しないよう、
+      // template_id を previewResult に保存しておく。
+      // これで leaveNow({ deleteDraft: true }) が draft DELETE を呼べる。
+      setPreviewResult({
+        template_id: previewData.template_id,
+        outcome: "success",
+        previews: [],
+      });
+
       const submitResponse = await fetch("/api/style-templates/submissions", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -596,6 +605,7 @@ export function UserStyleTemplateSubmissionForm({
     creatorLooksConsents,
     file,
     leaveNow,
+    setPreviewResult,
     submissionSource,
     t,
     toast,

--- a/features/inspire/components/UserStyleTemplateSubmissionForm.tsx
+++ b/features/inspire/components/UserStyleTemplateSubmissionForm.tsx
@@ -481,6 +481,126 @@ export function UserStyleTemplateSubmissionForm({
     creatorLooksConsents,
   ]);
 
+  /**
+   * Creator Looks モード専用の一気通貫送信。
+   *
+   * 既存 Inspire の Step 2 (preview 生成) / Step 3 (結果確認) は投稿者にとって
+   * 不要なため、Step 1 のチェック完了でそのまま「申請する」を押せる UX にする。
+   *
+   * 内部:
+   *   1) preview-generation API を Creator Looks payload で叩く
+   *      → サーバ側で preview 生成は skip、draft 行のみ作成して template_id を返す
+   *   2) 返ってきた template_id で submissions API を叩いて pending に昇格
+   *      → DB Trigger 経由で extract-creator-looks-prompt Edge Function が起動
+   *
+   * 既存 Inspire の handleGeneratePreview / handleSubmit はこの関数の影響を受けない。
+   */
+  const handleCreatorLooksSubmit = useCallback(async () => {
+    if (!file) return;
+    if (submissionSource === null) {
+      setErrorMessage(t("submitFailedConsent"));
+      return;
+    }
+    if (!isAllConsentsAcknowledged(creatorLooksConsents)) {
+      setErrorMessage(t("submitFailedConsent"));
+      return;
+    }
+    setSubmitting(true);
+    setErrorMessage(null);
+    try {
+      const base64 = await readFileAsBase64(file);
+      const previewResponse = await fetch(
+        "/api/style-templates/preview-generation",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            imageBase64: base64,
+            imageMimeType: file.type,
+            alt: alt || null,
+            is_creator_looks: true,
+            submission_source: submissionSource,
+            submission_consents: buildSubmissionConsents(creatorLooksConsents),
+          }),
+        }
+      );
+      if (previewResponse.status === 429) {
+        const data = await previewResponse.json().catch(() => null);
+        if (data?.errorCode === "CREATOR_LOOKS_DAILY_CAP_EXCEEDED") {
+          setErrorMessage(t("submitFailedCap"));
+        } else {
+          setErrorMessage(t("submitFailedRateLimit"));
+        }
+        return;
+      }
+      if (previewResponse.status === 403) {
+        setErrorMessage(t("submitFailedGeneric"));
+        return;
+      }
+      if (previewResponse.status === 400) {
+        const data = await previewResponse.json().catch(() => null);
+        if (
+          typeof data?.errorCode === "string" &&
+          data.errorCode.startsWith("CREATOR_LOOKS_IMAGE_")
+        ) {
+          setErrorMessage(t("submitFailedSafety"));
+          return;
+        }
+        if (data?.errorCode === "INSPIRE_IMAGE_TOO_LARGE") {
+          setErrorMessage(t("submitFailedTooLarge"));
+          return;
+        }
+        setErrorMessage(t("submitFailedGeneric"));
+        return;
+      }
+      if (!previewResponse.ok) {
+        setErrorMessage(t("submitFailedGeneric"));
+        return;
+      }
+      const previewData = (await previewResponse.json()) as {
+        template_id?: string;
+      };
+      if (!previewData.template_id) {
+        setErrorMessage(t("submitFailedGeneric"));
+        return;
+      }
+
+      const submitResponse = await fetch("/api/style-templates/submissions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          templateId: previewData.template_id,
+          copyrightConsent: true,
+        }),
+      });
+      if (submitResponse.status === 429) {
+        setErrorMessage(t("submitFailedCap"));
+        return;
+      }
+      if (!submitResponse.ok) {
+        setErrorMessage(t("submitFailedGeneric"));
+        return;
+      }
+
+      toast({ title: t("submitSuccess") });
+      // 申請成功時は draft → pending 昇格済み。leaveNow は draft DELETE を呼ばない。
+      leaveNow({ deleteDraft: false });
+    } catch (err) {
+      console.error("[submission] creator-looks submit failed", err);
+      setErrorMessage(t("submitFailedGeneric"));
+    } finally {
+      setSubmitting(false);
+    }
+  }, [
+    alt,
+    creatorLooksConsents,
+    file,
+    leaveNow,
+    submissionSource,
+    t,
+    toast,
+  ]);
+
   const handleSubmit = useCallback(async () => {
     if (!previewResult || !consent) {
       setErrorMessage(t("submitFailedConsent"));
@@ -534,7 +654,11 @@ export function UserStyleTemplateSubmissionForm({
           <p className="text-sm text-muted-foreground">{t("dialogDescription")}</p>
         </header>
 
-        <StepIndicator current={step} />
+        {/*
+          Creator Looks モードでは preview を生成せず Step 1 で完結するため、
+          3 step インジケータは表示しない。
+        */}
+        {!isCreatorLooksMode && <StepIndicator current={step} />}
 
         {step === 1 && (
           <div className="space-y-4">
@@ -615,24 +739,44 @@ export function UserStyleTemplateSubmissionForm({
               <Button type="button" variant="ghost" onClick={requestLeave}>
                 {t("cancelButton")}
               </Button>
-              <Button
-                type="button"
-                onClick={() => setStep(2)}
-                disabled={
-                  !file ||
-                  (isCreatorLooksMode
-                    ? submissionSource === null ||
-                      !isAllConsentsAcknowledged(creatorLooksConsents)
-                    : !consent)
-                }
-              >
-                {t("step1NextButton")}
-              </Button>
+              {isCreatorLooksMode ? (
+                <Button
+                  type="button"
+                  onClick={handleCreatorLooksSubmit}
+                  disabled={
+                    !file ||
+                    submissionSource === null ||
+                    !isAllConsentsAcknowledged(creatorLooksConsents) ||
+                    submitting
+                  }
+                  className="cursor-pointer"
+                >
+                  {submitting ? (
+                    <>
+                      <Loader2
+                        className="mr-1.5 size-4 motion-safe:animate-spin"
+                        aria-hidden="true"
+                      />
+                      {t("submitting")}
+                    </>
+                  ) : (
+                    t("step3SubmitButton")
+                  )}
+                </Button>
+              ) : (
+                <Button
+                  type="button"
+                  onClick={() => setStep(2)}
+                  disabled={!file || !consent}
+                >
+                  {t("step1NextButton")}
+                </Button>
+              )}
             </div>
           </div>
         )}
 
-        {step === 2 && (
+        {step === 2 && !isCreatorLooksMode && (
           <div className="space-y-4">
             <h2 className="text-base font-semibold">{t("step2Title")}</h2>
             <p className="text-sm text-muted-foreground">{t("step2Description")}</p>
@@ -709,7 +853,7 @@ export function UserStyleTemplateSubmissionForm({
           </div>
         )}
 
-        {step === 3 && previewResult && (
+        {step === 3 && previewResult && !isCreatorLooksMode && (
           <div className="space-y-4">
             <h2 className="text-base font-semibold">{t("step3Title")}</h2>
             <p className="text-sm text-muted-foreground">{t("step3Description")}</p>


### PR DESCRIPTION
## 概要

Creator Looks 投稿フォームを **Step 1 のみで完結する UX** に改修。
既存の試着シミュレーション (Step 2 / Step 3) は投稿者にとって不要なため、Creator Looks モードでは UI 上 + サーバ側ともにスキップする。

### Before (= マージ前の挙動)

```
Step 1: 画像 + 5 consent + 出典
   ↓ 「プレビュー生成へ進む」ボタン
Step 2: 試着シミュレーション (60〜90 秒待ち、OpenAI + Gemini)  ← 不要
   ↓ 「このキャラクターで試着します」ボタン
Step 3: 結果比較 (= 3 枚並べる)                            ← 不要
   ↓ 「申請する」ボタン
申請確定
```

### After (= 本 PR の挙動)

```
Step 1: 画像 + 5 consent + 出典
   ↓ 「申請する」ボタン (= consent 5 件すべてチェックで enable)
申請確定
```

### なぜ不要か

- Step 2/3 の試着シミュレーションは「投稿した衣装が他キャラに着られたらどう見えるか」を投稿者に見せるもの
- Creator Looks 投稿者の関心は「自分のイラストが公開されること」であって、「他キャラに着せた品質」は消費者が利用時に確認する内容
- 投稿者を 90 秒待たせる + OpenAI/Gemini に課金が発生 → UX とコストの両面でデメリット

### moat への影響

ゼロ。`hidden_prompt` 抽出は **submissions API での pending 昇格時に Trigger 経由**で従来通り発火する。preview 生成と hidden_prompt 抽出は別フロー。

## 変更内容

### サーバ (`app/api/style-templates/preview-generation/handler.ts`)

- Creator Looks payload (`is_creator_looks=true`) を受けたら、画像 Storage アップロード + draft 行作成完了直後に `{ template_id, outcome: "skipped", previews: [] }` で早期 return
- OpenAI / Gemini の preview 生成は走らない
- 既存 Inspire (`is_creator_looks` 無し) は **完全に無変更**

### クライアント (`features/inspire/components/UserStyleTemplateSubmissionForm.tsx`)

- `isCreatorLooksMode=true` のとき:
  - `StepIndicator` を非表示 (= 単一ステップ)
  - `step === 2 / 3` のレンダリングを抑制
  - Step 1 末尾に「申請する」ボタンを直接表示 (= 既存「プレビュー生成へ進む」と差し替え)
  - disable 条件: 画像 + 出典 + 5 consent すべて
- 新ハンドラ `handleCreatorLooksSubmit`:
  1. preview-generation API を Creator Looks payload で呼ぶ (= サーバ側で preview skip)
  2. 返ってきた `template_id` で submissions API を即時呼び pending 昇格
  3. 成功で `/my-page` リダイレクト + 通知トースト
- 既存 Inspire モード (`isCreatorLooksMode=false`) のフローは **完全に無変更**

### DB / Trigger / Edge Function

無変更。Trigger 経由の `extract-creator-looks-prompt` 起動は submissions API の pending 昇格時にこれまで通り発火する。

## 影響範囲

| 経路 | 影響 |
|---|---|
| 既存 Inspire 投稿 (`is_creator_looks=false`) | **無し** (3 step ウィザード維持) |
| Creator Looks 投稿 (`is_creator_looks=true`) | UX 改善: Step 1 のみで完結、申請まで 30 秒以内 |
| `hidden_prompt` 抽出 | 無変更 (Trigger 経由で submissions 後に発火) |
| moat (= hidden_prompt 隠蔽) | 無変更 |
| Stage 1 隠蔽 (= 一般ユーザー不可視) | 無変更 |

## Test plan

- [x] `npm run lint`: baseline (148/45/103) と同一
- [x] `npm run typecheck`: baseline と同一
- [x] `npm run test`: 1593 件パス
- [x] `npm run build -- --webpack`: 成功
- [ ] マージ後の本番動作確認:
  - [ ] admin で `/inspire/submit` Creator Looks モード → Step 1 のみ表示
  - [ ] 5 consent + 画像 + 出典で「申請する」ボタンが enable
  - [ ] クリックで preview 生成画面を経ず即時申請完了 → `/my-page` リダイレクト
  - [ ] 通知 ①「投稿を受け付けました」が即時届く
  - [ ] 30秒〜2分後、通知 ②「衣装情報の抽出が完了しました」が届く
  - [ ] 一般アカウントで `/inspire/submit` → Creator Looks タブが見えない (= 無変更)
  - [ ] 一般アカウントで既存 Inspire 投稿フロー → 3 step ウィザードが動く (= 無変更)

## 残作業 (= 本 PR 外、将来検討)

- Stage 2 前に「投稿者向け事前品質確認 UI」が必要なら、シミュレーション時に hidden_prompt 抽出 + 本気の生成を行う案 (= 当初検討した案 B) を別 issue で復活させる

🤖 Generated with [Claude Code](https://claude.com/claude-code)