### PR TITLE
fix(creator-looks): hidden_prompt 編集を UPSERT から UPDATE に変更 (PGRST204 解消)

### DIFF
--- a/app/api/admin/creator-looks/[templateId]/secret/route.ts
+++ b/app/api/admin/creator-looks/[templateId]/secret/route.ts
@@ -147,25 +147,31 @@ export async function PATCH(
     return NextResponse.json({ error: "not_creator_looks" }, { status: 400 });
   }
 
-  // UPSERT (= 存在しなければ INSERT、存在すれば UPDATE)
-  // user_style_template_secrets AFTER INSERT/UPDATE trigger が hidden_prompt 変更時に
+  // 既存 row の hidden_prompt のみを UPDATE。
+  // (= upsert + updated_at は user_style_template_secrets に updated_at カラムが
+  // 存在しないため PGRST204 になる。抽出済 row があることが前提なので UPDATE で十分)
+  // user_style_template_secrets AFTER UPDATE trigger が hidden_prompt 変更時に
   // admin preview 再生成を enqueue する (= 20260603100400)。
-  const { error: upsertError } = await adminClient
+  const { error: updateError, count: updatedCount } = await adminClient
     .from("user_style_template_secrets")
-    .upsert(
-      {
-        template_id: templateId,
-        hidden_prompt: parsed.data.hidden_prompt,
-        updated_at: new Date().toISOString(),
-      },
-      { onConflict: "template_id" },
-    );
-  if (upsertError) {
+    .update(
+      { hidden_prompt: parsed.data.hidden_prompt },
+      { count: "exact" },
+    )
+    .eq("template_id", templateId);
+  if (updateError) {
     console.error(
-      "[admin/creator-looks/secret PATCH] upsert failed",
-      upsertError,
+      "[admin/creator-looks/secret PATCH] update failed",
+      updateError,
     );
-    return NextResponse.json({ error: "upsert_failed" }, { status: 500 });
+    return NextResponse.json({ error: "update_failed" }, { status: 500 });
+  }
+  if (!updatedCount || updatedCount === 0) {
+    // 抽出前の状態 (= secrets 行が無い) で編集しようとした
+    return NextResponse.json(
+      { error: "hidden_prompt_not_ready" },
+      { status: 404 },
+    );
   }
 
   // 監査ログ (= hidden_prompt の値は metadata に絶対含めない、ADR-009)


### PR DESCRIPTION
## 概要

PR #306 で追加した hidden_prompt 編集 API が **400 PGRST204** で保存失敗していた問題を修正。

## 原因

`user_style_template_secrets` テーブルには **`updated_at` カラムが存在しない** (= 設計上、抽出時の `generated_at` のみ持つ)。

PR #306 で書いた upsert payload:
\`\`\`typescript
{
  template_id: templateId,
  hidden_prompt: parsed.data.hidden_prompt,
  updated_at: new Date().toISOString(),  // ← このカラムが無い
}
\`\`\`

→ PostgREST が PGRST204 (missing column) で 400 reject。

## 修正

UPSERT + `updated_at` を **UPDATE のみ + hidden_prompt 単独更新**に変更:

\`\`\`typescript
const { error, count } = await adminClient
  .from("user_style_template_secrets")
  .update({ hidden_prompt: ... }, { count: "exact" })
  .eq("template_id", templateId);

if (!count) return 404;  // 抽出前の row が無い状態での編集を防止
\`\`\`

- `generator_version` / `vlm_model` などの抽出時メタデータは保持
- 抽出済 row があることが前提なので UPDATE で十分

## Test plan

- [x] `npm run typecheck`: baseline 同一
- [ ] マージ + デプロイ後、admin Sheet で hidden_prompt 編集 → Save が 200 で成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)