### PR TITLE
feat(creator-looks): admin/allowlist を cap 対象外化 + template 削除可能化 + メッセージ正確化

### DIFF
--- a/app/api/style-templates/preview-generation/handler.ts
+++ b/app/api/style-templates/preview-generation/handler.ts
@@ -23,7 +23,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { getUser, isInspireSubmitterAllowed } from "@/lib/auth";
-import { isCreatorLooksEnabledForUser } from "@/lib/auth/creator-looks";
+import {
+  isAdminUser,
+  isCreatorLooksEnabledForUser,
+  isInCreatorLooksAllowlist,
+} from "@/lib/auth/creator-looks";
 import { ensureSameOrigin } from "@/lib/security/same-origin";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { env, isInspireFeatureEnabled } from "@/lib/env";
@@ -247,33 +251,39 @@ export async function handlePreviewGeneration(
       );
     }
     // (c) 1 日 2 件 cap (= REQ-011 API 層先行 reject、Storage upload と Edge Function 起動を防ぐ)
-    const dailyWindowStart = new Date(
-      Date.now() - CREATOR_LOOKS_DAILY_WINDOW_HOURS * 60 * 60 * 1000
-    ).toISOString();
-    const { count: dailyCount, error: dailyError } = await adminClient
-      .from("user_style_templates")
-      .select("id", { count: "exact", head: true })
-      .eq("submitted_by_user_id", user.id)
-      .eq("is_creator_looks", true)
-      .neq("moderation_status", "draft")
-      .gte("created_at", dailyWindowStart);
-    if (dailyError) {
-      console.error(
-        "[preview-generation] creator_looks daily cap query failed",
-        dailyError
-      );
-      return jsonError(
-        copy.templateGenerationFailed,
-        "CREATOR_LOOKS_CAP_QUERY_FAILED",
-        500
-      );
-    }
-    if ((dailyCount ?? 0) >= CREATOR_LOOKS_DAILY_CAP) {
-      return jsonError(
-        copy.rateLimitDaily,
-        "CREATOR_LOOKS_DAILY_CAP_EXCEEDED",
-        429
-      );
+    // 運営者 (admin_users) と Stage 2 招待クリエイター (creator_looks_allowlist) は対象外
+    // (= 動作確認 / 運用テストで投稿を繰り返すため)
+    const isExemptFromDailyCap =
+      isAdminUser(user) || (await isInCreatorLooksAllowlist(user.id));
+    if (!isExemptFromDailyCap) {
+      const dailyWindowStart = new Date(
+        Date.now() - CREATOR_LOOKS_DAILY_WINDOW_HOURS * 60 * 60 * 1000
+      ).toISOString();
+      const { count: dailyCount, error: dailyError } = await adminClient
+        .from("user_style_templates")
+        .select("id", { count: "exact", head: true })
+        .eq("submitted_by_user_id", user.id)
+        .eq("is_creator_looks", true)
+        .neq("moderation_status", "draft")
+        .gte("created_at", dailyWindowStart);
+      if (dailyError) {
+        console.error(
+          "[preview-generation] creator_looks daily cap query failed",
+          dailyError
+        );
+        return jsonError(
+          copy.templateGenerationFailed,
+          "CREATOR_LOOKS_CAP_QUERY_FAILED",
+          500
+        );
+      }
+      if ((dailyCount ?? 0) >= CREATOR_LOOKS_DAILY_CAP) {
+        return jsonError(
+          copy.rateLimitDaily,
+          "CREATOR_LOOKS_DAILY_CAP_EXCEEDED",
+          429
+        );
+      }
     }
   }
 

