### PR TITLE
fix(auth): 保存導線の認証フォームを縦に詰めてモバイルで操作可能にする

### DIFF
--- a/features/auth/components/AuthForm.tsx
+++ b/features/auth/components/AuthForm.tsx
@@ -39,6 +39,11 @@ interface AuthFormProps {
    * 指定時は URL クエリより優先する。
    */
   signupSource?: SignupSource | null;
+  /**
+   * フォーム自身の見出し(タイトル＋説明)を隠す。モーダル側が既に
+   * 見出しを持つ場合(保存導線など)に true にして縦の重複を避ける。
+   */
+  hideHeading?: boolean;
 }
 
 export function AuthForm({
@@ -47,6 +52,7 @@ export function AuthForm({
   redirectTo,
   hideModeSwitch,
   signupSource: signupSourceProp,
+  hideHeading,
 }: AuthFormProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -268,19 +274,21 @@ export function AuthForm({
         </div>
       )}
 
-      <div className="mb-6 text-center">
-        <h2 className="text-xl sm:text-2xl font-bold text-gray-900">
-          {isSignUp ? t("signupTitle") : t("signinTitle")}
-        </h2>
-        <p className="mt-2 text-sm text-gray-600">
-          {isSignUp
-            ? t("signupDescription")
-            : t("signinDescription")}
-        </p>
-      </div>
+      {!hideHeading ? (
+        <div className="mb-4 text-center">
+          <h2 className="text-xl sm:text-2xl font-bold text-gray-900">
+            {isSignUp ? t("signupTitle") : t("signinTitle")}
+          </h2>
+          <p className="mt-2 text-sm text-gray-600">
+            {isSignUp
+              ? t("signupDescription")
+              : t("signinDescription")}
+          </p>
+        </div>
+      ) : null}
 
       {isWardrobeClaimFlow ? (
-        <Alert className="mb-4 border-amber-200 bg-amber-50">
+        <Alert className="mb-2 border-amber-200 bg-amber-50">
           <AlertDescription className="text-xs leading-5 text-amber-800">
             {t("wardrobeClaimBrowserHint")}
           </AlertDescription>
@@ -293,7 +301,7 @@ export function AuthForm({
         </Alert>
       )}
 
-      <form onSubmit={handleSubmit} className="space-y-4">
+      <form onSubmit={handleSubmit} className="space-y-3">
         {/* メールアドレス */}
         <div>
           <Label htmlFor="email">{t("emailLabel")}</Label>
@@ -434,7 +442,7 @@ export function AuthForm({
       </form>
 
       {/* SNSログイン */}
-      <div className="mt-6">
+      <div className="mt-4">
         <div className="relative">
           <div className="absolute inset-0 flex items-center">
             <div className="w-full border-t border-gray-300" />
@@ -444,7 +452,7 @@ export function AuthForm({
           </div>
         </div>
 
-        <div className="mt-6 space-y-3">
+        <div className="mt-4 space-y-3">
           {/* Google */}
           <Button
             type="button"

--- a/features/auth/components/AuthForm.tsx
+++ b/features/auth/components/AuthForm.tsx
@@ -274,7 +274,7 @@ export function AuthForm({
         </div>
       )}
 
-      {!hideHeading ? (
+      {!hideHeading && (
         <div className="mb-4 text-center">
           <h2 className="text-xl sm:text-2xl font-bold text-gray-900">
             {isSignUp ? t("signupTitle") : t("signinTitle")}
@@ -285,7 +285,7 @@ export function AuthForm({
               : t("signinDescription")}
           </p>
         </div>
-      ) : null}
+      )}
 
       {isWardrobeClaimFlow ? (
         <Alert className="mb-2 border-amber-200 bg-amber-50">

--- a/features/auth/components/AuthModal.tsx
+++ b/features/auth/components/AuthModal.tsx
@@ -71,6 +71,7 @@ export function AuthModal({
             redirectTo={redirectTo}
             hideModeSwitch={hideModeSwitch}
             signupSource={signupSource}
+            hideHeading={Boolean(title || description)}
           />
         </div>
       </div>

--- a/tests/unit/components/auth-form.test.tsx
+++ b/tests/unit/components/auth-form.test.tsx
@@ -158,6 +158,30 @@ describe("AuthForm unit tests from EARS specs", () => {
     expect(container.querySelector('a[href="/login"]')).toBeNull();
   });
 
+  test("hideHeading_未指定または false の場合_フォーム見出しを表示する", () => {
+    // 既定(未指定)では自身の見出し(新規登録/作成して…)を表示する
+    const { rerender } = render(<AuthForm mode="signup" />);
+    expect(
+      screen.getByRole("heading", { name: "新規登録" })
+    ).toBeInTheDocument();
+
+    // 明示的に false でも表示する
+    rerender(<AuthForm mode="signup" hideHeading={false} />);
+    expect(
+      screen.getByRole("heading", { name: "新規登録" })
+    ).toBeInTheDocument();
+  });
+
+  test("hideHeading_true の場合_フォーム見出しを隠す", () => {
+    // モーダルが独自ヘッダーを持つときに重複を避けるため見出しを隠す
+    render(<AuthForm mode="signup" hideHeading />);
+    expect(
+      screen.queryByRole("heading", { name: "新規登録" })
+    ).not.toBeInTheDocument();
+    // 見出しを隠してもフォーム本体(入力欄)は描画される
+    expect(screen.getByLabelText("メールアドレス")).toBeInTheDocument();
+  });
+
   describe("AUTH-001 handleSubmit", () => {
     test("handleSubmit_有効な新規登録入力の場合_確認トースト表示後にloginへ遷移する", async () => {
       // ============================================================

--- a/tests/unit/components/auth-modal.test.tsx
+++ b/tests/unit/components/auth-modal.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from "@testing-library/react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { AuthModal } from "@/features/auth/components/AuthModal";
+import { useToast } from "@/components/ui/use-toast";
+import { jaMessages } from "@/messages/ja";
+
+jest.mock("next-intl", () => {
+  return {
+    useTranslations: (namespace?: string) => {
+      const table =
+        namespace && namespace in jaMessages
+          ? (jaMessages as unknown as Record<string, Record<string, string>>)[namespace]
+          : {};
+
+      return (key: string) => table[key] ?? key;
+    },
+  };
+});
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(),
+  useSearchParams: jest.fn(),
+}));
+
+jest.mock("@/features/auth/lib/auth-client", () => ({
+  signIn: jest.fn(),
+  signUp: jest.fn(),
+  signInWithOAuth: jest.fn(),
+}));
+
+jest.mock("@/components/ui/use-toast", () => ({
+  useToast: jest.fn(),
+}));
+
+describe("AuthModal unit tests", () => {
+  const useRouterMock = useRouter as jest.MockedFunction<typeof useRouter>;
+  const useSearchParamsMock = useSearchParams as jest.MockedFunction<
+    typeof useSearchParams
+  >;
+  const useToastMock = useToast as jest.MockedFunction<typeof useToast>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    useRouterMock.mockReturnValue({
+      push: jest.fn(),
+      refresh: jest.fn(),
+    } as unknown as ReturnType<typeof useRouter>);
+    useSearchParamsMock.mockReturnValue({
+      get: () => null,
+    } as unknown as ReturnType<typeof useSearchParams>);
+    (useToastMock as jest.Mock).mockReturnValue({ toast: jest.fn() });
+  });
+
+  test("open=false の場合_何も描画しない", () => {
+    const { container } = render(
+      <AuthModal open={false} onClose={() => {}} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test("title/description 指定時_モーダル見出しを出しフォーム側の見出しは隠す", () => {
+    // 保存導線: モーダルが独自ヘッダーを持つため hideHeading=true が渡り、
+    // フォーム側の「新規登録」見出しは重複回避で出さない。
+    render(
+      <AuthModal
+        open
+        onClose={() => {}}
+        mode="signup"
+        title="このイラストを保存する"
+        description="ログインすると、生成したイラストがあなたのアカウントに保存され、いつでも見返せます。"
+        hideModeSwitch
+      />
+    );
+
+    // モーダルヘッダーのタイトル/説明は表示される
+    expect(
+      screen.getByRole("heading", { name: "このイラストを保存する" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/生成したイラストがあなたのアカウントに保存され/)
+    ).toBeInTheDocument();
+
+    // フォーム自身の見出しは隠れる(2段重複の解消)
+    expect(
+      screen.queryByRole("heading", { name: "新規登録" })
+    ).not.toBeInTheDocument();
+
+    // フォーム本体は描画される
+    expect(screen.getByLabelText("メールアドレス")).toBeInTheDocument();
+  });
+
+  test("title/description 未指定時_フォーム側の見出しを表示する", () => {
+    // いいね/コメント等の導線: モーダルヘッダーが無いので
+    // フォーム自身の見出しを表示する(hideHeading=false)。
+    render(<AuthModal open onClose={() => {}} mode="signup" />);
+
+    expect(
+      screen.getByRole("heading", { name: "新規登録" })
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### 概要
<!-- UXとしてどのような課題があり、どのように対応したのかを端的に記載 -->
未ログインユーザーが style 画面で生成後に「保存する」を押すと表示される認証モーダルが縦に長く、iPhone 等のモバイルで最下部の「Googleで続ける」ボタンまでスクロールできず押せない状態だった。フォームの余白を詰め、さらにモーダル内で重複していた見出しを解消することで、1画面に収まり操作できるようにした。

### 変更内容
<!-- 具体的にどのような変更を行ったのかを記載 -->
- `AuthForm.tsx`：縦の余白を縮小
  - 見出し下 `mb-6`→`mb-4`
  - 黄色枠（保存導線の注意文）下 `mb-4`→`mb-2`
  - 入力欄どうしの間隔 `space-y-4`→`space-y-3`
  - 「アカウントを作成」↔「─または─」 `mt-6`→`mt-4`
  - 「─または─」↔「Googleで続ける」 `mt-6`→`mt-4`
- `AuthForm.tsx` / `AuthModal.tsx`：`hideHeading` プロップを追加
  - `AuthModal` が独自ヘッダー（`title` / `description`）を持つ保存導線では、フォーム側の「新規登録／アカウントを作成して…」見出しを省略し、見出しの2段重複を解消（約60〜70px短縮）
- 影響範囲：いいね/コメント等の `title`/`description` を渡さないモーダル、および `/signup`・`/login` ページ（`AuthModal` 非経由）は `hideHeading` 未指定で従来どおり表示。挙動への影響なし。

### 実機テスト
<!-- 実機で確認する項目をチェックボックスで記載 -->
- [ ] iOS Safari で主要導線を確認（ゲスト生成→保存→Googleで続けるボタンが押せること）
- [ ] Android Chrome で主要導線を確認
- [ ] PC（Chrome）で主要導線を確認
- [ ] レスポンシブ表示崩れがないことを確認
- [ ] エラーメッセージやバリデーション表示を確認

### テスト方法
<!-- PR提出までに実施したテスト（手動/自動）を記載 -->
- `npm run build -- --webpack` 成功（エラーなし）
- 変更2ファイルの ESLint パス（既存の `tests/unit/**` のlintエラーは本変更と無関係）
- Playwright（iPhone 390×844 幅）で `/signup?next=claim_wardrobe` を撮影し、余白短縮で「Googleで続ける」ボタンが1画面に収まることを確認