### PR TITLE
feat(tutorial): 新規ユーザー向けチュートリアルを Persta らしいポップなUIに刷新

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1536,12 +1536,13 @@ html[lang="en"]:not(.ppr-locale-ready) .main-content {
 }
 
 /*
- * /style（One-Tap Style）画面チュートリアル用ポップオーバー。
- * StyleTourButton が driver.js の popoverClass で適用する。
+ * Persta 共通のチュートリアル用ポップオーバー（ポップで明るいトーン）。
+ * /style の StyleTourButton と、新規ユーザー向け TutorialTourProvider が
+ * driver.js の popoverClass: "persta-tour-popover" で共有する。
  * driver.css（遅延読み込み）より高い詳細度で上書きするため
  * .driver-popover を併記している。
  */
-.driver-popover.style-tour-popover {
+.driver-popover.persta-tour-popover {
   max-width: 21rem;
   border-radius: 1.25rem;
   padding: 1.25rem 1.25rem 1rem;
@@ -1551,7 +1552,7 @@ html[lang="en"]:not(.ppr-locale-ready) .main-content {
     0 4px 12px rgba(15, 23, 42, 0.08);
 }
 
-.driver-popover.style-tour-popover .driver-popover-title {
+.driver-popover.persta-tour-popover .driver-popover-title {
   font-size: 1.05rem;
   font-weight: 700;
   line-height: 1.5;
@@ -1561,27 +1562,27 @@ html[lang="en"]:not(.ppr-locale-ready) .main-content {
   color: transparent;
 }
 
-.driver-popover.style-tour-popover .driver-popover-description {
+.driver-popover.persta-tour-popover .driver-popover-description {
   margin-top: 0.375rem;
   font-size: 0.9rem;
   line-height: 1.6;
   color: #334155;
 }
 
-.driver-popover.style-tour-popover .driver-popover-progress-text {
+.driver-popover.persta-tour-popover .driver-popover-progress-text {
   font-size: 0.75rem;
   font-weight: 600;
   color: #ec4899;
 }
 
-.driver-popover.style-tour-popover .driver-popover-footer {
+.driver-popover.persta-tour-popover .driver-popover-footer {
   margin-top: 0.875rem;
   gap: 0.5rem;
 }
 
 /* 押し間違い防止のため、ボタンはタップしやすい大きめのピル型にする */
-.driver-popover.style-tour-popover .driver-popover-prev-btn,
-.driver-popover.style-tour-popover .driver-popover-next-btn {
+.driver-popover.persta-tour-popover .driver-popover-prev-btn,
+.driver-popover.persta-tour-popover .driver-popover-next-btn {
   border-radius: 9999px;
   padding: 0.5rem 1.125rem;
   font-size: 0.85rem;
@@ -1589,34 +1590,34 @@ html[lang="en"]:not(.ppr-locale-ready) .main-content {
   text-shadow: none;
 }
 
-.driver-popover.style-tour-popover .driver-popover-next-btn {
+.driver-popover.persta-tour-popover .driver-popover-next-btn {
   border: none;
   background: linear-gradient(90deg, #ec4899, #f97316);
   color: #ffffff;
 }
 
-.driver-popover.style-tour-popover .driver-popover-next-btn:hover {
+.driver-popover.persta-tour-popover .driver-popover-next-btn:hover {
   background: linear-gradient(90deg, #db2777, #ea580c);
   color: #ffffff;
 }
 
-.driver-popover.style-tour-popover .driver-popover-prev-btn {
+.driver-popover.persta-tour-popover .driver-popover-prev-btn {
   border: 1px solid #e2e8f0;
   background: #ffffff;
   color: #475569;
 }
 
-.driver-popover.style-tour-popover .driver-popover-prev-btn:hover {
+.driver-popover.persta-tour-popover .driver-popover-prev-btn:hover {
   background: #f8fafc;
 }
 
-.driver-popover.style-tour-popover .driver-popover-close-btn {
+.driver-popover.persta-tour-popover .driver-popover-close-btn {
   width: 1.75rem;
   height: 1.75rem;
   border-radius: 9999px;
   color: #94a3b8;
 }
 
-.driver-popover.style-tour-popover .driver-popover-close-btn:hover {
+.driver-popover.persta-tour-popover .driver-popover-close-btn:hover {
   color: #475569;
 }

--- a/features/style/components/StyleTourButton.tsx
+++ b/features/style/components/StyleTourButton.tsx
@@ -102,7 +102,7 @@ export function StyleTourButton() {
         overlayOpacity: 0.6,
         stagePadding: 8,
         stageRadius: 16,
-        popoverClass: "style-tour-popover",
+        popoverClass: "persta-tour-popover",
         prevBtnText: t("tourPrevButton"),
         nextBtnText: t("tourNextButton"),
         doneBtnText: t("tourDoneButton"),

--- a/features/tutorial/components/TutorialStartModal.tsx
+++ b/features/tutorial/components/TutorialStartModal.tsx
@@ -50,21 +50,27 @@ export function TutorialStartModal({
         }
       }}
     >
-      <DialogContent showCloseButton={false} className="sm:max-w-md">
+      <DialogContent
+        showCloseButton={false}
+        className="overflow-hidden rounded-3xl border-0 bg-[linear-gradient(160deg,#ffffff_0%,#fff5f9_55%,#fff3e8_100%)] p-6 shadow-[0_18px_48px_rgba(236,72,153,0.22),0_6px_16px_rgba(15,23,42,0.08)] sm:max-w-md"
+      >
         {showDeclinedMessage ? (
           <>
             <DialogHeader>
-              <DialogTitle>
+              <DialogTitle className="bg-gradient-to-r from-pink-500 to-orange-400 bg-clip-text text-xl font-bold text-transparent">
                 {t("startDeclinedTitleLine1")}
                 <br />
                 {t("startDeclinedTitleLine2")}
               </DialogTitle>
-              <DialogDescription>
+              <DialogDescription className="text-slate-600">
                 {t("startDeclinedDescription")}
               </DialogDescription>
             </DialogHeader>
             <DialogFooter className="sm:justify-end">
-              <Button onClick={handleCloseDeclined} className="min-h-[44px]">
+              <Button
+                onClick={handleCloseDeclined}
+                className="min-h-[44px] rounded-full border-0 bg-gradient-to-r from-pink-500 to-orange-400 font-bold text-white shadow-sm transition hover:from-pink-600 hover:to-orange-500"
+              >
                 {t("close")}
               </Button>
             </DialogFooter>
@@ -72,8 +78,10 @@ export function TutorialStartModal({
         ) : (
           <>
             <DialogHeader className="text-left">
-              <DialogTitle>{t("startTitle")}</DialogTitle>
-              <div className="relative my-4 w-full overflow-hidden rounded-lg">
+              <DialogTitle className="bg-gradient-to-r from-pink-500 to-orange-400 bg-clip-text text-2xl font-bold leading-snug text-transparent">
+                {t("startTitle")}
+              </DialogTitle>
+              <div className="relative my-4 w-full overflow-hidden rounded-2xl shadow-sm ring-1 ring-pink-100">
                 <Image
                   src="/tutorial_main_image.webp"
                   alt={t("startImageAlt")}
@@ -83,22 +91,21 @@ export function TutorialStartModal({
                   priority
                 />
               </div>
-              <DialogDescription className="mb-2">
+              <DialogDescription className="mb-2 text-[0.95rem] leading-relaxed text-slate-600">
                 {t("startDescription")}
               </DialogDescription>
             </DialogHeader>
-            <DialogFooter className="flex flex-col gap-2 sm:justify-end">
+            <DialogFooter className="flex flex-col gap-2.5 sm:justify-end">
               <Button
-                variant="info"
                 onClick={onConfirm}
-                className="min-h-[44px]"
+                className="min-h-[48px] rounded-full border-0 bg-gradient-to-r from-pink-500 to-orange-400 text-base font-bold text-white shadow-[0_6px_16px_rgba(236,72,153,0.28)] transition hover:from-pink-600 hover:to-orange-500"
               >
                 {t("startConfirm")}
               </Button>
               <Button
                 variant="outline"
                 onClick={handleDeclineClick}
-                className="min-h-[44px]"
+                className="min-h-[44px] rounded-full border-slate-200 bg-white font-semibold text-slate-600 shadow-sm hover:bg-slate-50"
               >
                 {t("startDecline")}
               </Button>

--- a/features/tutorial/components/TutorialStartModal.tsx
+++ b/features/tutorial/components/TutorialStartModal.tsx
@@ -57,30 +57,21 @@ export function TutorialStartModal({
         {showDeclinedMessage ? (
           <>
             <DialogHeader>
-              <DialogTitle className="bg-gradient-to-r from-pink-500 to-orange-400 bg-clip-text text-xl font-bold text-transparent">
-                {t("startDeclinedTitleLine1")}
-                <br />
-                {t("startDeclinedTitleLine2")}
-              </DialogTitle>
-              <DialogDescription className="text-slate-600">
-                {t("startDeclinedDescription")}
-              </DialogDescription>
+              <DialogTitle className="bg-gradient-to-r from-pink-500 to-orange-400 bg-clip-text text-xl font-bold text-transparent">{t("startDeclinedTitleLine1")}<br />{t("startDeclinedTitleLine2")}</DialogTitle>
+              <DialogDescription className="text-slate-600">{t("startDeclinedDescription")}</DialogDescription>
             </DialogHeader>
             <DialogFooter className="sm:justify-end">
               <Button
+                type="button"
                 onClick={handleCloseDeclined}
                 className="min-h-[44px] rounded-full border-0 bg-gradient-to-r from-pink-500 to-orange-400 font-bold text-white shadow-sm transition hover:from-pink-600 hover:to-orange-500"
-              >
-                {t("close")}
-              </Button>
+              >{t("close")}</Button>
             </DialogFooter>
           </>
         ) : (
           <>
             <DialogHeader className="text-left">
-              <DialogTitle className="bg-gradient-to-r from-pink-500 to-orange-400 bg-clip-text text-2xl font-bold leading-snug text-transparent">
-                {t("startTitle")}
-              </DialogTitle>
+              <DialogTitle className="bg-gradient-to-r from-pink-500 to-orange-400 bg-clip-text text-2xl font-bold leading-snug text-transparent">{t("startTitle")}</DialogTitle>
               <div className="relative my-4 w-full overflow-hidden rounded-2xl shadow-sm ring-1 ring-pink-100">
                 <Image
                   src="/tutorial_main_image.webp"
@@ -91,24 +82,20 @@ export function TutorialStartModal({
                   priority
                 />
               </div>
-              <DialogDescription className="mb-2 text-[0.95rem] leading-relaxed text-slate-600">
-                {t("startDescription")}
-              </DialogDescription>
+              <DialogDescription className="mb-2 text-[0.95rem] leading-relaxed text-slate-600">{t("startDescription")}</DialogDescription>
             </DialogHeader>
             <DialogFooter className="flex flex-col gap-2.5 sm:justify-end">
               <Button
+                type="button"
                 onClick={onConfirm}
                 className="min-h-[48px] rounded-full border-0 bg-gradient-to-r from-pink-500 to-orange-400 text-base font-bold text-white shadow-[0_6px_16px_rgba(236,72,153,0.28)] transition hover:from-pink-600 hover:to-orange-500"
-              >
-                {t("startConfirm")}
-              </Button>
+              >{t("startConfirm")}</Button>
               <Button
+                type="button"
                 variant="outline"
                 onClick={handleDeclineClick}
                 className="min-h-[44px] rounded-full border-slate-200 bg-white font-semibold text-slate-600 shadow-sm hover:bg-slate-50"
-              >
-                {t("startDecline")}
-              </Button>
+              >{t("startDecline")}</Button>
             </DialogFooter>
           </>
         )}

--- a/features/tutorial/components/TutorialTourProvider.tsx
+++ b/features/tutorial/components/TutorialTourProvider.tsx
@@ -211,6 +211,11 @@ export function TutorialTourProvider() {
       showProgress: true,
       animate: !prefersReducedMotion(),
       allowClose: false,
+      // Persta 共通のポップなトーン（/style と統一。globals.css 参照）
+      popoverClass: "persta-tour-popover",
+      overlayOpacity: 0.6,
+      stagePadding: 8,
+      stageRadius: 16,
       prevBtnText: t("prevButton"),
       nextBtnText: t("nextButton"),
       steps,
@@ -474,6 +479,11 @@ export function TutorialTourProvider() {
         showProgress: true,
         animate: !prefersReducedMotion(),
         allowClose: true,
+        // Persta 共通のポップなトーン（/style と統一。globals.css 参照）
+        popoverClass: "persta-tour-popover",
+        overlayOpacity: 0.6,
+        stagePadding: 8,
+        stageRadius: 16,
         prevBtnText: t("prevButton"),
         nextBtnText: t("nextButton"),
         doneBtnText: t("doneButton"),

--- a/tests/unit/features/style/style-tour-button.test.tsx
+++ b/tests/unit/features/style/style-tour-button.test.tsx
@@ -102,7 +102,7 @@ describe("StyleTourButton", () => {
     const config = await startTourAndGetConfig();
 
     expect(config.steps).toHaveLength(3);
-    expect(config.popoverClass).toBe("style-tour-popover");
+    expect(config.popoverClass).toBe("persta-tour-popover");
     expect(config.disableActiveInteraction).toBe(true);
     expect(driverInstance.drive).toHaveBeenCalledWith(0);
   });


### PR DESCRIPTION
### 概要
`/style`（One-Tap Style）画面のチュートリアルで採用した、Persta らしいポップで明るいトーンを、新規登録ユーザー向けの通常チュートリアルにも適用しました。これまでホーム画面に表示される開始モーダルは標準ダイアログ、ツアーの吹き出しは driver.js デフォルトの素朴な見た目でしたが、両方を `/style` と統一して一貫した体験にしています。見た目のみの変更で、ステップ進行・コイン付与などのロジックには一切手を入れていません。

### 変更内容
- ポップオーバーの共通スタイルを `.style-tour-popover` から `.persta-tour-popover` にリネームし、`/style` ツアーと新規ユーザー向けチュートリアルで単一の定義を共有（重複なし）
- `TutorialTourProvider` の2箇所（ホーム開始時・コーディネート再開時）の `driver()` に `popoverClass: "persta-tour-popover"` と `overlayOpacity` / `stagePadding` / `stageRadius` を付与。グラデーション見出し・ピル型ボタン・丸みのある吹き出しに統一
- `TutorialStartModal`（ホーム画面の「チュートリアルを開始しますか？」ポップアップ）を刷新
  - 角丸を `rounded-3xl` に、背景を白→ピンク→オレンジの淡いグラデーションに
  - タイトルをピンク→オレンジのグラデーション文字に
  - 「はい」をピンク〜オレンジのピル型ボタン、「いいえ」を丸ピル型の白ボタンに
  - メイン画像にピンクの薄リングを追加
- `StyleTourButton` の `popoverClass` と既存テストの期待値を共通クラス名へ更新

### 確認方法（ローカル）
- 開始モーダル：ログイン状態で `http://localhost:3000/?tutorial_reset=1` を開くと、完了/辞退フラグを無視して刷新後モーダルが表示される
- ツアー本体：上記モーダルで「はい」を押すと `/coordinate` に遷移し、新デザインの吹き出しでツアーが始まる
- 参考：`/style` のタイトル横「チュートリアル」ボタンでも同一の共通スタイルを確認できる

### 実機テスト
- [ ] iOS Safari で主要導線を確認
- [ ] Android Chrome で主要導線を確認
- [ ] PC（Chrome）で主要導線を確認
- [ ] レスポンシブ表示崩れがないことを確認
- [ ] エラーメッセージやバリデーション表示を確認

### テスト方法
- `npm run test`：全1906件パス
- `npm run typecheck` / `npm run lint`：main と同数で新規エラーなし
- `npm run build -- --webpack`：成功
- ヘッドレスブラウザでモーダルのデザインと、共通クラス適用後のツアー吹き出し（通常／reduced-motion 含む）を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
