### PR TITLE
fix(creator-looks): admin secret API を server client に変更 (403 修正)

### DIFF
--- a/app/api/admin/creator-looks/[templateId]/secret/route.ts
+++ b/app/api/admin/creator-looks/[templateId]/secret/route.ts
@@ -12,7 +12,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/auth";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -37,7 +37,11 @@ export async function GET(
     );
   }
 
-  const supabase = createAdminClient();
+  // 認証済みユーザーの Cookie/JWT を持つ server client を使う。
+  // get_creator_looks_secret_for_admin RPC は内部で auth.uid() を読んで
+  // admin_users 所属を確認するため、service-role の createAdminClient() では
+  // auth.uid() が NULL になり常に 403 (not_authorized) が返ってしまう。
+  const supabase = await createClient();
   const { data, error } = await supabase.rpc(
     "get_creator_looks_secret_for_admin",
     { p_template_id: templateId },


### PR DESCRIPTION
## 概要

`/admin/style-templates` で Creator Looks 投稿の hidden_prompt が **常に「未生成」表示**になり、`/api/admin/creator-looks/[templateId]/secret` が **403** を返していた問題を修正。

## 原因

`route.ts` で `createAdminClient()` (= service role 接続) を使って RPC を呼んでいた。

```
service role で RPC 呼び出し
  → 関数内の auth.uid() は NULL (= service role には authenticated user が無い)
  → admin_users.user_id = NULL で検索 → 0 件
  → 'not_authorized' (= 403)
```

`get_creator_looks_secret_for_admin` RPC は SECURITY DEFINER + 内部 admin 判定を持つため、**authenticated user のクライアントで呼ぶのが正しい**設計。GRANT も `authenticated` に対して付与されている。

## 修正

```diff
- import { createAdminClient } from "@/lib/supabase/admin";
+ import { createClient } from "@/lib/supabase/server";

- const supabase = createAdminClient();
+ const supabase = await createClient();
```

これで Cookie/JWT 経由で admin の user.id が RPC 内の `auth.uid()` に渡り、`admin_users` マッチして hidden_prompt が返る。

## 多層防御は維持

route handler 側の `requireAdmin()` (= Cookie session で admin 判定) は変更せず、API 層と DB 層で二重チェック。

## Vercel ログでの再現

```
GET /api/admin/creator-looks/8ec24571-.../secret → 403
POST hnrccaxrvhtbuihfvitc.supabase.co/rest/v1/rpc/get_creator_looks_secret_for_admin → 403
```

## Test plan

- [x] `npm run lint`: baseline (148/45/103) と同一
- [x] `npm run typecheck`: baseline と同一
- [x] `npm run test`: 1593 件パス
- [x] `npm run build -- --webpack`: 成功
- [ ] マージ + デプロイ後:
  - admin で `/admin/style-templates` を開く → 投稿の詳細パネルで `[REDACTED]` 表示 (= 取得成功し API 層でマスク) になる
  - 非 admin で 同 API を直接叩く → 403 (= server client でも未ログインなら auth.uid()=null で RPC 側で reject)

🤖 Generated with [Claude Code](https://claude.com/claude-code)