### PR TITLE
feat(share): シェア/保存UIを共通コンポーネントに統一しスマホ・PC挙動を揃える

### DIFF
--- a/app/m/[token]/page.tsx
+++ b/app/m/[token]/page.tsx
@@ -98,7 +98,6 @@ export default async function PublicMountPage({
         <MountShareButton
           completionId={mount.completionId}
           mountImageUrl={mount.mountImageUrl}
-          displayName={mount.displayNameJa}
         />
       ) : null}
 

--- a/components/CollectionProgressChecker.tsx
+++ b/components/CollectionProgressChecker.tsx
@@ -3,7 +3,6 @@
 import { CollectionProgressModal } from "@/features/collections/components/CollectionProgressModal";
 import { CollectionMountComposer } from "@/features/collections/components/CollectionMountComposer";
 import { useCollectionProgress } from "@/features/collections/hooks/useCollectionProgress";
-import { shareMount } from "@/features/collections/lib/share-mount";
 
 /**
  * 全画面共通のコレクション進捗チェッカー。AppShell にマウントし、
@@ -30,11 +29,6 @@ export function CollectionProgressChecker() {
         open={!!celebration}
         celebration={celebration}
         onClose={dismiss}
-        onShare={(c) => {
-          if (c.completionId) {
-            void shareMount(c.completionId, c.mountImageUrl).catch(() => {});
-          }
-        }}
         onCreateMount={openComposerFromCelebration}
       />
       {composer ? (

--- a/components/ShareLinkButton.tsx
+++ b/components/ShareLinkButton.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useState } from "react";
+import { Copy, Share2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useToast } from "@/components/ui/use-toast";
+import { copyTextToClipboard } from "@/lib/clipboard";
+import { sharePost } from "@/lib/share-post";
+import type { ComponentProps, ReactNode } from "react";
+
+export type ShareLinkMethod = "share" | "clipboard";
+
+export interface ShareLinkMessages {
+  /** PC メニュー: リンクをコピー */
+  copyLink: string;
+  /** PC メニュー: その他の方法で共有 */
+  moreOptions: string;
+  /** コピー成功トーストの title */
+  copiedTitle: string;
+  /** 失敗トーストの title */
+  errorTitle: string;
+  /** 失敗時の汎用 description(詳細メッセージが取れない場合) */
+  failed: string;
+  /** navigator.share 非対応時の description */
+  webApiUnsupported: string;
+}
+
+export interface ShareLinkButtonProps {
+  /** シェアする絶対URL。クリック時点で評価したい場合は関数を渡す */
+  url: string | (() => string);
+  /** 表示文言。i18n 配線済み画面は t() を、未配線画面(/m 等)は直書きを渡す */
+  messages: ShareLinkMessages;
+  /** 共有/コピーが実際に行われた後に呼ばれる(キャンセル時は呼ばれない) */
+  onShared?: (method: ShareLinkMethod) => void;
+  variant?: ComponentProps<typeof Button>["variant"];
+  size?: ComponentProps<typeof Button>["size"];
+  className?: string;
+  ariaLabel?: string;
+  /** トリガーボタンの中身(アイコン/ラベル) */
+  children: ReactNode;
+}
+
+/**
+ * URL 共有ボタンの汎用コンポーネント(posts の ShareButton から抽出)。
+ *
+ * - モバイル(UA判定): クリックで sharePost — Web Share のシェアシートを開き、
+ *   非対応環境ではクリップボードコピーにフォールバックして copied トーストを出す。
+ * - PC: ドロップダウンで「リンクをコピー」「その他の方法で共有(navigator.share)」。
+ * - ユーザーキャンセル(AbortError)は無音。失敗は destructive トースト。
+ */
+export function ShareLinkButton({
+  url,
+  messages,
+  onShared,
+  variant,
+  size,
+  className,
+  ariaLabel,
+  children,
+}: ShareLinkButtonProps) {
+  const [isLoading, setIsLoading] = useState(false);
+  const { toast } = useToast();
+
+  const resolveUrl = () => (typeof url === "function" ? url() : url);
+
+  const isMobile = () => {
+    if (typeof navigator === "undefined") return false;
+    return /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+  };
+
+  const showError = (description: string) => {
+    toast({
+      title: messages.errorTitle,
+      description,
+      variant: "destructive",
+    });
+  };
+
+  // モバイル: シェアシート優先(非対応はクリップボードフォールバック)
+  const handleMobileShare = async () => {
+    if (isLoading) return;
+    setIsLoading(true);
+    try {
+      const result = await sharePost(resolveUrl());
+      if (result.method === "clipboard") {
+        toast({ title: messages.copiedTitle });
+      }
+      // method === "share" はシェアシートで完結するためトーストなし
+      onShared?.(result.method);
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        return;
+      }
+      showError(error instanceof Error ? error.message : messages.failed);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // PC メニュー: URL のみをコピー
+  const handleCopyLink = async () => {
+    if (isLoading) return;
+    setIsLoading(true);
+    try {
+      await copyTextToClipboard(resolveUrl());
+      toast({ title: messages.copiedTitle });
+      onShared?.("clipboard");
+    } catch {
+      showError(messages.failed);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // PC メニュー: Web Share API を直接呼ぶ(「その他の方法で共有」)
+  const handleShareViaWebApi = async () => {
+    if (isLoading) return;
+    setIsLoading(true);
+    try {
+      if (typeof navigator.share !== "function") {
+        throw new Error(messages.webApiUnsupported);
+      }
+      // OGP 表示を優先するため URL のみをシェアする(text を含めると
+      // OGP カードが出ない場合がある — sharePost と同じ方針)
+      await navigator.share({ title: "Persta.AI", url: resolveUrl() });
+      onShared?.("share");
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        return;
+      }
+      showError(error instanceof Error ? error.message : messages.failed);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const triggerButton = (onClick?: () => void) => (
+    <Button
+      type="button"
+      variant={variant}
+      size={size}
+      className={className}
+      aria-label={ariaLabel}
+      disabled={isLoading}
+      onClick={onClick}
+    >
+      {children}
+    </Button>
+  );
+
+  if (isMobile()) {
+    return triggerButton(() => {
+      void handleMobileShare();
+    });
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>{triggerButton()}</DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        <DropdownMenuItem
+          onClick={() => {
+            void handleCopyLink();
+          }}
+        >
+          <Copy className="mr-2 h-4 w-4" />
+          {messages.copyLink}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => {
+            void handleShareViaWebApi();
+          }}
+        >
+          <Share2 className="mr-2 h-4 w-4" />
+          {messages.moreOptions}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/components/ShareLinkButton.tsx
+++ b/components/ShareLinkButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Copy, Share2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -65,14 +65,20 @@ export function ShareLinkButton({
   children,
 }: ShareLinkButtonProps) {
   const [isLoading, setIsLoading] = useState(false);
+  // SSR とハイドレーション初回は必ず PC 分岐を描画し、マウント後に UA 判定で
+  // モバイル分岐へ切り替える(レンダー中に navigator を参照すると SSR との
+  // 構造差で hydration mismatch になる)。両分岐ともトリガーの見た目は
+  // 同一なので、切替によるちらつきはない。
+  const [isMobile, setIsMobile] = useState(false);
   const { toast } = useToast();
 
-  const resolveUrl = () => (typeof url === "function" ? url() : url);
+  useEffect(() => {
+    if (typeof navigator !== "undefined") {
+      setIsMobile(/Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent));
+    }
+  }, []);
 
-  const isMobile = () => {
-    if (typeof navigator === "undefined") return false;
-    return /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
-  };
+  const resolveUrl = () => (typeof url === "function" ? url() : url);
 
   const showError = (description: string) => {
     toast({
@@ -154,7 +160,7 @@ export function ShareLinkButton({
     </Button>
   );
 
-  if (isMobile()) {
+  if (isMobile) {
     return triggerButton(() => {
       void handleMobileShare();
     });

--- a/features/collections/components/CollectionProgressModal.tsx
+++ b/features/collections/components/CollectionProgressModal.tsx
@@ -9,7 +9,13 @@ import {
   DialogContent,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { ShareLinkButton } from "@/components/ShareLinkButton";
 import { mountAspectForCategory } from "@/features/collections/lib/mount-aspects";
+import { MOUNT_SHARE_MESSAGES } from "@/features/collections/lib/mount-share-messages";
+import {
+  buildPublicMountUrl,
+  trackMountShareEvent,
+} from "@/features/collections/lib/share-mount";
 
 export interface CollectionCelebration {
   categoryKey: string;
@@ -39,8 +45,6 @@ interface Props {
   open: boolean;
   celebration: CollectionCelebration | null;
   onClose: () => void;
-  /** シェアボタン押下(公開ページURLのシェア)。 */
-  onShare?: (celebration: CollectionCelebration) => void;
   /** N種到達かつ台紙未作成のとき「台紙を作成する」ボタン押下で呼ばれる */
   onCreateMount?: (celebration: CollectionCelebration) => void;
 }
@@ -202,7 +206,6 @@ export function CollectionProgressModal({
   open,
   celebration,
   onClose,
-  onShare,
   onCreateMount,
 }: Props) {
   // リングと %バッジは fromCount → toCount を rAF で滑らかにアニメさせる。
@@ -282,7 +285,7 @@ export function CollectionProgressModal({
 
   if (!celebration) return null;
 
-  const { displayName, toCount, threshold } = celebration;
+  const { displayName, toCount, threshold, completionId } = celebration;
   const mountImageUrl = cMountImageUrl;
   const characterImageUrl = cCharacterImageUrl;
   const collectedImageUrls = cCollectedImageUrls;
@@ -397,14 +400,17 @@ export function CollectionProgressModal({
                 onError={onImgLoad}
               />
             </div>
-            {onShare ? (
-              <button
-                type="button"
-                onClick={() => onShare(celebration)}
-                className="w-full rounded-full bg-gradient-to-r from-amber-400 to-orange-500 px-6 py-3 text-base font-bold text-white shadow-[0_4px_0_rgba(234,88,12,0.4)] transition-transform hover:-translate-y-0.5"
+            {completionId ? (
+              /* posts / /m と同じ共有 UI(モバイル=シェアシート、PC=コピー/Web Share
+                 メニュー)。成功時に share-event を計測する。 */
+              <ShareLinkButton
+                url={() => buildPublicMountUrl(completionId, mountImageUrl)}
+                messages={MOUNT_SHARE_MESSAGES}
+                onShared={() => trackMountShareEvent(completionId)}
+                className="h-auto w-full rounded-full bg-gradient-to-r from-amber-400 to-orange-500 px-6 py-3 text-base font-bold text-white shadow-[0_4px_0_rgba(234,88,12,0.4)] transition-transform hover:-translate-y-0.5"
               >
                 台紙をシェアする
-              </button>
+              </ShareLinkButton>
             ) : null}
             {celebration.sharePath ? (
               <Link

--- a/features/collections/components/MountShareButton.tsx
+++ b/features/collections/components/MountShareButton.tsx
@@ -1,69 +1,70 @@
 "use client";
 
 import { useState } from "react";
-import { shareMount } from "../lib/share-mount";
+import { ShareLinkButton } from "@/components/ShareLinkButton";
+import { useToast } from "@/components/ui/use-toast";
+import { shareOrDownloadGeneratedImage } from "@/features/generation/lib/download-image";
+import { MOUNT_SHARE_MESSAGES } from "../lib/mount-share-messages";
+import { buildPublicMountUrl, trackMountShareEvent } from "../lib/share-mount";
 
 /**
  * 公開台紙ページで「所有者のみ」に表示するシェア/保存ボタン。
- * シェアは公開ページURLの URL 共有(shareMount)。保存は台紙画像のダウンロード。
+ * シェアは posts と同じ汎用 ShareLinkButton(モバイル=シェアシート、
+ * PC=コピー/Web Share メニュー)で、成功時に share-event を計測する。
+ * 保存は style 画面の生成一覧と同じ共通ヘルパに委譲する
+ * (モバイル=Web Share のシェアシート、PC=ブラウザDL)。
  */
 export function MountShareButton({
   completionId,
   mountImageUrl,
-  displayName,
 }: {
   completionId: string;
   mountImageUrl: string;
-  displayName: string;
 }) {
-  const [busy, setBusy] = useState(false);
-
-  async function handleShare() {
-    setBusy(true);
-    try {
-      await shareMount(completionId, mountImageUrl);
-    } catch {
-      // ユーザーキャンセル等は無視
-    } finally {
-      setBusy(false);
-    }
-  }
+  const [downloading, setDownloading] = useState(false);
+  const { toast } = useToast();
 
   async function handleDownload() {
-    setBusy(true);
+    setDownloading(true);
     try {
-      const res = await fetch(mountImageUrl, { mode: "cors" });
-      const blob = await res.blob();
-      const objectUrl = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = objectUrl;
-      a.download = `${displayName || "collection"}-mount.png`;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      URL.revokeObjectURL(objectUrl);
-    } catch {
-      // 失敗時は新規タブで開く(最低限の保存導線)
-      window.open(mountImageUrl, "_blank", "noopener,noreferrer");
+      // リストタブの ja.ts と同じ文言を直書き(i18n は Phase 7)。
+      await shareOrDownloadGeneratedImage(
+        { id: completionId, url: mountImageUrl },
+        {
+          accessDenied:
+            "画像へのアクセス権限がありません。認証が必要な可能性があります。",
+          fetchFailed: (statusText) =>
+            `画像の取得に失敗しました: ${statusText}`,
+        },
+      );
+    } catch (error) {
+      console.error("ダウンロードエラー:", error);
+      toast({
+        title:
+          error instanceof Error
+            ? error.message
+            : "画像のダウンロードに失敗しました",
+        variant: "destructive",
+      });
     } finally {
-      setBusy(false);
+      setDownloading(false);
     }
   }
 
   return (
     <div className="flex flex-wrap justify-center gap-3">
-      <button
-        type="button"
-        onClick={handleShare}
-        disabled={busy}
-        className="rounded-md bg-primary px-5 py-2 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50"
+      <ShareLinkButton
+        url={() => buildPublicMountUrl(completionId, mountImageUrl)}
+        messages={MOUNT_SHARE_MESSAGES}
+        onShared={() => trackMountShareEvent(completionId)}
+        className="px-5"
       >
         台紙をシェアする
-      </button>
+      </ShareLinkButton>
       <button
         type="button"
         onClick={handleDownload}
-        disabled={busy}
+        disabled={downloading}
         className="rounded-md border border-gray-300 px-5 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
       >
         画像を保存

--- a/features/collections/lib/mount-share-messages.ts
+++ b/features/collections/lib/mount-share-messages.ts
@@ -1,0 +1,15 @@
+import type { ShareLinkMessages } from "@/components/ShareLinkButton";
+
+/**
+ * 台紙シェア(ShareLinkButton)用の日本語文言。
+ * /m 公開ページ・コンプリート演出モーダルは i18n 未配線(Phase 7 予定)のため、
+ * posts の ja.ts と同じ文言をここに一本化して直書きする。
+ */
+export const MOUNT_SHARE_MESSAGES: ShareLinkMessages = {
+  copyLink: "リンクをコピー",
+  moreOptions: "その他の方法で共有",
+  copiedTitle: "URLをコピーしました",
+  errorTitle: "エラー",
+  failed: "共有に失敗しました",
+  webApiUnsupported: "Web Share APIがサポートされていません",
+};

--- a/features/collections/lib/share-mount.ts
+++ b/features/collections/lib/share-mount.ts
@@ -1,5 +1,3 @@
-import { sharePost } from "@/lib/share-post";
-
 /**
  * 台紙ストレージURLから「mount-{timestamp}」のタイムスタンプ部分だけ抜く。
  * 古い台紙(タイムスタンプ前の固定パス)は null を返す。
@@ -13,27 +11,28 @@ export function extractMountVersionFromUrl(url: string | null | undefined): stri
 }
 
 /**
- * 台紙の公開ページURL(/m/{completionId}?v={ts})を Web Share / クリップボードで共有し、
- * 成功したら mount_shared を記録する(client 用)。
+ * 台紙の公開ページURL(/m/{completionId}?v={ts})を組み立てる(client 用)。
  *
  * mountImageUrl を渡すと、台紙更新ごとに ?v=...が付き、SNS(X/Facebook 等)の
  * カードキャッシュが新しい URL として扱われ即時に新しい OGP が反映される。
  * 引数省略時はバージョン無しの旧形式 URL を出す(後方互換)。
- *
- * ユーザーがキャンセルした場合は sharePost が AbortError を throw するので、
- * 呼び出し側で握りつぶす。
  */
-export async function shareMount(
+export function buildPublicMountUrl(
   completionId: string,
   mountImageUrl?: string | null,
-): Promise<void> {
+): string {
   const version = extractMountVersionFromUrl(mountImageUrl);
   const path = version
     ? `/m/${completionId}?v=${version}`
     : `/m/${completionId}`;
-  const url = `${window.location.origin}${path}`;
-  await sharePost(url);
-  // 共有成功時のみ計測(best-effort)
+  return `${window.location.origin}${path}`;
+}
+
+/**
+ * mount_shared を記録する(best-effort)。失敗は握りつぶす。
+ * 共有/コピーの成功時(ShareLinkButton の onShared)から呼ぶ。
+ */
+export function trackMountShareEvent(completionId: string): void {
   void fetch("/api/collections/share-event", {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/features/my-page/components/MyPageCollections.tsx
+++ b/features/my-page/components/MyPageCollections.tsx
@@ -14,7 +14,6 @@ import {
 } from "@/features/collections/components/CollectionMountComposer";
 import { CollectionProgressRing } from "@/features/collections/components/CollectionProgressRing";
 import { mountAspectForCategory } from "@/features/collections/lib/mount-aspects";
-import { shareMount } from "@/features/collections/lib/share-mount";
 import type { CollectionProgress } from "@/features/collections/lib/collection-types";
 
 interface ComposerTarget {
@@ -309,11 +308,6 @@ export function MyPageCollections({
         open={!!celebration}
         celebration={celebration}
         onClose={() => setCelebration(null)}
-        onShare={(c) => {
-          if (c.completionId) {
-            void shareMount(c.completionId, c.mountImageUrl).catch(() => {});
-          }
-        }}
         onCreateMount={openComposerFromCelebration}
       />
 

--- a/features/posts/components/ShareButton.tsx
+++ b/features/posts/components/ShareButton.tsx
@@ -1,19 +1,9 @@
 "use client";
 
-import { useState } from "react";
-import { Share2, Copy } from "lucide-react";
+import { Share2 } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 import type { Locale } from "@/i18n/config";
-import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { useToast } from "@/components/ui/use-toast";
-import { copyTextToClipboard } from "@/lib/clipboard";
-import { sharePost } from "@/lib/share-post";
+import { ShareLinkButton } from "@/components/ShareLinkButton";
 import { getPostDetailUrl } from "@/lib/url-utils";
 
 interface ShareButtonProps {
@@ -23,163 +13,29 @@ interface ShareButtonProps {
 }
 
 /**
- * シェアボタンコンポーネント
- * Web Share APIを使用して投稿をシェア
+ * 投稿シェアボタン。共有 UI の実体は汎用 ShareLinkButton
+ * (モバイル=シェアシート、PC=コピー/Web Share メニュー)。
  */
-export function ShareButton({
-  postId,
-}: ShareButtonProps) {
-  const [isLoading, setIsLoading] = useState(false);
-  const { toast } = useToast();
+export function ShareButton({ postId }: ShareButtonProps) {
   const t = useTranslations("posts");
   const locale = useLocale() as Locale;
 
-  const isMobile = () => {
-    if (typeof navigator === "undefined") return false;
-    return /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
-  };
-
-  const getPostUrl = () => {
-    return getPostDetailUrl(postId, locale);
-  };
-
-  // URLのみをコピーする関数
-  const handleCopyLink = async () => {
-    if (isLoading) return;
-
-    setIsLoading(true);
-
-    try {
-      const url = getPostUrl();
-      await copyTextToClipboard(url);
-      toast({
-        title: t("shareCopyTitle"),
-      });
-    } catch {
-      toast({
-        title: t("errorTitle"),
-        description: t("shareFailed"),
-        variant: "destructive",
-      });
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  // Web Share APIを直接呼び出す関数（「その他の方法で共有」用）
-  const handleShareViaWebAPI = async () => {
-    if (isLoading) return;
-
-    setIsLoading(true);
-
-    try {
-      const url = getPostUrl();
-      const shareData: ShareData = {
-        title: "Persta.AI",
-        url: url,
-      };
-
-      if (typeof navigator.share === "function") {
-        await navigator.share(shareData);
-        // Share Sheetが開かれた場合はトーストを表示しない
-      } else {
-        throw new Error(t("shareWebApiUnsupported"));
-      }
-    } catch (error) {
-      // ユーザーキャンセルは無視（トーストを表示しない）
-      if (error instanceof DOMException && error.name === "AbortError") {
-        return;
-      }
-
-      // その他のエラーのみトースト表示
-      toast({
-        title: t("errorTitle"),
-        description:
-          error instanceof Error ? error.message : t("shareFailed"),
-        variant: "destructive",
-      });
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  // モバイル版用のシェア関数（従来通り）
-  const handleShare = async () => {
-    if (isLoading) return;
-
-    setIsLoading(true);
-
-    try {
-      // 投稿詳細ページの絶対URLを生成
-      const url = getPostUrl();
-
-      // シェアを実行
-      const result = await sharePost(url);
-
-      // sharePostが「何をしたか」を返す想定
-      if (result.method === "clipboard") {
-        toast({
-          title: t("shareCopyTitle"),
-        });
-      }
-      // result.method === "share" の場合はトーストを表示しない（共有画面が開かれるため）
-    } catch (error) {
-      // ユーザーキャンセルは無視（トーストを表示しない）
-      if (error instanceof DOMException && error.name === "AbortError") {
-        return;
-      }
-
-      // その他のエラーのみトースト表示
-      toast({
-        title: t("errorTitle"),
-        description:
-          error instanceof Error ? error.message : t("shareFailed"),
-        variant: "destructive",
-      });
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  // モバイル版のシェアボタン（従来通り）
-  const mobileShareButton = (
-    <Button
+  return (
+    <ShareLinkButton
+      url={() => getPostDetailUrl(postId, locale)}
       variant="ghost"
       size="sm"
-      onClick={handleShare}
-      disabled={isLoading}
       className="flex items-center gap-1.5 px-2 py-1 h-auto"
+      messages={{
+        copyLink: t("shareCopyLink"),
+        moreOptions: t("shareMoreOptions"),
+        copiedTitle: t("shareCopyTitle"),
+        errorTitle: t("errorTitle"),
+        failed: t("shareFailed"),
+        webApiUnsupported: t("shareWebApiUnsupported"),
+      }}
     >
       <Share2 className="h-5 w-5 text-gray-600" />
-    </Button>
+    </ShareLinkButton>
   );
-
-  // PC版のシェアボタン（ドロップダウンメニュー付き）
-  const desktopShareButton = (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="ghost"
-          size="sm"
-          disabled={isLoading}
-          className="flex items-center gap-1.5 px-2 py-1 h-auto"
-        >
-          <Share2 className="h-5 w-5 text-gray-600" />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="start">
-        <DropdownMenuItem onClick={handleCopyLink}>
-          <Copy className="mr-2 h-4 w-4" />
-          {t("shareCopyLink")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onClick={handleShareViaWebAPI}>
-          <Share2 className="mr-2 h-4 w-4" />
-          {t("shareMoreOptions")}
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-
-  // シェアボタン（PC版: ドロップダウンメニュー、モバイル版: 直接シェア）
-  return isMobile() ? mobileShareButton : desktopShareButton;
 }

--- a/tests/unit/components/share-link-button.test.tsx
+++ b/tests/unit/components/share-link-button.test.tsx
@@ -1,0 +1,451 @@
+/**
+ * `ShareLinkButton` の単体テスト。
+ *
+ * posts の ShareButton から抽出した共有 UI の汎用コンポーネント。
+ * - モバイル(UA判定): 直接 sharePost（シェアシート → クリップボードフォールバック）
+ * - PC: ドロップダウン「リンクをコピー」「その他の方法で共有(navigator.share)」
+ * - キャンセル(AbortError)は無音、成功時のみ onShared を呼ぶ
+ * を、ui/dropdown-menu と lib 境界(share-post / clipboard)のモックで検証する。
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const mockToast = jest.fn();
+jest.mock("@/components/ui/use-toast", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+const mockSharePost = jest.fn();
+jest.mock("@/lib/share-post", () => ({
+  sharePost: (...args: unknown[]) => mockSharePost(...args),
+}));
+
+const mockCopyText = jest.fn();
+jest.mock("@/lib/clipboard", () => ({
+  copyTextToClipboard: (...args: unknown[]) => mockCopyText(...args),
+}));
+
+// Radix の DropdownMenu は jsdom でポインタイベントが再現しづらいため、
+// 既存テスト(language-settings-menu.test.tsx)と同じくパススルーでモックする。
+jest.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="menu-root">{children}</div>
+  ),
+  DropdownMenuTrigger: ({
+    children,
+    asChild,
+  }: {
+    children: React.ReactNode;
+    asChild?: boolean;
+  }) =>
+    asChild ? (
+      <>{children}</>
+    ) : (
+      <button type="button" data-testid="menu-trigger">
+        {children}
+      </button>
+    ),
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="menu-content">{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button type="button" role="menuitem" onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+import { ShareLinkButton } from "@/components/ShareLinkButton";
+
+const MOBILE_UA =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15";
+const DESKTOP_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36";
+
+function setNavigator(opts: {
+  userAgent: string;
+  share?: ((data: ShareData) => Promise<void>) | undefined;
+}) {
+  Object.defineProperty(window.navigator, "userAgent", {
+    configurable: true,
+    value: opts.userAgent,
+  });
+  Object.defineProperty(window.navigator, "share", {
+    configurable: true,
+    value: opts.share,
+  });
+}
+
+const baseMessages = {
+  copyLink: "リンクをコピー",
+  moreOptions: "その他の方法で共有",
+  copiedTitle: "URLをコピーしました",
+  errorTitle: "エラー",
+  failed: "共有に失敗しました",
+  webApiUnsupported: "Web Share APIがサポートされていません",
+};
+
+const mockOnShared = jest.fn();
+
+function renderButton(
+  props: Partial<React.ComponentProps<typeof ShareLinkButton>> = {},
+) {
+  return render(
+    <ShareLinkButton
+      url="https://example.com/p/1"
+      messages={baseMessages}
+      onShared={mockOnShared}
+      {...props}
+    >
+      シェア
+    </ShareLinkButton>,
+  );
+}
+
+beforeEach(() => {
+  mockToast.mockReset();
+  mockSharePost.mockReset();
+  mockCopyText.mockReset();
+  mockOnShared.mockReset();
+  mockSharePost.mockResolvedValue({ method: "share" });
+  mockCopyText.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  setNavigator({ userAgent: DESKTOP_UA, share: undefined });
+});
+
+describe("ShareLinkButton (モバイル)", () => {
+  beforeEach(() => {
+    setNavigator({ userAgent: MOBILE_UA, share: undefined });
+  });
+
+  test("クリックで sharePost に URL を渡し、share 完結時はトーストなしで onShared('share') を呼ぶ", async () => {
+    renderButton();
+
+    fireEvent.click(screen.getByRole("button", { name: "シェア" }));
+
+    await waitFor(() => {
+      expect(mockSharePost).toHaveBeenCalledWith("https://example.com/p/1");
+    });
+    await waitFor(() => {
+      expect(mockOnShared).toHaveBeenCalledWith("share");
+    });
+    expect(mockToast).not.toHaveBeenCalled();
+    // モバイルはメニューを出さない
+    expect(screen.queryByRole("menuitem")).not.toBeInTheDocument();
+  });
+
+  test("クリップボードフォールバック時は copied トーストと onShared('clipboard')", async () => {
+    mockSharePost.mockResolvedValueOnce({ method: "clipboard" });
+    renderButton();
+
+    fireEvent.click(screen.getByRole("button", { name: "シェア" }));
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "URLをコピーしました" }),
+      );
+    });
+    expect(mockOnShared).toHaveBeenCalledWith("clipboard");
+  });
+
+  test("url が関数の場合は render 時でなくクリック時に評価される", async () => {
+    const urlFn = jest.fn(() => "https://example.com/late");
+    renderButton({ url: urlFn });
+
+    expect(urlFn).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "シェア" }));
+
+    await waitFor(() => {
+      expect(mockSharePost).toHaveBeenCalledWith("https://example.com/late");
+    });
+    expect(urlFn).toHaveBeenCalledTimes(1);
+  });
+
+  test("進行中の再クリックでは sharePost を二重実行しない", async () => {
+    let resolveShare: () => void = () => {};
+    mockSharePost.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveShare = () => resolve({ method: "share" });
+        }),
+    );
+    renderButton();
+    const button = screen.getByRole("button", { name: "シェア" });
+
+    fireEvent.click(button);
+    await waitFor(() => {
+      expect(button).toBeDisabled();
+    });
+
+    fireEvent.click(button);
+    expect(mockSharePost).toHaveBeenCalledTimes(1);
+
+    resolveShare();
+    await waitFor(() => {
+      expect(button).toBeEnabled();
+    });
+    expect(mockSharePost).toHaveBeenCalledTimes(1);
+  });
+
+  test("AbortError(ユーザーキャンセル)は無音: トーストも onShared もなし", async () => {
+    mockSharePost.mockRejectedValueOnce(
+      new DOMException("cancelled", "AbortError"),
+    );
+    renderButton();
+
+    fireEvent.click(screen.getByRole("button", { name: "シェア" }));
+
+    // 共有は試行されたうえでキャンセルされたこと(素通り防止のアンカー)
+    await waitFor(() => {
+      expect(mockSharePost).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "シェア" })).toBeEnabled();
+    });
+    expect(mockToast).not.toHaveBeenCalled();
+    expect(mockOnShared).not.toHaveBeenCalled();
+  });
+
+  test("非 Abort の失敗は destructive トースト(詳細メッセージ入り)で onShared なし", async () => {
+    mockSharePost.mockRejectedValueOnce(new Error("net dead"));
+    renderButton();
+
+    fireEvent.click(screen.getByRole("button", { name: "シェア" }));
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "エラー",
+          description: "net dead",
+          variant: "destructive",
+        }),
+      );
+    });
+    expect(mockOnShared).not.toHaveBeenCalled();
+  });
+
+  test("非 Error 値の reject は failed 固定文言のトースト", async () => {
+    mockSharePost.mockRejectedValueOnce("boom");
+    renderButton();
+
+    fireEvent.click(screen.getByRole("button", { name: "シェア" }));
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "エラー",
+          description: "共有に失敗しました",
+          variant: "destructive",
+        }),
+      );
+    });
+    expect(mockOnShared).not.toHaveBeenCalled();
+  });
+});
+
+describe("ShareLinkButton (PC)", () => {
+  beforeEach(() => {
+    setNavigator({ userAgent: DESKTOP_UA, share: undefined });
+  });
+
+  test("「リンクをコピー」で URL をコピーし copied トーストと onShared('clipboard')", async () => {
+    renderButton();
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "リンクをコピー" }));
+
+    await waitFor(() => {
+      expect(mockCopyText).toHaveBeenCalledWith("https://example.com/p/1");
+    });
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "URLをコピーしました" }),
+      );
+    });
+    expect(mockOnShared).toHaveBeenCalledWith("clipboard");
+    // PC のコピーは sharePost を経由しない
+    expect(mockSharePost).not.toHaveBeenCalled();
+  });
+
+  test("「その他の方法で共有」で navigator.share を直接呼び onShared('share')", async () => {
+    const navigatorShare = jest.fn().mockResolvedValue(undefined);
+    setNavigator({ userAgent: DESKTOP_UA, share: navigatorShare });
+    renderButton();
+
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: "その他の方法で共有" }),
+    );
+
+    await waitFor(() => {
+      expect(navigatorShare).toHaveBeenCalledWith({
+        title: "Persta.AI",
+        url: "https://example.com/p/1",
+      });
+    });
+    await waitFor(() => {
+      expect(mockOnShared).toHaveBeenCalledWith("share");
+    });
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  test("「その他の方法で共有」の AbortError は無音", async () => {
+    const navigatorShare = jest
+      .fn()
+      .mockRejectedValue(new DOMException("cancelled", "AbortError"));
+    setNavigator({ userAgent: DESKTOP_UA, share: navigatorShare });
+    renderButton();
+
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: "その他の方法で共有" }),
+    );
+
+    await waitFor(() => {
+      expect(navigatorShare).toHaveBeenCalledTimes(1);
+    });
+    expect(mockToast).not.toHaveBeenCalled();
+    expect(mockOnShared).not.toHaveBeenCalled();
+  });
+
+  test("「その他の方法で共有」の非 Error reject は failed 固定文言のトースト", async () => {
+    const navigatorShare = jest.fn().mockRejectedValue("boom");
+    setNavigator({ userAgent: DESKTOP_UA, share: navigatorShare });
+    renderButton();
+
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: "その他の方法で共有" }),
+    );
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "エラー",
+          description: "共有に失敗しました",
+          variant: "destructive",
+        }),
+      );
+    });
+    expect(mockOnShared).not.toHaveBeenCalled();
+  });
+
+  test("コピー進行中はトリガーが disabled になり menu item の二重実行もしない", async () => {
+    let resolveCopy: () => void = () => {};
+    mockCopyText.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCopy = resolve;
+        }),
+    );
+    renderButton();
+    const trigger = screen.getByRole("button", { name: "シェア" });
+    const copyItem = screen.getByRole("menuitem", { name: "リンクをコピー" });
+
+    fireEvent.click(copyItem);
+    await waitFor(() => {
+      expect(trigger).toBeDisabled();
+    });
+
+    fireEvent.click(copyItem);
+    expect(mockCopyText).toHaveBeenCalledTimes(1);
+
+    resolveCopy();
+    await waitFor(() => {
+      expect(trigger).toBeEnabled();
+    });
+    expect(mockCopyText).toHaveBeenCalledTimes(1);
+  });
+
+  test("コピー失敗は destructive トースト(固定文言)で onShared なし", async () => {
+    mockCopyText.mockRejectedValueOnce(new Error("clipboard denied"));
+    renderButton();
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "リンクをコピー" }));
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "エラー",
+          description: "共有に失敗しました",
+          variant: "destructive",
+        }),
+      );
+    });
+    expect(mockOnShared).not.toHaveBeenCalled();
+  });
+
+  test("Web Share 進行中はトリガーが disabled になり menu item の二重実行もしない", async () => {
+    let resolveShare: () => void = () => {};
+    const navigatorShare = jest.fn().mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveShare = resolve;
+        }),
+    );
+    setNavigator({ userAgent: DESKTOP_UA, share: navigatorShare });
+    renderButton();
+    const trigger = screen.getByRole("button", { name: "シェア" });
+    const moreItem = screen.getByRole("menuitem", {
+      name: "その他の方法で共有",
+    });
+
+    fireEvent.click(moreItem);
+    await waitFor(() => {
+      expect(trigger).toBeDisabled();
+    });
+
+    fireEvent.click(moreItem);
+    expect(navigatorShare).toHaveBeenCalledTimes(1);
+
+    resolveShare();
+    await waitFor(() => {
+      expect(trigger).toBeEnabled();
+    });
+    expect(navigatorShare).toHaveBeenCalledTimes(1);
+  });
+
+  test("navigator 自体が無い環境(SSR 相当)では PC メニュー側として描画する", () => {
+    const originalNavigator = window.navigator;
+    Object.defineProperty(window, "navigator", {
+      configurable: true,
+      value: undefined,
+    });
+    try {
+      renderButton();
+      expect(
+        screen.getByRole("menuitem", { name: "リンクをコピー" }),
+      ).toBeInTheDocument();
+    } finally {
+      Object.defineProperty(window, "navigator", {
+        configurable: true,
+        value: originalNavigator,
+      });
+    }
+  });
+
+  test("navigator.share 未対応で「その他の方法で共有」は webApiUnsupported のトースト", async () => {
+    setNavigator({ userAgent: DESKTOP_UA, share: undefined });
+    renderButton();
+
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: "その他の方法で共有" }),
+    );
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "エラー",
+          description: "Web Share APIがサポートされていません",
+          variant: "destructive",
+        }),
+      );
+    });
+    expect(mockOnShared).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/features/collections/collection-progress-modal.test.tsx
+++ b/tests/unit/features/collections/collection-progress-modal.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * `CollectionProgressModal` 完了ビューのシェア導線テスト。
+ *
+ * シェアは posts / /m と同じ汎用 ShareLinkButton(実体)を使う。
+ * コンポーネント自体の振る舞いは share-link-button.test.tsx で網羅済みのため、
+ * ここでは配線(URL組立・計測・表示条件)と「シェアページへ」リンクの回帰を検証する。
+ * Dialog は実体(Radix)、DropdownMenu は既存規約どおりパススルーでモックする。
+ * 画像ロード前(ready=false)は opacity:0 になるだけで DOM には存在するため、
+ * クエリ・クリックはロード完了を待たずに行える。
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const mockToast = jest.fn();
+jest.mock("@/components/ui/use-toast", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+const mockCopyText = jest.fn();
+jest.mock("@/lib/clipboard", () => ({
+  copyTextToClipboard: (...args: unknown[]) => mockCopyText(...args),
+}));
+
+const mockSharePost = jest.fn();
+jest.mock("@/lib/share-post", () => ({
+  sharePost: (...args: unknown[]) => mockSharePost(...args),
+}));
+
+const mockBuildPublicMountUrl = jest.fn(
+  () => "https://persta.ai/m/completion-1?v=42",
+);
+const mockTrackMountShareEvent = jest.fn();
+jest.mock("@/features/collections/lib/share-mount", () => ({
+  buildPublicMountUrl: (...args: unknown[]) => mockBuildPublicMountUrl(...args),
+  trackMountShareEvent: (...args: unknown[]) =>
+    mockTrackMountShareEvent(...args),
+}));
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: { src: string; alt: string }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img src={props.src} alt={props.alt} />
+  ),
+}));
+
+jest.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="menu-root">{children}</div>
+  ),
+  DropdownMenuTrigger: ({
+    children,
+    asChild,
+  }: {
+    children: React.ReactNode;
+    asChild?: boolean;
+  }) =>
+    asChild ? (
+      <>{children}</>
+    ) : (
+      <button type="button" data-testid="menu-trigger">
+        {children}
+      </button>
+    ),
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="menu-content">{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button type="button" role="menuitem" onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+import {
+  CollectionProgressModal,
+  type CollectionCelebration,
+} from "@/features/collections/components/CollectionProgressModal";
+
+const completedCelebration: CollectionCelebration = {
+  categoryKey: "collectible_wafer_sticker",
+  displayName: "うちの子",
+  fromCount: 4,
+  toCount: 4,
+  threshold: 4,
+  isCompleted: true,
+  mountImageUrl: "https://cdn.example.com/mounts/mount-42.png",
+  sharePath: "/m/completion-1",
+  completionId: "completion-1",
+  characterImageUrl: null,
+  collectedImageUrls: [],
+};
+
+function renderModal(celebration: CollectionCelebration) {
+  return render(
+    <CollectionProgressModal
+      open
+      celebration={celebration}
+      onClose={jest.fn()}
+    />,
+  );
+}
+
+beforeEach(() => {
+  mockToast.mockReset();
+  mockCopyText.mockReset();
+  mockSharePost.mockReset();
+  mockBuildPublicMountUrl.mockClear();
+  mockTrackMountShareEvent.mockReset();
+  mockCopyText.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  Object.defineProperty(window.navigator, "share", {
+    configurable: true,
+    value: undefined,
+  });
+});
+
+describe("CollectionProgressModal: 完了ビューのシェア (PC)", () => {
+  test("「リンクをコピー」で公開URLをコピーし copied トーストと share-event 計測", async () => {
+    renderModal(completedCelebration);
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "リンクをコピー" }));
+
+    await waitFor(() => {
+      expect(mockCopyText).toHaveBeenCalledWith(
+        "https://persta.ai/m/completion-1?v=42",
+      );
+    });
+    expect(mockBuildPublicMountUrl).toHaveBeenCalledWith(
+      "completion-1",
+      completedCelebration.mountImageUrl,
+    );
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "URLをコピーしました" }),
+      );
+    });
+    expect(mockTrackMountShareEvent).toHaveBeenCalledWith("completion-1");
+  });
+
+  test("「シェアページへ」リンクは従来どおり sharePath へ遷移する(回帰)", () => {
+    renderModal(completedCelebration);
+
+    const link = screen.getByRole("link", { name: "シェアページへ" });
+    expect(link).toHaveAttribute("href", "/m/completion-1");
+  });
+
+  test("completionId が null ならシェアメニューを出さない", () => {
+    renderModal({
+      ...completedCelebration,
+      completionId: null,
+      sharePath: null,
+    });
+
+    // 台紙ビュー自体は出る(台紙画像)が、シェア導線は無い
+    // ※「コンプリート！」は sr-only タイトルと h2 の2箇所にあるため
+    //   一意な台紙画像 alt をアンカーにする
+    expect(
+      screen.getByAltText("うちの子 コンプリート台紙"),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "台紙をシェアする" }),
+    ).not.toBeInTheDocument();
+  });
+
+  test("navigator.share 未対応時の「その他の方法で共有」はエラートーストで計測なし", async () => {
+    Object.defineProperty(window.navigator, "share", {
+      configurable: true,
+      value: undefined,
+    });
+
+    renderModal(completedCelebration);
+
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: "その他の方法で共有" }),
+    );
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "エラー",
+          description: "Web Share APIがサポートされていません",
+          variant: "destructive",
+        }),
+      );
+    });
+    expect(mockTrackMountShareEvent).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/features/collections/mount-share-button.test.tsx
+++ b/tests/unit/features/collections/mount-share-button.test.tsx
@@ -1,0 +1,284 @@
+/**
+ * `MountShareButton` の UI レイヤテスト。
+ *
+ * - 「画像を保存」: モバイル/PC 分岐・Web Share・DL フォールバックは共通ヘルパ側の
+ *   `download-image.test.ts` で網羅済み。ここでは委譲・失敗トースト・busy を検証。
+ * - 「台紙をシェアする」: posts と同じ共通コンポーネント `ShareLinkButton` を
+ *   実体のまま使い（メニュー部の ui/dropdown-menu はパススルーモック）、
+ *   PC メニューからのコピー・計測(trackMountShareEvent)・未対応エラーを検証。
+ *   コンポーネント自体の振る舞いは share-link-button.test.tsx で網羅済み。
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const mockToast = jest.fn();
+jest.mock("@/components/ui/use-toast", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+const mockShareOrDownload = jest.fn();
+jest.mock("@/features/generation/lib/download-image", () => ({
+  shareOrDownloadGeneratedImage: (...args: unknown[]) =>
+    mockShareOrDownload(...args),
+}));
+
+const mockBuildPublicMountUrl = jest.fn(
+  () => "https://persta.ai/m/completion-1?v=123",
+);
+const mockTrackMountShareEvent = jest.fn();
+jest.mock("@/features/collections/lib/share-mount", () => ({
+  buildPublicMountUrl: (...args: unknown[]) => mockBuildPublicMountUrl(...args),
+  trackMountShareEvent: (...args: unknown[]) =>
+    mockTrackMountShareEvent(...args),
+}));
+
+const mockSharePost = jest.fn();
+jest.mock("@/lib/share-post", () => ({
+  sharePost: (...args: unknown[]) => mockSharePost(...args),
+}));
+
+const mockCopyText = jest.fn();
+jest.mock("@/lib/clipboard", () => ({
+  copyTextToClipboard: (...args: unknown[]) => mockCopyText(...args),
+}));
+
+jest.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="menu-root">{children}</div>
+  ),
+  DropdownMenuTrigger: ({
+    children,
+    asChild,
+  }: {
+    children: React.ReactNode;
+    asChild?: boolean;
+  }) =>
+    asChild ? (
+      <>{children}</>
+    ) : (
+      <button type="button" data-testid="menu-trigger">
+        {children}
+      </button>
+    ),
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="menu-content">{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button type="button" role="menuitem" onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+import { MountShareButton } from "@/features/collections/components/MountShareButton";
+
+const defaultProps = {
+  completionId: "completion-1",
+  mountImageUrl: "https://example.com/mounts/mount-1717999999999.png",
+};
+
+beforeEach(() => {
+  mockToast.mockReset();
+  mockShareOrDownload.mockReset();
+  mockBuildPublicMountUrl.mockClear();
+  mockTrackMountShareEvent.mockReset();
+  mockSharePost.mockReset();
+  mockCopyText.mockReset();
+  mockShareOrDownload.mockResolvedValue(undefined);
+  mockCopyText.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  Object.defineProperty(window.navigator, "share", {
+    configurable: true,
+    value: undefined,
+  });
+});
+
+describe("MountShareButton: 画像を保存", () => {
+  test("クリックで共通ヘルパに completionId と画像URL・リストタブ同等の文言を渡す", async () => {
+    render(<MountShareButton {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "画像を保存" }));
+
+    await waitFor(() => {
+      expect(mockShareOrDownload).toHaveBeenCalledTimes(1);
+    });
+    expect(mockShareOrDownload).toHaveBeenCalledWith(
+      { id: "completion-1", url: defaultProps.mountImageUrl },
+      expect.objectContaining({
+        // accessDenied はヘルパが Error message としてそのままトーストに出す
+        // ユーザー向けコピーなので、リストタブ(ja)と同一文言をピン留めする
+        accessDenied:
+          "画像へのアクセス権限がありません。認証が必要な可能性があります。",
+        fetchFailed: expect.any(Function),
+      }),
+    );
+    // fetchFailed はステータステキスト入りのリストタブ(ja)同等文言を返すこと
+    const messages = mockShareOrDownload.mock.calls[0][1] as {
+      fetchFailed: (statusText: string) => string;
+    };
+    expect(messages.fetchFailed("Not Found")).toBe(
+      "画像の取得に失敗しました: Not Found",
+    );
+    // 成功時はリストタブ同様トーストを出さない（モバイル share はシェアシートで完結）
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  test("DL中は保存ボタンのみ disabled になり二重実行しない(シェアとは独立)", async () => {
+    let resolveDownload: () => void = () => {};
+    mockShareOrDownload.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveDownload = resolve;
+        }),
+    );
+
+    render(<MountShareButton {...defaultProps} />);
+    const downloadButton = screen.getByRole("button", { name: "画像を保存" });
+    const shareTrigger = screen.getByRole("button", {
+      name: "台紙をシェアする",
+    });
+
+    fireEvent.click(downloadButton);
+    await waitFor(() => {
+      expect(downloadButton).toBeDisabled();
+    });
+    // posts と同じ独立 busy: DL 中でもシェア操作は塞がない
+    expect(shareTrigger).toBeEnabled();
+
+    fireEvent.click(downloadButton);
+    expect(mockShareOrDownload).toHaveBeenCalledTimes(1);
+
+    resolveDownload();
+    await waitFor(() => {
+      expect(downloadButton).toBeEnabled();
+    });
+    // 解決後も遅延実行された二重呼び出しが無いこと
+    expect(mockShareOrDownload).toHaveBeenCalledTimes(1);
+  });
+
+  test("失敗時（Error）は destructive トーストを出し window.open は呼ばず再有効化する", async () => {
+    mockShareOrDownload.mockRejectedValueOnce(new Error("fetch dead"));
+    const openSpy = jest.spyOn(window, "open").mockImplementation(() => null);
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    render(<MountShareButton {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: "画像を保存" }));
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "fetch dead",
+          variant: "destructive",
+        }),
+      );
+    });
+    // 旧実装の window.open フォールバックが廃止されていること
+    expect(openSpy).not.toHaveBeenCalled();
+    // リストタブと同じくエラーはログに残す
+    expect(errorSpy).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "画像を保存" }),
+      ).toBeEnabled();
+    });
+
+    openSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  test("失敗時（非 Error 値）は固定文言の destructive トーストを出す", async () => {
+    mockShareOrDownload.mockRejectedValueOnce("boom");
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    render(<MountShareButton {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: "画像を保存" }));
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "画像のダウンロードに失敗しました",
+          variant: "destructive",
+        }),
+      );
+    });
+
+    errorSpy.mockRestore();
+  });
+});
+
+describe("MountShareButton: 台紙をシェアする (PC, posts と同一挙動)", () => {
+  // jsdom の既定 UA はデスクトップ扱いなので PC メニュー経路になる
+
+  test("「リンクをコピー」で公開URLをコピーし copied トーストと share-event 計測", async () => {
+    render(<MountShareButton {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "リンクをコピー" }));
+
+    await waitFor(() => {
+      expect(mockCopyText).toHaveBeenCalledWith(
+        "https://persta.ai/m/completion-1?v=123",
+      );
+    });
+    expect(mockBuildPublicMountUrl).toHaveBeenCalledWith(
+      "completion-1",
+      defaultProps.mountImageUrl,
+    );
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "URLをコピーしました" }),
+      );
+    });
+    expect(mockTrackMountShareEvent).toHaveBeenCalledWith("completion-1");
+  });
+
+  test("「リンクをコピー」失敗時は固定文言の destructive トーストで計測なし", async () => {
+    mockCopyText.mockRejectedValueOnce(new Error("clipboard denied"));
+
+    render(<MountShareButton {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "リンクをコピー" }));
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "エラー",
+          description: "共有に失敗しました",
+          variant: "destructive",
+        }),
+      );
+    });
+    expect(mockTrackMountShareEvent).not.toHaveBeenCalled();
+  });
+
+  test("navigator.share 未対応時の「その他の方法で共有」はエラートーストで計測なし", async () => {
+    Object.defineProperty(window.navigator, "share", {
+      configurable: true,
+      value: undefined,
+    });
+
+    render(<MountShareButton {...defaultProps} />);
+
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: "その他の方法で共有" }),
+    );
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "エラー",
+          description: "Web Share APIがサポートされていません",
+          variant: "destructive",
+        }),
+      );
+    });
+    expect(mockTrackMountShareEvent).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/features/collections/share-mount.test.ts
+++ b/tests/unit/features/collections/share-mount.test.ts
@@ -1,0 +1,83 @@
+/**
+ * `share-mount` ライブラリのテスト。
+ *
+ * buildPublicMountUrl / trackMountShareEvent は MountShareButton(/m ページ)と
+ * CollectionProgressModal(マイページ・コンプリート演出)のシェア導線
+ * (ShareLinkButton 経由)が使う。URL 組立の互換(?v= バージョニング・旧URL
+ * フォールバック)と、計測のベストエフォート性(失敗握りつぶし)を固定する。
+ */
+
+import {
+  buildPublicMountUrl,
+  extractMountVersionFromUrl,
+  trackMountShareEvent,
+} from "@/features/collections/lib/share-mount";
+
+const origin = window.location.origin;
+const mockFetch = jest.fn();
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  mockFetch.mockResolvedValue({ ok: true });
+  global.fetch = mockFetch as unknown as typeof fetch;
+});
+
+describe("extractMountVersionFromUrl", () => {
+  test("mount-{ts}.png からタイムスタンプを抜き、無ければ null", () => {
+    expect(
+      extractMountVersionFromUrl("https://cdn/x/mount-123.png?v=9"),
+    ).toBe("123");
+    expect(extractMountVersionFromUrl("https://cdn/x/legacy.png")).toBeNull();
+    expect(extractMountVersionFromUrl(null)).toBeNull();
+    expect(extractMountVersionFromUrl(undefined)).toBeNull();
+  });
+});
+
+describe("buildPublicMountUrl", () => {
+  test("mount-{ts}.png 形式の画像URLからバージョン付き公開URLを組み立てる", () => {
+    expect(
+      buildPublicMountUrl(
+        "c1",
+        "https://cdn.example.com/mounts/mount-1717999999999.png?x=1",
+      ),
+    ).toBe(`${origin}/m/c1?v=1717999999999`);
+  });
+
+  test("タイムスタンプの無い旧URLや null ではバージョン無しURLになる", () => {
+    expect(buildPublicMountUrl("c1", "https://cdn.example.com/legacy.png")).toBe(
+      `${origin}/m/c1`,
+    );
+    expect(buildPublicMountUrl("c1", null)).toBe(`${origin}/m/c1`);
+    expect(buildPublicMountUrl("c1", undefined)).toBe(`${origin}/m/c1`);
+  });
+});
+
+describe("trackMountShareEvent", () => {
+  test("share-event エンドポイントへ completionId 付きで POST する", async () => {
+    trackMountShareEvent("c9");
+
+    await waitForMicrotasks();
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/collections/share-event",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ completionId: "c9" }),
+      }),
+    );
+  });
+
+  test("fetch が失敗しても例外にしない(ベストエフォート計測)", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("network down"));
+
+    expect(() => trackMountShareEvent("c1")).not.toThrow();
+    // fire-and-forget の reject が unhandled rejection にならないこと
+    await waitForMicrotasks();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+async function waitForMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}

--- a/tests/unit/features/posts/share-button.test.tsx
+++ b/tests/unit/features/posts/share-button.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * posts `ShareButton` の characterization テスト。
+ *
+ * ShareLinkButton への共通化リファクタの前後で、投稿シェアの観測可能な挙動
+ * （モバイル=sharePost 直呼び / PC=メニューからコピー・Web Share、文言、
+ * エラートースト）が変わらないことを担保する。リファクタ前の実装でも
+ * 後の実装でも緑であること。
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const mockToast = jest.fn();
+jest.mock("@/components/ui/use-toast", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+const mockSharePost = jest.fn();
+jest.mock("@/lib/share-post", () => ({
+  sharePost: (...args: unknown[]) => mockSharePost(...args),
+}));
+
+const mockCopyText = jest.fn();
+jest.mock("@/lib/clipboard", () => ({
+  copyTextToClipboard: (...args: unknown[]) => mockCopyText(...args),
+}));
+
+const mockGetPostDetailUrl = jest.fn(
+  () => "https://persta.ai/ja/posts/post-1",
+);
+jest.mock("@/lib/url-utils", () => ({
+  getPostDetailUrl: (...args: unknown[]) => mockGetPostDetailUrl(...args),
+}));
+
+// posts 名前空間の実文言をピン留めする(キー素通しだと文言回帰を検知できない)
+const POSTS_JA: Record<string, string> = {
+  shareCopyLink: "リンクをコピー",
+  shareMoreOptions: "その他の方法で共有",
+  shareCopyTitle: "URLをコピーしました",
+  errorTitle: "エラー",
+  shareFailed: "共有に失敗しました",
+  shareWebApiUnsupported: "Web Share APIがサポートされていません",
+};
+jest.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => POSTS_JA[key] ?? key,
+  useLocale: () => "ja",
+}));
+
+jest.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="menu-root">{children}</div>
+  ),
+  DropdownMenuTrigger: ({
+    children,
+    asChild,
+  }: {
+    children: React.ReactNode;
+    asChild?: boolean;
+  }) =>
+    asChild ? (
+      <>{children}</>
+    ) : (
+      <button type="button" data-testid="menu-trigger">
+        {children}
+      </button>
+    ),
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="menu-content">{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button type="button" role="menuitem" onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+import { ShareButton } from "@/features/posts/components/ShareButton";
+
+const MOBILE_UA =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15";
+const DESKTOP_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36";
+
+function setNavigator(opts: {
+  userAgent: string;
+  share?: ((data: ShareData) => Promise<void>) | undefined;
+}) {
+  Object.defineProperty(window.navigator, "userAgent", {
+    configurable: true,
+    value: opts.userAgent,
+  });
+  Object.defineProperty(window.navigator, "share", {
+    configurable: true,
+    value: opts.share,
+  });
+}
+
+beforeEach(() => {
+  mockToast.mockReset();
+  mockSharePost.mockReset();
+  mockCopyText.mockReset();
+  mockGetPostDetailUrl.mockClear();
+  mockSharePost.mockResolvedValue({ method: "share" });
+  mockCopyText.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  setNavigator({ userAgent: DESKTOP_UA, share: undefined });
+});
+
+describe("ShareButton (characterization)", () => {
+  test("モバイル: クリックで投稿詳細URLを sharePost に渡す", async () => {
+    setNavigator({ userAgent: MOBILE_UA, share: undefined });
+    render(<ShareButton postId="post-1" />);
+
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => {
+      expect(mockSharePost).toHaveBeenCalledWith(
+        "https://persta.ai/ja/posts/post-1",
+      );
+    });
+    expect(mockGetPostDetailUrl).toHaveBeenCalledWith("post-1", "ja");
+  });
+
+  test("PC: 「リンクをコピー」で URL コピーと copied トースト", async () => {
+    setNavigator({ userAgent: DESKTOP_UA, share: undefined });
+    render(<ShareButton postId="post-1" />);
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "リンクをコピー" }));
+
+    await waitFor(() => {
+      expect(mockCopyText).toHaveBeenCalledWith(
+        "https://persta.ai/ja/posts/post-1",
+      );
+    });
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "URLをコピーしました" }),
+      );
+    });
+  });
+
+  test("PC: コピー失敗は固定文言「共有に失敗しました」の destructive トースト", async () => {
+    setNavigator({ userAgent: DESKTOP_UA, share: undefined });
+    mockCopyText.mockRejectedValueOnce(new Error("clipboard denied"));
+    render(<ShareButton postId="post-1" />);
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "リンクをコピー" }));
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "エラー",
+          // 現行実装はコピー失敗時 error.message でなく固定文言を出す
+          description: "共有に失敗しました",
+          variant: "destructive",
+        }),
+      );
+    });
+  });
+
+  test("PC: navigator.share 未対応時の「その他の方法で共有」はエラートースト", async () => {
+    setNavigator({ userAgent: DESKTOP_UA, share: undefined });
+    render(<ShareButton postId="post-1" />);
+
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: "その他の方法で共有" }),
+    );
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "エラー",
+          description: "Web Share APIがサポートされていません",
+          variant: "destructive",
+        }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
### 概要
画像の保存・シェアの挙動が画面ごとにバラバラで、特に以下の UX 課題があった:

- `/m/[id]`（公開台紙ページ）の「画像を保存」が独自実装で、スマホでもシェアシートが開かず「ファイル」へのDL扱いになっていた（style 画面の生成一覧と挙動不一致）
- `/m` の「台紙をシェアする」と、マイページ・コンプリート演出モーダル内のシェアが、PC（`navigator.share` 非対応ブラウザ）では**無言でクリップボードコピー**され、何も起きていないように見えた

posts のシェアボタン（PC=「リンクをコピー／その他の方法で共有」メニュー）を汎用コンポーネント `ShareLinkButton` として切り出し、全導線を統一した。

### 変更内容
- `components/ShareLinkButton.tsx`（新規）: URL共有の汎用ボタン。モバイル=Web Share シェアシート（非対応時クリップボード+トースト）、PC=ドロップダウン「リンクをコピー」「その他の方法で共有」。キャンセル無音・失敗は destructive トースト・busy 制御つき
- `features/posts/components/ShareButton.tsx`: 上記の薄いラッパーに置換（**挙動不変**。characterization テストで前後の同一性を担保）
- `features/collections/components/MountShareButton.tsx`（/m ページ）:
  - 「画像を保存」を style 画面リストタブと同じ `shareOrDownloadGeneratedImage` に委譲（スマホ=シェアシートで写真へ保存、PC=ブラウザDL、失敗時トースト）
  - 「台紙をシェアする」を `ShareLinkButton` に置換
- `features/collections/components/CollectionProgressModal.tsx`: `onShare` prop を廃止し、完了ビューのシェアをモーダル内で `ShareLinkButton` 直接描画（`completionId` 無しなら非表示）。share-event 計測は `onShared` で維持
- `features/my-page/components/MyPageCollections.tsx` / `components/CollectionProgressChecker.tsx`: `onShare` 配線と `shareMount` import を削除
- `features/collections/lib/share-mount.ts`: `buildPublicMountUrl` / `trackMountShareEvent` を分離し、呼び出し元が無くなった `shareMount()` を削除
- `features/collections/lib/mount-share-messages.ts`（新規）: 台紙シェアの日本語文言を一本化（i18n Phase 7 までの暫定）
- テスト: 新規4ファイル+更新1ファイル（計38件）。ヘルパ委譲・PCメニュー・トースト文言・計測・busy・キャンセル無音・URL組立互換を検証

### 実機テスト
- [ ] iOS Safari で主要導線を確認（/m の保存=シェアシート、台紙シェア、posts シェア）
- [ ] Android Chrome で主要導線を確認
- [ ] PC（Chrome）で主要導線を確認（各シェアボタンでメニュー表示・コピートースト）
- [ ] レスポンシブ表示崩れがないことを確認（/m・コンプリートモーダルのボタン見た目）
- [ ] エラーメッセージやバリデーション表示を確認（DL失敗・コピー失敗トースト）

### テスト方法
- `npm run test`: 188 suites / 1810 件パス（新規・更新テスト 38 件含む）
- `npm run lint` / `npm run typecheck`: 変更ファイルへの指摘・本体コードのエラーなし（typecheck の増分は既知の jest-dom 型クラスのみ）
- `npm run build -- --webpack`: 成功
- 変更ファイルのカバレッジ: ShareLinkButton branches 94.7%・他ロジック系 100%（未カバーは UI から到達不能な防御行と既存未テストのモーダル演出部のみ）

> マージ方式: 短命 feature ブランチのため **Squash and merge** を推奨します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)