### PR TITLE
style(preset-card): カテゴリバッジを左上→左下に移動

### DIFF
--- a/features/style/components/StylePresetPreviewCard.tsx
+++ b/features/style/components/StylePresetPreviewCard.tsx
@@ -28,7 +28,8 @@ interface StylePresetPreviewCardData {
   hasBackgroundPrompt: boolean;
   /**
    * 紐づく preset_categories のサマリ。`coordinate` (= default) はバッジ非表示で
-   * 既存挙動と同じ見た目を保つ。それ以外のカテゴリのみバッジを左上に表示する。
+   * 既存挙動と同じ見た目を保つ。それ以外のカテゴリのみバッジをサムネ画像の
+   * 左下に表示する(キャラの顔まわりをバッジで覆わないための配置)。
    */
   category?: StylePresetPreviewCardCategory;
 }
@@ -103,7 +104,7 @@ export function StylePresetPreviewCard({
           />
           {shouldShowBadge && preset.category && (
             <span
-              className="absolute left-1.5 top-1.5 inline-flex max-w-[80%] items-center truncate rounded px-1.5 py-0.5 text-[10px] font-semibold leading-tight shadow-sm"
+              className="absolute bottom-1.5 left-1.5 inline-flex max-w-[80%] items-center truncate rounded px-1.5 py-0.5 text-[10px] font-semibold leading-tight shadow-sm"
               style={{
                 backgroundColor: preset.category.badgeColor,
                 color: preset.category.badgeTextColor,


### PR DESCRIPTION
## 概要

ホーム画面（プリセットカルーセル）と /style 画面のスタイルカードに表示している
カテゴリバッジ（例: 「うちの子の神コレクション」）を、サムネ画像の **左上 → 左下** に
移動する。

## 変更内容

- `features/style/components/StylePresetPreviewCard.tsx`
  - badge の Tailwind クラス `absolute left-1.5 top-1.5` → `absolute bottom-1.5 left-1.5`
  - JSDoc コメントも「左下に表示」と更新

共通コンポーネントなので、`HomeStylePresetCarousel` / `StylePageClient` / `OneTapStyleDetailCard`
すべてが同時に新位置になる。

## 理由

左上はキャラクターの顔まわりに重なりがちで、サムネ本来見せたい部分をバッジが
隠してしまうケースがあった。左下にすると画像の余白側に寄り、視線の妨げが減る。

## Test plan

- [ ] ホーム画面のカルーセルで `admin_only` カテゴリのカード（うちの子の神コレクション 等）の
      バッジが左下に表示されること
- [ ] /style の同カードでも左下に表示されること
- [ ] `coordinate` (default) カテゴリは引き続きバッジ非表示のままであること
- [ ] バッジの色（`badgeColor` / `badgeTextColor`）は変わらないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)