### PR TITLE
feat(creator-looks): モデル選択 + 「コーデ開始！(◯◯ペルコイン)」ボタンに刷新

### DIFF
--- a/features/inspire/components/CreatorLooksDetailClient.tsx
+++ b/features/inspire/components/CreatorLooksDetailClient.tsx
@@ -2,12 +2,19 @@
 
 import { useState } from "react";
 import { useTranslations } from "next-intl";
-import { ImageUploader } from "@/features/generation/components/ImageUploader";
-import { normalizeSourceImage } from "@/features/generation/lib/normalize-source-image";
+import { Card } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
-import { Button } from "@/components/ui/button";
 import { useToast } from "@/components/ui/use-toast";
+import { ImageUploader } from "@/features/generation/components/ImageUploader";
+import { normalizeSourceImage } from "@/features/generation/lib/normalize-source-image";
+import { GenerationModelControls } from "@/features/generation/components/GenerationModelControls";
+import { GenerationSubmitButton } from "@/features/generation/components/GenerationSubmitButton";
+import {
+  getPercoinCost,
+  isFreePlanAllowedModel,
+} from "@/features/generation/lib/model-config";
+import { SubscriptionUpsellDialog } from "@/features/subscription/components/SubscriptionUpsellDialog";
 import type {
   UploadedImage,
   GeminiModel,
@@ -24,13 +31,16 @@ import { InspireGenerationFlow } from "./InspireGenerationFlow";
  *   - 注釈で「カメラアングル / ポーズは変わらない (今後対応予定)」を明示 (REQ-018, モックアップ 03)
  *   - generationType=inspire で API に投げる (= 既存パイプラインに乗せる、ADR-002)
  *   - override_outfit=true / override_background=<チェック状態> / override_angle=false / override_pose=false
+ *   - モデル選択 + ペルコイン消費量表示は Style/Inspire と同じ GenerationModelControls /
+ *     GenerationSubmitButton を流用 (= UX 統一、Free plan upsell も同じ動線)
+ *   - 生成枚数は 1 枚固定 (= Creator Looks は「着せ替えを 1 回試す」用途)
  */
 
 interface CreatorLooksDetailClientProps {
   templateId: string;
   /**
-   * 将来モデル選択 UI を出すための情報。Stage 1 では未使用 (= 固定モデル)。
-   * Phase 5 以降で MODEL 選択 UI を追加する際に活用予定。
+   * Subscription plan (= Free plan で課金モデルを選んだ時に Upsell ダイアログを開くため)。
+   * 未指定なら "free" 扱い (= fail-closed、課金モデル選択は upsell へ誘導)。
    */
   subscriptionPlan?: string;
 }
@@ -50,6 +60,7 @@ async function fileToBase64(file: File): Promise<string> {
 
 export function CreatorLooksDetailClient({
   templateId,
+  subscriptionPlan,
 }: CreatorLooksDetailClientProps) {
   const t = useTranslations("creatorLooksDetail");
   const { toast } = useToast();
@@ -58,8 +69,13 @@ export function CreatorLooksDetailClient({
   const [backgroundEnabled, setBackgroundEnabled] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [activeJobId, setActiveJobId] = useState<string | null>(null);
+  const [selectedModel, setSelectedModel] = useState<GeminiModel>(
+    DEFAULT_GENERATION_MODEL,
+  );
+  const [isUpsellOpen, setIsUpsellOpen] = useState(false);
 
-  const selectedModel: GeminiModel = DEFAULT_GENERATION_MODEL;
+  const isFreePlan = subscriptionPlan === "free" || !subscriptionPlan;
+  const totalPercoinCost = getPercoinCost(selectedModel) * 1;
 
   const handleSubmit = async () => {
     if (!uploadedImage) {
@@ -167,18 +183,35 @@ export function CreatorLooksDetailClient({
         {t("poseAngleNote")}
       </p>
 
-      {/* Try this look CTA */}
-      <div>
-        <Button
-          type="button"
-          size="lg"
-          className="w-full"
-          onClick={handleSubmit}
-          disabled={submitDisabled}
-        >
-          {submitting ? t("submitting") : t("tryThisLook")}
-        </Button>
-      </div>
+      {/* モデル選択 + 生成 CTA (= Style / Inspire と同じ GenerationModelControls / SubmitButton) */}
+      <Card className="p-6">
+        <div className="space-y-6">
+          <GenerationModelControls
+            value={selectedModel}
+            onChange={setSelectedModel}
+            onLockedClick={() => {
+              if (isFreePlan) {
+                setIsUpsellOpen(true);
+              }
+            }}
+            authState="authenticated"
+            modelLabel={t("modelLabel")}
+            disabled={submitting || activeJobId !== null}
+            isModelSelectable={
+              isFreePlan ? isFreePlanAllowedModel : undefined
+            }
+          />
+
+          <GenerationSubmitButton
+            onClick={handleSubmit}
+            disabled={submitDisabled}
+            isGenerating={submitting}
+            generateLabel={t("tryThisLook")}
+            generatingLabel={t("submitting")}
+            costAmount={totalPercoinCost}
+          />
+        </div>
+      </Card>
 
       {/* 生成中フロー (= 既存 InspireGenerationFlow 完全流用) */}
       {/* aspectRatio: モックアップ通り 1:1 を仮定 (= 詳細ページのテンプレ大画像が aspect-square) */}
@@ -198,6 +231,12 @@ export function CreatorLooksDetailClient({
           onComplete={() => setActiveJobId(null)}
         />
       )}
+
+      {/* Free plan upsell ダイアログ (= 課金モデルを選択しようとした時に表示) */}
+      <SubscriptionUpsellDialog
+        open={isUpsellOpen}
+        onOpenChange={setIsUpsellOpen}
+      />
     </div>
   );
 }

--- a/messages/ar.ts
+++ b/messages/ar.ts
@@ -1748,6 +1748,7 @@ export const arMessages = {
       "When OFF, the original background is preserved as much as possible. When ON, the background from the creator's image is extracted and applied.",
     poseAngleNote:
       "* Camera angle and pose are preserved. Future update planned.",
+    modelLabel: "نموذج الإنشاء",
     tryThisLook: "Try this look",
     submitting: "Generating...",
     missingMyCharacter: "Please upload your character image.",

--- a/messages/de.ts
+++ b/messages/de.ts
@@ -1751,6 +1751,7 @@ export const deMessages = {
       "When OFF, the original background is preserved as much as possible. When ON, the background from the creator's image is extracted and applied.",
     poseAngleNote:
       "* Camera angle and pose are preserved. Future update planned.",
+    modelLabel: "Generierungsmodell",
     tryThisLook: "Try this look",
     submitting: "Generating...",
     missingMyCharacter: "Please upload your character image.",

--- a/messages/en.ts
+++ b/messages/en.ts
@@ -1747,6 +1747,7 @@ export const enMessages = {
       "When OFF, the original background is preserved as much as possible. When ON, the background from the creator's image is extracted and applied.",
     poseAngleNote:
       "* Camera angle and pose are preserved. Future update planned.",
+    modelLabel: "Generation model",
     tryThisLook: "Try this look",
     submitting: "Generating...",
     missingMyCharacter: "Please upload your character image.",

--- a/messages/es.ts
+++ b/messages/es.ts
@@ -1751,6 +1751,7 @@ export const esMessages = {
       "When OFF, the original background is preserved as much as possible. When ON, the background from the creator's image is extracted and applied.",
     poseAngleNote:
       "* Camera angle and pose are preserved. Future update planned.",
+    modelLabel: "Modelo de generación",
     tryThisLook: "Try this look",
     submitting: "Generating...",
     missingMyCharacter: "Please upload your character image.",

--- a/messages/fr.ts
+++ b/messages/fr.ts
@@ -1751,6 +1751,7 @@ export const frMessages = {
       "When OFF, the original background is preserved as much as possible. When ON, the background from the creator's image is extracted and applied.",
     poseAngleNote:
       "* Camera angle and pose are preserved. Future update planned.",
+    modelLabel: "Modèle de génération",
     tryThisLook: "Try this look",
     submitting: "Generating...",
     missingMyCharacter: "Please upload your character image.",

--- a/messages/hi.ts
+++ b/messages/hi.ts
@@ -1749,6 +1749,7 @@ export const hiMessages = {
       "When OFF, the original background is preserved as much as possible. When ON, the background from the creator's image is extracted and applied.",
     poseAngleNote:
       "* Camera angle and pose are preserved. Future update planned.",
+    modelLabel: "जनरेशन मॉडल",
     tryThisLook: "Try this look",
     submitting: "Generating...",
     missingMyCharacter: "Please upload your character image.",

--- a/messages/id.ts
+++ b/messages/id.ts
@@ -1750,6 +1750,7 @@ export const idMessages = {
       "When OFF, the original background is preserved as much as possible. When ON, the background from the creator's image is extracted and applied.",
     poseAngleNote:
       "* Camera angle and pose are preserved. Future update planned.",
+    modelLabel: "Model generasi",
     tryThisLook: "Try this look",
     submitting: "Generating...",
     missingMyCharacter: "Please upload your character image.",

--- a/messages/it.ts
+++ b/messages/it.ts
@@ -1751,6 +1751,7 @@ export const itMessages = {
       "When OFF, the original background is preserved as much as possible. When ON, the background from the creator's image is extracted and applied.",
     poseAngleNote:
       "* Camera angle and pose are preserved. Future update planned.",
+    modelLabel: "Modello di generazione",
     tryThisLook: "Try this look",
     submitting: "Generating...",
     missingMyCharacter: "Please upload your character image.",

--- a/messages/ja.ts
+++ b/messages/ja.ts
@@ -1675,7 +1675,8 @@ export const jaMessages = {
       "OFF のときは元の背景をできるだけ維持し、ON のときはクリエイターの作品から背景を抽出して反映します。",
     poseAngleNote:
       "※ カメラアングルとポーズは変わりません。今後のアップデートで対応予定です。",
-    tryThisLook: "これを着せる",
+    modelLabel: "生成モデル",
+    tryThisLook: "コーデ開始！",
     submitting: "生成中...",
     missingMyCharacter: "マイキャラの画像をアップロードしてください。",
     rateLimitedCooldown:

--- a/messages/ko.ts
+++ b/messages/ko.ts
@@ -1747,6 +1747,7 @@ export const koMessages = {
       "When OFF, the original background is preserved as much as possible. When ON, the background from the creator's image is extracted and applied.",
     poseAngleNote:
       "* Camera angle and pose are preserved. Future update planned.",
+    modelLabel: "생성 모델",
     tryThisLook: "Try this look",
     submitting: "Generating...",
     missingMyCharacter: "Please upload your character image.",

--- a/messages/pt.ts
+++ b/messages/pt.ts
@@ -1751,6 +1751,7 @@ export const ptMessages = {
       "When OFF, the original background is preserved as much as possible. When ON, the background from the creator's image is extracted and applied.",
     poseAngleNote:
       "* Camera angle and pose are preserved. Future update planned.",
+    modelLabel: "Modelo de geração",
     tryThisLook: "Try this look",
     submitting: "Generating...",
     missingMyCharacter: "Please upload your character image.",

--- a/messages/th.ts
+++ b/messages/th.ts
@@ -1747,6 +1747,7 @@ export const thMessages = {
       "When OFF, the original background is preserved as much as possible. When ON, the background from the creator's image is extracted and applied.",
     poseAngleNote:
       "* Camera angle and pose are preserved. Future update planned.",
+    modelLabel: "โมเดลการสร้าง",
     tryThisLook: "Try this look",
     submitting: "Generating...",
     missingMyCharacter: "Please upload your character image.",

--- a/messages/vi.ts
+++ b/messages/vi.ts
@@ -1748,6 +1748,7 @@ export const viMessages = {
       "When OFF, the original background is preserved as much as possible. When ON, the background from the creator's image is extracted and applied.",
     poseAngleNote:
       "* Camera angle and pose are preserved. Future update planned.",
+    modelLabel: "Mô hình tạo",
     tryThisLook: "Try this look",
     submitting: "Generating...",
     missingMyCharacter: "Please upload your character image.",

--- a/messages/zh-CN.ts
+++ b/messages/zh-CN.ts
@@ -1745,6 +1745,7 @@ export const zhCnMessages = {
       "When OFF, the original background is preserved as much as possible. When ON, the background from the creator's image is extracted and applied.",
     poseAngleNote:
       "* Camera angle and pose are preserved. Future update planned.",
+    modelLabel: "生成模型",
     tryThisLook: "Try this look",
     submitting: "Generating...",
     missingMyCharacter: "Please upload your character image.",

--- a/messages/zh-TW.ts
+++ b/messages/zh-TW.ts
@@ -1745,6 +1745,7 @@ export const zhTwMessages = {
       "When OFF, the original background is preserved as much as possible. When ON, the background from the creator's image is extracted and applied.",
     poseAngleNote:
       "* Camera angle and pose are preserved. Future update planned.",
+    modelLabel: "生成模型",
     tryThisLook: "Try this look",
     submitting: "Generating...",
     missingMyCharacter: "Please upload your character image.",


### PR DESCRIPTION
## 概要

Creator Looks 詳細ページ (= `/inspire/[templateId]`) のシンプルな「これを着せる」ボタンを、**Style / Inspire と同じ `GenerationModelControls` + `GenerationSubmitButton` パターン**に置き換え。

## 解決すること

| 観点 | Before | After |
|---|---|---|
| ボタン文言 | 「これを着せる」 | **「コーデ開始！(◯◯ペルコイン)」** (= Style 統一) |
| モデル選択 UI | 無し (= 固定モデル) | **`GenerationModelControls` で選択可** |
| ペルコイン消費量表示 | 無し | ボタンに明示 |
| Free plan upsell | 無し | 課金モデル選択時に `SubscriptionUpsellDialog` |
| 枚数 | 1 枚固定 (= 維持) | 1 枚固定 (= 維持、CountSelector は導入しない) |

## 変更内容

### `features/inspire/components/CreatorLooksDetailClient.tsx`
- `GenerationModelControls`、`GenerationSubmitButton`、`SubscriptionUpsellDialog`、`getPercoinCost`、`isFreePlanAllowedModel`、`Card` を import
- `selectedModel` を state 化 (= 現状は `const` で固定)
- `isUpsellOpen` state 追加
- `totalPercoinCost = getPercoinCost(selectedModel) * 1` 計算
- UI: `<Button>` を `<Card>` + `<GenerationModelControls>` + `<GenerationSubmitButton>` に置き換え
- `<SubscriptionUpsellDialog>` をマウント

### i18n (`messages/*.ts`)
- ja: `tryThisLook: "これを着せる"` → `"コーデ開始！"` (= Style 画面と統一)
- 全 15 言語: `modelLabel: "生成モデル"` / `"Generation model"` 等を新規追加

## 設計判断

| 判断 | 理由 |
|---|---|
| 既存共通 component (`GenerationModelControls` / `GenerationSubmitButton` / `SubscriptionUpsellDialog`) を再利用 | 既に Style/Inspire で動作実績、UX 統一 + メンテナンス性向上 |
| 新規 component 化は **しない** | 既存 components を流用するだけで十分、過剰抽象化を避ける |
| 生成枚数は 1 枚固定 (= CountSelector 導入しない) | Creator Looks は「着せ替えを 1 回試す」用途、UI シンプル維持 |
| Free plan upsell ダイアログを追加 | Stage 2/3 で投稿者 ≠ admin になった時に必要、Stage 1 では実質発火しないが先回り |
| ja 以外の `tryThisLook` 文言は **既存維持** | 各言語の生成ボタンラベルは独自の自然な訳に従う方が良い (= 「コーデ開始！」を全言語に強要しない) |

## 影響範囲

- 既存 InspirePageClient: **無変更**
- 既存 Style/Coordinate: **無変更**
- Creator Looks 詳細ページのみ: ボタン UI 刷新、モデル選択 + ペルコイン表示

## Test plan

- [x] `npm run lint`: baseline (148/45/103) と同一
- [x] `npm run typecheck`: baseline と同一
- [x] `npm run test`: 1593 件パス (= 全 15 言語 i18n キー追加で TMSG-002 もパス維持)
- [x] `npm run build -- --webpack`: 成功
- [ ] マージ + デプロイ後:
  - `/inspire/[templateId]` (= visible な Creator Looks 投稿) で「コーデ開始！(◯◯ペルコイン)」ボタン表示
  - 「生成モデル」UI でモデル選択可能、選択でコスト表示が変化
  - Free plan で課金モデル (例: gemini-3.1) を選択しようとすると Upsell ダイアログが開く
  - 既存 `/inspire` 投稿フロー (= 非 Creator Looks) は無変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)