### PR TITLE
feat(creator-looks): 画像出所を「自分が AI 生成 / 制作した」のみに限定

### DIFF
--- a/features/inspire/components/UserStyleTemplateSubmissionForm.tsx
+++ b/features/inspire/components/UserStyleTemplateSubmissionForm.tsx
@@ -228,8 +228,9 @@ export function UserStyleTemplateSubmissionForm({
   const [closeConfirmOpen, setCloseConfirmOpen] = useState(false);
 
   // Creator Looks 追加 state (= isCreatorLooksMode=true のときだけ意味を持つ)
+  // 出所は self_created (= 本人 AI 生成 / 制作) のみ受け付けるため、初期値で固定。
   const [submissionSource, setSubmissionSource] =
-    useState<SubmissionSource | null>(null);
+    useState<SubmissionSource>("self_created");
   const [creatorLooksConsents, setCreatorLooksConsents] = useState({
     copyright: false,
     third_party_ip: false,
@@ -402,7 +403,6 @@ export function UserStyleTemplateSubmissionForm({
       // この preview-generation 呼び出し前に validate する。
       const creatorLooksPayload =
         isCreatorLooksMode &&
-        submissionSource !== null &&
         isAllConsentsAcknowledged(creatorLooksConsents)
           ? {
               is_creator_looks: true as const,
@@ -497,10 +497,6 @@ export function UserStyleTemplateSubmissionForm({
    */
   const handleCreatorLooksSubmit = useCallback(async () => {
     if (!file) return;
-    if (submissionSource === null) {
-      setErrorMessage(t("submitFailedConsent"));
-      return;
-    }
     if (!isAllConsentsAcknowledged(creatorLooksConsents)) {
       setErrorMessage(t("submitFailedConsent"));
       return;
@@ -755,7 +751,6 @@ export function UserStyleTemplateSubmissionForm({
                   onClick={handleCreatorLooksSubmit}
                   disabled={
                     !file ||
-                    submissionSource === null ||
                     !isAllConsentsAcknowledged(creatorLooksConsents) ||
                     submitting
                   }
@@ -991,7 +986,7 @@ export function UserStyleTemplateSubmissionForm({
 
 type CreatorLooksConsentBlockProps = {
   t: ReturnType<typeof useTranslations>;
-  source: SubmissionSource | null;
+  source: SubmissionSource;
   onSourceChange: (next: SubmissionSource) => void;
   consents: {
     copyright: boolean;

--- a/features/inspire/lib/creator-looks-submission.ts
+++ b/features/inspire/lib/creator-looks-submission.ts
@@ -8,11 +8,11 @@
 
 import { z } from "zod";
 
-export const SUBMISSION_SOURCES = [
-  "self_created",
-  "self_photographed",
-  "licensed_other",
-] as const;
+/**
+ * 受付対象の画像出所。本人が AI 生成 / 制作したものに限定する (= 著作権リスク最小化)。
+ * 撮影物・他者作品 (許諾済を含む) は将来検討。
+ */
+export const SUBMISSION_SOURCES = ["self_created"] as const;
 
 export type SubmissionSource = (typeof SUBMISSION_SOURCES)[number];
 

--- a/messages/ja.ts
+++ b/messages/ja.ts
@@ -462,7 +462,7 @@ export const jaMessages = {
     creatorLooksSectionDescription:
       "あなたの作品が他のユーザーの着せ替え素材として使われます。下記の出所申告と同意にすべてチェックを入れてください。",
     creatorLooksSourceLabel: "画像の出所",
-    creatorLooksSource_self_created: "自分が描いた / 制作した",
+    creatorLooksSource_self_created: "自分が AI 生成した / 制作した",
     creatorLooksSource_self_photographed: "自分で撮影した",
     creatorLooksSource_licensed_other: "他者の作品（明示的に許諾を得たもの）",
     creatorLooksConsentsLabel: "同意事項（すべて必須）",

--- a/tests/unit/features/inspire/creator-looks-submission.test.ts
+++ b/tests/unit/features/inspire/creator-looks-submission.test.ts
@@ -10,12 +10,8 @@ import {
 } from "@/features/inspire/lib/creator-looks-submission";
 
 describe("SUBMISSION_SOURCES", () => {
-  test("3 つの値が定義済み", () => {
-    expect(SUBMISSION_SOURCES).toEqual([
-      "self_created",
-      "self_photographed",
-      "licensed_other",
-    ]);
+  test("self_created のみ受け付ける (= 本人 AI 生成 / 制作)", () => {
+    expect(SUBMISSION_SOURCES).toEqual(["self_created"]);
   });
 });
 


### PR DESCRIPTION
## 概要

Creator Looks 投稿の「画像の出所」を **`self_created` (= 自分が AI 生成 / 制作した) のみに限定**する。撮影物 (`self_photographed`) と他者作品許諾済 (`licensed_other`) は受け付けない。

## 背景

Stage 1 の運用方針として、著作権リスクを最小化したい。第三者写真や他者作品 (たとえ許諾を取っていても証憑審査が困難) を受け付けると以下のリスクがある:

- 撮影物 → モデルリリース・公開承諾の有無を運営側で確認不可能
- 他者作品許諾済 → 許諾の証憑提出フローが現状無く、虚偽申告で submit されると検知できない

→ 本人が AI 生成 / 制作した作品 (= self_created) のみに限定すれば、責任の所在が投稿者本人に明確になり、運営側の著作権審査負担も最小化できる。

## Before / After

### Before
```
画像の出所 *
○ 自分が描いた / 制作した
○ 自分で撮影した
○ 他者の作品（明示的に許諾を得たもの）
```

### After
```
画像の出所 *
◉ 自分が AI 生成した / 制作した   ← デフォルト選択済 (= 1 ラジオで明示)
```

## 変更内容

| ファイル | 変更 |
|---|---|
| `features/inspire/lib/creator-looks-submission.ts` | `SUBMISSION_SOURCES = ["self_created"]` のみに絞る (= zod / TS 型レベルで他値を reject) |
| `features/inspire/components/UserStyleTemplateSubmissionForm.tsx` | `submissionSource` の初期値を `"self_created"` に固定、`null` チェックを削除、`CreatorLooksConsentBlockProps.source` を non-nullable に |
| `messages/ja.ts` | ラベルを「自分が AI 生成した / 制作した」に変更 |
| `tests/unit/features/inspire/creator-looks-submission.test.ts` | 期待値を `["self_created"]` のみに更新 |

## 既存データへの影響

- Stage 1 開始直後のため、本番 DB の `user_style_templates.submission_source` には `self_photographed` / `licensed_other` の row が **ほぼゼロ** (= テスト投稿のみ)
- 万一存在しても DB CHECK 制約は変更しないため、過去 row は残る (= 表示は引き続き旧ラベルで)
- 新規投稿は API 層で `self_created` 以外を 400 で reject

## i18n の残作業

`messages/*.ts` の他 14 言語の `creatorLooksSource_self_photographed` / `_licensed_other` キーは参照されなくなるが、型互換維持のため**残置**。文言更新 (= self_created のラベルを「AI 生成 / 制作」に揃える) は別 PR で対応する。

## Test plan

- [x] `npm run lint`: baseline (148/45/103) と同一
- [x] `npm run typecheck`: baseline と同一
- [x] `npm run test`: 1593 件パス (= SUBMISSION_SOURCES 期待値テストも更新)
- [x] `npm run build -- --webpack`: 成功
- [ ] マージ + デプロイ後:
  - admin で `/inspire/submit` → Creator Looks タブ → 画像の出所ラジオが **1 つだけ「自分が AI 生成した / 制作した」**、デフォルトで selected
  - 投稿可能 (= 5 consent + 画像 + alt で「申請する」ボタン enable)
  - DB 直接 INSERT で `submission_source='self_photographed'` を送ると CHECK 制約は通る (= DB 緩和なし) が、API 経由では zod で 400 reject される

🤖 Generated with [Claude Code](https://claude.com/claude-code)