### PR TITLE
fix(creator-looks): 生成フロー UX を Style / Inspire と統一 (ステータスバー即時 + 完了後自動更新)

### DIFF
--- a/features/inspire/components/CreatorLooksDetailClient.tsx
+++ b/features/inspire/components/CreatorLooksDetailClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { Card } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -64,6 +65,7 @@ export function CreatorLooksDetailClient({
 }: CreatorLooksDetailClientProps) {
   const t = useTranslations("creatorLooksDetail");
   const { toast } = useToast();
+  const router = useRouter();
 
   const [uploadedImage, setUploadedImage] = useState<UploadedImage | null>(null);
   const [backgroundEnabled, setBackgroundEnabled] = useState(true);
@@ -76,6 +78,10 @@ export function CreatorLooksDetailClient({
 
   const isFreePlan = subscriptionPlan === "free" || !subscriptionPlan;
   const totalPercoinCost = getPercoinCost(selectedModel) * 1;
+  // Style / InspirePageClient と同じ: 「コーデ開始」押下直後 (= fetch 中で jobId 未取得) から
+  // ステータスバーを表示するため、submitting または activeJobId のどちらかで InspireGenerationFlow を
+  // マウントする。jobId が null の間は内部で「準備中」表示。
+  const isGenerating = submitting || activeJobId !== null;
 
   const handleSubmit = async () => {
     if (!uploadedImage) {
@@ -213,10 +219,15 @@ export function CreatorLooksDetailClient({
         </div>
       </Card>
 
-      {/* 生成中フロー (= 既存 InspireGenerationFlow 完全流用) */}
-      {/* aspectRatio: モックアップ通り 1:1 を仮定 (= 詳細ページのテンプレ大画像が aspect-square) */}
-      {/* showResultPanel=false: 下の CachedGeneratedImageGallery が結果を一覧表示するため二重表示を避ける */}
-      {activeJobId && (
+      {/*
+        生成中フロー (= InspirePageClient と同パターン)。
+        - 「コーデ開始」押下直後の fetch 中 (= submitting=true, activeJobId=null) からマウントし、
+          内部で「準備中」表示 → jobId 取得後に polling 開始 → 完了で結果。
+        - showResultPanel=false: 下の CachedGeneratedImageGallery が結果一覧表示するため二重表示回避。
+        - onComplete で router.refresh() を呼び、Server Component な gallery を再 fetch して
+          新しい生成画像を即時表示する。
+      */}
+      {isGenerating && (
         <InspireGenerationFlow
           jobId={activeJobId}
           aspectRatio={1}
@@ -228,7 +239,10 @@ export function CreatorLooksDetailClient({
             resultsPlaceholder: "",
             resultImageAlt: t("generationResultAlt"),
           }}
-          onComplete={() => setActiveJobId(null)}
+          onComplete={() => {
+            setActiveJobId(null);
+            router.refresh();
+          }}
         />
       )}
 


### PR DESCRIPTION
## 概要

CreatorLooksDetailClient の生成 UX が Style / InspirePageClient と 2 点ずれていたため修正。

| 観点 | Before | After (= 既存 Style / InspirePageClient と同じ) |
|---|---|---|
| ステータスバー表示 | jobId 取得まで非表示 → fetch 中の体感遅延 | **submitting 中から「準備中」表示が出る** |
| 完了後の結果画像 | 手動 reload が必要 | **`router.refresh()` で gallery が自動更新** |

## 変更内容

### `features/inspire/components/CreatorLooksDetailClient.tsx`

1. **`isGenerating` derived state を追加**:
   \`\`\`typescript
   const isGenerating = submitting || activeJobId !== null;
   \`\`\`

2. **`InspireGenerationFlow` のマウント条件を変更**:
   \`\`\`diff
   - {activeJobId && (
   + {isGenerating && (
       <InspireGenerationFlow jobId={activeJobId} ... />
     )}
   \`\`\`
   - jobId=null でも内部で「準備中」表示が出る (= 既存 InspireGenerationFlow が対応済)

3. **`onComplete` で `router.refresh()` を追加**:
   \`\`\`diff
   onComplete={() => {
     setActiveJobId(null);
   + router.refresh();
   }}
   \`\`\`
   - 下部の `CachedGeneratedImageGallery` (= Server Component) を再 fetch し、新規生成画像を即時表示

## Test plan

- [x] `npm run lint` / `typecheck`: baseline 同一
- [x] `npm run test`: 1593 件パス
- [x] `npm run build -- --webpack`: 成功
- [ ] デプロイ後:
  - 「コーデ開始」押下直後に「準備中」のステータスバーが出る
  - 生成完了で結果画像が手動 reload なしで gallery に追加表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)