### PR TITLE
feat(creator-looks): admin 用 preview 自動生成 (非同期、hidden_prompt + テストキャラ)

### DIFF
--- a/app/api/internal/generate-creator-looks-admin-preview/route.ts
+++ b/app/api/internal/generate-creator-looks-admin-preview/route.ts
@@ -1,0 +1,360 @@
+/**
+ * POST /api/internal/generate-creator-looks-admin-preview
+ *
+ * Creator Looks 投稿に対し、admin 審査画面で表示する「テストキャラに着せ替えた」preview を
+ * OpenAI / Gemini で 2 枚生成し、user_style_templates の preview_*_image_url に保存する。
+ *
+ * 呼出元:
+ *   - DB Trigger (user_style_template_secrets AFTER INSERT) → enqueue RPC → pg_net 経由
+ *   - Bearer 認証は Vault `creator_looks_extract_secret` (= Edge Function Secrets `EDGE_FUNCTION_SECRET`)
+ *     と同じ値を Vercel env `EDGE_FUNCTION_SECRET` に同期して使う
+ *
+ * 設計判断: docs/planning/creator-looks-implementation-plan.md (admin preview 追加、案 C 派生)
+ *   - 投稿者向け preview は PR #296 で skip 済 (= UX 改善)
+ *   - admin の審査判断には preview が必要 (= テンプレ画像だけでは hidden_prompt の効きが分からない)
+ *   - 非同期生成: 投稿者は即時申請完了、admin は生成完了を待つ
+ *
+ * 入力:
+ *   - Body: { template_id: UUID }
+ *   - Header: Authorization: Bearer <EDGE_FUNCTION_SECRET>
+ *
+ * 処理:
+ *   1. Bearer 認証
+ *   2. user_style_template_secrets から hidden_prompt 取得
+ *   3. user_style_templates から submitted_by_user_id / is_creator_looks 取得 (= Storage path 構築 + 検証)
+ *   4. env INSPIRE_TEST_CHARACTER_IMAGE_URL からテストキャラ画像 fetch
+ *   5. OpenAI + Gemini を並列起動 (= 既存 preview-generation handler と同じパターン)
+ *   6. 成功した preview を Storage に upsert
+ *   7. user_style_templates の preview_*_image_url + preview_generated_at を UPDATE
+ *
+ * 失敗時:
+ *   - hidden_prompt 無し → 404 (= secrets テーブル INSERT 前に誤って呼ばれた可能性)
+ *   - 全 provider 失敗 → 500、preview URL は NULL のまま (= admin 画面で空白表示)
+ *   - 片方失敗 → partial、成功した分だけ保存
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { env } from "@/lib/env";
+import {
+  callOpenAIImageEditMultiInput,
+  parseImageDimensions,
+} from "@/features/generation/lib/openai-image";
+import { createNanobananaClient } from "@/features/generation/lib/nanobanana-client";
+import { resolveGeminiAspectRatio } from "@/shared/generation/gemini-aspect-ratio";
+import { GEMINI_GENERATION_ENABLED } from "@/features/generation/lib/model-config";
+import { sanitizeProviderErrorMessage } from "@/shared/generation/errors";
+
+const OPENAI_TIMEOUT_MS = 90_000;
+
+const requestSchema = z.object({
+  template_id: z.string().uuid(),
+});
+
+type ProviderResult =
+  | { ok: true; provider: "openai" | "gemini"; storagePath: string }
+  | { ok: false; provider: "openai" | "gemini"; error: string };
+
+export async function POST(request: NextRequest) {
+  // 1. Bearer 認証
+  const expectedSecret = env.EDGE_FUNCTION_SECRET;
+  if (!expectedSecret) {
+    console.error(
+      "[admin-preview] EDGE_FUNCTION_SECRET is not set; refusing request",
+    );
+    return NextResponse.json({ error: "server_misconfigured" }, { status: 500 });
+  }
+  const authHeader = request.headers.get("Authorization") || "";
+  if (authHeader !== `Bearer ${expectedSecret}`) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  // 2. body parse
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "invalid_body" }, { status: 400 });
+  }
+  const parsed = requestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "invalid_request" }, { status: 400 });
+  }
+  const templateId = parsed.data.template_id;
+
+  const adminClient = createAdminClient();
+
+  // 3. hidden_prompt 取得 (= secrets テーブル)
+  const { data: secretRow, error: secretError } = await adminClient
+    .from("user_style_template_secrets")
+    .select("hidden_prompt")
+    .eq("template_id", templateId)
+    .maybeSingle();
+  if (secretError) {
+    console.error("[admin-preview] secrets fetch failed", secretError);
+    return NextResponse.json({ error: "secret_fetch_failed" }, { status: 500 });
+  }
+  if (!secretRow?.hidden_prompt) {
+    return NextResponse.json(
+      { error: "hidden_prompt_not_ready" },
+      { status: 404 },
+    );
+  }
+  const hiddenPrompt = secretRow.hidden_prompt;
+
+  // 4. template 行 (= 所有者 + is_creator_looks 検証)
+  const { data: template, error: templateError } = await adminClient
+    .from("user_style_templates")
+    .select("submitted_by_user_id, is_creator_looks")
+    .eq("id", templateId)
+    .maybeSingle();
+  if (templateError || !template) {
+    console.error("[admin-preview] template fetch failed", templateError);
+    return NextResponse.json({ error: "template_not_found" }, { status: 404 });
+  }
+  if (template.is_creator_looks !== true) {
+    return NextResponse.json({ error: "not_creator_looks" }, { status: 400 });
+  }
+  const ownerId = template.submitted_by_user_id;
+
+  // 5. テストキャラ画像取得
+  const testCharacter = await fetchTestCharacterImage();
+  if (!testCharacter) {
+    console.error("[admin-preview] test character missing");
+    return NextResponse.json(
+      { error: "test_character_missing" },
+      { status: 500 },
+    );
+  }
+
+  // 6. OpenAI / Gemini 並列起動
+  const openaiPromise: Promise<ProviderResult> = (async () => {
+    try {
+      const results = await callOpenAIImageEditMultiInput({
+        prompt: hiddenPrompt,
+        inputImages: [
+          { base64: testCharacter.base64, mimeType: testCharacter.mimeType },
+        ],
+        targetSizeBaseIndex: 0,
+        timeoutMs: OPENAI_TIMEOUT_MS,
+        n: 1,
+        quality: "low",
+        sizeTier: "1k",
+      });
+      const result = results[0];
+      const storagePath = `${ownerId}/preview/${templateId}-admin-openai.png`;
+      const upload = await uploadBase64ToStorage(
+        adminClient,
+        storagePath,
+        result.data,
+        "image/png",
+      );
+      if (upload.error) {
+        return { ok: false, provider: "openai", error: upload.error };
+      }
+      return { ok: true, provider: "openai", storagePath };
+    } catch (err) {
+      return {
+        ok: false,
+        provider: "openai",
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  })();
+
+  const geminiPromise: Promise<ProviderResult> = (async () => {
+    try {
+      if (!GEMINI_GENERATION_ENABLED) {
+        return { ok: false, provider: "gemini", error: "gemini_disabled" };
+      }
+      if (!env.GEMINI_API_KEY) {
+        return {
+          ok: false,
+          provider: "gemini",
+          error: "GEMINI_API_KEY is not set",
+        };
+      }
+      const client = createNanobananaClient();
+      const testCharacterDims = parseImageDimensions(
+        new Uint8Array(Buffer.from(testCharacter.base64, "base64")),
+        testCharacter.mimeType,
+      );
+      const aspectRatio = resolveGeminiAspectRatio(testCharacterDims);
+      const response = await client.generateContent({
+        apiKey: env.GEMINI_API_KEY,
+        model: "gemini-3.1-flash-image-preview",
+        body: {
+          contents: [
+            {
+              parts: [
+                {
+                  inline_data: {
+                    mime_type: testCharacter.mimeType,
+                    data: testCharacter.base64,
+                  },
+                },
+                { text: hiddenPrompt },
+              ],
+            },
+          ],
+          generationConfig: {
+            candidateCount: 1,
+            responseModalities: ["TEXT", "IMAGE"],
+            imageConfig: {
+              imageSize: "512",
+              aspectRatio,
+            },
+          },
+        },
+      });
+      if (!response.ok) {
+        const text = await response.text();
+        return {
+          ok: false,
+          provider: "gemini",
+          error: `Gemini HTTP ${response.status}: ${sanitizeProviderErrorMessage(text).slice(0, 300)}`,
+        };
+      }
+      const json = (await response.json()) as {
+        candidates?: Array<{
+          content?: {
+            parts?: Array<{
+              inline_data?: { mime_type?: string; data?: string };
+              inlineData?: { mimeType?: string; data?: string };
+            }>;
+          };
+        }>;
+      };
+      const part = json.candidates?.[0]?.content?.parts?.find(
+        (p) =>
+          (p.inline_data?.data && p.inline_data?.mime_type) ||
+          (p.inlineData?.data && p.inlineData?.mimeType),
+      );
+      const data = part?.inline_data?.data ?? part?.inlineData?.data;
+      const mimeType =
+        part?.inline_data?.mime_type ??
+        part?.inlineData?.mimeType ??
+        "image/png";
+      if (!data) {
+        return {
+          ok: false,
+          provider: "gemini",
+          error: "No image returned from Gemini",
+        };
+      }
+      const ext = mimeType.includes("jpeg") ? "jpg" : "png";
+      const storagePath = `${ownerId}/preview/${templateId}-admin-gemini.${ext}`;
+      const upload = await uploadBase64ToStorage(
+        adminClient,
+        storagePath,
+        data,
+        mimeType,
+      );
+      if (upload.error) {
+        return { ok: false, provider: "gemini", error: upload.error };
+      }
+      return { ok: true, provider: "gemini", storagePath };
+    } catch (err) {
+      return {
+        ok: false,
+        provider: "gemini",
+        error: sanitizeProviderErrorMessage(
+          err instanceof Error ? err.message : String(err),
+        ),
+      };
+    }
+  })();
+
+  const [openaiOutcome, geminiOutcome] = await Promise.all([
+    openaiPromise,
+    geminiPromise,
+  ]);
+
+  // 失敗詳細はログだけ残す (= レスポンスには含めず、admin 画面の空白で示す)
+  if (!openaiOutcome.ok) {
+    console.warn("[admin-preview] openai failed", {
+      templateId,
+      error: openaiOutcome.error,
+    });
+  }
+  if (!geminiOutcome.ok) {
+    console.warn("[admin-preview] gemini failed", {
+      templateId,
+      error: geminiOutcome.error,
+    });
+  }
+
+  // 7. preview URL を DB に書き戻す
+  const updatePayload: Record<string, string | null> = {
+    preview_generated_at: new Date().toISOString(),
+  };
+  if (openaiOutcome.ok) {
+    updatePayload.preview_openai_image_url = openaiOutcome.storagePath;
+  }
+  if (geminiOutcome.ok) {
+    updatePayload.preview_gemini_image_url = geminiOutcome.storagePath;
+  }
+
+  const { error: updateError } = await adminClient
+    .from("user_style_templates")
+    .update(updatePayload)
+    .eq("id", templateId);
+  if (updateError) {
+    console.error("[admin-preview] template update failed", updateError);
+    return NextResponse.json(
+      { error: "template_update_failed" },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({
+    success: openaiOutcome.ok || geminiOutcome.ok,
+    openai_ok: openaiOutcome.ok,
+    gemini_ok: geminiOutcome.ok,
+  });
+}
+
+// ---- inline helpers (= preview-generation handler のロジックを最小流用) ----
+
+async function uploadBase64ToStorage(
+  adminClient: ReturnType<typeof createAdminClient>,
+  storagePath: string,
+  base64: string,
+  mimeType: string,
+): Promise<{ error: string | null }> {
+  const buffer = Buffer.from(base64, "base64");
+  const { error } = await adminClient.storage
+    .from("style-templates")
+    .upload(storagePath, buffer, {
+      contentType: mimeType,
+      upsert: true,
+    });
+  return { error: error ? error.message : null };
+}
+
+async function fetchTestCharacterImage(): Promise<{
+  base64: string;
+  mimeType: string;
+} | null> {
+  const url = env.INSPIRE_TEST_CHARACTER_IMAGE_URL;
+  if (!url) return null;
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      console.error(
+        "[admin-preview] test character fetch failed",
+        response.status,
+      );
+      return null;
+    }
+    const arrayBuffer = await response.arrayBuffer();
+    const base64 = Buffer.from(arrayBuffer).toString("base64");
+    const mimeType =
+      response.headers.get("content-type")?.split(";")[0] ?? "image/png";
+    return { base64, mimeType };
+  } catch (err) {
+    console.error("[admin-preview] test character fetch error", err);
+    return null;
+  }
+}

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -83,6 +83,9 @@ const envSchema = {
   // サーバ専用 kill switch。NEXT_PUBLIC_ プレフィックスを意図的に付けない (= クライアントバンドルに展開させない)
   // Stage 1 では false (= admin role のみアクセス可)、Stage 3 で true (= 全公開)
   CREATOR_LOOKS_ENABLED: process.env.CREATOR_LOOKS_ENABLED,
+  // pg_net → Next.js internal API の Bearer 認証用。
+  // Supabase Vault `creator_looks_extract_secret` と Edge Function Secrets `EDGE_FUNCTION_SECRET` と同じ値にする。
+  EDGE_FUNCTION_SECRET: process.env.EDGE_FUNCTION_SECRET,
 } as const;
 
 /**
@@ -172,6 +175,7 @@ function getEnv() {
     TURNSTILE_SECRET_KEY: envSchema.TURNSTILE_SECRET_KEY || "",
     NEXT_PUBLIC_CATALOG_ENABLED: envSchema.NEXT_PUBLIC_CATALOG_ENABLED || "",
     CREATOR_LOOKS_ENABLED: envSchema.CREATOR_LOOKS_ENABLED || "",
+    EDGE_FUNCTION_SECRET: envSchema.EDGE_FUNCTION_SECRET || "",
   };
 }
 

--- a/supabase/migrations/20260603100400_creator_looks_admin_preview_trigger.sql
+++ b/supabase/migrations/20260603100400_creator_looks_admin_preview_trigger.sql
@@ -1,0 +1,145 @@
+-- ===============================================
+-- Creator Looks: admin 用 preview 自動生成 Trigger
+-- ===============================================
+-- 設計判断: docs/planning/creator-looks-implementation-plan.md (admin preview 追加)
+--
+-- フロー:
+--   1. ユーザー申請 → submissions API → promote RPC → extract-creator-looks-prompt Edge Function (= 既存)
+--   2. Edge Function: hidden_prompt 抽出 → user_style_template_secrets に UPSERT
+--   3. 本 Trigger: secrets テーブル INSERT/UPDATE を捕捉
+--   4. enqueue_creator_looks_admin_preview RPC: Vault secret + pg_net で Next.js API を非同期 POST
+--   5. Next.js API: hidden_prompt + テストキャラ画像 + OpenAI/Gemini で 2 枚生成 → DB UPDATE
+--   6. admin/style-templates: 既存 preview 枠で表示
+--
+-- 注意:
+--   - Next.js API URL は本番固定 (= https://www.persta.ai)。preview/staging 環境では呼ばれない
+--     (= 必要なら別途 Vault に URL を保存して動的解決する設計に変える)
+--   - Bearer 認証は既存 Vault `creator_looks_extract_secret` を流用 (= Vercel env EDGE_FUNCTION_SECRET と同じ値)
+--   - 失敗時は WARNING ログのみ、関数本体の return は true (= INSERT 自体は成功扱い)
+
+BEGIN;
+
+-- ===============================================
+-- 1) enqueue_creator_looks_admin_preview RPC
+-- ===============================================
+
+CREATE OR REPLACE FUNCTION public.enqueue_creator_looks_admin_preview(
+  p_template_id UUID
+) RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_secret TEXT;
+  v_function_url TEXT := 'https://www.persta.ai/api/internal/generate-creator-looks-admin-preview';
+  v_headers JSONB;
+  v_body JSONB;
+  v_is_creator_looks BOOLEAN;
+BEGIN
+  IF p_template_id IS NULL THEN
+    RETURN false;
+  END IF;
+
+  -- 防御: Creator Looks 投稿でなければ no-op
+  SELECT is_creator_looks INTO v_is_creator_looks
+  FROM public.user_style_templates
+  WHERE id = p_template_id;
+  IF v_is_creator_looks IS DISTINCT FROM true THEN
+    RETURN false;
+  END IF;
+
+  -- Vault から secret を取得 (= 既存 enqueue_creator_looks_extraction と同じパターン)
+  BEGIN
+    SELECT decrypted_secret INTO v_secret
+    FROM vault.decrypted_secrets
+    WHERE name = 'creator_looks_extract_secret'
+    LIMIT 1;
+  EXCEPTION WHEN OTHERS THEN
+    v_secret := NULL;
+  END;
+
+  IF v_secret IS NULL OR v_secret = '' THEN
+    RAISE NOTICE 'creator_looks_extract_secret is not set in vault; admin preview will not be enqueued';
+    RETURN false;
+  END IF;
+
+  v_headers := jsonb_build_object(
+    'Content-Type', 'application/json',
+    'Authorization', 'Bearer ' || v_secret
+  );
+
+  v_body := jsonb_build_object('template_id', p_template_id);
+
+  -- pg_net で Next.js API を非同期 POST
+  -- timeout は OpenAI/Gemini の並列実行 (= 最大 90 秒) + バッファ
+  BEGIN
+    PERFORM net.http_post(
+      url := v_function_url,
+      headers := v_headers,
+      body := v_body,
+      timeout_milliseconds := 120000
+    );
+  EXCEPTION WHEN OTHERS THEN
+    RAISE WARNING 'enqueue_creator_looks_admin_preview: net.http_post failed for template %: %',
+      p_template_id, SQLERRM;
+    RETURN false;
+  END;
+
+  RETURN true;
+END;
+$$;
+
+COMMENT ON FUNCTION public.enqueue_creator_looks_admin_preview(UUID) IS
+  'Creator Looks の admin 用 preview (OpenAI/Gemini で着せ替え画像 2 枚) を pg_net 経由で Next.js API に非同期 POST する';
+
+-- authenticated user からは直接呼ばない (= Trigger 内部呼び出し限定)
+REVOKE ALL ON FUNCTION public.enqueue_creator_looks_admin_preview(UUID) FROM PUBLIC, anon, authenticated;
+
+-- ===============================================
+-- 2) Trigger function: secrets INSERT/UPDATE を捕捉
+-- ===============================================
+
+CREATE OR REPLACE FUNCTION public.handle_creator_looks_secrets_change_for_preview()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- INSERT または hidden_prompt が変化した UPDATE の時に admin preview を再生成
+  IF TG_OP = 'INSERT' OR
+     (TG_OP = 'UPDATE' AND NEW.hidden_prompt IS DISTINCT FROM OLD.hidden_prompt) THEN
+    PERFORM public.enqueue_creator_looks_admin_preview(NEW.template_id);
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.handle_creator_looks_secrets_change_for_preview() IS
+  'user_style_template_secrets の INSERT または hidden_prompt 変化時に admin preview 生成を enqueue する Trigger 関数';
+
+-- ===============================================
+-- 3) Trigger 定義
+-- ===============================================
+-- idempotent: 既存 Trigger を消してから作る
+
+DROP TRIGGER IF EXISTS trg_creator_looks_secrets_admin_preview
+  ON public.user_style_template_secrets;
+
+CREATE TRIGGER trg_creator_looks_secrets_admin_preview
+AFTER INSERT OR UPDATE ON public.user_style_template_secrets
+FOR EACH ROW
+EXECUTE FUNCTION public.handle_creator_looks_secrets_change_for_preview();
+
+COMMIT;
+
+-- ===============================================
+-- DOWN:
+-- BEGIN;
+-- DROP TRIGGER IF EXISTS trg_creator_looks_secrets_admin_preview
+--   ON public.user_style_template_secrets;
+-- DROP FUNCTION IF EXISTS public.handle_creator_looks_secrets_change_for_preview();
+-- DROP FUNCTION IF EXISTS public.enqueue_creator_looks_admin_preview(UUID);
+-- COMMIT;
+-- ===============================================


### PR DESCRIPTION
## 概要

admin が `/admin/style-templates` で Creator Looks 投稿を審査するとき、**hidden_prompt + テストキャラ画像で着せ替えた preview を 2 枚自動生成**して表示する。

### 解決する問題

PR #296 (= Step 1 完結化) で投稿者向け試着 preview を skip した。結果として:

- ✅ 投稿者の UX (= 即時申請完了) は改善
- ❌ **admin の審査画面に preview が出なくなった** → テンプレ元画像だけで承認判断は不可能

本 PR で admin 用 preview を **非同期**で生成し、投稿者を待たせず admin の判断材料も確保する (= 両立)。

---

## 完成形フロー

```
[投稿者] 申請する → 即時完了
                ↓ (= 既存)
        Edge Function extract-creator-looks-prompt
                ↓ hidden_prompt 抽出 → user_style_template_secrets UPSERT
                ↓
[新 Trigger]    secrets AFTER INSERT/UPDATE で発火
                ↓
[新 RPC]        enqueue_creator_looks_admin_preview
                ↓ Vault secret + pg_net で非同期 POST (timeout 120秒)
                ↓
[新 API]        /api/internal/generate-creator-looks-admin-preview
                ↓ hidden_prompt + テストキャラ画像 + OpenAI/Gemini 並列 (= 既存 preview-generation 流用)
                ↓ Storage に 2 枚保存 + user_style_templates.preview_*_image_url を UPDATE
                ↓
[admin/style-templates] 既存 preview 枠で自動表示 ✅
```

---

## 変更内容

| ファイル | 操作 | 内容 |
|---|---|---|
| `lib/env.ts` | 修正 | `EDGE_FUNCTION_SECRET` を追加 (= Vercel env 必須) |
| `app/api/internal/generate-creator-looks-admin-preview/route.ts` | 新規 | Bearer 認証 + hidden_prompt 取得 + OpenAI/Gemini 並列 + Storage 保存 + DB UPDATE |
| `supabase/migrations/20260603100400_creator_looks_admin_preview_trigger.sql` | 新規 | secrets AFTER INSERT/UPDATE Trigger + `enqueue_creator_looks_admin_preview` RPC |

---

## 設計判断

| 判断 | 理由 |
|---|---|
| Vault secret は既存 `creator_looks_extract_secret` を流用 | 同じ値を 1 つ管理すれば良い、Vault/Edge Function Secrets/Vercel env の 3 箇所同期で済む |
| Next.js API URL は `https://www.persta.ai` でハードコード | preview/staging 環境への配信は対象外 (= 本番動作確認のみ前提) |
| OpenAI/Gemini 両方並列 | 既存 Inspire preview と同じ。1 枚失敗しても片方は表示できる |
| hidden_prompt をそのまま prompt に使う | テンプレ全体 (= 服+背景) を適用する admin プレビュー用途。`composeCreatorLooksPrompt` の override 機能は不要 |
| 失敗時は WARNING ログのみ | preview URL が NULL のままで admin 画面が空白表示 (= 既存挙動と整合) |
| OpenAI/Gemini 呼び出しロジックは既存 preview-generation handler から最小流用 | 共通化は別 PR で検討 (= DRY violation を許容して最小修正) |

---

## ユーザー側残作業

### 1. Migration を本番に適用

```bash
# CLAUDE.md の Supabase 操作許可範囲に従い、適用は本人 (or 私の承認下) で実行
supabase migration up
```

### 2. Vercel env `EDGE_FUNCTION_SECRET` を追加

Vercel Dashboard → Settings → Environment Variables (Production) で:
- **Key**: `EDGE_FUNCTION_SECRET`
- **Value**: **既存の Vault `creator_looks_extract_secret` と完全に同じ値**

### 3. 動作確認

新規投稿で:
1. admin で `/inspire/submit` → Creator Looks タブで投稿
2. 30 秒〜2 分後、SQL で `user_style_templates.preview_openai_image_url` / `preview_gemini_image_url` に値が入っているか確認
3. `/admin/style-templates` の詳細パネルで preview 枠に 2 枚の試着画像が表示されることを確認

---

## Test plan

- [x] `npm run lint`: baseline (148/45/103) と同一
- [x] `npm run typecheck`: baseline と同一
- [x] `npm run test`: 1593 件パス
- [x] `npm run build -- --webpack`: 成功
- [ ] 本番デプロイ後の動作確認 (= 上記)

---

## 既存テンプレ `8ec24571-...` への対処

既に hidden_prompt は抽出済 (`prompt_length=1565`)。本 PR マージ + migration 適用後に Trigger を手動発火すれば admin preview が生成されます:

```sql
SELECT public.enqueue_creator_looks_admin_preview('8ec24571-0ae2-45b4-81e0-29f1fe965a9c'::uuid);
```

(= もしくは hidden_prompt を UPDATE で touch すれば Trigger 自動発火)

🤖 Generated with [Claude Code](https://claude.com/claude-code)