### PR TITLE
fix(popup-banners): チュートリアル表示中はポップアップバナーを抑制する

### DIFF
--- a/features/popup-banners/hooks/usePopupBanner.ts
+++ b/features/popup-banners/hooks/usePopupBanner.ts
@@ -5,6 +5,7 @@ import {
   getCurrentUser,
   onAuthStateChange,
 } from "@/features/auth/lib/auth-client";
+import { isTutorialActiveOrPending } from "@/features/tutorial/lib/tutorial-status";
 import {
   buildPopupBannerHistoryEntry,
   buildPopupBannerHistoryMap,
@@ -143,6 +144,7 @@ export function usePopupBanner(
     null
   );
   const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null);
+  const [tutorialCompleted, setTutorialCompleted] = useState(false);
   const [isReady, setIsReady] = useState(false);
   const sentImpressionIdsRef = useRef<Set<string>>(new Set());
 
@@ -159,10 +161,12 @@ export function usePopupBanner(
       }
 
       setIsAuthenticated(Boolean(user));
+      setTutorialCompleted(user?.user_metadata?.tutorial_completed === true);
     });
 
     const subscription = onAuthStateChange((user) => {
       setIsAuthenticated(Boolean(user));
+      setTutorialCompleted(user?.user_metadata?.tutorial_completed === true);
     });
 
     return () => {
@@ -180,6 +184,19 @@ export function usePopupBanner(
 
     async function initialize() {
       setIsReady(false);
+
+      // チュートリアル表示中(または開始予定)はバナーを出さない。
+      // ホームでチュートリアルとバナーが重なり、進行を妨げるのを防ぐ。
+      if (
+        isTutorialActiveOrPending({
+          isAuthenticated: isAuthenticated === true,
+          tutorialCompleted,
+        })
+      ) {
+        setCurrentBanner(null);
+        setIsReady(true);
+        return;
+      }
 
       const resolved = isAuthenticated
         ? await loadRemoteHistory()
@@ -211,7 +228,7 @@ export function usePopupBanner(
     return () => {
       cancelled = true;
     };
-  }, [banners, isAuthenticated]);
+  }, [banners, isAuthenticated, tutorialCompleted]);
 
   const markBannerDisplayed = useCallback(
     (bannerId: string) => {

--- a/features/tutorial/lib/tutorial-status.ts
+++ b/features/tutorial/lib/tutorial-status.ts
@@ -1,0 +1,33 @@
+import { TUTORIAL_STORAGE_KEYS } from "@/features/tutorial/types";
+
+/**
+ * チュートリアルが「表示中 or これから表示される」状態かを判定する。
+ * true の間はホーム画面で他のオーバーレイ(ポップアップバナー等)を抑制し、
+ * チュートリアルの進行を妨げないために使う。
+ *
+ * 判定条件(いずれか):
+ * - ツアー進行中(sessionStorage の in_progress)
+ * - 開始モーダルが出る条件: ログイン済み かつ 未完了 かつ 未スキップ
+ *
+ * スキップ(declined)済みユーザーはチュートリアルが出ないため対象外
+ * (= バナーを出してよい)。
+ */
+export function isTutorialActiveOrPending(opts: {
+  isAuthenticated: boolean;
+  tutorialCompleted: boolean;
+}): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  const inProgress =
+    window.sessionStorage.getItem(TUTORIAL_STORAGE_KEYS.IN_PROGRESS) === "true";
+  if (inProgress) {
+    return true;
+  }
+
+  const declined =
+    window.localStorage.getItem(TUTORIAL_STORAGE_KEYS.DECLINED) === "true";
+
+  return opts.isAuthenticated && !opts.tutorialCompleted && !declined;
+}

--- a/features/tutorial/lib/tutorial-status.ts
+++ b/features/tutorial/lib/tutorial-status.ts
@@ -20,14 +20,21 @@ export function isTutorialActiveOrPending(opts: {
     return false;
   }
 
-  const inProgress =
-    window.sessionStorage.getItem(TUTORIAL_STORAGE_KEYS.IN_PROGRESS) === "true";
-  if (inProgress) {
-    return true;
+  try {
+    const inProgress =
+      window.sessionStorage.getItem(TUTORIAL_STORAGE_KEYS.IN_PROGRESS) ===
+      "true";
+    if (inProgress) {
+      return true;
+    }
+
+    const declined =
+      window.localStorage.getItem(TUTORIAL_STORAGE_KEYS.DECLINED) === "true";
+
+    return opts.isAuthenticated && !opts.tutorialCompleted && !declined;
+  } catch {
+    // プライベートモード等でストレージにアクセスできない場合はクラッシュさせず、
+    // 抑制しない(= バナーを出してよい)安全側に倒す。
+    return false;
   }
-
-  const declined =
-    window.localStorage.getItem(TUTORIAL_STORAGE_KEYS.DECLINED) === "true";
-
-  return opts.isAuthenticated && !opts.tutorialCompleted && !declined;
 }

--- a/tests/unit/features/popup-banners/use-popup-banner.test.tsx
+++ b/tests/unit/features/popup-banners/use-popup-banner.test.tsx
@@ -86,7 +86,11 @@ const onAuthStateChangeMock = onAuthStateChange as jest.MockedFunction<
 describe("usePopupBanner", () => {
   const originalFetch = global.fetch;
   let fetchMock: jest.MockedFunction<typeof fetch>;
-  let authStateChangeCallback: ((user: { id: string } | null) => void) | null;
+  type AuthUser = {
+    id: string;
+    user_metadata?: { tutorial_completed?: boolean };
+  };
+  let authStateChangeCallback: ((user: AuthUser | null) => void) | null;
   let unsubscribeMock: jest.Mock;
 
   beforeEach(() => {
@@ -101,14 +105,17 @@ describe("usePopupBanner", () => {
       configurable: true,
       value: fetchMock,
     });
-    getCurrentUserMock.mockResolvedValue({ id: "user-1" } as Awaited<
-      ReturnType<typeof getCurrentUser>
-    >);
+    // 既定はチュートリアル完了済みユーザー(バナー表示の前提)。
+    // 未完了ユーザーはチュートリアルが出るためバナーは抑制される。
+    getCurrentUserMock.mockResolvedValue({
+      id: "user-1",
+      user_metadata: { tutorial_completed: true },
+    } as unknown as Awaited<ReturnType<typeof getCurrentUser>>);
     onAuthStateChangeMock.mockImplementation((callback) => {
-      authStateChangeCallback = callback as (user: { id: string } | null) => void;
+      authStateChangeCallback = callback as (user: AuthUser | null) => void;
       return {
         unsubscribe: unsubscribeMock,
-      } as ReturnType<typeof onAuthStateChange>;
+      } as unknown as ReturnType<typeof onAuthStateChange>;
     });
   });
 
@@ -461,7 +468,10 @@ describe("usePopupBanner", () => {
     expect(fetchMock).not.toHaveBeenCalled();
 
     act(() => {
-      authStateChangeCallback?.({ id: "user-1" });
+      authStateChangeCallback?.({
+        id: "user-1",
+        user_metadata: { tutorial_completed: true },
+      });
     });
 
     await waitFor(() => {
@@ -533,6 +543,55 @@ describe("usePopupBanner", () => {
       expect(result.current.currentBanner?.id).toBe("banner-a");
     });
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("チュートリアル未完了ユーザー(開始予定)はバナーを抑制する", async () => {
+    getCurrentUserMock.mockResolvedValue({
+      id: "user-1",
+      user_metadata: {},
+    } as unknown as Awaited<ReturnType<typeof getCurrentUser>>);
+    const banners = [createBanner("banner-a", 1)];
+
+    const { result } = renderHook(() => usePopupBanner(banners));
+
+    await waitFor(() => {
+      expect(result.current.isReady).toBe(true);
+    });
+
+    expect(result.current.currentBanner).toBeNull();
+    // バナー履歴 API も呼ばれない(チュートリアル優先)
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("チュートリアル進行中(in_progress)はバナーを抑制する", async () => {
+    window.sessionStorage.setItem("tutorial_in_progress", "true");
+    const banners = [createBanner("banner-a", 1)];
+
+    const { result } = renderHook(() => usePopupBanner(banners));
+
+    await waitFor(() => {
+      expect(result.current.isReady).toBe(true);
+    });
+
+    expect(result.current.currentBanner).toBeNull();
+  });
+
+  test("チュートリアルをスキップ(declined)したユーザーにはバナーを出す", async () => {
+    window.localStorage.setItem("tutorial_declined", "true");
+    getCurrentUserMock.mockResolvedValue({
+      id: "user-1",
+      user_metadata: {},
+    } as unknown as Awaited<ReturnType<typeof getCurrentUser>>);
+    fetchMock.mockResolvedValue(createJsonResponse([]));
+    const banners = [createBanner("banner-a", 1)];
+
+    const { result } = renderHook(() => usePopupBanner(banners));
+
+    await waitFor(() => {
+      expect(result.current.isReady).toBe(true);
+    });
+
+    expect(result.current.currentBanner?.id).toBe("banner-a");
   });
 
   test("currentBanner がない状態で close と click を呼んでも何もしない", async () => {

--- a/tests/unit/features/tutorial/tutorial-status.ssr.test.ts
+++ b/tests/unit/features/tutorial/tutorial-status.ssr.test.ts
@@ -1,0 +1,15 @@
+/** @jest-environment node */
+
+import { isTutorialActiveOrPending } from "@/features/tutorial/lib/tutorial-status";
+
+describe("isTutorialActiveOrPending (SSR / window 未定義)", () => {
+  it("window が無い環境では false を返す", () => {
+    expect(typeof window).toBe("undefined");
+    expect(
+      isTutorialActiveOrPending({
+        isAuthenticated: true,
+        tutorialCompleted: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/tests/unit/features/tutorial/tutorial-status.test.ts
+++ b/tests/unit/features/tutorial/tutorial-status.test.ts
@@ -52,4 +52,21 @@ describe("isTutorialActiveOrPending", () => {
       }),
     ).toBe(false);
   });
+
+  it("ストレージアクセスが例外でも false を返す(クラッシュさせない)", () => {
+    const spy = jest
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation(() => {
+        throw new Error("SecurityError");
+      });
+
+    expect(
+      isTutorialActiveOrPending({
+        isAuthenticated: true,
+        tutorialCompleted: false,
+      }),
+    ).toBe(false);
+
+    spy.mockRestore();
+  });
 });

--- a/tests/unit/features/tutorial/tutorial-status.test.ts
+++ b/tests/unit/features/tutorial/tutorial-status.test.ts
@@ -1,0 +1,55 @@
+import { isTutorialActiveOrPending } from "@/features/tutorial/lib/tutorial-status";
+
+describe("isTutorialActiveOrPending", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  it("ツアー進行中(in_progress)なら true", () => {
+    window.sessionStorage.setItem("tutorial_in_progress", "true");
+    expect(
+      isTutorialActiveOrPending({
+        isAuthenticated: true,
+        tutorialCompleted: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("ログイン済み・未完了・未スキップなら true(開始モーダルが出る)", () => {
+    expect(
+      isTutorialActiveOrPending({
+        isAuthenticated: true,
+        tutorialCompleted: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("完了済みなら false", () => {
+    expect(
+      isTutorialActiveOrPending({
+        isAuthenticated: true,
+        tutorialCompleted: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("スキップ(declined)済みなら false(バナーを出してよい)", () => {
+    window.localStorage.setItem("tutorial_declined", "true");
+    expect(
+      isTutorialActiveOrPending({
+        isAuthenticated: true,
+        tutorialCompleted: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("未ログインなら false", () => {
+    expect(
+      isTutorialActiveOrPending({
+        isAuthenticated: false,
+        tutorialCompleted: false,
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
### 概要
新規登録ユーザーがホーム画面でチュートリアルを開始した直後に、ポップアップバナーが重なって表示され、チュートリアルを進められなくなることがある問題を修正しました。ポップアップバナーとチュートリアルはどちらもホーム画面に表示されますが、互いの状態を認識していなかったため衝突していました。

### 変更内容
- `isTutorialActiveOrPending` ヘルパー（[features/tutorial/lib/tutorial-status.ts](features/tutorial/lib/tutorial-status.ts)）を追加。チュートリアル自身と同じ3つの信号（`tutorial_in_progress` / `tutorial_completed` / `tutorial_declined`）で「表示中 or 表示予定」を判定する
- `usePopupBanner` の初期化時に上記ヘルパーで判定し、チュートリアルが表示される場合はバナーを出さない（`getCurrentUser` で取得済みのユーザーから `tutorial_completed` を読むため追加通信なし）
- スキップ（declined）済みユーザーはチュートリアルが出ないため、従来どおりバナーを表示する

### 抑制条件
- ツアー進行中（`tutorial_in_progress === "true"`）
- または 開始モーダルが出る条件（ログイン済み・未完了・未スキップ）

### 補足
- バナーはもともとホーム画面でのみ表示されるため、「ホームでのみ抑制」が自然に成立する
- 判定はバナー初期化時のため、チュートリアル完了/スキップ後にホームへ戻る・再読み込みすると通常どおりバナーが出る

### 実機テスト
- [ ] iOS Safari で主要導線を確認
- [ ] Android Chrome で主要導線を確認
- [ ] PC（Chrome）で主要導線を確認
- [ ] 新規登録直後のチュートリアル開始時にバナーが出ないことを確認
- [ ] チュートリアル完了後・スキップ後にホームでバナーが出ることを確認

### テスト方法
- 新規テスト：`tutorial-status` ヘルパー（5件）、バナー抑制挙動（未完了で抑制／進行中で抑制／スキップ済みは表示）
- `npm run test`（1890件すべてパス）
- `npm run build -- --webpack`（成功）
- `npm run lint` / `npm run typecheck`（該当ファイルのエラーなし）

> このPRは **Squash and merge** でマージしてください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)