### PR TITLE
feat(style): ユーザープロンプトを category 単位で記憶し prefill する

### DIFF
--- a/features/style/components/StylePageClient.tsx
+++ b/features/style/components/StylePageClient.tsx
@@ -455,10 +455,30 @@ export function StylePageClient({
 
   // プリセット切り替え時に preset 固有の入力 (userPrompt / 参考画像) をリセットする。
   // 別 preset で意図しない入力が引き継がれてクレジット浪費しないための防御。
+  // userPrompt は category 単位で localStorage に「前回の入力」を保存しており、
+  // 復元することで「ユーザーがまた来た時にも同じ追記を再利用できる」UX を提供する。
   useEffect(() => {
     setUserReferenceImage(null);
-    setUserPromptInputValue("");
-  }, [selectedPreset?.id]);
+    if (!selectedPreset?.category.showUserPromptInput) {
+      setUserPromptInputValue("");
+      return;
+    }
+    const key = selectedPreset.category.key;
+    const maxLen =
+      selectedPreset.category.userPromptMaxLength ?? GENERATION_PROMPT_MAX_LENGTH;
+    try {
+      const saved = window.localStorage.getItem(`user-prompt:${key}`);
+      setUserPromptInputValue(saved ? saved.slice(0, maxLen) : "");
+    } catch {
+      // localStorage 不可(プライベートモード等) → 復元せず空で開始
+      setUserPromptInputValue("");
+    }
+  }, [
+    selectedPreset?.id,
+    selectedPreset?.category.key,
+    selectedPreset?.category.showUserPromptInput,
+    selectedPreset?.category.userPromptMaxLength,
+  ]);
 
   const shouldShowSourceImageTypeControl =
     selectedPreset?.category.showSourceImageTypeControl ?? true;
