### PR TITLE
admin プロンプト編集の文字数上限を 4000→10000 字に緩和(creator_looks.meta_extractor 対応)

### DIFF
--- a/app/api/admin/generation-prompts/[key]/route.ts
+++ b/app/api/admin/generation-prompts/[key]/route.ts
@@ -15,7 +15,8 @@ import {
 } from "@/shared/generation/prompt-registry";
 import { extractTemplateVariables } from "@/shared/generation/prompt-template";
 
-const MAX_CONTENT_LENGTH = 4000;
+// DB の prompt_overrides_content_check と同値に保つこと (defense in depth)
+const MAX_CONTENT_LENGTH = 10000;
 
 /**
  * 編集後に変更を即時反映させるための共通リバリデーション。

--- a/features/generation-prompts/components/AdminPromptEditClient.tsx
+++ b/features/generation-prompts/components/AdminPromptEditClient.tsx
@@ -5,7 +5,8 @@ import { useRouter } from "next/navigation";
 import { applyTemplate } from "@/shared/generation/prompt-template";
 import { extractTemplateVariables } from "@/shared/generation/prompt-template";
 
-const MAX_CONTENT_LENGTH = 4000;
+// API (route.ts) / DB (prompt_overrides_content_check) の上限と同値に保つこと
+const MAX_CONTENT_LENGTH = 10000;
 const SIGNIFICANT_CHANGE_RATIO = 0.3; // ±30% で大幅変更とみなす
 
 interface Props {

--- a/supabase/migrations/20260603101100_relax_prompt_overrides_content_length.sql
+++ b/supabase/migrations/20260603101100_relax_prompt_overrides_content_length.sql
@@ -1,0 +1,39 @@
+-- ===============================================
+-- prompt_overrides.content の最大文字数を 4000 → 10000 に緩和
+-- ===============================================
+-- 背景:
+--   admin の生成 prompt エディタ (/admin/generation-prompts/[key]) で、
+--   creator_looks.meta_extractor のような長文 meta-prompt が 4000 字上限に
+--   達して保存できないケースが出てきたため、上限を 10000 字に引き上げる。
+--
+-- 設計判断:
+--   - 文字数上限は「暴走入力 (監査ログ肥大・PII 肥大) を防ぐ安全ガード」であり、
+--     特定 key 専用ではなく全 prompt_key 共通のグローバル上限のまま緩和する。
+--   - API (route.ts) / client (AdminPromptEditClient) / DB の 3 層で同じ上限を持つ
+--     defense in depth 設計を維持 (各層の MAX_CONTENT_LENGTH も 10000 に更新済み)。
+--   - 上限の緩和のみで、既存 row は全て length<=4000 のため制約違反は発生しない。
+
+BEGIN;
+
+ALTER TABLE public.prompt_overrides
+  DROP CONSTRAINT IF EXISTS prompt_overrides_content_check;
+
+ALTER TABLE public.prompt_overrides
+  ADD CONSTRAINT prompt_overrides_content_check
+  CHECK (length(content) <= 10000 AND length(trim(content)) > 0);
+
+COMMENT ON COLUMN public.prompt_overrides.content IS
+  '{{varname}} プレースホルダー記法でテンプレ変数を含む prompt テキスト。max 10000 文字';
+
+COMMIT;
+
+-- ===============================================
+-- DOWN: 上限を 4000 に戻す (= length>4000 の row が無い前提)
+-- BEGIN;
+-- ALTER TABLE public.prompt_overrides
+--   DROP CONSTRAINT IF EXISTS prompt_overrides_content_check;
+-- ALTER TABLE public.prompt_overrides
+--   ADD CONSTRAINT prompt_overrides_content_check
+--   CHECK (length(content) <= 4000 AND length(trim(content)) > 0);
+-- COMMIT;
+-- ===============================================

--- a/tests/integration/api/admin-generation-prompts-routes.test.ts
+++ b/tests/integration/api/admin-generation-prompts-routes.test.ts
@@ -169,12 +169,21 @@ describe("PUT /api/admin/generation-prompts/[key]", () => {
     expect(res.status).toBe(400);
   });
 
-  test("4000 文字超過は 400", async () => {
+  test("10000 文字超過は 400", async () => {
     mockRequireAdmin.mockResolvedValue(FAKE_ADMIN);
-    const res = await PUT(makePutRequest({ content: "x".repeat(4001) }), {
+    const res = await PUT(makePutRequest({ content: "x".repeat(10001) }), {
       params: Promise.resolve({ key: "style.base_prefix" }),
     });
     expect(res.status).toBe(400);
+  });
+
+  test("4000 超〜10000 以内は許可 (上限緩和後)", async () => {
+    mockRequireAdmin.mockResolvedValue(FAKE_ADMIN);
+    mockUpsert.mockResolvedValue({ previousContent: null });
+    const res = await PUT(makePutRequest({ content: "x".repeat(8000) }), {
+      params: Promise.resolve({ key: "style.base_prefix" }),
+    });
+    expect(res.status).toBe(200);
   });
 
   test("正常系は upsert + audit log + revalidate を呼ぶ", async () => {


### PR DESCRIPTION
### 概要
admin のプロンプト編集画面 `/admin/generation-prompts/[key]`(特に `creator_looks.meta_extractor`)で、プロンプト本文が 4000 字の上限に達して保存できない課題があった。長文の meta-prompt を扱えるよう、文字数上限を **4000 → 10000 字** に引き上げる。

上限は特定キー専用ではなく、全 `prompt_key` 共通のグローバル安全ガード(監査ログ肥大・暴走入力の防止)として緩和する。クライアントは非公開 meta-prompt の漏洩防止のため registry を import せず、API / client / DB の各層が独立してリテラルを持つ defense-in-depth 構成を維持している。

### 変更内容
- **client**: `features/generation-prompts/components/AdminPromptEditClient.tsx` の `MAX_CONTENT_LENGTH` を 4000→10000(文字数カウンタ・バリデーション・エラー文言は定数参照のため自動追従)
- **API**: `app/api/admin/generation-prompts/[key]/route.ts` の `MAX_CONTENT_LENGTH` を 4000→10000
- **DB**: マイグレーション `supabase/migrations/20260603101100_relax_prompt_overrides_content_length.sql` を追加。`prompt_overrides_content_check` を `length(content) <= 10000` に緩和 + カラム COMMENT 更新 + DOWN 記載(緩和のみ・既存 row は全て違反なし)
- **テスト**: `tests/integration/api/admin-generation-prompts-routes.test.ts` の「4000 文字超過は 400」を「10000 文字超過は 400」に更新し、「4000 超〜10000 以内は許可」ケースを追加

> ⚠️ DB マイグレーションは **本番(linked: AI coordinate)に適用済み** です(`supabase db push` 実行 → 制約が `<= 10000` であることをクエリで確認済み、`Remote database is up to date`)。デプロイ時の再適用は履歴記録済みのためスキップされます。

### 実機テスト
<!-- admin 専用(PC)の編集画面のみ。モバイル UI / レイアウトへの影響なし -->
- [ ] iOS Safari で主要導線を確認(N/A: admin PC 専用)
- [ ] Android Chrome で主要導線を確認(N/A: admin PC 専用)
- [ ] PC（Chrome）で主要導線を確認
- [ ] レスポンシブ表示崩れがないことを確認(N/A: レイアウト変更なし)
- [ ] エラーメッセージやバリデーション表示を確認(上限超過時の赤表示・`10,000` 文字カウンタ)

### テスト方法
- `npm run test -- admin-generation-prompts-routes` → **18/18 パス**(更新・追加ケース含む)
- 編集ファイルの lint / typecheck エラーなし、`npm run build -- --webpack` 成功(exit 0)
- 本番 DB 制約をクエリで検証: `prompt_overrides_content_check` = `CHECK ((length(content) <= 10000) AND (length(trim(content)) > 0))`
- 参考: リポジトリ全体の `npm run typecheck` は `tests/unit/**` の既存エラー(jest-dom 型)が多数あるが本 PR とは無関係・ビルドには影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
