### PR TITLE
feat(preset-categories): モデル選択OFF時の既定モデル名を説明文に表示

### DIFF
--- a/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
+++ b/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
@@ -654,8 +654,7 @@ export function AdminPresetCategoryFormClient({
             <span className="font-medium">生成モデル選択を表示</span>
             <br />
             <span className="text-xs text-slate-500">
-              OFF の場合、/style ではモデル選択を表示せず、既定モデル（
-              {DEFAULT_GENERATION_MODEL_LABEL}）で生成します。
+              OFF の場合、/style ではモデル選択を表示せず、既定モデル（{DEFAULT_GENERATION_MODEL_LABEL}）で生成します。
             </span>
           </span>
         </label>

--- a/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
+++ b/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
@@ -3,8 +3,14 @@
 import { useRouter } from "next/navigation";
 import { useState, type FormEvent } from "react";
 import type { PresetCategoryAdmin } from "@/features/style-presets/lib/preset-category-repository";
+import { DEFAULT_GENERATION_MODEL } from "@/features/generation/types";
+import { getModelDisplayInfo } from "@/features/generation/lib/model-display";
 
 type Mode = "create" | "edit";
+
+/** 「生成モデル選択を表示」OFF 時にサーバー側で使われる既定モデルの表示名。 */
+const DEFAULT_GENERATION_MODEL_LABEL =
+  getModelDisplayInfo(DEFAULT_GENERATION_MODEL).displayName;
 
 interface Props {
   mode: Mode;
@@ -648,7 +654,8 @@ export function AdminPresetCategoryFormClient({
             <span className="font-medium">生成モデル選択を表示</span>
             <br />
             <span className="text-xs text-slate-500">
-              OFF の場合、/style ではモデル選択を表示せず、既定モデルで生成します。
+              OFF の場合、/style ではモデル選択を表示せず、既定モデル（
+              {DEFAULT_GENERATION_MODEL_LABEL}）で生成します。
             </span>
           </span>
         </label>


### PR DESCRIPTION
### 概要
プリセットカテゴリ管理画面の「生成モデル選択を表示」設定について、OFF にしたときにどのモデルで生成されるのかが説明文から分からず、管理者が判断しづらい状態でした。OFF 時に実際に使われる既定モデル名を説明文に表示するようにしました。

### 変更内容
- [AdminPresetCategoryFormClient.tsx](features/preset-categories/components/AdminPresetCategoryFormClient.tsx) の「生成モデル選択を表示」説明文を変更
  - 変更前：「OFF の場合、/style ではモデル選択を表示せず、既定モデルで生成します。」
  - 変更後：「OFF の場合、/style ではモデル選択を表示せず、既定モデル（ChatGPT Images 2.0 | Low）で生成します。」
- モデル名のベタ書きで将来ズレるのを防ぐため、正本の `DEFAULT_GENERATION_MODEL` から `getModelDisplayInfo` で表示名を動的に取得。既定モデルが変われば説明文も自動追従する

### 補足
- サーバー側の生成ハンドラ（generate / generate-async）は `showGenerationModelControl` が OFF のとき `DEFAULT_GENERATION_MODEL`（= `gpt-image-2-low-1k`）に固定しており、本表示はその実値と一致する

### 実機テスト
- [ ] PC（Chrome）で管理画面のプリセットカテゴリ編集フォームを開き、説明文にモデル名が表示されることを確認
- [ ] レスポンシブ表示崩れがないことを確認

### テスト方法
- `npm run test`（全パス）
- `npm run build -- --webpack`（成功）
- `npm run lint` / `npm run typecheck`（該当ファイルのエラーなし）

> このPRは **Squash and merge** でマージしてください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)