### PR TITLE
fix(creator-looks): normalizeSourceImage 流用で 413 Content Too Large を解消

### DIFF
--- a/features/inspire/components/CreatorLooksDetailClient.tsx
+++ b/features/inspire/components/CreatorLooksDetailClient.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useTranslations } from "next-intl";
 import { ImageUploader } from "@/features/generation/components/ImageUploader";
+import { normalizeSourceImage } from "@/features/generation/lib/normalize-source-image";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
@@ -67,7 +68,10 @@ export function CreatorLooksDetailClient({
     }
     setSubmitting(true);
     try {
-      const base64 = await fileToBase64(uploadedImage.file);
+      // 4.5MB の Vercel Serverless body 制限を回避するため、送信前にリサイズ/圧縮する
+      // (= 既存 Style / Coordinate と同じ normalizeSourceImage を流用)
+      const normalized = await normalizeSourceImage(uploadedImage.file);
+      const base64 = await fileToBase64(normalized);
       const response = await fetch("/api/generate-async", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -78,7 +82,7 @@ export function CreatorLooksDetailClient({
           count: 1,
           styleTemplateId: templateId,
           sourceImageBase64: base64,
-          sourceImageMimeType: uploadedImage.file.type,
+          sourceImageMimeType: normalized.type,
           // Creator Looks: 衣装は必ず移植 / 背景はユーザー選択
           // アングル / ポーズは現状常に false (= 将来 UI で開放、計画 §A-4)
           overrides: {

--- a/features/inspire/components/InspirePageClient.tsx
+++ b/features/inspire/components/InspirePageClient.tsx
@@ -8,6 +8,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Card } from "@/components/ui/card";
 import { useToast } from "@/components/ui/use-toast";
 import { ImageUploader } from "@/features/generation/components/ImageUploader";
+import { normalizeSourceImage } from "@/features/generation/lib/normalize-source-image";
 import { ImageSourcePicker } from "@/features/generation/components/ImageSourcePicker/ImageSourcePicker";
 import { ImageSourcePickerTrigger } from "@/features/generation/components/ImageSourcePickerTrigger";
 import { useImageSourcePicker } from "@/features/generation/hooks/useImageSourcePicker";
@@ -192,9 +193,12 @@ export function InspirePageClient({
       } else if (selectedRemoteSource?.kind === "generated") {
         requestBody.sourceImageGeneratedId = selectedRemoteSource.id;
       } else if (uploadedImage) {
-        const base64 = await fileToBase64(uploadedImage.file);
+        // 4.5MB の Vercel Serverless body 制限を回避するため、送信前にリサイズ/圧縮する
+        // (= 既存 Style / Coordinate と同じ normalizeSourceImage を流用)
+        const normalized = await normalizeSourceImage(uploadedImage.file);
+        const base64 = await fileToBase64(normalized);
         requestBody.sourceImageBase64 = base64;
-        requestBody.sourceImageMimeType = uploadedImage.file.type;
+        requestBody.sourceImageMimeType = normalized.type;
       }
 
       const response = await fetch("/api/generate-async", {

--- a/tests/unit/features/inspire/inspire-page-client.test.tsx
+++ b/tests/unit/features/inspire/inspire-page-client.test.tsx
@@ -90,6 +90,12 @@ jest.mock(
   }),
 );
 
+// normalizeSourceImage は内部で URL.createObjectURL を使うため jsdom では動かない。
+// テストでは pass-through で十分 (= 元 file をそのまま返す)。
+jest.mock("@/features/generation/lib/normalize-source-image", () => ({
+  normalizeSourceImage: jest.fn(async (file: File) => file),
+}));
+
 // 生成済みタブ/ストックタブの fetch を mock
 const getSourceImageStocksMock = jest.fn(async () => []);
 jest.mock("@/features/generation/lib/database", () => ({


### PR DESCRIPTION
## 概要

Creator Looks (= `/inspire/[templateId]` の「これを着せる」) と既存 Inspire (= `InspirePageClient` の生成) で、マイキャラ画像を base64 化して直接 JSON で `/api/generate-async` に POST していたため、Vercel Serverless の **body 制限 (4.5MB)** を超えた画像で **413 Content Too Large** エラーになっていた問題を修正。

## 原因

| 経路 | 画像送信方法 | 4.5MB 制限対策 |
|---|---|---|
| **Style** (= `/style`) | FormData + `normalizeSourceImage` | ✅ |
| **Coordinate** (= `/coordinate`) | 同上 | ✅ |
| **Inspire** (= `InspirePageClient`) | JSON + base64 (= 33% 増) | ❌ |
| **Creator Looks** (= `CreatorLooksDetailClient`) | 同上 | ❌ |

つまり Style / Coordinate 経路には既に `features/generation/lib/normalize-source-image.ts` の `normalizeSourceImage` (= 2MB 超で長辺 1024px + JPEG 70% に強圧縮) が適用されていたが、Inspire / Creator Looks には未適用だった。

## 修正

**既存共通 helper の再利用** (= 新規依存追加なし、新規 hook 作成なし)。

```typescript
// before
const base64 = await fileToBase64(uploadedImage.file);

// after
const normalized = await normalizeSourceImage(uploadedImage.file);
const base64 = await fileToBase64(normalized);
```

加えて、JPEG 圧縮で MIME が変わる可能性があるため `sourceImageMimeType` も `normalized.type` を使うように修正。

### 変更ファイル

| ファイル | 操作 | 内容 |
|---|---|---|
| `features/inspire/components/CreatorLooksDetailClient.tsx` | 修正 | `normalizeSourceImage` import + 送信前呼び出し |
| `features/inspire/components/InspirePageClient.tsx` | 修正 | 同上 (= 直接アップロード経路) |
| `tests/unit/features/inspire/inspire-page-client.test.tsx` | 修正 | `normalizeSourceImage` を pass-through で mock (= jsdom default で `URL.createObjectURL` が未実装のため) |

## normalizeSourceImage の仕様

```
2MB 超             → 長辺 1024px + JPEG 70% 強圧縮
2MB 以下 + 長辺 > 2048px → 長辺 2048px + JPEG 80%
それ以外            → そのまま
```

## コンポーネント化方針

ユーザー要望 (= 「同じようにしてください」「コンポーネント化できるならして」) について:

- **既存共通 helper `normalizeSourceImage` を流用する**形を採用 (= 関数レベルの共通化、Style/Coordinate と同じパターン)
- 新規 hook (`useNormalizedFileUpload` 等) や component 化はオーバーキルと判断 (= 1 行追加で済む)
- 将来 ImageSourcePicker (= 生成済み画像 / ストック画像から選ぶ UI) を Creator Looks にも導入する案は別 PR で検討

## Test plan

- [x] `npm run lint`: baseline (148/45/103) と同一
- [x] `npm run typecheck`: baseline と同一
- [x] `npm run test`: 1593 件パス (= 既存 inspire-page-client.test.tsx の mock 追加で失敗回避)
- [x] `npm run build -- --webpack`: 成功
- [ ] マージ + デプロイ後:
  - Creator Looks 投稿の admin 生成で 4MB 以上のマイキャラ画像でも 413 が出ないことを確認
  - 既存 Inspire 投稿でも同様に大きい画像で生成できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)