@@ -1234,6 +1254,20 @@ export function StylePageClient({
       ) {
         formData.set("userPrompt", userPromptInputValue);
       }
+      // category 単位で「最後に submit したプロンプト」を localStorage に記憶し、
+      // 次回 /style 来訪時に prefill する。空(=クリア後)送信は記憶を消去する。
+      if (selectedPreset.category.showUserPromptInput) {
+        try {
+          const k = `user-prompt:${selectedPreset.category.key}`;
+          if (userPromptInputValue.trim().length > 0) {
+            window.localStorage.setItem(k, userPromptInputValue);
+          } else {
+            window.localStorage.removeItem(k);
+          }
+        } catch {
+          // private mode 等で書けなくても無視
+        }
+      }
 
       const response = await fetch("/style/generate", {
         method: "POST",
@@ -1327,6 +1361,20 @@ export function StylePageClient({
         userPromptInputValue.trim().length > 0
       ) {
         formData.set("userPrompt", userPromptInputValue);
+      }
+      // category 単位で「最後に submit したプロンプト」を localStorage に記憶し、
+      // 次回 /style 来訪時に prefill する。空(=クリア後)送信は記憶を消去する。
+      if (selectedPreset.category.showUserPromptInput) {
+        try {
+          const k = `user-prompt:${selectedPreset.category.key}`;
+          if (userPromptInputValue.trim().length > 0) {
+            window.localStorage.setItem(k, userPromptInputValue);
+          } else {
+            window.localStorage.removeItem(k);
+          }
+        } catch {
+          // private mode 等で書けなくても無視
+        }
       }
 
       if (selectedRemoteSource?.kind === "stock") {

--- a/features/style/components/StylePageClient.tsx
+++ b/features/style/components/StylePageClient.tsx
@@ -33,6 +33,10 @@ import { ImageSourcePicker } from "@/features/generation/components/ImageSourceP
 import { ImageSourcePickerTrigger } from "@/features/generation/components/ImageSourcePickerTrigger";
 import { PromptInputField } from "@/features/generation/components/PromptInputField";
 import { GENERATION_PROMPT_MAX_LENGTH } from "@/features/generation/lib/prompt-validation";
+import {
+  loadUserPromptForCategory,
+  saveUserPromptForCategory,
+} from "@/features/style/lib/user-prompt-recall";
 import { LabelInfoTooltip } from "@/components/LabelInfoTooltip";
 import { useImageSourcePicker } from "@/features/generation/hooks/useImageSourcePicker";
 import type { SourceImageStock } from "@/features/generation/lib/database";
@@ -463,16 +467,13 @@ export function StylePageClient({
       setUserPromptInputValue("");
       return;
     }
-    const key = selectedPreset.category.key;
-    const maxLen =
-      selectedPreset.category.userPromptMaxLength ?? GENERATION_PROMPT_MAX_LENGTH;
-    try {
-      const saved = window.localStorage.getItem(`user-prompt:${key}`);
-      setUserPromptInputValue(saved ? saved.slice(0, maxLen) : "");
-    } catch {
-      // localStorage 不可(プライベートモード等) → 復元せず空で開始
-      setUserPromptInputValue("");
-    }
+    setUserPromptInputValue(
+      loadUserPromptForCategory(
+        selectedPreset.category.key,
+        selectedPreset.category.userPromptMaxLength ??
+          GENERATION_PROMPT_MAX_LENGTH,
+      ),
+    );
   }, [
     selectedPreset?.id,
     selectedPreset?.category.key,
@@ -1257,16 +1258,10 @@ export function StylePageClient({
       // category 単位で「最後に submit したプロンプト」を localStorage に記憶し、
       // 次回 /style 来訪時に prefill する。空(=クリア後)送信は記憶を消去する。
       if (selectedPreset.category.showUserPromptInput) {
-        try {
-          const k = `user-prompt:${selectedPreset.category.key}`;
-          if (userPromptInputValue.trim().length > 0) {
-            window.localStorage.setItem(k, userPromptInputValue);
-          } else {
-            window.localStorage.removeItem(k);
-          }
-        } catch {
-          // private mode 等で書けなくても無視
-        }
+        saveUserPromptForCategory(
+          selectedPreset.category.key,
+          userPromptInputValue,
+        );
       }
 
       const response = await fetch("/style/generate", {
@@ -1365,16 +1360,10 @@ export function StylePageClient({
       // category 単位で「最後に submit したプロンプト」を localStorage に記憶し、
       // 次回 /style 来訪時に prefill する。空(=クリア後)送信は記憶を消去する。
       if (selectedPreset.category.showUserPromptInput) {
-        try {
-          const k = `user-prompt:${selectedPreset.category.key}`;
-          if (userPromptInputValue.trim().length > 0) {
-            window.localStorage.setItem(k, userPromptInputValue);
-          } else {
-            window.localStorage.removeItem(k);
-          }
-        } catch {
-          // private mode 等で書けなくても無視
-        }
+        saveUserPromptForCategory(
+          selectedPreset.category.key,
+          userPromptInputValue,
+        );
       }
 
       if (selectedRemoteSource?.kind === "stock") {

--- a/features/style/lib/user-prompt-recall.ts
+++ b/features/style/lib/user-prompt-recall.ts
@@ -1,0 +1,56 @@
+/**
+ * /style のユーザープロンプト入力欄を「前回入力」で prefill するための
+ * localStorage アクセサ。category 単位で覚える(=ウエハース風用とちびキャラ用
+ * を混ぜない)。
+ *
+ * 復元時は admin が後から userPromptMaxLength を縮めても安全なように slice する。
+ * private mode 等で localStorage が触れないときは透過的に空 / no-op で返す。
+ */
+
+const STORAGE_KEY_PREFIX = "user-prompt:";
+
+function buildKey(categoryKey: string): string {
+  return `${STORAGE_KEY_PREFIX}${categoryKey}`;
+}
+
+/**
+ * 指定 category の「前回入力」を取り出す。値が無い / localStorage 不可なら "".
+ * 取得後、安全のため maxLength で切り詰める(admin が後から縮めた場合の保険)。
+ */
+export function loadUserPromptForCategory(
+  categoryKey: string,
+  maxLength: number | null | undefined,
+): string {
+  if (typeof window === "undefined") return "";
+  try {
+    const raw = window.localStorage.getItem(buildKey(categoryKey));
+    if (raw === null) return "";
+    const limit =
+      typeof maxLength === "number" && maxLength > 0 ? maxLength : Infinity;
+    return raw.slice(0, limit);
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * 指定 category に対し「submit したプロンプト」を保存する。
+ * 値が空文字(trim 後) なら削除する(=「クリアして実行」が「次回も空で開く」と
+ * 自然に結びつく)。private mode 等で書けなくても例外を投げない。
+ */
+export function saveUserPromptForCategory(
+  categoryKey: string,
+  value: string,
+): void {
+  if (typeof window === "undefined") return;
+  const trimmed = value.trim();
+  try {
+    if (trimmed.length > 0) {
+      window.localStorage.setItem(buildKey(categoryKey), value);
+    } else {
+      window.localStorage.removeItem(buildKey(categoryKey));
+    }
+  } catch {
+    // private mode 等で書けなくても無視
+  }
+}

--- a/tests/unit/features/style/user-prompt-recall.test.ts
+++ b/tests/unit/features/style/user-prompt-recall.test.ts
@@ -1,0 +1,137 @@
+/**
+ * features/style/lib/user-prompt-recall のテスト。
+ *
+ * jest の jsdom 環境では window.localStorage がデフォルトで使えるので、
+ * 各テスト前に localStorage.clear() してから検証する。
+ */
+import {
+  loadUserPromptForCategory,
+  saveUserPromptForCategory,
+} from "@/features/style/lib/user-prompt-recall";
+
+describe("user-prompt-recall", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  describe("loadUserPromptForCategory", () => {
+    test("未保存 category は空文字を返す", () => {
+      expect(loadUserPromptForCategory("collectible_wafer_sticker", 200)).toBe(
+        "",
+      );
+    });
+
+    test("保存済み category の値が返る", () => {
+      window.localStorage.setItem(
+        "user-prompt:collectible_wafer_sticker",
+        "ハイビスカスを持たせて",
+      );
+      expect(loadUserPromptForCategory("collectible_wafer_sticker", 200)).toBe(
+        "ハイビスカスを持たせて",
+      );
+    });
+
+    test("maxLength を超える値は slice される (admin が後から縮めた保険)", () => {
+      window.localStorage.setItem(
+        "user-prompt:collectible_wafer_sticker",
+        "0123456789",
+      );
+      expect(loadUserPromptForCategory("collectible_wafer_sticker", 5)).toBe(
+        "01234",
+      );
+    });
+
+    test("maxLength が null / undefined / 0 のときは無制限扱いで全文を返す", () => {
+      window.localStorage.setItem(
+        "user-prompt:collectible_wafer_sticker",
+        "fulltext",
+      );
+      expect(loadUserPromptForCategory("collectible_wafer_sticker", null)).toBe(
+        "fulltext",
+      );
+      expect(
+        loadUserPromptForCategory("collectible_wafer_sticker", undefined),
+      ).toBe("fulltext");
+      expect(loadUserPromptForCategory("collectible_wafer_sticker", 0)).toBe(
+        "fulltext",
+      );
+    });
+
+    test("category 単位で独立して取り出す (別 category は混ざらない)", () => {
+      window.localStorage.setItem(
+        "user-prompt:collectible_wafer_sticker",
+        "wafer-text",
+      );
+      window.localStorage.setItem("user-prompt:chibi", "chibi-text");
+      expect(loadUserPromptForCategory("collectible_wafer_sticker", 200)).toBe(
+        "wafer-text",
+      );
+      expect(loadUserPromptForCategory("chibi", 200)).toBe("chibi-text");
+    });
+
+    test("localStorage が throw しても空文字に fallback (private mode の保険)", () => {
+      const spy = jest
+        .spyOn(Storage.prototype, "getItem")
+        .mockImplementation(() => {
+          throw new Error("blocked");
+        });
+      expect(loadUserPromptForCategory("collectible_wafer_sticker", 200)).toBe(
+        "",
+      );
+      spy.mockRestore();
+    });
+  });
+
+  describe("saveUserPromptForCategory", () => {
+    test("非空の値は category キーで保存される", () => {
+      saveUserPromptForCategory("collectible_wafer_sticker", "アロハシャツで");
+      expect(
+        window.localStorage.getItem("user-prompt:collectible_wafer_sticker"),
+      ).toBe("アロハシャツで");
+    });
+
+    test("空文字 / trim 後空文字は保存ではなく削除", () => {
+      window.localStorage.setItem(
+        "user-prompt:collectible_wafer_sticker",
+        "old",
+      );
+      saveUserPromptForCategory("collectible_wafer_sticker", "");
+      expect(
+        window.localStorage.getItem("user-prompt:collectible_wafer_sticker"),
+      ).toBeNull();
+
+      window.localStorage.setItem(
+        "user-prompt:collectible_wafer_sticker",
+        "old2",
+      );
+      saveUserPromptForCategory("collectible_wafer_sticker", "   \n\t  ");
+      expect(
+        window.localStorage.getItem("user-prompt:collectible_wafer_sticker"),
+      ).toBeNull();
+    });
+
+    test("category 単位で独立 (別 category の保存値は触らない)", () => {
+      window.localStorage.setItem("user-prompt:chibi", "keep-me");
+      saveUserPromptForCategory(
+        "collectible_wafer_sticker",
+        "new-wafer",
+      );
+      expect(window.localStorage.getItem("user-prompt:chibi")).toBe("keep-me");
+      expect(
+        window.localStorage.getItem("user-prompt:collectible_wafer_sticker"),
+      ).toBe("new-wafer");
+    });
+
+    test("localStorage が throw しても例外を吐かない", () => {
+      const spy = jest
+        .spyOn(Storage.prototype, "setItem")
+        .mockImplementation(() => {
+          throw new Error("quota_exceeded");
+        });
+      expect(() =>
+        saveUserPromptForCategory("collectible_wafer_sticker", "x"),
+      ).not.toThrow();
+      spy.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
## 概要

「ユーザープロンプト入力欄を表示」が ON のカテゴリ(ウエハース風 / ちびキャラ 等)
で、ユーザーが入力した追記文を localStorage に保存して、次回 /style に来訪した
ときに同じカテゴリのプリセットを開くと textarea に prefill する。

## 変更内容

- `features/style/components/StylePageClient.tsx`
  - useEffect: プリセット切り替え時に `localStorage.getItem('user-prompt:{category.key}')` から復元
    - `userPromptMaxLength` 超えは安全のため切り詰め
    - private mode 不可時は空文字フォールバック
  - submit (sync/async 両方): `formData.set('userPrompt')` 直後に書き込み
    - 値が空 (= クリア後 submit) なら `removeItem` で消去 → 「クリアして実行」 = 「次回も空で開く」が直感どおり

## UX 観点

- カテゴリごとに別 key で持つので、ウエハース風用とちびキャラ用が混じらない
- admin が `userPromptMaxLength` を縮めても復元時に切り詰めで安全
- 既存の `PromptInputField` の `クリア` ボタンはそのまま機能

## Test plan

- [ ] /style で「ユーザープロンプト入力欄を表示」 ON のカテゴリ(ウエハース風)を選び、textarea に何か入力して生成 → 完了
- [ ] 別タブ・別画面に行ってから /style に戻り、同じカテゴリを開くと textarea に前回の文字が prefill されていること
- [ ] textarea を「クリア」 → 空のまま生成 → 別画面 → /style 戻る → textarea が空のまま (= 消去された) ことを確認
- [ ] 別カテゴリ(`ちびキャラ` 等、admin が user_prompt 有効化していれば)に切り替えると、ウエハース風で覚えた文字は引きずらないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)