--- a/features/inspire/components/UserStyleTemplateSubmissionForm.tsx
+++ b/features/inspire/components/UserStyleTemplateSubmissionForm.tsx
@@ -523,7 +523,7 @@ export function UserStyleTemplateSubmissionForm({
       if (previewResponse.status === 429) {
         const data = await previewResponse.json().catch(() => null);
         if (data?.errorCode === "CREATOR_LOOKS_DAILY_CAP_EXCEEDED") {
-          setErrorMessage(t("submitFailedCap"));
+          setErrorMessage(t("submitFailedCreatorLooksDailyCap"));
         } else {
           setErrorMessage(t("submitFailedRateLimit"));
         }

--- a/messages/ar.ts
+++ b/messages/ar.ts
@@ -443,6 +443,7 @@ export const arMessages = {
     submitFailedConsent: "يُرجى تأكيد موافقة حقوق الطبع والنشر.",
     submitFailedRateLimit:
       "وصلت إلى حد توليد المعاينات (10 لكل 24 ساعة).",
+    submitFailedCreatorLooksDailyCap: "منشورات Creator Looks محدودة بـ ٢ منشورات يوميًا. يرجى المحاولة غدًا.",
     submitFailedCap:
       "وصلت إلى حد 5 إرسالات نشطة. اسحب إرسالًا قائمًا وحاول مرة أخرى.",
     submitFailedSafety:

--- a/messages/de.ts
+++ b/messages/de.ts
@@ -446,6 +446,7 @@ export const deMessages = {
     submitFailedConsent: "Bitte die Urheberrechtszustimmung bestätigen.",
     submitFailedRateLimit:
       "Du hast das Vorschau-Generierungslimit erreicht (10 pro 24 h).",
+    submitFailedCreatorLooksDailyCap: "Creator-Looks-Beiträge sind auf 2 pro Tag begrenzt. Bitte versuchen Sie es morgen erneut.",
     submitFailedCap:
       "Du hast das Limit von 5 aktiven Einreichungen erreicht. Ziehe eine zurück und versuche es erneut.",
     submitFailedSafety:

--- a/messages/en.ts
+++ b/messages/en.ts
@@ -443,6 +443,7 @@ export const enMessages = {
     submitFailedConsent: "Please confirm copyright consent.",
     submitFailedRateLimit:
       "You've reached the preview generation limit (10 per 24h).",
+    submitFailedCreatorLooksDailyCap: "Creator Looks submissions are limited to 2 per day. Please try again tomorrow.",
     submitFailedCap:
       "You've reached the limit of 5 active submissions. Withdraw an existing one and try again.",
     submitFailedSafety:

--- a/messages/es.ts
+++ b/messages/es.ts
@@ -446,6 +446,7 @@ export const esMessages = {
     submitFailedConsent: "Confirma el consentimiento de derechos de autor.",
     submitFailedRateLimit:
       "Has alcanzado el límite de generaciones de previsualización (10 cada 24 h).",
+    submitFailedCreatorLooksDailyCap: "Las publicaciones de Creator Looks están limitadas a 2 por día. Inténtalo de nuevo mañana.",
     submitFailedCap:
       "Has llegado al límite de 5 envíos activos. Retira uno y vuelve a intentarlo.",
     submitFailedSafety:

--- a/messages/fr.ts
+++ b/messages/fr.ts
@@ -446,6 +446,7 @@ export const frMessages = {
     submitFailedConsent: "Veuillez confirmer le consentement aux droits d'auteur.",
     submitFailedRateLimit:
       "Vous avez atteint la limite de génération d'aperçus (10 par 24 h).",
+    submitFailedCreatorLooksDailyCap: "Les publications Creator Looks sont limitées à 2 par jour. Veuillez réessayer demain.",
     submitFailedCap:
       "Vous avez atteint la limite de 5 soumissions actives. Retirez-en une et réessayez.",
     submitFailedSafety:

--- a/messages/hi.ts
+++ b/messages/hi.ts
@@ -444,6 +444,7 @@ export const hiMessages = {
     submitFailedConsent: "कृपया कॉपीराइट सहमति की पुष्टि करें।",
     submitFailedRateLimit:
       "आप पूर्वावलोकन उत्पन्न करने की सीमा (24 घंटे में 10) तक पहुँच गए हैं।",
+    submitFailedCreatorLooksDailyCap: "Creator Looks पोस्ट प्रति दिन 2 तक सीमित हैं। कृपया कल पुनः प्रयास करें।",
     submitFailedCap:
       "आप 5 सक्रिय सबमिशन की सीमा तक पहुँच गए हैं। मौजूदा सबमिशन वापस लें और फिर से प्रयास करें।",
     submitFailedSafety:

--- a/messages/id.ts
+++ b/messages/id.ts
@@ -445,6 +445,7 @@ export const idMessages = {
     submitFailedConsent: "Mohon konfirmasi persetujuan hak cipta.",
     submitFailedRateLimit:
       "Kamu telah mencapai batas pembuatan pratinjau (10 per 24 jam).",
+    submitFailedCreatorLooksDailyCap: "Postingan Creator Looks dibatasi 2 per hari. Silakan coba lagi besok.",
     submitFailedCap:
       "Kamu telah mencapai batas 5 kiriman aktif. Tarik salah satu dan coba lagi.",
     submitFailedSafety:

--- a/messages/it.ts
+++ b/messages/it.ts
@@ -446,6 +446,7 @@ export const itMessages = {
     submitFailedConsent: "Conferma il consenso al copyright.",
     submitFailedRateLimit:
       "Hai raggiunto il limite di generazione delle anteprime (10 ogni 24 ore).",
+    submitFailedCreatorLooksDailyCap: "I post di Creator Looks sono limitati a 2 al giorno. Riprova domani.",
     submitFailedCap:
       "Hai raggiunto il limite di 5 invii attivi. Ritirane uno e riprova.",
     submitFailedSafety:

--- a/messages/ja.ts
+++ b/messages/ja.ts
@@ -439,6 +439,8 @@ export const jaMessages = {
       "プレビュー生成回数の上限に達しました（24h で 10 回まで）。",
     submitFailedCap:
       "申請可能なテンプレ数の上限（5 件）を超えています。既存の申請を取り下げてから再試行してください。",
+    submitFailedCreatorLooksDailyCap:
+      "Creator Looks の投稿は 1 日 2 件までです。明日以降に再度お試しください。",
     submitFailedSafety:
       "安全性ポリシーによりプレビューを生成できませんでした。別の画像でお試しください。",
     submitFailedTooLarge:

--- a/messages/ko.ts
+++ b/messages/ko.ts
@@ -443,6 +443,7 @@ export const koMessages = {
     submitFailedConsent: "저작권 동의를 확인해 주세요.",
     submitFailedRateLimit:
       "미리보기 생성 한도(24시간 10회)에 도달했습니다.",
+    submitFailedCreatorLooksDailyCap: "Creator Looks 게시는 하루 2건까지입니다. 내일 다시 시도해 주세요.",
     submitFailedCap:
       "공개 중인 투고 한도(5건)에 도달했습니다. 기존 투고를 취하한 뒤 다시 시도해 주세요.",
     submitFailedSafety:

--- a/messages/pt.ts
+++ b/messages/pt.ts
@@ -446,6 +446,7 @@ export const ptMessages = {
     submitFailedConsent: "Confirme o consentimento de direitos autorais.",
     submitFailedRateLimit:
       "Você atingiu o limite de gerações de preview (10 a cada 24h).",
+    submitFailedCreatorLooksDailyCap: "As publicações do Creator Looks são limitadas a 2 por dia. Tente novamente amanhã.",
     submitFailedCap:
       "Você atingiu o limite de 5 envios ativos. Retire um existente e tente novamente.",
     submitFailedSafety:

--- a/messages/th.ts
+++ b/messages/th.ts
@@ -443,6 +443,7 @@ export const thMessages = {
     submitFailedConsent: "โปรดยืนยันความยินยอมเรื่องลิขสิทธิ์",
     submitFailedRateLimit:
       "ถึงขีดจำกัดการสร้างตัวอย่างแล้ว (10 ครั้งต่อ 24 ชั่วโมง)",
+    submitFailedCreatorLooksDailyCap: "การโพสต์ Creator Looks จำกัด 2 รายการต่อวัน กรุณาลองใหม่ในวันพรุ่งนี้",
     submitFailedCap:
       "ถึงขีดจำกัด 5 รายการที่กำลังเผยแพร่อยู่ ถอนออกหนึ่งรายการแล้วลองอีกครั้ง",
     submitFailedSafety:

--- a/messages/vi.ts
+++ b/messages/vi.ts
@@ -443,6 +443,7 @@ export const viMessages = {
     submitFailedConsent: "Vui lòng xác nhận đồng ý về bản quyền.",
     submitFailedRateLimit:
       "Bạn đã đạt giới hạn tạo bản xem trước (10 lần / 24 giờ).",
+    submitFailedCreatorLooksDailyCap: "Bài đăng Creator Looks giới hạn 2 bài/ngày. Vui lòng thử lại vào ngày mai.",
     submitFailedCap:
       "Bạn đã đạt giới hạn 5 lần gửi đang hoạt động. Hãy rút một lần và thử lại.",
     submitFailedSafety:

--- a/messages/zh-CN.ts
+++ b/messages/zh-CN.ts
@@ -442,6 +442,7 @@ export const zhCnMessages = {
     submitFailedConsent: "请确认版权同意。",
     submitFailedRateLimit:
       "已达到预览生成上限 (24 小时 10 次)。",
+    submitFailedCreatorLooksDailyCap: "Creator Looks 投稿每日限 2 件。请明天再试。",
     submitFailedCap:
       "已达到 5 个公开投稿上限。请撤回一个现有投稿后再试。",
     submitFailedSafety:

--- a/messages/zh-TW.ts
+++ b/messages/zh-TW.ts
@@ -442,6 +442,7 @@ export const zhTwMessages = {
     submitFailedConsent: "請確認著作權同意。",
     submitFailedRateLimit:
       "已達到預覽生成上限 (24 小時 10 次)。",
+    submitFailedCreatorLooksDailyCap: "Creator Looks 投稿每日限 2 件。請明天再試。",
     submitFailedCap:
       "公開中的投稿已達 5 件上限。請先撤回現有投稿後再試。",
     submitFailedSafety:

--- a/supabase/migrations/20260603100500_relax_image_jobs_inspire_template_check.sql
+++ b/supabase/migrations/20260603100500_relax_image_jobs_inspire_template_check.sql
@@ -1,0 +1,36 @@
+-- ===============================================
+-- image_jobs.inspire_template_consistency_check を緩和
+-- ===============================================
+-- 背景:
+--   user_style_templates.id に対する FK (image_jobs.style_template_id) は ON DELETE SET NULL。
+--   テンプレートを削除すると参照側 image_jobs.style_template_id が NULL になるが、
+--   既存 CHECK 制約 `(generation_type = 'inspire') = (style_template_id IS NOT NULL)` に
+--   違反して DELETE が失敗していた。
+--
+-- 設計判断:
+--   - 削除済テンプレを参照する過去 image_jobs は「生成記録としては残す」(= 消費者の生成履歴を保全)
+--   - inspire 生成記録だが style_template_id=NULL (= 削除済テンプレ参照) のパターンを許容する
+--   - INSERT 時の整合性 (= 新規 inspire 生成では style_template_id 必須) は API 層 (/api/generate-async handler)
+--     で validate しているので DB 制約は不要
+--
+-- 緩和方針:
+--   - CHECK 制約を削除 (= 過去の inspire jobs で style_template_id=NULL を許容)
+
+BEGIN;
+
+ALTER TABLE public.image_jobs
+  DROP CONSTRAINT IF EXISTS image_jobs_inspire_template_consistency_check;
+
+COMMENT ON COLUMN public.image_jobs.style_template_id IS
+  'Inspire 生成時の参照テンプレ id。テンプレが削除された場合は ON DELETE SET NULL で NULL になる (= 過去生成記録としては残る)';
+
+COMMIT;
+
+-- ===============================================
+-- DOWN: 制約を復元 (= 削除済テンプレを参照する row が無い前提)
+-- BEGIN;
+-- ALTER TABLE public.image_jobs
+--   ADD CONSTRAINT image_jobs_inspire_template_consistency_check
+--   CHECK ((generation_type = 'inspire') = (style_template_id IS NOT NULL));
+-- COMMIT;
+-- ===============================================

--- a/supabase/migrations/20260603100600_exempt_admin_from_inspire_cap.sql
+++ b/supabase/migrations/20260603100600_exempt_admin_from_inspire_cap.sql
@@ -1,0 +1,88 @@
+-- ===============================================
+-- Inspire 投稿数 cap (5 件) から admin / Creator Looks allowlist を除外
+-- ===============================================
+-- 設計判断:
+--   運営者 (admin_users) と Stage 2 招待クリエイター (creator_looks_allowlist 内の
+--   is_active=true) は動作確認・運用テストで投稿を繰り返すため、
+--   既存 Inspire 5 件 cap の対象外とする。
+--
+-- 変更点:
+--   既存 enforce_user_style_template_submission_cap 関数の早期 return 条件に追加:
+--     - admin_users に登録されている user は cap 対象外
+--     - creator_looks_allowlist (is_active=true) に登録されている user も cap 対象外
+--   それ以外のロジックは元 (20260602100900) と同じ。
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.enforce_user_style_template_submission_cap()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_active_count INTEGER;
+  v_lock_key BIGINT;
+BEGIN
+  -- pending への遷移時のみチェック
+  IF NEW.moderation_status <> 'pending' THEN
+    RETURN NEW;
+  END IF;
+
+  -- UPDATE で OLD.status='pending' のままなら状態遷移ではないのでスキップ
+  IF TG_OP = 'UPDATE' AND OLD.moderation_status = NEW.moderation_status THEN
+    RETURN NEW;
+  END IF;
+
+  -- Creator Looks 投稿は別 cap (= 1 日 2 件、API 層) で管理するため、ここでは素通し
+  IF NEW.is_creator_looks = true THEN
+    RETURN NEW;
+  END IF;
+
+  -- admin_users に登録された運営者は cap 対象外
+  IF EXISTS (
+    SELECT 1 FROM public.admin_users
+    WHERE user_id = NEW.submitted_by_user_id
+  ) THEN
+    RETURN NEW;
+  END IF;
+
+  -- Stage 2 招待クリエイター (creator_looks_allowlist.is_active=true) も cap 対象外
+  IF EXISTS (
+    SELECT 1 FROM public.creator_looks_allowlist
+    WHERE user_id = NEW.submitted_by_user_id
+      AND is_active = true
+  ) THEN
+    RETURN NEW;
+  END IF;
+
+  -- ユーザー単位の排他ロック（同一ユーザーからの 2 並列 submit を防ぐ）
+  v_lock_key := hashtextextended('user_style_template_cap:' || NEW.submitted_by_user_id::text, 0);
+  PERFORM pg_advisory_xact_lock(v_lock_key);
+
+  -- Inspire のみカウント (= Creator Looks 行は除外)
+  SELECT COUNT(*) INTO v_active_count
+  FROM public.user_style_templates
+  WHERE submitted_by_user_id = NEW.submitted_by_user_id
+    AND moderation_status IN ('pending', 'visible')
+    AND is_creator_looks = false
+    AND (TG_OP <> 'UPDATE' OR id <> NEW.id);
+
+  IF v_active_count >= 5 THEN
+    RAISE EXCEPTION 'user_style_template_submission_cap_exceeded'
+      USING ERRCODE = '23514',  -- check_violation
+            HINT = 'A user can have at most 5 templates in pending or visible state.';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.enforce_user_style_template_submission_cap() IS
+  'Inspire 投稿の cap (5 件) を強制する trigger 関数。admin_users / creator_looks_allowlist(is_active) と Creator Looks 投稿は対象外';
+
+COMMIT;
+
+-- ===============================================
+-- DOWN: 20260602100900 時点の定義 (admin/allowlist 除外なし) に戻す
+-- ===============================================


### PR DESCRIPTION
## 概要

運営者 (admin) の動作確認・運用テストが cap で阻害される問題と、関連 UX 不具合を一括解消。

| 改善 | Before | After |
|---|---|---|
| 既存 Inspire 5 件 cap | admin も対象 → 動作確認で 5 件超で reject | **admin/allowlist は対象外** |
| Creator Looks 1 日 2 件 cap | admin も対象 → 1 日 3 件目以降 reject | **admin/allowlist は対象外** |
| withdrawn テンプレの物理削除 | image_jobs CHECK 制約違反で削除不可 | **削除可能** (過去生成画像は保全) |
| Creator Looks daily cap エラー表示 | 「申請可能なテンプレ数の上限（**5 件**）」と誤表示 | **「Creator Looks の投稿は 1 日 2 件まで」** に正確化 |

## 変更内容

### Migration A: `20260603100500_relax_image_jobs_inspire_template_check.sql`
- `image_jobs_inspire_template_consistency_check` を **DROP**
- `user_style_templates` の ON DELETE SET NULL 後の `image_jobs.style_template_id=NULL` を許容
- 新規 INSERT 時の整合性は API 層 (`/api/generate-async`) で validate するため DB 制約不要

### Migration B: `20260603100600_exempt_admin_from_inspire_cap.sql`
- `enforce_user_style_template_submission_cap` 関数を上書き
- 早期 return 条件に追加:
  - `admin_users` に登録された運営者
  - `creator_looks_allowlist` (is_active=true) に登録された招待クリエイター

### サーバコード: `app/api/style-templates/preview-generation/handler.ts`
- Creator Looks 1 日 2 件 cap の前に `isAdminUser(user) || isInCreatorLooksAllowlist(user.id)` チェック
- 対象外なら daily cap query 自体を skip (= DB 負荷も削減)

### クライアント: `features/inspire/components/UserStyleTemplateSubmissionForm.tsx`
- `CREATOR_LOOKS_DAILY_CAP_EXCEEDED` (= 429) 受領時のメッセージ key を
  `submitFailedCap` (= Inspire 5 件用) から `submitFailedCreatorLooksDailyCap` (= 新規) に切替

### i18n: 全 15 言語に `submitFailedCreatorLooksDailyCap` 追加
- ja: 「Creator Looks の投稿は 1 日 2 件までです。明日以降に再度お試しください。」
- en: 「Creator Looks submissions are limited to 2 per day. Please try again tomorrow.」
- 他 13 言語も同等の文言

## 影響範囲

| 対象 | 影響 |
|---|---|
| admin / Stage 2 allowlist | cap 対象外で投稿無制限 |
| 一般ユーザー (Stage 3 公開時) | 既存 cap 適用継続 |
| 過去 inspire 生成記録 | 削除されない (= 生成履歴保全) |
| 既存テストデータ | 既存 withdrawn テンプレを物理削除可能に |

## デプロイ後の運営オペレーション

migration 適用 + デプロイ後、admin で以下が可能:
1. Inspire 投稿を 6 件以上 pending/visible にしても reject されない
2. Creator Looks 投稿を 1 日 3 件以上行っても reject されない
3. `/admin/style-templates` で withdrawn 状態のテンプレを完全削除可能

## Test plan

- [x] `npm run lint`: baseline (148/45/103) と同一
- [x] `npm run typecheck`: baseline と同一
- [x] `npm run test`: 1593 件パス
- [x] `npm run build -- --webpack`: 成功
- [ ] Migration 適用 + デプロイ後:
  - admin の既存 withdrawn テンプレ (6a3bdef6 / 555619bd) を REST API で物理削除 → 成功
  - admin で Creator Looks を 3 件目を投稿しようとして 429 が出ないことを確認
  - 非 admin / 非 allowlist ユーザーで Creator Looks 3 件目を投稿すると 429 + 正しいメッセージ

🤖 Generated with [Claude Code](https://claude.com/claude-code)