### PR TITLE
fix(creator-looks): creatorLooksDetail を clientNamespaces に追加 (raw key 表示の修正)

### DIFF
--- a/i18n/messages.ts
+++ b/i18n/messages.ts
@@ -67,6 +67,9 @@ const clientNamespaces = [
   "inspirePage",
   "adminStyleTemplates",
   "imageSourcePicker",
+  // Creator Looks 詳細ページの Client Component (CreatorLooksDetailClient) が
+  // useTranslations("creatorLooksDetail") を使うため client bundle に含める
+  "creatorLooksDetail",
 ] as const satisfies readonly ClientMessageNamespace[];
 
 type NamespaceSelection<TMessages, TNamespaces extends readonly (keyof TMessages)[]> = {

--- a/tests/unit/lib/translation-messages.test.ts
+++ b/tests/unit/lib/translation-messages.test.ts
@@ -12,6 +12,7 @@ const expectedClientNamespaces = [
   "coordinate",
   "contact",
   "credits",
+  "creatorLooksDetail",
   "imageSourcePicker",
   "inspirePage",
   "inspireSubmission",


### PR DESCRIPTION
## 概要

`/inspire/[templateId]` の Creator Looks 詳細ページで、Client Component (= `CreatorLooksDetailClient`) が render する箇所が **i18n キーそのまま (= `creatorLooksDetail.myCharacterLabel` 等)** で表示されていた問題を修正。

## 原因

`i18n/messages.ts` の `clientNamespaces` 配列 (= `getClientMessages` が client にバンドル送出する namespace 一覧) に **`creatorLooksDetail` が含まれていなかった**。

そのため:
- Server Component (= `CreatorLooksDetailSection`) で render される `untitled` / `byLabel` / `usageCount` 等 → 翻訳済 ✅
- Client Component (= `CreatorLooksDetailClient`) の `useTranslations("creatorLooksDetail")` → namespace が undefined → next-intl が raw key を返す ❌

## 修正

`i18n/messages.ts` の `clientNamespaces` に 1 行追加:

```typescript
"imageSourcePicker",
+ // Creator Looks 詳細ページの Client Component (CreatorLooksDetailClient) が
+ // useTranslations("creatorLooksDetail") を使うため client bundle に含める
+ "creatorLooksDetail",
] as const satisfies readonly ClientMessageNamespace[];
```

加えて、対応する TMSG-004 テストの期待値も更新。

## 修正後に正しく表示されるキー一覧

| キー | 日本語 |
|---|---|
| `myCharacterLabel` | マイキャラ |
| `myCharacterHint` | PNG / JPEG / WebP / HEIC、10MB まで。1024px 以上推奨。 |
| `backgroundLabel` | 背景設定 |
| `backgroundCheckboxLabel` | 背景もクリエイターの世界に合わせて変更する |
| `backgroundCheckboxDescription` | OFF のときは元の背景を…ON のときはクリエイターの作品から背景を抽出して反映します。 |
| `poseAngleNote` | ※ カメラアングルとポーズは変わりません。今後のアップデートで対応予定です。 |
| `tryThisLook` | これを着せる |
| `submitting` | 生成中... |
| `missingMyCharacter` | マイキャラの画像をアップロードしてください。 |
| `rateLimitedCooldown` | 少々お待ちください。前回の生成から 60 秒以内です。 |
| `hiddenPromptNotReady` | 準備中です。しばらくしてから再度お試しください。 |
| `generateFailed` | 生成に失敗しました。時間をおいて再試行してください。 |

## 影響範囲

- 既存挙動 (= Server Component の翻訳) は **無変更**
- 既存 Inspire 詳細ページ (= `is_creator_looks=false` で `InspirePageClient` が render される側) は **無関係** (= 別 namespace)

## Test plan

- [x] `npm run lint`: baseline (148/45/103) と同一
- [x] `npm run typecheck`: baseline と同一
- [x] `npm run test`: 1593 件パス (= TMSG-004 期待値も更新)
- [x] `npm run build -- --webpack`: 成功
- [ ] マージ + デプロイ後:
  - `/inspire/[templateId]` (= visible な Creator Looks 投稿) で UI 全体が日本語表示
  - 「マイキャラ」「背景設定」「これを着せる」等が正しく見える

🤖 Generated with [Claude Code](https://claude.com/claude-code)