### PR TITLE
feat(admin): コレクションKPIをダッシュボードに集約し神コレ計測指標を拡充

### DIFF
--- a/app/(app)/admin/admin-nav-items.ts
+++ b/app/(app)/admin/admin-nav-items.ts
@@ -116,12 +116,6 @@ export const adminNavItems: AdminNavItem[] = [
     iconKey: "image",
   },
   {
-    path: "/admin/collections",
-    label: "コレクション",
-    description: "シリーズ別 KPI と達成者一覧を確認",
-    iconKey: "rectangle-horizontal",
-  },
-  {
     path: "/admin/style-templates",
     label: "スタイルテンプレート審査",
     description: "ユーザー投稿テンプレを審査・管理",

--- a/app/(app)/admin/collections/page.tsx
+++ b/app/(app)/admin/collections/page.tsx
@@ -1,51 +1,9 @@
-import { connection } from "next/server";
 import { redirect } from "next/navigation";
-import { getUser } from "@/lib/auth";
-import { getAdminUserIds } from "@/lib/env";
-import { listPresetCategories } from "@/features/style-presets/lib/preset-category-repository";
-import {
-  AdminCollectionsView,
-  type AdminCollectionSeries,
-} from "@/features/admin-dashboard/components/AdminCollectionsView";
 
-export const metadata = {
-  title: "コレクション | Admin",
-};
-
-export default async function AdminCollectionsPage() {
-  await connection();
-
-  const user = await getUser();
-  const adminUserIds = getAdminUserIds();
-  if (!user || adminUserIds.length === 0 || !adminUserIds.includes(user.id)) {
-    redirect("/");
-  }
-
-  const categories = await listPresetCategories({ includeInactive: true });
-  const series: AdminCollectionSeries[] = categories
-    .filter((c) => c.isCollectionSeries)
-    .map((c) => ({
-      key: c.key,
-      displayName: c.displayNameJa,
-      threshold: c.completionThreshold ?? 0,
-    }));
-
-  return (
-    <div className="space-y-6">
-      <header>
-        <h1
-          className="text-2xl font-bold tracking-tight text-slate-900 sm:text-3xl"
-          style={{
-            fontFamily: "var(--font-admin-heading), ui-monospace, monospace",
-          }}
-        >
-          コレクション
-        </h1>
-        <p className="mt-1 text-slate-600">
-          シリーズ別の KPI と、誰がコンプリートしたか(達成者一覧)を確認できます。
-        </p>
-      </header>
-      <AdminCollectionsView series={series} />
-    </div>
-  );
+/**
+ * コレクションKPIは /admin のダッシュボードタブへ集約済み。
+ * 旧URL /admin/collections は新タブへ 308 リダイレクトする(既存ブックマーク保護)。
+ */
+export default function AdminCollectionsPage() {
+  redirect("/admin?tab=collections");
 }

--- a/app/(app)/admin/page.tsx
+++ b/app/(app)/admin/page.tsx
@@ -10,7 +10,9 @@ import { listPresetCategories } from "@/features/style-presets/lib/preset-catego
 import { getAdminDashboardData } from "@/features/admin-dashboard/lib/get-admin-dashboard-data";
 import {
   formatAdminDateTimeLabel,
+  getCustomDashboardRangeBounds,
   getOneTapStyleRangeBounds,
+  parseCustomDashboardRange,
   parseDashboardRange,
   parseOneTapStyleDashboardRange,
 } from "@/features/admin-dashboard/lib/dashboard-range";
@@ -24,6 +26,9 @@ interface AdminDashboardPageProps {
     styleRange?: string;
     styleFrom?: string;
     styleTo?: string;
+    collectionRange?: string;
+    collectionFrom?: string;
+    collectionTo?: string;
   }>;
 }
 
@@ -44,6 +49,19 @@ export default async function AdminDashboardPage({
   const formattedStyleFrom = formatAdminDateTimeLabel(oneTapStyleRangeBounds.fromIso);
   const formattedStyleTo = formatAdminDateTimeLabel(oneTapStyleRangeBounds.toIso);
   const data = await getAdminDashboardData(range, oneTapStyleRangeBounds);
+
+  const collectionRange = parseCustomDashboardRange(params.collectionRange);
+  const collectionRangeBounds = getCustomDashboardRangeBounds({
+    range: collectionRange,
+    from: params.collectionFrom,
+    to: params.collectionTo,
+  });
+  const formattedCollectionFrom = formatAdminDateTimeLabel(
+    collectionRangeBounds.fromIso,
+  );
+  const formattedCollectionTo = formatAdminDateTimeLabel(
+    collectionRangeBounds.toIso,
+  );
 
   let collectionSeries: AdminCollectionSeries[] = [];
   if (tab === "collections") {
@@ -66,7 +84,15 @@ export default async function AdminDashboardPage({
       currentStyleTo={oneTapStyleRangeBounds.toIso}
     >
       {tab === "collections" ? (
-        <AdminCollectionsView series={collectionSeries} currentRange={range} />
+        <AdminCollectionsView
+          series={collectionSeries}
+          globalRange={range}
+          currentRange={collectionRangeBounds.range}
+          currentFrom={collectionRangeBounds.fromIso}
+          currentTo={collectionRangeBounds.toIso}
+          currentFromLabel={formattedCollectionFrom}
+          currentToLabel={formattedCollectionTo}
+        />
       ) : tab === "one-tap-style" ? (
         <AdminOneTapStyleFocusView
           analytics={data.oneTapStyleDetailed}

--- a/app/(app)/admin/page.tsx
+++ b/app/(app)/admin/page.tsx
@@ -1,7 +1,12 @@
 import { AdminDashboardView } from "@/features/admin-dashboard/components/AdminDashboardView";
+import {
+  AdminCollectionsView,
+  type AdminCollectionSeries,
+} from "@/features/admin-dashboard/components/AdminCollectionsView";
 import { AdminOneTapStyleFocusView } from "@/features/admin-dashboard/components/AdminOneTapStyleFocusView";
 import { AdminPageAnalyticsSectionServer } from "@/features/admin-dashboard/components/AdminPageAnalyticsSectionServer";
 import { parseAdminDashboardTab } from "@/features/admin-dashboard/lib/dashboard-tab";
+import { listPresetCategories } from "@/features/style-presets/lib/preset-category-repository";
 import { getAdminDashboardData } from "@/features/admin-dashboard/lib/get-admin-dashboard-data";
 import {
   formatAdminDateTimeLabel,
@@ -40,6 +45,18 @@ export default async function AdminDashboardPage({
   const formattedStyleTo = formatAdminDateTimeLabel(oneTapStyleRangeBounds.toIso);
   const data = await getAdminDashboardData(range, oneTapStyleRangeBounds);
 
+  let collectionSeries: AdminCollectionSeries[] = [];
+  if (tab === "collections") {
+    const categories = await listPresetCategories({ includeInactive: true });
+    collectionSeries = categories
+      .filter((c) => c.isCollectionSeries)
+      .map((c) => ({
+        key: c.key,
+        displayName: c.displayNameJa,
+        threshold: c.completionThreshold ?? 0,
+      }));
+  }
+
   return (
     <AdminDashboardView
       data={data}
@@ -48,7 +65,9 @@ export default async function AdminDashboardPage({
       currentStyleFrom={oneTapStyleRangeBounds.fromIso}
       currentStyleTo={oneTapStyleRangeBounds.toIso}
     >
-      {tab === "one-tap-style" ? (
+      {tab === "collections" ? (
+        <AdminCollectionsView series={collectionSeries} currentRange={range} />
+      ) : tab === "one-tap-style" ? (
         <AdminOneTapStyleFocusView
           analytics={data.oneTapStyleDetailed}
           currentRange={range}

--- a/app/api/admin/collections/route.ts
+++ b/app/api/admin/collections/route.ts
@@ -4,8 +4,8 @@ import { getPresetCategoryByKey } from "@/features/style-presets/lib/preset-cate
 import { getCollectionKpi } from "@/features/admin-dashboard/lib/get-collection-kpi";
 import { getCollectionCompleters } from "@/features/admin-dashboard/lib/get-collection-completions";
 import {
-  getRangeBounds,
-  parseDashboardRange,
+  getCustomDashboardRangeBounds,
+  parseCustomDashboardRange,
 } from "@/features/admin-dashboard/lib/dashboard-range";
 
 const KEY_PATTERN = /^[a-z][a-z0-9_]{1,49}$/;
@@ -28,10 +28,14 @@ export async function GET(request: NextRequest) {
   const categoryKey = request.nextUrl.searchParams.get("categoryKey") ?? "";
   const pageRaw = request.nextUrl.searchParams.get("page") ?? "0";
   const page = Number.parseInt(pageRaw, 10);
-  const range = parseDashboardRange(
+  const range = parseCustomDashboardRange(
     request.nextUrl.searchParams.get("range") ?? undefined,
   );
-  const { currentStart, previousStart, now } = getRangeBounds(range);
+  const { currentStart, previousStart, now } = getCustomDashboardRangeBounds({
+    range,
+    from: request.nextUrl.searchParams.get("from") ?? undefined,
+    to: request.nextUrl.searchParams.get("to") ?? undefined,
+  });
 
   if (!KEY_PATTERN.test(categoryKey)) {
     return NextResponse.json({ error: "invalid categoryKey" }, { status: 400 });

--- a/app/api/admin/collections/route.ts
+++ b/app/api/admin/collections/route.ts
@@ -1,7 +1,10 @@
 import { connection, NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/auth";
 import { getPresetCategoryByKey } from "@/features/style-presets/lib/preset-category-repository";
-import { getCollectionKpi } from "@/features/admin-dashboard/lib/get-collection-kpi";
+import {
+  getCollectionKpi,
+  getCollectionUuFunnel,
+} from "@/features/admin-dashboard/lib/get-collection-kpi";
 import { getCollectionCompleters } from "@/features/admin-dashboard/lib/get-collection-completions";
 import {
   getCustomDashboardRangeBounds,
@@ -50,12 +53,18 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const [kpi, completers] = await Promise.all([
+    const [kpi, uuFunnel, completers] = await Promise.all([
       getCollectionKpi({
         categoryKey,
         categoryId: category.id,
         currentStart,
         previousStart,
+        now,
+      }),
+      getCollectionUuFunnel({
+        categoryKey,
+        categoryId: category.id,
+        currentStart,
         now,
       }),
       getCollectionCompleters({
@@ -64,7 +73,7 @@ export async function GET(request: NextRequest) {
         pageSize: PAGE_SIZE,
       }),
     ]);
-    return NextResponse.json({ kpi, completers });
+    return NextResponse.json({ kpi, uuFunnel, completers });
   } catch (error) {
     console.error("[admin collections GET] failed:", error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });

--- a/app/api/admin/collections/route.ts
+++ b/app/api/admin/collections/route.ts
@@ -3,6 +3,10 @@ import { requireAdmin } from "@/lib/auth";
 import { getPresetCategoryByKey } from "@/features/style-presets/lib/preset-category-repository";
 import { getCollectionKpi } from "@/features/admin-dashboard/lib/get-collection-kpi";
 import { getCollectionCompleters } from "@/features/admin-dashboard/lib/get-collection-completions";
+import {
+  getRangeBounds,
+  parseDashboardRange,
+} from "@/features/admin-dashboard/lib/dashboard-range";
 
 const KEY_PATTERN = /^[a-z][a-z0-9_]{1,49}$/;
 const PAGE_SIZE = 20;
@@ -24,6 +28,10 @@ export async function GET(request: NextRequest) {
   const categoryKey = request.nextUrl.searchParams.get("categoryKey") ?? "";
   const pageRaw = request.nextUrl.searchParams.get("page") ?? "0";
   const page = Number.parseInt(pageRaw, 10);
+  const range = parseDashboardRange(
+    request.nextUrl.searchParams.get("range") ?? undefined,
+  );
+  const { currentStart, previousStart, now } = getRangeBounds(range);
 
   if (!KEY_PATTERN.test(categoryKey)) {
     return NextResponse.json({ error: "invalid categoryKey" }, { status: 400 });
@@ -39,7 +47,13 @@ export async function GET(request: NextRequest) {
 
   try {
     const [kpi, completers] = await Promise.all([
-      getCollectionKpi({ categoryKey, categoryId: category.id }),
+      getCollectionKpi({
+        categoryKey,
+        categoryId: category.id,
+        currentStart,
+        previousStart,
+        now,
+      }),
       getCollectionCompleters({
         categoryKey,
         page: Number.isFinite(page) ? page : 0,

--- a/app/api/collections/share-event/route.ts
+++ b/app/api/collections/share-event/route.ts
@@ -37,7 +37,7 @@ export async function POST(request: NextRequest) {
   // 所有者確認(本人の completed 行のみ。RLS で他人の行は見えない)
   const { data, error } = await supabase
     .from("collection_completions")
-    .select("id")
+    .select("id, category_key")
     .eq("id", completionId)
     .eq("mount_status", "completed")
     .maybeSingle();
@@ -50,6 +50,8 @@ export async function POST(request: NextRequest) {
       userId: user.id,
       authState: "authenticated",
       eventType: "mount_shared",
+      // series 別集計のため category_key を style_id に格納する(KPI が series で絞る)
+      styleId: (data.category_key as string | null) ?? null,
     });
   } catch (e) {
     console.error("[collections share-event] record failed:", e);

--- a/app/api/collections/share-event/route.ts
+++ b/app/api/collections/share-event/route.ts
@@ -50,8 +50,9 @@ export async function POST(request: NextRequest) {
       userId: user.id,
       authState: "authenticated",
       eventType: "mount_shared",
-      // series 別集計のため category_key を style_id に格納する(KPI が series で絞る)
-      styleId: (data.category_key as string | null) ?? null,
+      // series 別集計のため category_key を style_id に格納する(KPI が series で絞る)。
+      // null-data は上の !data ガードで 404 済み。空文字も念のため null 化する。
+      styleId: (data.category_key as string | null) || null,
     });
   } catch (e) {
     console.error("[collections share-event] record failed:", e);

--- a/features/admin-dashboard/components/AdminCollectionRangeControls.tsx
+++ b/features/admin-dashboard/components/AdminCollectionRangeControls.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+import {
+  CUSTOM_DASHBOARD_RANGE_OPTIONS,
+  type CustomDashboardRange,
+  type DashboardRange,
+} from "../lib/dashboard-range";
+import { buildAdminDashboardHref } from "../lib/dashboard-tab";
+
+interface AdminCollectionRangeControlsProps {
+  globalRange: DashboardRange;
+  currentRange: CustomDashboardRange;
+  currentFrom: string | null;
+  currentTo: string | null;
+  currentFromLabel: string;
+  currentToLabel: string;
+}
+
+function toDateTimeLocalValue(value: string | null): string {
+  if (!value) {
+    return "";
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+
+  const local = new Date(date.getTime() - date.getTimezoneOffset() * 60_000);
+  return local.toISOString().slice(0, 16);
+}
+
+export function AdminCollectionRangeControls({
+  globalRange,
+  currentRange,
+  currentFrom,
+  currentTo,
+  currentFromLabel,
+  currentToLabel,
+}: AdminCollectionRangeControlsProps) {
+  const router = useRouter();
+  const [selectedRange, setSelectedRange] =
+    useState<CustomDashboardRange>(currentRange);
+  const [fromValue, setFromValue] = useState(() =>
+    toDateTimeLocalValue(currentFrom),
+  );
+  const [toValue, setToValue] = useState(() => toDateTimeLocalValue(currentTo));
+
+  useEffect(() => {
+    setSelectedRange(currentRange);
+  }, [currentRange]);
+
+  useEffect(() => {
+    setFromValue(toDateTimeLocalValue(currentFrom));
+  }, [currentFrom]);
+
+  useEffect(() => {
+    setToValue(toDateTimeLocalValue(currentTo));
+  }, [currentTo]);
+
+  const hasValidCustomInputs = useMemo(() => {
+    if (!fromValue || !toValue) {
+      return false;
+    }
+
+    return new Date(fromValue).getTime() < new Date(toValue).getTime();
+  }, [fromValue, toValue]);
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!hasValidCustomInputs) {
+      return;
+    }
+
+    const collectionFrom = new Date(fromValue).toISOString();
+    const collectionTo = new Date(toValue).toISOString();
+
+    router.push(
+      buildAdminDashboardHref({
+        range: globalRange,
+        tab: "collections",
+        collectionRange: "custom",
+        collectionFrom,
+        collectionTo,
+      }),
+    );
+  }
+
+  function handleRangeSelect(nextRange: CustomDashboardRange) {
+    if (nextRange === "custom") {
+      setSelectedRange("custom");
+      return;
+    }
+
+    setSelectedRange(nextRange);
+    router.push(
+      buildAdminDashboardHref({
+        range: globalRange,
+        tab: "collections",
+        collectionRange: nextRange,
+      }),
+    );
+  }
+
+  return (
+    <div className="space-y-4 rounded-2xl border border-violet-200/70 bg-white/95 p-4 shadow-sm">
+      <div className="space-y-1">
+        <p className="text-sm font-semibold text-slate-900">集計期間</p>
+        <p className="text-xs leading-5 text-slate-600">
+          既定の期間に加えて、企画の開催期間など任意の開始・終了日時で集計できます。
+        </p>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {CUSTOM_DASHBOARD_RANGE_OPTIONS.map((option) => {
+          const isActive = option.value === selectedRange;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => handleRangeSelect(option.value)}
+              className={cn(
+                "rounded-full border px-3 py-1.5 text-xs font-medium transition-colors",
+                isActive
+                  ? "border-violet-600 bg-violet-600 text-white"
+                  : "border-slate-200 bg-white text-slate-600 hover:border-violet-300 hover:text-violet-700",
+              )}
+            >
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <form
+        className="grid gap-3 md:grid-cols-[1fr_1fr_auto]"
+        onSubmit={handleSubmit}
+      >
+        <div className="space-y-1.5">
+          <Label htmlFor="collection-range-from">開始日時</Label>
+          <Input
+            id="collection-range-from"
+            type="datetime-local"
+            value={fromValue}
+            onChange={(event) => setFromValue(event.target.value)}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="collection-range-to">終了日時</Label>
+          <Input
+            id="collection-range-to"
+            type="datetime-local"
+            value={toValue}
+            onChange={(event) => setToValue(event.target.value)}
+          />
+        </div>
+        <div className="flex items-end gap-2">
+          <Button type="submit" disabled={!hasValidCustomInputs}>
+            カスタム期間を適用
+          </Button>
+        </div>
+      </form>
+      {currentRange === "custom" ? (
+        <p className="text-xs text-slate-500">
+          現在の custom 期間: {currentFromLabel} 〜 {currentToLabel}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/features/admin-dashboard/components/AdminCollectionRangeControls.tsx
+++ b/features/admin-dashboard/components/AdminCollectionRangeControls.tsx
@@ -47,10 +47,10 @@ export function AdminCollectionRangeControls({
   const router = useRouter();
   const [selectedRange, setSelectedRange] =
     useState<CustomDashboardRange>(currentRange);
-  const [fromValue, setFromValue] = useState(() =>
-    toDateTimeLocalValue(currentFrom),
-  );
-  const [toValue, setToValue] = useState(() => toDateTimeLocalValue(currentTo));
+  // SSR/CSR の Hydration Mismatch を避けるため、ローカル時刻(getTimezoneOffset)に
+  // 依存する初期値は使わず、マウント後の useEffect(下) で設定する。
+  const [fromValue, setFromValue] = useState("");
+  const [toValue, setToValue] = useState("");
 
   useEffect(() => {
     setSelectedRange(currentRange);

--- a/features/admin-dashboard/components/AdminCollectionTrendChart.tsx
+++ b/features/admin-dashboard/components/AdminCollectionTrendChart.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { CollectionTrendPoint } from "../lib/build-collection-kpi";
+
+interface AdminCollectionTrendChartProps {
+  data: CollectionTrendPoint[];
+}
+
+function CustomTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean;
+  payload?: Array<{ name?: string; value?: number | string }>;
+  label?: string;
+}) {
+  if (!active || !payload?.length) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-3 shadow-lg">
+      <p className="text-sm font-semibold text-slate-900">{label}</p>
+      <div className="mt-2 space-y-1 text-sm text-slate-600">
+        {payload.map((item) => (
+          <p key={String(item.name)}>
+            {item.name}:{" "}
+            {typeof item.value === "number"
+              ? item.value.toLocaleString("ja-JP")
+              : item.value}
+          </p>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function AdminCollectionTrendChart({
+  data,
+}: AdminCollectionTrendChartProps) {
+  if (data.length === 0) {
+    return (
+      <div className="flex h-[260px] items-center justify-center rounded-xl border border-dashed border-slate-200 bg-slate-50/70 text-sm text-slate-500 sm:h-[320px]">
+        この期間のデータはありません。
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-[260px] w-full sm:h-[320px]">
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart
+          data={data}
+          margin={{ top: 12, right: 12, left: 0, bottom: 0 }}
+          title="コレクションの日別トレンド"
+        >
+          <CartesianGrid stroke="#E2E8F0" strokeDasharray="3 3" />
+          <XAxis
+            dataKey="label"
+            tickLine={false}
+            axisLine={false}
+            tick={{ fill: "#64748B", fontSize: 12 }}
+            minTickGap={24}
+            tickMargin={10}
+          />
+          <YAxis
+            tickLine={false}
+            axisLine={false}
+            tick={{ fill: "#64748B", fontSize: 12 }}
+            width={36}
+          />
+          <Tooltip content={<CustomTooltip />} />
+          <Legend />
+          <Line
+            type="monotone"
+            dataKey="completions"
+            name="コンプリート達成数"
+            stroke="#7C3AED"
+            strokeWidth={2.5}
+            dot={false}
+            activeDot={{ r: 5 }}
+          />
+          <Line
+            type="monotone"
+            dataKey="seriesGenerations"
+            name="シリーズ生成数"
+            stroke="#2563EB"
+            strokeWidth={2.5}
+            dot={false}
+            activeDot={{ r: 5 }}
+          />
+          <Line
+            type="monotone"
+            dataKey="generates"
+            name="生成成功"
+            stroke="#059669"
+            strokeWidth={2.5}
+            dot={false}
+            activeDot={{ r: 5 }}
+          />
+          <Line
+            type="monotone"
+            dataKey="downloads"
+            name="ダウンロード"
+            stroke="#D97706"
+            strokeWidth={2.5}
+            dot={false}
+            activeDot={{ r: 5 }}
+          />
+          <Line
+            type="monotone"
+            dataKey="signupClicks"
+            name="登録CTAクリック"
+            stroke="#E11D48"
+            strokeWidth={2.5}
+            dot={false}
+            activeDot={{ r: 5 }}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/features/admin-dashboard/components/AdminCollectionTrendChart.tsx
+++ b/features/admin-dashboard/components/AdminCollectionTrendChart.tsx
@@ -127,6 +127,15 @@ export default function AdminCollectionTrendChart({
             dot={false}
             activeDot={{ r: 5 }}
           />
+          <Line
+            type="monotone"
+            dataKey="shares"
+            name="シェア"
+            stroke="#0D9488"
+            strokeWidth={2.5}
+            dot={false}
+            activeDot={{ r: 5 }}
+          />
         </LineChart>
       </ResponsiveContainer>
     </div>

--- a/features/admin-dashboard/components/AdminCollectionTrendChartPanel.tsx
+++ b/features/admin-dashboard/components/AdminCollectionTrendChartPanel.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { Loader2 } from "lucide-react";
+import type { CollectionTrendPoint } from "../lib/build-collection-kpi";
+
+const AdminCollectionTrendChart = dynamic(
+  () => import("./AdminCollectionTrendChart"),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex h-[320px] items-center justify-center rounded-xl border border-dashed border-slate-200 bg-slate-50/70 text-sm text-slate-500">
+        <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden />
+        チャートを読み込み中...
+      </div>
+    ),
+  }
+);
+
+interface AdminCollectionTrendChartPanelProps {
+  data: CollectionTrendPoint[];
+}
+
+export function AdminCollectionTrendChartPanel({
+  data,
+}: AdminCollectionTrendChartPanelProps) {
+  return (
+    <div className="overflow-x-auto pb-2 [-ms-overflow-style:none] [scrollbar-width:thin] [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-violet-200 [&::-webkit-scrollbar-track]:bg-transparent md:overflow-visible md:pb-0">
+      <div className="min-w-[680px] md:min-w-0">
+        <AdminCollectionTrendChart data={data} />
+      </div>
+    </div>
+  );
+}

--- a/features/admin-dashboard/components/AdminCollectionsView.tsx
+++ b/features/admin-dashboard/components/AdminCollectionsView.tsx
@@ -13,7 +13,10 @@ import type {
   CustomDashboardRange,
   DashboardRange,
 } from "@/features/admin-dashboard/lib/dashboard-range";
-import { buildCollectionTrendCsv } from "@/features/admin-dashboard/lib/build-collection-trend-csv";
+import {
+  buildCollectionOutfitDailyCsv,
+  buildCollectionTrendCsv,
+} from "@/features/admin-dashboard/lib/build-collection-trend-csv";
 import { AdminCollectionRangeControls } from "./AdminCollectionRangeControls";
 import { AdminCsvExportButtons } from "./AdminCsvExportButtons";
 import { AdminCollectionTrendChartPanel } from "./AdminCollectionTrendChartPanel";
@@ -168,11 +171,18 @@ export function AdminCollectionsView({
         ]
       : [];
 
-  const trendCsv = kpi ? buildCollectionTrendCsv(kpi.trend) : "";
-  const trendCsvFilename =
+  const csvSpan =
     kpi && kpi.trend.length > 0
-      ? `collection-${selectedKey}-${kpi.trend[0].bucket}_${kpi.trend[kpi.trend.length - 1].bucket}.csv`
-      : `collection-${selectedKey}.csv`;
+      ? `${kpi.trend[0].bucket}_${kpi.trend[kpi.trend.length - 1].bucket}`
+      : null;
+  const trendCsv = kpi ? buildCollectionTrendCsv(kpi.trend) : "";
+  const trendCsvFilename = csvSpan
+    ? `collection-${selectedKey}-${csvSpan}.csv`
+    : `collection-${selectedKey}.csv`;
+  const outfitDailyCsv = kpi ? buildCollectionOutfitDailyCsv(kpi) : "";
+  const outfitDailyCsvFilename = csvSpan
+    ? `collection-${selectedKey}-outfit-${csvSpan}.csv`
+    : `collection-${selectedKey}-outfit.csv`;
 
   return (
     <div className="space-y-6">
@@ -254,14 +264,23 @@ export function AdminCollectionsView({
 
       {kpi && kpi.outfitCounts.length > 0 ? (
         <div className="rounded-md border border-slate-200 bg-white p-4">
-          <h3 className="mb-2 text-sm font-semibold text-slate-800">
-            衣装別の生成数
-          </h3>
+          <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+            <h3 className="text-sm font-semibold text-slate-800">
+              柱別の生成数
+            </h3>
+            <AdminCsvExportButtons
+              csv={outfitDailyCsv}
+              filename={outfitDailyCsvFilename}
+            />
+          </div>
+          <p className="mb-2 text-[11px] text-slate-500">
+            CSV は「日別 × 柱別」のクロス集計です（1日1柱お披露目の効果検証用）。
+          </p>
           <ul className="space-y-1 text-sm text-slate-700">
             {kpi.outfitCounts.map((o, i) => (
-              <li key={o.presetId} className="flex justify-between">
-                <span className="font-mono text-xs text-slate-500">
-                  #{i + 1} {o.presetId.slice(0, 8)}
+              <li key={o.presetId} className="flex justify-between gap-3">
+                <span className="truncate text-slate-700">
+                  #{i + 1} {o.label}
                 </span>
                 <span className="tabular-nums">{o.count.toLocaleString()}</span>
               </li>

--- a/features/admin-dashboard/components/AdminCollectionsView.tsx
+++ b/features/admin-dashboard/components/AdminCollectionsView.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { ArrowDownRight, ArrowUpRight, Check, Copy, Download } from "lucide-react";
+import { ArrowDownRight, ArrowUpRight } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import type {
   CollectionKpi,
@@ -15,6 +15,7 @@ import type {
 } from "@/features/admin-dashboard/lib/dashboard-range";
 import { buildCollectionTrendCsv } from "@/features/admin-dashboard/lib/build-collection-trend-csv";
 import { AdminCollectionRangeControls } from "./AdminCollectionRangeControls";
+import { AdminCsvExportButtons } from "./AdminCsvExportButtons";
 import { AdminCollectionTrendChartPanel } from "./AdminCollectionTrendChartPanel";
 import { mountAspectForCategory } from "@/features/collections/lib/mount-aspects";
 
@@ -73,7 +74,6 @@ export function AdminCollectionsView({
   const [data, setData] = useState<ApiResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
 
   const load = useCallback(
     async (
@@ -148,38 +148,11 @@ export function AdminCollectionsView({
       ]
     : [];
 
-  function handleCopyCsv() {
-    if (!kpi) return;
-    const csv = buildCollectionTrendCsv(kpi.trend);
-    void navigator.clipboard.writeText(csv).then(
-      () => {
-        setCopied(true);
-        window.setTimeout(() => setCopied(false), 2000);
-      },
-      () => setError("クリップボードへのコピーに失敗しました"),
-    );
-  }
-
-  function handleDownloadCsv() {
-    if (!kpi) return;
-    const csv = buildCollectionTrendCsv(kpi.trend);
-    // 先頭に BOM を付け、Excel で UTF-8(日本語)が文字化けしないようにする
-    const blob = new Blob(["\uFEFF" + csv], {
-      type: "text/csv;charset=utf-8;",
-    });
-    const url = URL.createObjectURL(blob);
-    const span =
-      kpi.trend.length > 0
-        ? `${kpi.trend[0].bucket}_${kpi.trend[kpi.trend.length - 1].bucket}`
-        : "all";
-    const anchor = document.createElement("a");
-    anchor.href = url;
-    anchor.download = `collection-${selectedKey}-${span}.csv`;
-    document.body.appendChild(anchor);
-    anchor.click();
-    document.body.removeChild(anchor);
-    URL.revokeObjectURL(url);
-  }
+  const trendCsv = kpi ? buildCollectionTrendCsv(kpi.trend) : "";
+  const trendCsvFilename =
+    kpi && kpi.trend.length > 0
+      ? `collection-${selectedKey}-${kpi.trend[0].bucket}_${kpi.trend[kpi.trend.length - 1].bucket}.csv`
+      : `collection-${selectedKey}.csv`;
 
   return (
     <div className="space-y-6">
@@ -250,28 +223,7 @@ export function AdminCollectionsView({
         <div className="rounded-md border border-slate-200 bg-white p-4">
           <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
             <h3 className="text-sm font-semibold text-slate-800">日別トレンド</h3>
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                onClick={handleCopyCsv}
-                className="inline-flex items-center gap-1 rounded-md border border-slate-300 px-2.5 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50"
-              >
-                {copied ? (
-                  <Check className="h-3.5 w-3.5 text-emerald-600" aria-hidden />
-                ) : (
-                  <Copy className="h-3.5 w-3.5" aria-hidden />
-                )}
-                {copied ? "コピーしました" : "CSVをコピー"}
-              </button>
-              <button
-                type="button"
-                onClick={handleDownloadCsv}
-                className="inline-flex items-center gap-1 rounded-md border border-slate-300 px-2.5 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50"
-              >
-                <Download className="h-3.5 w-3.5" aria-hidden />
-                CSVダウンロード
-              </button>
-            </div>
+            <AdminCsvExportButtons csv={trendCsv} filename={trendCsvFilename} />
           </div>
           <AdminCollectionTrendChartPanel data={kpi.trend} />
         </div>

--- a/features/admin-dashboard/components/AdminCollectionsView.tsx
+++ b/features/admin-dashboard/components/AdminCollectionsView.tsx
@@ -9,7 +9,11 @@ import type {
   CollectionKpiMetric,
 } from "@/features/admin-dashboard/lib/get-collection-kpi";
 import type { CollectionCompletersPage } from "@/features/admin-dashboard/lib/get-collection-completions";
-import type { DashboardRange } from "@/features/admin-dashboard/lib/dashboard-range";
+import type {
+  CustomDashboardRange,
+  DashboardRange,
+} from "@/features/admin-dashboard/lib/dashboard-range";
+import { AdminCollectionRangeControls } from "./AdminCollectionRangeControls";
 import { AdminCollectionTrendChartPanel } from "./AdminCollectionTrendChartPanel";
 import { mountAspectForCategory } from "@/features/collections/lib/mount-aspects";
 
@@ -48,10 +52,20 @@ function MetricDelta({ metric }: { metric: CollectionKpiMetric }) {
 
 export function AdminCollectionsView({
   series,
+  globalRange,
   currentRange,
+  currentFrom,
+  currentTo,
+  currentFromLabel,
+  currentToLabel,
 }: {
   series: AdminCollectionSeries[];
-  currentRange: DashboardRange;
+  globalRange: DashboardRange;
+  currentRange: CustomDashboardRange;
+  currentFrom: string | null;
+  currentTo: string | null;
+  currentFromLabel: string;
+  currentToLabel: string;
 }) {
   const [selectedKey, setSelectedKey] = useState(series[0]?.key ?? "");
   const [page, setPage] = useState(0);
@@ -60,15 +74,29 @@ export function AdminCollectionsView({
   const [error, setError] = useState<string | null>(null);
 
   const load = useCallback(
-    async (categoryKey: string, pageIndex: number, range: DashboardRange) => {
+    async (
+      categoryKey: string,
+      pageIndex: number,
+      range: CustomDashboardRange,
+      from: string | null,
+      to: string | null,
+    ) => {
       if (!categoryKey) return;
       setLoading(true);
       setError(null);
       try {
-        const res = await fetch(
-          `/api/admin/collections?categoryKey=${encodeURIComponent(categoryKey)}&page=${pageIndex}&range=${range}`,
-          { cache: "no-store" },
-        );
+        const query = new URLSearchParams({
+          categoryKey,
+          page: String(pageIndex),
+          range,
+        });
+        if (range === "custom" && from && to) {
+          query.set("from", from);
+          query.set("to", to);
+        }
+        const res = await fetch(`/api/admin/collections?${query.toString()}`, {
+          cache: "no-store",
+        });
         if (!res.ok) {
           setError(`取得に失敗しました (${res.status})`);
           setData(null);
@@ -86,8 +114,8 @@ export function AdminCollectionsView({
   );
 
   useEffect(() => {
-    void load(selectedKey, page, currentRange);
-  }, [load, selectedKey, page, currentRange]);
+    void load(selectedKey, page, currentRange, currentFrom, currentTo);
+  }, [load, selectedKey, page, currentRange, currentFrom, currentTo]);
 
   if (series.length === 0) {
     return (
@@ -140,6 +168,15 @@ export function AdminCollectionsView({
         ))}
       </div>
 
+      <AdminCollectionRangeControls
+        globalRange={globalRange}
+        currentRange={currentRange}
+        currentFrom={currentFrom}
+        currentTo={currentTo}
+        currentFromLabel={currentFromLabel}
+        currentToLabel={currentToLabel}
+      />
+
       {error ? (
         <p className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
           {error}
@@ -151,7 +188,9 @@ export function AdminCollectionsView({
       {kpi ? (
         <div className="space-y-3">
           <p className="text-xs text-slate-500">
-            数値は画面上部の期間タブ（{currentRange}）での集計です。前期間比つき。
+            {currentRange === "custom"
+              ? `集計期間: ${currentFromLabel} 〜 ${currentToLabel}（前期間比つき）`
+              : `集計期間: 直近 ${currentRange}（前期間比つき）`}
           </p>
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
             {kpiCards.map((c) => (

--- a/features/admin-dashboard/components/AdminCollectionsView.tsx
+++ b/features/admin-dashboard/components/AdminCollectionsView.tsx
@@ -133,20 +133,40 @@ export function AdminCollectionsView({
     ? Math.max(1, Math.ceil(completers.total / completers.pageSize))
     : 1;
 
-  const kpiCards: { label: string; metric: CollectionKpiMetric }[] = kpi
-    ? [
-        { label: "コンプリート達成数", metric: kpi.completions },
-        { label: "台紙生成数", metric: kpi.completions },
-        { label: "シリーズ生成数(成功)", metric: kpi.seriesGenerations },
-        { label: "訪問(ログイン)", metric: kpi.visitsMember },
-        { label: "訪問(ゲスト)", metric: kpi.visitsGuest },
-        { label: "生成成功", metric: kpi.generates },
-        { label: "ダウンロード", metric: kpi.downloads },
-        { label: "保存クリック", metric: kpi.saveClicks },
-        { label: "登録CTAクリック", metric: kpi.signupClicks },
-        { label: "台紙生成失敗", metric: kpi.mountsFailed },
-      ]
-    : [];
+  const kpiCards: { label: string; metric: CollectionKpiMetric; sub?: string }[] =
+    kpi
+      ? [
+          { label: "コンプリート達成数", metric: kpi.completions },
+          { label: "台紙生成数", metric: kpi.completions },
+          { label: "シリーズ生成数(成功)", metric: kpi.seriesGenerations },
+          { label: "訪問(ログイン)", metric: kpi.visitsMember },
+          { label: "訪問(ゲスト)", metric: kpi.visitsGuest },
+          {
+            label: "生成成功",
+            metric: kpi.generates,
+            sub:
+              kpi.generates.member !== undefined
+                ? `ログイン ${kpi.generates.member.toLocaleString()} / お試し ${(
+                    kpi.generates.guest ?? 0
+                  ).toLocaleString()}`
+                : undefined,
+          },
+          {
+            label: "ダウンロード",
+            metric: kpi.downloads,
+            sub:
+              kpi.downloads.member !== undefined
+                ? `ログイン ${kpi.downloads.member.toLocaleString()} / ゲスト ${(
+                    kpi.downloads.guest ?? 0
+                  ).toLocaleString()}`
+                : undefined,
+          },
+          { label: "保存クリック", metric: kpi.saveClicks },
+          { label: "登録CTAクリック", metric: kpi.signupClicks },
+          { label: "シェア", metric: kpi.shares },
+          { label: "台紙生成失敗", metric: kpi.mountsFailed },
+        ]
+      : [];
 
   const trendCsv = kpi ? buildCollectionTrendCsv(kpi.trend) : "";
   const trendCsvFilename =
@@ -213,6 +233,9 @@ export function AdminCollectionsView({
                 <div className="mt-1">
                   <MetricDelta metric={c.metric} />
                 </div>
+                {c.sub ? (
+                  <p className="mt-1 text-[11px] text-slate-500">{c.sub}</p>
+                ) : null}
               </div>
             ))}
           </div>

--- a/features/admin-dashboard/components/AdminCollectionsView.tsx
+++ b/features/admin-dashboard/components/AdminCollectionsView.tsx
@@ -16,6 +16,7 @@ import type {
 } from "@/features/admin-dashboard/lib/dashboard-range";
 import {
   buildCollectionOutfitDailyCsv,
+  buildCollectionSummaryCsv,
   buildCollectionTrendCsv,
 } from "@/features/admin-dashboard/lib/build-collection-trend-csv";
 import { AdminCollectionRangeControls } from "./AdminCollectionRangeControls";
@@ -190,6 +191,11 @@ export function AdminCollectionsView({
   const outfitDailyCsvFilename = csvSpan
     ? `collection-${selectedKey}-outfit-${csvSpan}.csv`
     : `collection-${selectedKey}-outfit.csv`;
+  const summaryCsv =
+    kpi && uuFunnel ? buildCollectionSummaryCsv(kpi, uuFunnel) : "";
+  const summaryCsvFilename = csvSpan
+    ? `collection-${selectedKey}-summary-${csvSpan}.csv`
+    : `collection-${selectedKey}-summary.csv`;
 
   return (
     <div className="space-y-6">
@@ -232,11 +238,17 @@ export function AdminCollectionsView({
 
       {kpi ? (
         <div className="space-y-3">
-          <p className="text-xs text-slate-500">
-            {currentRange === "custom"
-              ? `集計期間: ${currentFromLabel} 〜 ${currentToLabel}（前期間比つき）`
-              : `集計期間: 直近 ${currentRange}（前期間比つき）`}
-          </p>
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <p className="text-xs text-slate-500">
+              {currentRange === "custom"
+                ? `集計期間: ${currentFromLabel} 〜 ${currentToLabel}（前期間比つき）`
+                : `集計期間: 直近 ${currentRange}（前期間比つき）`}
+            </p>
+            <AdminCsvExportButtons
+              csv={summaryCsv}
+              filename={summaryCsvFilename}
+            />
+          </div>
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
             {kpiCards.map((c) => (
               <div

--- a/features/admin-dashboard/components/AdminCollectionsView.tsx
+++ b/features/admin-dashboard/components/AdminCollectionsView.tsx
@@ -2,9 +2,15 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { ArrowDownRight, ArrowUpRight } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
-import type { CollectionKpi } from "@/features/admin-dashboard/lib/get-collection-kpi";
+import type {
+  CollectionKpi,
+  CollectionKpiMetric,
+} from "@/features/admin-dashboard/lib/get-collection-kpi";
 import type { CollectionCompletersPage } from "@/features/admin-dashboard/lib/get-collection-completions";
+import type { DashboardRange } from "@/features/admin-dashboard/lib/dashboard-range";
+import { AdminCollectionTrendChartPanel } from "./AdminCollectionTrendChartPanel";
 import { mountAspectForCategory } from "@/features/collections/lib/mount-aspects";
 
 export interface AdminCollectionSeries {
@@ -18,10 +24,34 @@ interface ApiResponse {
   completers: CollectionCompletersPage;
 }
 
+function MetricDelta({ metric }: { metric: CollectionKpiMetric }) {
+  if (metric.deltaPct === null) {
+    return (
+      <span className="text-[11px] font-medium uppercase tracking-wide text-violet-600">
+        New
+      </span>
+    );
+  }
+
+  if (metric.deltaDirection === "flat") {
+    return <span className="text-[11px] font-medium text-slate-400">±0%</span>;
+  }
+
+  const Icon = metric.deltaDirection === "up" ? ArrowUpRight : ArrowDownRight;
+  return (
+    <span className="inline-flex items-center gap-0.5 text-[11px] font-medium text-slate-500">
+      <Icon className="h-3 w-3" aria-hidden />
+      {metric.deltaPct.toLocaleString("ja-JP")}%
+    </span>
+  );
+}
+
 export function AdminCollectionsView({
   series,
+  currentRange,
 }: {
   series: AdminCollectionSeries[];
+  currentRange: DashboardRange;
 }) {
   const [selectedKey, setSelectedKey] = useState(series[0]?.key ?? "");
   const [page, setPage] = useState(0);
@@ -29,32 +59,35 @@ export function AdminCollectionsView({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const load = useCallback(async (categoryKey: string, pageIndex: number) => {
-    if (!categoryKey) return;
-    setLoading(true);
-    setError(null);
-    try {
-      const res = await fetch(
-        `/api/admin/collections?categoryKey=${encodeURIComponent(categoryKey)}&page=${pageIndex}`,
-        { cache: "no-store" },
-      );
-      if (!res.ok) {
-        setError(`取得に失敗しました (${res.status})`);
+  const load = useCallback(
+    async (categoryKey: string, pageIndex: number, range: DashboardRange) => {
+      if (!categoryKey) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(
+          `/api/admin/collections?categoryKey=${encodeURIComponent(categoryKey)}&page=${pageIndex}&range=${range}`,
+          { cache: "no-store" },
+        );
+        if (!res.ok) {
+          setError(`取得に失敗しました (${res.status})`);
+          setData(null);
+          return;
+        }
+        setData((await res.json()) as ApiResponse);
+      } catch {
+        setError("取得に失敗しました");
         setData(null);
-        return;
+      } finally {
+        setLoading(false);
       }
-      setData((await res.json()) as ApiResponse);
-    } catch {
-      setError("取得に失敗しました");
-      setData(null);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+    },
+    [],
+  );
 
   useEffect(() => {
-    void load(selectedKey, page);
-  }, [load, selectedKey, page]);
+    void load(selectedKey, page, currentRange);
+  }, [load, selectedKey, page, currentRange]);
 
   if (series.length === 0) {
     return (
@@ -70,18 +103,18 @@ export function AdminCollectionsView({
     ? Math.max(1, Math.ceil(completers.total / completers.pageSize))
     : 1;
 
-  const kpiCards: { label: string; value: number }[] = kpi
+  const kpiCards: { label: string; metric: CollectionKpiMetric }[] = kpi
     ? [
-        { label: "コンプリート達成数", value: kpi.completions },
-        { label: "台紙生成数", value: kpi.completions },
-        { label: "シリーズ生成数(成功)", value: kpi.seriesGenerations },
-        { label: "訪問(ログイン)", value: kpi.visitsMember },
-        { label: "訪問(ゲスト)", value: kpi.visitsGuest },
-        { label: "生成成功", value: kpi.generates },
-        { label: "ダウンロード", value: kpi.downloads },
-        { label: "保存クリック", value: kpi.saveClicks },
-        { label: "登録CTAクリック", value: kpi.signupClicks },
-        { label: "台紙生成失敗", value: kpi.mountsFailed },
+        { label: "コンプリート達成数", metric: kpi.completions },
+        { label: "台紙生成数", metric: kpi.completions },
+        { label: "シリーズ生成数(成功)", metric: kpi.seriesGenerations },
+        { label: "訪問(ログイン)", metric: kpi.visitsMember },
+        { label: "訪問(ゲスト)", metric: kpi.visitsGuest },
+        { label: "生成成功", metric: kpi.generates },
+        { label: "ダウンロード", metric: kpi.downloads },
+        { label: "保存クリック", metric: kpi.saveClicks },
+        { label: "登録CTAクリック", metric: kpi.signupClicks },
+        { label: "台紙生成失敗", metric: kpi.mountsFailed },
       ]
     : [];
 
@@ -116,18 +149,35 @@ export function AdminCollectionsView({
       {loading ? <p className="text-sm text-slate-500">読み込み中…</p> : null}
 
       {kpi ? (
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
-          {kpiCards.map((c) => (
-            <div
-              key={c.label}
-              className="rounded-md border border-slate-200 bg-white p-3"
-            >
-              <p className="text-xs text-slate-500">{c.label}</p>
-              <p className="mt-1 text-xl font-bold tabular-nums text-slate-900">
-                {c.value.toLocaleString()}
-              </p>
-            </div>
-          ))}
+        <div className="space-y-3">
+          <p className="text-xs text-slate-500">
+            数値は画面上部の期間タブ（{currentRange}）での集計です。前期間比つき。
+          </p>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+            {kpiCards.map((c) => (
+              <div
+                key={c.label}
+                className="rounded-md border border-slate-200 bg-white p-3"
+              >
+                <p className="text-xs text-slate-500">{c.label}</p>
+                <p className="mt-1 text-xl font-bold tabular-nums text-slate-900">
+                  {c.metric.current.toLocaleString()}
+                </p>
+                <div className="mt-1">
+                  <MetricDelta metric={c.metric} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {kpi ? (
+        <div className="rounded-md border border-slate-200 bg-white p-4">
+          <h3 className="mb-3 text-sm font-semibold text-slate-800">
+            日別トレンド
+          </h3>
+          <AdminCollectionTrendChartPanel data={kpi.trend} />
         </div>
       ) : null}
 
@@ -153,7 +203,7 @@ export function AdminCollectionsView({
         <div className="rounded-md border border-slate-200 bg-white">
           <div className="flex items-center justify-between border-b border-slate-100 px-4 py-3">
             <h3 className="text-sm font-semibold text-slate-800">
-              達成者一覧（{completers.total.toLocaleString()}人）
+              達成者一覧（累計 {completers.total.toLocaleString()}人）
             </h3>
           </div>
           {completers.items.length === 0 ? (

--- a/features/admin-dashboard/components/AdminCollectionsView.tsx
+++ b/features/admin-dashboard/components/AdminCollectionsView.tsx
@@ -7,6 +7,7 @@ import { useCallback, useEffect, useState } from "react";
 import type {
   CollectionKpi,
   CollectionKpiMetric,
+  CollectionUuFunnel,
 } from "@/features/admin-dashboard/lib/get-collection-kpi";
 import type { CollectionCompletersPage } from "@/features/admin-dashboard/lib/get-collection-completions";
 import type {
@@ -30,7 +31,12 @@ export interface AdminCollectionSeries {
 
 interface ApiResponse {
   kpi: CollectionKpi;
+  uuFunnel: CollectionUuFunnel;
   completers: CollectionCompletersPage;
+}
+
+function formatRatePct(value: number | null): string {
+  return value === null ? "N/A" : `${value.toLocaleString("ja-JP")}%`;
 }
 
 function MetricDelta({ metric }: { metric: CollectionKpiMetric }) {
@@ -131,6 +137,7 @@ export function AdminCollectionsView({
   }
 
   const kpi = data?.kpi;
+  const uuFunnel = data?.uuFunnel;
   const completers = data?.completers;
   const totalPages = completers
     ? Math.max(1, Math.ceil(completers.total / completers.pageSize))
@@ -259,6 +266,70 @@ export function AdminCollectionsView({
             <AdminCsvExportButtons csv={trendCsv} filename={trendCsvFilename} />
           </div>
           <AdminCollectionTrendChartPanel data={kpi.trend} />
+        </div>
+      ) : null}
+
+      {uuFunnel ? (
+        <div className="rounded-md border border-slate-200 bg-white p-4">
+          <h3 className="text-sm font-semibold text-slate-800">
+            ユニークユーザー・ファネル（ログインのみ）
+          </h3>
+          <p className="mb-3 mt-1 text-[11px] text-slate-500">
+            生成→コンプリート→シェアのUU歩留まり、および期間内に新規登録したUUのコンプリート到達。
+            ゲストは識別子を持たずUU計測できないためログイン側のみです。
+          </p>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+            {[
+              { label: "生成UU", value: uuFunnel.generatesUu },
+              { label: "コンプリートUU", value: uuFunnel.completionsUu },
+              { label: "シェアUU", value: uuFunnel.sharesUu },
+              { label: "期間内登録UU", value: uuFunnel.registeredUu },
+              { label: "登録→コンプリート", value: uuFunnel.registeredCompletedUu },
+            ].map((c) => (
+              <div
+                key={c.label}
+                className="rounded-md border border-slate-200 bg-white p-3"
+              >
+                <p className="text-xs text-slate-500">{c.label}</p>
+                <p className="mt-1 text-xl font-bold tabular-nums text-slate-900">
+                  {c.value.toLocaleString()}
+                </p>
+              </div>
+            ))}
+          </div>
+          <dl className="mt-3 grid gap-2 text-sm sm:grid-cols-2 lg:grid-cols-4">
+            {[
+              {
+                dt: "コンプリート到達率 (B-2)",
+                dd: formatRatePct(uuFunnel.reachRatePct),
+                note: "コンプリートUU / 生成UU",
+              },
+              {
+                dt: "登録→コンプリート率 (A-5)",
+                dd: formatRatePct(uuFunnel.registeredReachRatePct),
+                note: "期間内登録UUのうち到達",
+              },
+              {
+                dt: "登録後 未コンプリート (A-8)",
+                dd: `${uuFunnel.registeredNotCompletedUu.toLocaleString()}人`,
+                note: "登録したが6柱未完走",
+              },
+              {
+                dt: "コンプリート後 未シェア (A-8)",
+                dd: `${uuFunnel.completedNotSharedUu.toLocaleString()}人`,
+                note: "完走したが未シェア",
+              },
+            ].map((item) => (
+              <div
+                key={item.dt}
+                className="rounded-md border border-slate-200 bg-slate-50/70 px-3 py-2"
+              >
+                <dt className="text-xs text-slate-500">{item.dt}</dt>
+                <dd className="font-semibold text-slate-900">{item.dd}</dd>
+                <p className="mt-0.5 text-[11px] text-slate-400">{item.note}</p>
+              </div>
+            ))}
+          </dl>
         </div>
       ) : null}
 

--- a/features/admin-dashboard/components/AdminCollectionsView.tsx
+++ b/features/admin-dashboard/components/AdminCollectionsView.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { ArrowDownRight, ArrowUpRight } from "lucide-react";
+import { ArrowDownRight, ArrowUpRight, Check, Copy, Download } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import type {
   CollectionKpi,
@@ -13,6 +13,7 @@ import type {
   CustomDashboardRange,
   DashboardRange,
 } from "@/features/admin-dashboard/lib/dashboard-range";
+import { buildCollectionTrendCsv } from "@/features/admin-dashboard/lib/build-collection-trend-csv";
 import { AdminCollectionRangeControls } from "./AdminCollectionRangeControls";
 import { AdminCollectionTrendChartPanel } from "./AdminCollectionTrendChartPanel";
 import { mountAspectForCategory } from "@/features/collections/lib/mount-aspects";
@@ -72,6 +73,7 @@ export function AdminCollectionsView({
   const [data, setData] = useState<ApiResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
 
   const load = useCallback(
     async (
@@ -146,6 +148,39 @@ export function AdminCollectionsView({
       ]
     : [];
 
+  function handleCopyCsv() {
+    if (!kpi) return;
+    const csv = buildCollectionTrendCsv(kpi.trend);
+    void navigator.clipboard.writeText(csv).then(
+      () => {
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 2000);
+      },
+      () => setError("クリップボードへのコピーに失敗しました"),
+    );
+  }
+
+  function handleDownloadCsv() {
+    if (!kpi) return;
+    const csv = buildCollectionTrendCsv(kpi.trend);
+    // 先頭に BOM を付け、Excel で UTF-8(日本語)が文字化けしないようにする
+    const blob = new Blob(["\uFEFF" + csv], {
+      type: "text/csv;charset=utf-8;",
+    });
+    const url = URL.createObjectURL(blob);
+    const span =
+      kpi.trend.length > 0
+        ? `${kpi.trend[0].bucket}_${kpi.trend[kpi.trend.length - 1].bucket}`
+        : "all";
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `collection-${selectedKey}-${span}.csv`;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+  }
+
   return (
     <div className="space-y-6">
       <div className="flex flex-wrap gap-2">
@@ -213,9 +248,31 @@ export function AdminCollectionsView({
 
       {kpi ? (
         <div className="rounded-md border border-slate-200 bg-white p-4">
-          <h3 className="mb-3 text-sm font-semibold text-slate-800">
-            日別トレンド
-          </h3>
+          <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+            <h3 className="text-sm font-semibold text-slate-800">日別トレンド</h3>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={handleCopyCsv}
+                className="inline-flex items-center gap-1 rounded-md border border-slate-300 px-2.5 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50"
+              >
+                {copied ? (
+                  <Check className="h-3.5 w-3.5 text-emerald-600" aria-hidden />
+                ) : (
+                  <Copy className="h-3.5 w-3.5" aria-hidden />
+                )}
+                {copied ? "コピーしました" : "CSVをコピー"}
+              </button>
+              <button
+                type="button"
+                onClick={handleDownloadCsv}
+                className="inline-flex items-center gap-1 rounded-md border border-slate-300 px-2.5 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50"
+              >
+                <Download className="h-3.5 w-3.5" aria-hidden />
+                CSVダウンロード
+              </button>
+            </div>
+          </div>
           <AdminCollectionTrendChartPanel data={kpi.trend} />
         </div>
       ) : null}

--- a/features/admin-dashboard/components/AdminCsvExportButtons.tsx
+++ b/features/admin-dashboard/components/AdminCsvExportButtons.tsx
@@ -19,6 +19,11 @@ export function AdminCsvExportButtons({
   const [copied, setCopied] = useState(false);
 
   function handleCopy() {
+    // 非secure context など navigator.clipboard が undefined の環境では
+    // 直接呼ぶと TypeError でクラッシュするため、存在チェックしてから使う。
+    if (!navigator.clipboard?.writeText) {
+      return;
+    }
     void navigator.clipboard
       .writeText(csv)
       .then(() => {
@@ -26,7 +31,7 @@ export function AdminCsvExportButtons({
         window.setTimeout(() => setCopied(false), 2000);
       })
       .catch(() => {
-        // クリップボードが使えない環境(非secure context 等)は黙って無視
+        // クリップボードが使えない環境は黙って無視(ダウンロードは利用可)
       });
   }
 

--- a/features/admin-dashboard/components/AdminCsvExportButtons.tsx
+++ b/features/admin-dashboard/components/AdminCsvExportButtons.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { Check, Copy, Download } from "lucide-react";
+import { useState } from "react";
+
+interface AdminCsvExportButtonsProps {
+  csv: string;
+  filename: string;
+}
+
+/**
+ * CSV 文字列を「ワンタップでコピー」「ダウンロード」する共通ボタン。
+ * server / client いずれの親からも利用可(csv は文字列で受け取る)。
+ */
+export function AdminCsvExportButtons({
+  csv,
+  filename,
+}: AdminCsvExportButtonsProps) {
+  const [copied, setCopied] = useState(false);
+
+  function handleCopy() {
+    void navigator.clipboard
+      .writeText(csv)
+      .then(() => {
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 2000);
+      })
+      .catch(() => {
+        // クリップボードが使えない環境(非secure context 等)は黙って無視
+      });
+  }
+
+  function handleDownload() {
+    // 先頭に BOM を付け、Excel で UTF-8(日本語)が文字化けしないようにする
+    const blob = new Blob(["\uFEFF" + csv], {
+      type: "text/csv;charset=utf-8;",
+    });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="inline-flex items-center gap-1 rounded-md border border-slate-300 px-2.5 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50"
+      >
+        {copied ? (
+          <Check className="h-3.5 w-3.5 text-emerald-600" aria-hidden />
+        ) : (
+          <Copy className="h-3.5 w-3.5" aria-hidden />
+        )}
+        {copied ? "コピーしました" : "CSVをコピー"}
+      </button>
+      <button
+        type="button"
+        onClick={handleDownload}
+        className="inline-flex items-center gap-1 rounded-md border border-slate-300 px-2.5 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50"
+      >
+        <Download className="h-3.5 w-3.5" aria-hidden />
+        CSVダウンロード
+      </button>
+    </div>
+  );
+}

--- a/features/admin-dashboard/components/AdminDashboardView.tsx
+++ b/features/admin-dashboard/components/AdminDashboardView.tsx
@@ -48,7 +48,9 @@ export function AdminDashboardView({
   const description =
     currentTab === "one-tap-style"
       ? "One-Tap Style の利用状況、上限到達、スタイル別パフォーマンスを確認できます。"
-      : "運営状況と主要KPIをまとめて確認できます。";
+      : currentTab === "collections"
+        ? "コレクション企画のシリーズ別KPIと日別推移、達成者を確認できます。"
+        : "運営状況と主要KPIをまとめて確認できます。";
 
   return (
     <div className="space-y-8">

--- a/features/admin-dashboard/components/AdminDashboardView.tsx
+++ b/features/admin-dashboard/components/AdminDashboardView.tsx
@@ -81,13 +81,15 @@ export function AdminDashboardView({
             currentStyleFrom={currentStyleFrom}
             currentStyleTo={currentStyleTo}
           />
-          <AdminDashboardRangeTabs
-            currentRange={data.range}
-            currentTab={currentTab}
-            currentStyleRange={currentStyleRange}
-            currentStyleFrom={currentStyleFrom}
-            currentStyleTo={currentStyleTo}
-          />
+          {currentTab === "all" ? (
+            <AdminDashboardRangeTabs
+              currentRange={data.range}
+              currentTab={currentTab}
+              currentStyleRange={currentStyleRange}
+              currentStyleFrom={currentStyleFrom}
+              currentStyleTo={currentStyleTo}
+            />
+          ) : null}
           <p className="text-xs text-slate-500">
             最終更新 {new Date(data.updatedAt).toLocaleString("ja-JP")}
           </p>

--- a/features/admin-dashboard/components/AdminOneTapStyleCard.tsx
+++ b/features/admin-dashboard/components/AdminOneTapStyleCard.tsx
@@ -24,6 +24,11 @@ import type {
 } from "../lib/dashboard-types";
 import { computeWardrobeConversionRatePct } from "../lib/build-one-tap-style-summary";
 import { AdminOneTapStyleTrendChartPanel } from "./AdminOneTapStyleTrendChartPanel";
+import { AdminCsvExportButtons } from "./AdminCsvExportButtons";
+import {
+  buildOneTapStyleTrendCsv,
+  csvDateSpanSuffix,
+} from "../lib/admin-csv";
 
 interface AdminOneTapStyleCardProps {
   analytics: DashboardOneTapStyleAnalytics;
@@ -219,6 +224,17 @@ export function AdminOneTapStyleCard({
         </div>
 
         <div className="rounded-2xl border border-slate-200/80 bg-white/80 p-3">
+          <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+            <p className="text-sm font-semibold text-slate-800">
+              日別トレンド
+            </p>
+            <AdminCsvExportButtons
+              csv={buildOneTapStyleTrendCsv(analytics.trend)}
+              filename={`onetap-style-trend-${csvDateSpanSuffix(
+                analytics.trend.map((point) => point.bucket),
+              )}.csv`}
+            />
+          </div>
           <AdminOneTapStyleTrendChartPanel data={analytics.trend} />
         </div>
       </CardContent>

--- a/features/admin-dashboard/components/AdminPageAnalyticsSection.tsx
+++ b/features/admin-dashboard/components/AdminPageAnalyticsSection.tsx
@@ -18,6 +18,11 @@ import { AdminTopPagesCard } from "./AdminTopPagesCard";
 import { AdminTopTransitionsCard } from "./AdminTopTransitionsCard";
 import { AdminOneTapStyleCard } from "./AdminOneTapStyleCard";
 import { AdminTrendChartPanel } from "./AdminTrendChartPanel";
+import { AdminCsvExportButtons } from "./AdminCsvExportButtons";
+import {
+  buildDashboardTrendCsv,
+  csvDateSpanSuffix,
+} from "@/features/admin-dashboard/lib/admin-csv";
 
 interface AdminPageAnalyticsGa4SectionProps {
   ga4: Ga4DashboardData;
@@ -145,18 +150,27 @@ export function AdminTrendAndFunnelSection({
   funnel,
   modelMix,
 }: AdminTrendAndFunnelSectionProps) {
+  const trendCsv = buildDashboardTrendCsv(trend);
+  const trendCsvFilename = `dashboard-trend-${csvDateSpanSuffix(
+    trend.map((point) => point.bucket),
+  )}.csv`;
+
   return (
     <section className="space-y-4">
       <Card className="border-violet-200/60 bg-white/95 shadow-sm">
         <CardHeader className="pb-4">
-          <CardTitle
-            className="text-lg text-slate-900"
-            style={{
-              fontFamily: "var(--font-admin-heading), ui-monospace, monospace",
-            }}
-          >
-            ユーザー・生成トレンド
-          </CardTitle>
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <CardTitle
+              className="text-lg text-slate-900"
+              style={{
+                fontFamily:
+                  "var(--font-admin-heading), ui-monospace, monospace",
+              }}
+            >
+              ユーザー・生成トレンド
+            </CardTitle>
+            <AdminCsvExportButtons csv={trendCsv} filename={trendCsvFilename} />
+          </div>
         </CardHeader>
         <CardContent>
           <AdminTrendChartPanel data={trend} />

--- a/features/admin-dashboard/lib/admin-csv.ts
+++ b/features/admin-dashboard/lib/admin-csv.ts
@@ -1,0 +1,78 @@
+import type {
+  DashboardOneTapStyleTrendPoint,
+  DashboardTrendPoint,
+} from "./dashboard-types";
+
+export function escapeCsvField(value: string): string {
+  if (/[",\n\r]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+/**
+ * ヘッダー + 行(文字列 or 数値)を CSV 文字列にする(純関数)。
+ * - 改行は CRLF(CSV/Excel 標準)、数値は区切りなしの生値
+ */
+export function toCsvString(
+  headers: readonly string[],
+  rows: ReadonlyArray<ReadonlyArray<string | number>>,
+): string {
+  const lines = [
+    headers.join(","),
+    ...rows.map((row) =>
+      row.map((value) => escapeCsvField(String(value))).join(","),
+    ),
+  ];
+  return lines.join("\r\n");
+}
+
+/** トレンド配列の最初/最後の bucket からファイル名サフィックスを作る。 */
+export function csvDateSpanSuffix(buckets: readonly string[]): string {
+  if (buckets.length === 0) {
+    return "all";
+  }
+  return `${buckets[0]}_${buckets[buckets.length - 1]}`;
+}
+
+// ---- 「すべて」タブ: ユーザー・生成トレンド ----
+export const DASHBOARD_TREND_CSV_HEADERS = [
+  "日付",
+  "新規登録数",
+  "生成完了数",
+] as const;
+
+export function buildDashboardTrendCsv(trend: DashboardTrendPoint[]): string {
+  return toCsvString(
+    DASHBOARD_TREND_CSV_HEADERS,
+    trend.map((point) => [point.bucket, point.signups, point.generations]),
+  );
+}
+
+// ---- 「ワンタップスタイル」: One-Tap Style 日別トレンド ----
+export const ONE_TAP_STYLE_TREND_CSV_HEADERS = [
+  "日付",
+  "訪問数",
+  "生成成功数",
+  "登録CTAクリック",
+  "登録完了",
+  "保存クリック",
+  "保存完了",
+] as const;
+
+export function buildOneTapStyleTrendCsv(
+  trend: DashboardOneTapStyleTrendPoint[],
+): string {
+  return toCsvString(
+    ONE_TAP_STYLE_TREND_CSV_HEADERS,
+    trend.map((point) => [
+      point.bucket,
+      point.visits,
+      point.generations,
+      point.signupClicks,
+      point.signupCompletions,
+      point.wardrobeSaveClicks,
+      point.wardrobeSaveCompletions,
+    ]),
+  );
+}

--- a/features/admin-dashboard/lib/build-collection-kpi.ts
+++ b/features/admin-dashboard/lib/build-collection-kpi.ts
@@ -94,14 +94,10 @@ export interface CollectionEventRow {
 export function extractOneTapStyleId(
   metadata: Record<string, unknown> | null,
 ): string | null {
-  if (!metadata || typeof metadata !== "object") {
-    return null;
-  }
-  const oneTapStyle = (metadata as Record<string, unknown>)["oneTapStyle"];
-  if (!oneTapStyle || typeof oneTapStyle !== "object") {
-    return null;
-  }
-  const id = (oneTapStyle as Record<string, unknown>)["id"];
+  const oneTapStyle = metadata?.["oneTapStyle"] as
+    | Record<string, unknown>
+    | undefined;
+  const id = oneTapStyle?.["id"];
   return typeof id === "string" ? id : null;
 }
 

--- a/features/admin-dashboard/lib/build-collection-kpi.ts
+++ b/features/admin-dashboard/lib/build-collection-kpi.ts
@@ -1,0 +1,305 @@
+import {
+  enumerateJstDateKeys,
+  formatJstDateLabel,
+  isWithinDateRange,
+  toJstDateKey,
+} from "./dashboard-range";
+
+export interface OutfitGenerationCount {
+  presetId: string;
+  count: number;
+}
+
+export type DeltaDirection = "up" | "down" | "flat";
+
+export interface CollectionKpiMetric {
+  current: number;
+  previous: number;
+  deltaPct: number | null;
+  deltaDirection: DeltaDirection;
+}
+
+export interface CollectionTrendPoint {
+  bucket: string; // JST date key "YYYY-MM-DD"
+  label: string; // "M/D"
+  completions: number;
+  seriesGenerations: number;
+  generates: number;
+  downloads: number;
+  saveClicks: number;
+  signupClicks: number;
+}
+
+export interface CollectionKpi {
+  categoryKey: string;
+  completions: CollectionKpiMetric;
+  mountsFailed: CollectionKpiMetric;
+  seriesGenerations: CollectionKpiMetric;
+  visitsMember: CollectionKpiMetric;
+  visitsGuest: CollectionKpiMetric;
+  generates: CollectionKpiMetric;
+  downloads: CollectionKpiMetric;
+  saveClicks: CollectionKpiMetric;
+  signupClicks: CollectionKpiMetric;
+  outfitCounts: OutfitGenerationCount[];
+  trend: CollectionTrendPoint[];
+}
+
+// 集計元の生行(getCollectionKpi が Supabase から取得して渡す)
+export interface CollectionCompletionRow {
+  mount_status: string | null;
+  completed_at: string | null;
+}
+
+export interface CollectionImageJobRow {
+  created_at: string;
+  generation_metadata: Record<string, unknown> | null;
+}
+
+export interface CollectionEventRow {
+  auth_state: string | null;
+  event_type: string | null;
+  created_at: string;
+}
+
+/**
+ * image_jobs.generation_metadata から oneTapStyle.id を安全に取り出す。
+ * 旧 SQL `generation_metadata->oneTapStyle->>id` の JS 等価。
+ * 欠落・型不一致は null(= SQL の null と同じく未カウント)。
+ */
+export function extractOneTapStyleId(
+  metadata: Record<string, unknown> | null,
+): string | null {
+  if (!metadata || typeof metadata !== "object") {
+    return null;
+  }
+  const oneTapStyle = (metadata as Record<string, unknown>)["oneTapStyle"];
+  if (!oneTapStyle || typeof oneTapStyle !== "object") {
+    return null;
+  }
+  const id = (oneTapStyle as Record<string, unknown>)["id"];
+  return typeof id === "string" ? id : null;
+}
+
+// dashboard 全体で重複している calculateDelta と同一ロジック(既知の重複)。
+function calculateDelta(current: number, previous: number): {
+  deltaPct: number | null;
+  deltaDirection: DeltaDirection;
+} {
+  if (previous === 0) {
+    if (current === 0) {
+      return { deltaPct: 0, deltaDirection: "flat" };
+    }
+    return { deltaPct: null, deltaDirection: "up" };
+  }
+
+  const deltaPct = Number((((current - previous) / previous) * 100).toFixed(1));
+
+  if (deltaPct > 0) {
+    return { deltaPct, deltaDirection: "up" };
+  }
+  if (deltaPct < 0) {
+    return { deltaPct: Math.abs(deltaPct), deltaDirection: "down" };
+  }
+  return { deltaPct: 0, deltaDirection: "flat" };
+}
+
+function toMetric(current: number, previous: number): CollectionKpiMetric {
+  const { deltaPct, deltaDirection } = calculateDelta(current, previous);
+  return { current, previous, deltaPct, deltaDirection };
+}
+
+interface RangeCounter {
+  current: number;
+  previous: number;
+}
+
+function createCounter(): RangeCounter {
+  return { current: 0, previous: 0 };
+}
+
+/**
+ * 指定シリーズの KPI を期間付きで集計する純関数(I/O なし・テスト対象)。
+ * - current = [currentStart, now], previous = [previousStart, currentStart]
+ * - trend は currentStart..now を JST 日別でゼロ埋めした配列
+ * - 達成者ロスター(累計)は別関数 getCollectionCompleters の責務(ここには含めない)
+ */
+export function buildCollectionKpi(params: {
+  categoryKey: string;
+  presetIds: string[];
+  completionRows: CollectionCompletionRow[];
+  imageJobRows: CollectionImageJobRow[];
+  eventRows: CollectionEventRow[];
+  currentStart: Date;
+  previousStart: Date;
+  now: Date;
+}): CollectionKpi {
+  const {
+    categoryKey,
+    presetIds,
+    completionRows,
+    imageJobRows,
+    eventRows,
+    currentStart,
+    previousStart,
+    now,
+  } = params;
+
+  const dayKeys = enumerateJstDateKeys(currentStart, now);
+  const trendMap = new Map<string, CollectionTrendPoint>(
+    dayKeys.map((key) => [
+      key,
+      {
+        bucket: key,
+        label: formatJstDateLabel(key),
+        completions: 0,
+        seriesGenerations: 0,
+        generates: 0,
+        downloads: 0,
+        saveClicks: 0,
+        signupClicks: 0,
+      },
+    ]),
+  );
+
+  const inCurrent = (value: string) => isWithinDateRange(value, currentStart, now);
+  const inPrevious = (value: string) =>
+    isWithinDateRange(value, previousStart, currentStart);
+
+  const completions = createCounter();
+  const mountsFailed = createCounter();
+  const seriesGenerations = createCounter();
+  const visitsMember = createCounter();
+  const visitsGuest = createCounter();
+  const generates = createCounter();
+  const downloads = createCounter();
+  const saveClicks = createCounter();
+  const signupClicks = createCounter();
+  const outfitMap = new Map<string, number>();
+
+  // collection_completions(completed / failed)
+  for (const row of completionRows) {
+    if (!row.completed_at) {
+      continue;
+    }
+    const cur = inCurrent(row.completed_at);
+    const prev = !cur && inPrevious(row.completed_at);
+    if (!cur && !prev) {
+      continue;
+    }
+
+    if (row.mount_status === "completed") {
+      if (cur) {
+        completions.current += 1;
+        const bucket = trendMap.get(toJstDateKey(row.completed_at));
+        if (bucket) bucket.completions += 1;
+      } else {
+        completions.previous += 1;
+      }
+    } else if (row.mount_status === "failed") {
+      if (cur) mountsFailed.current += 1;
+      else mountsFailed.previous += 1;
+    }
+  }
+
+  // image_jobs(成功ジョブ): シリーズ生成数 + 衣装別
+  for (const row of imageJobRows) {
+    const cur = inCurrent(row.created_at);
+    const prev = !cur && inPrevious(row.created_at);
+    if (!cur && !prev) {
+      continue;
+    }
+
+    if (cur) {
+      seriesGenerations.current += 1;
+      const bucket = trendMap.get(toJstDateKey(row.created_at));
+      if (bucket) bucket.seriesGenerations += 1;
+      const presetId = extractOneTapStyleId(row.generation_metadata);
+      if (presetId) {
+        outfitMap.set(presetId, (outfitMap.get(presetId) ?? 0) + 1);
+      }
+    } else {
+      seriesGenerations.previous += 1;
+    }
+  }
+
+  // style_usage_events: 企画ファネル
+  for (const row of eventRows) {
+    const cur = inCurrent(row.created_at);
+    const prev = !cur && inPrevious(row.created_at);
+    if (!cur && !prev) {
+      continue;
+    }
+    const bucket = cur ? trendMap.get(toJstDateKey(row.created_at)) : undefined;
+
+    switch (row.event_type) {
+      case "visit":
+        if (row.auth_state === "authenticated") {
+          if (cur) visitsMember.current += 1;
+          else visitsMember.previous += 1;
+        } else if (row.auth_state === "guest") {
+          if (cur) visitsGuest.current += 1;
+          else visitsGuest.previous += 1;
+        }
+        break;
+      case "generate":
+        if (cur) {
+          generates.current += 1;
+          if (bucket) bucket.generates += 1;
+        } else {
+          generates.previous += 1;
+        }
+        break;
+      case "download":
+        if (cur) {
+          downloads.current += 1;
+          if (bucket) bucket.downloads += 1;
+        } else {
+          downloads.previous += 1;
+        }
+        break;
+      case "wardrobe_save_click":
+        if (cur) {
+          saveClicks.current += 1;
+          if (bucket) bucket.saveClicks += 1;
+        } else {
+          saveClicks.previous += 1;
+        }
+        break;
+      case "signup_click":
+        if (cur) {
+          signupClicks.current += 1;
+          if (bucket) bucket.signupClicks += 1;
+        } else {
+          signupClicks.previous += 1;
+        }
+        break;
+      default:
+        break;
+    }
+  }
+
+  // 衣装別: preset の display_order を維持(0 件も含めて表示)
+  const outfitCounts: OutfitGenerationCount[] = presetIds.map((presetId) => ({
+    presetId,
+    count: outfitMap.get(presetId) ?? 0,
+  }));
+
+  return {
+    categoryKey,
+    completions: toMetric(completions.current, completions.previous),
+    mountsFailed: toMetric(mountsFailed.current, mountsFailed.previous),
+    seriesGenerations: toMetric(
+      seriesGenerations.current,
+      seriesGenerations.previous,
+    ),
+    visitsMember: toMetric(visitsMember.current, visitsMember.previous),
+    visitsGuest: toMetric(visitsGuest.current, visitsGuest.previous),
+    generates: toMetric(generates.current, generates.previous),
+    downloads: toMetric(downloads.current, downloads.previous),
+    saveClicks: toMetric(saveClicks.current, saveClicks.previous),
+    signupClicks: toMetric(signupClicks.current, signupClicks.previous),
+    outfitCounts,
+    trend: dayKeys.map((key) => trendMap.get(key)!),
+  };
+}

--- a/features/admin-dashboard/lib/build-collection-kpi.ts
+++ b/features/admin-dashboard/lib/build-collection-kpi.ts
@@ -17,6 +17,9 @@ export interface CollectionKpiMetric {
   previous: number;
   deltaPct: number | null;
   deltaDirection: DeltaDirection;
+  // current 期間のログイン/ゲスト内訳(分離可能な指標のみ設定)
+  member?: number;
+  guest?: number;
 }
 
 export interface CollectionTrendPoint {
@@ -24,10 +27,16 @@ export interface CollectionTrendPoint {
   label: string; // "M/D"
   completions: number;
   seriesGenerations: number;
+  visitsMember: number;
+  visitsGuest: number;
   generates: number;
+  generatesGuest: number; // お試し生成(未ログイン)
   downloads: number;
+  downloadsMember: number;
+  downloadsGuest: number;
   saveClicks: number;
   signupClicks: number;
+  shares: number;
 }
 
 export interface CollectionKpi {
@@ -41,6 +50,7 @@ export interface CollectionKpi {
   downloads: CollectionKpiMetric;
   saveClicks: CollectionKpiMetric;
   signupClicks: CollectionKpiMetric;
+  shares: CollectionKpiMetric;
   outfitCounts: OutfitGenerationCount[];
   trend: CollectionTrendPoint[];
 }
@@ -104,9 +114,19 @@ function calculateDelta(current: number, previous: number): {
   return { deltaPct: 0, deltaDirection: "flat" };
 }
 
-function toMetric(current: number, previous: number): CollectionKpiMetric {
+function toMetric(
+  current: number,
+  previous: number,
+  auth?: { member: number; guest: number },
+): CollectionKpiMetric {
   const { deltaPct, deltaDirection } = calculateDelta(current, previous);
-  return { current, previous, deltaPct, deltaDirection };
+  const base: CollectionKpiMetric = {
+    current,
+    previous,
+    deltaPct,
+    deltaDirection,
+  };
+  return auth ? { ...base, member: auth.member, guest: auth.guest } : base;
 }
 
 interface RangeCounter {
@@ -122,6 +142,9 @@ function createCounter(): RangeCounter {
  * 指定シリーズの KPI を期間付きで集計する純関数(I/O なし・テスト対象)。
  * - current = [currentStart, now], previous = [previousStart, currentStart]
  * - trend は currentStart..now を JST 日別でゼロ埋めした配列
+ * - visits / generates / downloads はログイン(member) / ゲスト(guest) 内訳も集計
+ * - shareRows は mount_shared イベント(style_id を持たないため別取得)。
+ *   現状コレクション横断のため series 固有ではない点に注意(category 付与は別途)。
  * - 達成者ロスター(累計)は別関数 getCollectionCompleters の責務(ここには含めない)
  */
 export function buildCollectionKpi(params: {
@@ -130,6 +153,7 @@ export function buildCollectionKpi(params: {
   completionRows: CollectionCompletionRow[];
   imageJobRows: CollectionImageJobRow[];
   eventRows: CollectionEventRow[];
+  shareRows: CollectionEventRow[];
   currentStart: Date;
   previousStart: Date;
   now: Date;
@@ -140,6 +164,7 @@ export function buildCollectionKpi(params: {
     completionRows,
     imageJobRows,
     eventRows,
+    shareRows,
     currentStart,
     previousStart,
     now,
@@ -154,10 +179,16 @@ export function buildCollectionKpi(params: {
         label: formatJstDateLabel(key),
         completions: 0,
         seriesGenerations: 0,
+        visitsMember: 0,
+        visitsGuest: 0,
         generates: 0,
+        generatesGuest: 0,
         downloads: 0,
+        downloadsMember: 0,
+        downloadsGuest: 0,
         saveClicks: 0,
         signupClicks: 0,
+        shares: 0,
       },
     ]),
   );
@@ -175,6 +206,12 @@ export function buildCollectionKpi(params: {
   const downloads = createCounter();
   const saveClicks = createCounter();
   const signupClicks = createCounter();
+  const shares = createCounter();
+  // current 期間の member/guest 内訳
+  let generatesMemberCur = 0;
+  let generatesGuestCur = 0;
+  let downloadsMemberCur = 0;
+  let downloadsGuestCur = 0;
   const outfitMap = new Map<string, number>();
 
   // collection_completions(completed / failed)
@@ -223,7 +260,7 @@ export function buildCollectionKpi(params: {
     }
   }
 
-  // style_usage_events: 企画ファネル
+  // style_usage_events: 企画ファネル(visit/generate/download/save/signup)
   for (const row of eventRows) {
     const cur = inCurrent(row.created_at);
     const prev = !cur && inPrevious(row.created_at);
@@ -231,21 +268,36 @@ export function buildCollectionKpi(params: {
       continue;
     }
     const bucket = cur ? trendMap.get(toJstDateKey(row.created_at)) : undefined;
+    const isGuest = row.auth_state === "guest";
+    const isMember = row.auth_state === "authenticated";
 
     switch (row.event_type) {
       case "visit":
-        if (row.auth_state === "authenticated") {
-          if (cur) visitsMember.current += 1;
-          else visitsMember.previous += 1;
-        } else if (row.auth_state === "guest") {
-          if (cur) visitsGuest.current += 1;
-          else visitsGuest.previous += 1;
+        if (isMember) {
+          if (cur) {
+            visitsMember.current += 1;
+            if (bucket) bucket.visitsMember += 1;
+          } else {
+            visitsMember.previous += 1;
+          }
+        } else if (isGuest) {
+          if (cur) {
+            visitsGuest.current += 1;
+            if (bucket) bucket.visitsGuest += 1;
+          } else {
+            visitsGuest.previous += 1;
+          }
         }
         break;
       case "generate":
         if (cur) {
           generates.current += 1;
-          if (bucket) bucket.generates += 1;
+          if (isMember) generatesMemberCur += 1;
+          else if (isGuest) generatesGuestCur += 1;
+          if (bucket) {
+            bucket.generates += 1;
+            if (isGuest) bucket.generatesGuest += 1;
+          }
         } else {
           generates.previous += 1;
         }
@@ -253,7 +305,13 @@ export function buildCollectionKpi(params: {
       case "download":
         if (cur) {
           downloads.current += 1;
-          if (bucket) bucket.downloads += 1;
+          if (isMember) downloadsMemberCur += 1;
+          else if (isGuest) downloadsGuestCur += 1;
+          if (bucket) {
+            bucket.downloads += 1;
+            if (isMember) bucket.downloadsMember += 1;
+            else if (isGuest) bucket.downloadsGuest += 1;
+          }
         } else {
           downloads.previous += 1;
         }
@@ -279,6 +337,22 @@ export function buildCollectionKpi(params: {
     }
   }
 
+  // mount_shared(台紙シェア)。style_id を持たないため別取得。
+  for (const row of shareRows) {
+    if (row.event_type !== "mount_shared") {
+      continue;
+    }
+    const cur = inCurrent(row.created_at);
+    const prev = !cur && inPrevious(row.created_at);
+    if (cur) {
+      shares.current += 1;
+      const bucket = trendMap.get(toJstDateKey(row.created_at));
+      if (bucket) bucket.shares += 1;
+    } else if (prev) {
+      shares.previous += 1;
+    }
+  }
+
   // 衣装別: preset の display_order を維持(0 件も含めて表示)
   const outfitCounts: OutfitGenerationCount[] = presetIds.map((presetId) => ({
     presetId,
@@ -295,10 +369,17 @@ export function buildCollectionKpi(params: {
     ),
     visitsMember: toMetric(visitsMember.current, visitsMember.previous),
     visitsGuest: toMetric(visitsGuest.current, visitsGuest.previous),
-    generates: toMetric(generates.current, generates.previous),
-    downloads: toMetric(downloads.current, downloads.previous),
+    generates: toMetric(generates.current, generates.previous, {
+      member: generatesMemberCur,
+      guest: generatesGuestCur,
+    }),
+    downloads: toMetric(downloads.current, downloads.previous, {
+      member: downloadsMemberCur,
+      guest: downloadsGuestCur,
+    }),
     saveClicks: toMetric(saveClicks.current, saveClicks.previous),
     signupClicks: toMetric(signupClicks.current, signupClicks.previous),
+    shares: toMetric(shares.current, shares.previous),
     outfitCounts,
     trend: dayKeys.map((key) => trendMap.get(key)!),
   };

--- a/features/admin-dashboard/lib/build-collection-kpi.ts
+++ b/features/admin-dashboard/lib/build-collection-kpi.ts
@@ -5,9 +5,22 @@ import {
   toJstDateKey,
 } from "./dashboard-range";
 
+export interface CollectionPreset {
+  id: string;
+  label: string; // 柱名(style_presets.title)
+}
+
 export interface OutfitGenerationCount {
   presetId: string;
+  label: string;
   count: number;
+}
+
+/** 日別 × 柱別 の生成数(B-3)。counts は outfitCounts と同じ柱順に並ぶ。 */
+export interface CollectionOutfitDailyPoint {
+  bucket: string;
+  label: string;
+  counts: number[];
 }
 
 export type DeltaDirection = "up" | "down" | "flat";
@@ -52,6 +65,7 @@ export interface CollectionKpi {
   signupClicks: CollectionKpiMetric;
   shares: CollectionKpiMetric;
   outfitCounts: OutfitGenerationCount[];
+  outfitDaily: CollectionOutfitDailyPoint[];
   trend: CollectionTrendPoint[];
 }
 
@@ -143,13 +157,13 @@ function createCounter(): RangeCounter {
  * - current = [currentStart, now], previous = [previousStart, currentStart]
  * - trend は currentStart..now を JST 日別でゼロ埋めした配列
  * - visits / generates / downloads はログイン(member) / ゲスト(guest) 内訳も集計
- * - shareRows は mount_shared イベント(style_id を持たないため別取得)。
- *   現状コレクション横断のため series 固有ではない点に注意(category 付与は別途)。
+ * - outfitCounts(柱別合計) と outfitDaily(日別×柱別, B-3) を柱(preset)順に出力
+ * - shareRows は mount_shared イベント(style_id を持たないため別取得)
  * - 達成者ロスター(累計)は別関数 getCollectionCompleters の責務(ここには含めない)
  */
 export function buildCollectionKpi(params: {
   categoryKey: string;
-  presetIds: string[];
+  presets: CollectionPreset[];
   completionRows: CollectionCompletionRow[];
   imageJobRows: CollectionImageJobRow[];
   eventRows: CollectionEventRow[];
@@ -160,7 +174,7 @@ export function buildCollectionKpi(params: {
 }): CollectionKpi {
   const {
     categoryKey,
-    presetIds,
+    presets,
     completionRows,
     imageJobRows,
     eventRows,
@@ -170,6 +184,7 @@ export function buildCollectionKpi(params: {
     now,
   } = params;
 
+  const presetIds = presets.map((preset) => preset.id);
   const dayKeys = enumerateJstDateKeys(currentStart, now);
   const trendMap = new Map<string, CollectionTrendPoint>(
     dayKeys.map((key) => [
@@ -191,6 +206,10 @@ export function buildCollectionKpi(params: {
         shares: 0,
       },
     ]),
+  );
+  // 日別 × 柱別(B-3): dayKey -> (presetId -> count)
+  const outfitDailyMap = new Map<string, Map<string, number>>(
+    dayKeys.map((key) => [key, new Map<string, number>()]),
   );
 
   const inCurrent = (value: string) => isWithinDateRange(value, currentStart, now);
@@ -239,7 +258,7 @@ export function buildCollectionKpi(params: {
     }
   }
 
-  // image_jobs(成功ジョブ): シリーズ生成数 + 衣装別
+  // image_jobs(成功ジョブ): シリーズ生成数 + 衣装別(合計 + 日別)
   for (const row of imageJobRows) {
     const cur = inCurrent(row.created_at);
     const prev = !cur && inPrevious(row.created_at);
@@ -249,11 +268,16 @@ export function buildCollectionKpi(params: {
 
     if (cur) {
       seriesGenerations.current += 1;
-      const bucket = trendMap.get(toJstDateKey(row.created_at));
+      const dayKey = toJstDateKey(row.created_at);
+      const bucket = trendMap.get(dayKey);
       if (bucket) bucket.seriesGenerations += 1;
       const presetId = extractOneTapStyleId(row.generation_metadata);
       if (presetId) {
         outfitMap.set(presetId, (outfitMap.get(presetId) ?? 0) + 1);
+        const dayMap = outfitDailyMap.get(dayKey);
+        if (dayMap) {
+          dayMap.set(presetId, (dayMap.get(presetId) ?? 0) + 1);
+        }
       }
     } else {
       seriesGenerations.previous += 1;
@@ -353,11 +377,20 @@ export function buildCollectionKpi(params: {
     }
   }
 
-  // 衣装別: preset の display_order を維持(0 件も含めて表示)
-  const outfitCounts: OutfitGenerationCount[] = presetIds.map((presetId) => ({
-    presetId,
-    count: outfitMap.get(presetId) ?? 0,
+  // 衣装別(柱別): preset の display_order を維持(0 件も含めて表示)
+  const outfitCounts: OutfitGenerationCount[] = presets.map((preset) => ({
+    presetId: preset.id,
+    label: preset.label,
+    count: outfitMap.get(preset.id) ?? 0,
   }));
+  const outfitDaily: CollectionOutfitDailyPoint[] = dayKeys.map((key) => {
+    const dayMap = outfitDailyMap.get(key);
+    return {
+      bucket: key,
+      label: formatJstDateLabel(key),
+      counts: presetIds.map((presetId) => dayMap?.get(presetId) ?? 0),
+    };
+  });
 
   return {
     categoryKey,
@@ -381,6 +414,7 @@ export function buildCollectionKpi(params: {
     signupClicks: toMetric(signupClicks.current, signupClicks.previous),
     shares: toMetric(shares.current, shares.previous),
     outfitCounts,
+    outfitDaily,
     trend: dayKeys.map((key) => trendMap.get(key)!),
   };
 }

--- a/features/admin-dashboard/lib/build-collection-trend-csv.ts
+++ b/features/admin-dashboard/lib/build-collection-trend-csv.ts
@@ -1,4 +1,5 @@
 import type { CollectionTrendPoint } from "./build-collection-kpi";
+import { toCsvString } from "./admin-csv";
 
 export const COLLECTION_TREND_CSV_HEADERS = [
   "日付",
@@ -10,34 +11,22 @@ export const COLLECTION_TREND_CSV_HEADERS = [
   "登録CTAクリック",
 ] as const;
 
-function escapeCsvField(value: string): string {
-  if (/[",\n\r]/.test(value)) {
-    return `"${value.replace(/"/g, '""')}"`;
-  }
-  return value;
-}
-
 /**
  * コレクションの日別トレンドを CSV 文字列に変換する(純関数)。
  * - 1 行目はヘッダー、以降は trend の各日 1 行
  * - 改行は CRLF(CSV/Excel 標準)、数値は区切りなしの生値
  */
 export function buildCollectionTrendCsv(trend: CollectionTrendPoint[]): string {
-  const lines = [
-    COLLECTION_TREND_CSV_HEADERS.join(","),
-    ...trend.map((point) =>
-      [
-        point.bucket,
-        point.completions,
-        point.seriesGenerations,
-        point.generates,
-        point.downloads,
-        point.saveClicks,
-        point.signupClicks,
-      ]
-        .map((value) => escapeCsvField(String(value)))
-        .join(","),
-    ),
-  ];
-  return lines.join("\r\n");
+  return toCsvString(
+    COLLECTION_TREND_CSV_HEADERS,
+    trend.map((point) => [
+      point.bucket,
+      point.completions,
+      point.seriesGenerations,
+      point.generates,
+      point.downloads,
+      point.saveClicks,
+      point.signupClicks,
+    ]),
+  );
 }

--- a/features/admin-dashboard/lib/build-collection-trend-csv.ts
+++ b/features/admin-dashboard/lib/build-collection-trend-csv.ts
@@ -1,0 +1,43 @@
+import type { CollectionTrendPoint } from "./build-collection-kpi";
+
+export const COLLECTION_TREND_CSV_HEADERS = [
+  "日付",
+  "コンプリート達成数",
+  "シリーズ生成数",
+  "生成成功",
+  "ダウンロード",
+  "保存クリック",
+  "登録CTAクリック",
+] as const;
+
+function escapeCsvField(value: string): string {
+  if (/[",\n\r]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+/**
+ * コレクションの日別トレンドを CSV 文字列に変換する(純関数)。
+ * - 1 行目はヘッダー、以降は trend の各日 1 行
+ * - 改行は CRLF(CSV/Excel 標準)、数値は区切りなしの生値
+ */
+export function buildCollectionTrendCsv(trend: CollectionTrendPoint[]): string {
+  const lines = [
+    COLLECTION_TREND_CSV_HEADERS.join(","),
+    ...trend.map((point) =>
+      [
+        point.bucket,
+        point.completions,
+        point.seriesGenerations,
+        point.generates,
+        point.downloads,
+        point.saveClicks,
+        point.signupClicks,
+      ]
+        .map((value) => escapeCsvField(String(value)))
+        .join(","),
+    ),
+  ];
+  return lines.join("\r\n");
+}

--- a/features/admin-dashboard/lib/build-collection-trend-csv.ts
+++ b/features/admin-dashboard/lib/build-collection-trend-csv.ts
@@ -5,15 +5,22 @@ export const COLLECTION_TREND_CSV_HEADERS = [
   "日付",
   "コンプリート達成数",
   "シリーズ生成数",
+  "訪問(ログイン)",
+  "訪問(ゲスト)",
   "生成成功",
+  "お試し生成(ゲスト)",
   "ダウンロード",
+  "ダウンロード(ログイン)",
+  "ダウンロード(ゲスト)",
   "保存クリック",
   "登録CTAクリック",
+  "シェア",
 ] as const;
 
 /**
  * コレクションの日別トレンドを CSV 文字列に変換する(純関数)。
  * - 1 行目はヘッダー、以降は trend の各日 1 行
+ * - 訪問/生成/ダウンロードはログイン・ゲスト内訳列も出力
  * - 改行は CRLF(CSV/Excel 標準)、数値は区切りなしの生値
  */
 export function buildCollectionTrendCsv(trend: CollectionTrendPoint[]): string {
@@ -23,10 +30,16 @@ export function buildCollectionTrendCsv(trend: CollectionTrendPoint[]): string {
       point.bucket,
       point.completions,
       point.seriesGenerations,
+      point.visitsMember,
+      point.visitsGuest,
       point.generates,
+      point.generatesGuest,
       point.downloads,
+      point.downloadsMember,
+      point.downloadsGuest,
       point.saveClicks,
       point.signupClicks,
+      point.shares,
     ]),
   );
 }

--- a/features/admin-dashboard/lib/build-collection-trend-csv.ts
+++ b/features/admin-dashboard/lib/build-collection-trend-csv.ts
@@ -1,4 +1,9 @@
-import type { CollectionKpi, CollectionTrendPoint } from "./build-collection-kpi";
+import type {
+  CollectionKpi,
+  CollectionKpiMetric,
+  CollectionTrendPoint,
+} from "./build-collection-kpi";
+import type { CollectionUuFunnel } from "./build-collection-uu-funnel";
 import { toCsvString } from "./admin-csv";
 
 export const COLLECTION_TREND_CSV_HEADERS = [
@@ -53,4 +58,69 @@ export function buildCollectionOutfitDailyCsv(kpi: CollectionKpi): string {
   const headers = ["日付", ...kpi.outfitCounts.map((outfit) => outfit.label)];
   const rows = kpi.outfitDaily.map((point) => [point.bucket, ...point.counts]);
   return toCsvString(headers, rows);
+}
+
+export const COLLECTION_SUMMARY_CSV_HEADERS = [
+  "指標",
+  "今期間",
+  "前期間",
+  "前期間比(%)",
+  "ログイン",
+  "ゲスト",
+] as const;
+
+function summaryRow(
+  label: string,
+  metric: CollectionKpiMetric,
+): (string | number)[] {
+  return [
+    label,
+    metric.current,
+    metric.previous,
+    metric.deltaPct ?? "",
+    metric.member ?? "",
+    metric.guest ?? "",
+  ];
+}
+
+/**
+ * 期間サマリー(期間合計)を CSV 文字列にする。
+ * - 各 KPI 指標の 今期間/前期間/前期間比 と、分離可能な指標の ログイン/ゲスト 内訳
+ * - 続けて UU ファネル(B-2/A-5/A-8)の指標を出力
+ */
+export function buildCollectionSummaryCsv(
+  kpi: CollectionKpi,
+  uuFunnel: CollectionUuFunnel,
+): string {
+  const pct = (value: number | null): string | number => (value === null ? "" : value);
+  const uuRow = (label: string, value: string | number): (string | number)[] => [
+    label,
+    value,
+    "",
+    "",
+    "",
+    "",
+  ];
+  const rows: (string | number)[][] = [
+    summaryRow("コンプリート達成数", kpi.completions),
+    summaryRow("シリーズ生成数(成功)", kpi.seriesGenerations),
+    summaryRow("訪問(ログイン)", kpi.visitsMember),
+    summaryRow("訪問(ゲスト)", kpi.visitsGuest),
+    summaryRow("生成成功", kpi.generates),
+    summaryRow("ダウンロード", kpi.downloads),
+    summaryRow("保存クリック", kpi.saveClicks),
+    summaryRow("登録CTAクリック", kpi.signupClicks),
+    summaryRow("シェア", kpi.shares),
+    summaryRow("台紙生成失敗", kpi.mountsFailed),
+    uuRow("生成UU", uuFunnel.generatesUu),
+    uuRow("コンプリートUU", uuFunnel.completionsUu),
+    uuRow("シェアUU", uuFunnel.sharesUu),
+    uuRow("コンプリート到達率(%)", pct(uuFunnel.reachRatePct)),
+    uuRow("期間内登録UU", uuFunnel.registeredUu),
+    uuRow("登録→コンプリートUU", uuFunnel.registeredCompletedUu),
+    uuRow("登録→コンプリート率(%)", pct(uuFunnel.registeredReachRatePct)),
+    uuRow("登録後 未コンプリートUU", uuFunnel.registeredNotCompletedUu),
+    uuRow("コンプリート後 未シェアUU", uuFunnel.completedNotSharedUu),
+  ];
+  return toCsvString(COLLECTION_SUMMARY_CSV_HEADERS, rows);
 }

--- a/features/admin-dashboard/lib/build-collection-trend-csv.ts
+++ b/features/admin-dashboard/lib/build-collection-trend-csv.ts
@@ -1,4 +1,4 @@
-import type { CollectionTrendPoint } from "./build-collection-kpi";
+import type { CollectionKpi, CollectionTrendPoint } from "./build-collection-kpi";
 import { toCsvString } from "./admin-csv";
 
 export const COLLECTION_TREND_CSV_HEADERS = [
@@ -42,4 +42,15 @@ export function buildCollectionTrendCsv(trend: CollectionTrendPoint[]): string {
       point.shares,
     ]),
   );
+}
+
+/**
+ * 日別 × 柱別の生成数(B-3)を CSV 文字列にする。
+ * - ヘッダー: 日付, <柱名...>(outfitCounts の柱順)
+ * - 各行: その日の各柱の生成数
+ */
+export function buildCollectionOutfitDailyCsv(kpi: CollectionKpi): string {
+  const headers = ["日付", ...kpi.outfitCounts.map((outfit) => outfit.label)];
+  const rows = kpi.outfitDaily.map((point) => [point.bucket, ...point.counts]);
+  return toCsvString(headers, rows);
 }

--- a/features/admin-dashboard/lib/build-collection-uu-funnel.ts
+++ b/features/admin-dashboard/lib/build-collection-uu-funnel.ts
@@ -1,0 +1,65 @@
+/**
+ * コレクション企画のユニークユーザー(UU)ファネル(B-2 / A-5 / A-8)。
+ * - ログイン側のみ。ゲストは style_usage_events.user_id が NULL のため UU 計測不可。
+ * - 生成UU → コンプリートUU → シェアUU の歩留まり、および
+ *   期間内登録UU → コンプリート の到達率/離脱を算出する。
+ */
+export interface CollectionUuFunnel {
+  generatesUu: number; // 神コレ生成したログインUU
+  completionsUu: number; // コンプリート到達UU
+  sharesUu: number; // シェアしたUU
+  reachRatePct: number | null; // B-2: コンプリートUU / 生成UU
+  registeredUu: number; // 期間内に新規登録したUU
+  registeredCompletedUu: number; // うちコンプリート到達
+  registeredReachRatePct: number | null; // A-5: 登録→コンプリート率
+  registeredNotCompletedUu: number; // A-8: 登録したが未コンプリート
+  completedNotSharedUu: number; // A-8: コンプリートしたが未シェア
+}
+
+function rate(numerator: number, denominator: number): number | null {
+  if (denominator <= 0) {
+    return null;
+  }
+  return Number(((numerator / denominator) * 100).toFixed(1));
+}
+
+function intersectionSize(target: Set<string>, other: Set<string>): number {
+  let count = 0;
+  for (const id of target) {
+    if (other.has(id)) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+export function buildCollectionUuFunnel(params: {
+  generateMemberUserIds: string[];
+  completerUserIds: string[];
+  shareUserIds: string[];
+  registeredUserIds: string[];
+}): CollectionUuFunnel {
+  const generates = new Set(params.generateMemberUserIds.filter(Boolean));
+  const completers = new Set(params.completerUserIds.filter(Boolean));
+  const sharers = new Set(params.shareUserIds.filter(Boolean));
+  const registered = new Set(params.registeredUserIds.filter(Boolean));
+
+  const generatesUu = generates.size;
+  const completionsUu = completers.size;
+  const sharesUu = sharers.size;
+  const registeredUu = registered.size;
+  const registeredCompletedUu = intersectionSize(completers, registered);
+  const completedSharedUu = intersectionSize(completers, sharers);
+
+  return {
+    generatesUu,
+    completionsUu,
+    sharesUu,
+    reachRatePct: rate(completionsUu, generatesUu),
+    registeredUu,
+    registeredCompletedUu,
+    registeredReachRatePct: rate(registeredCompletedUu, registeredUu),
+    registeredNotCompletedUu: Math.max(0, registeredUu - registeredCompletedUu),
+    completedNotSharedUu: Math.max(0, completionsUu - completedSharedUu),
+  };
+}

--- a/features/admin-dashboard/lib/dashboard-range.ts
+++ b/features/admin-dashboard/lib/dashboard-range.ts
@@ -128,6 +128,14 @@ export function getOneTapStyleRangeBounds(params: {
   };
 }
 
+// ---- 任意期間(custom)対応 range の共用エイリアス ----
+// One-Tap Style 用に実装した「プリセット + 任意日時」range を、
+// コレクションタブなど他タブでも共用するための別名(ロジックは同一)。
+export type CustomDashboardRange = OneTapStyleDashboardRange;
+export const CUSTOM_DASHBOARD_RANGE_OPTIONS = ONE_TAP_STYLE_DASHBOARD_RANGE_OPTIONS;
+export const parseCustomDashboardRange = parseOneTapStyleDashboardRange;
+export const getCustomDashboardRangeBounds = getOneTapStyleRangeBounds;
+
 export function isWithinDateRange(
   value: string,
   start: Date,

--- a/features/admin-dashboard/lib/dashboard-tab.ts
+++ b/features/admin-dashboard/lib/dashboard-tab.ts
@@ -23,6 +23,9 @@ export function buildAdminDashboardHref(params: {
   styleRange?: string;
   styleFrom?: string | null;
   styleTo?: string | null;
+  collectionRange?: string;
+  collectionFrom?: string | null;
+  collectionTo?: string | null;
 }): string {
   const searchParams = new URLSearchParams();
   searchParams.set("range", params.range);
@@ -38,6 +41,18 @@ export function buildAdminDashboardHref(params: {
 
   if (params.styleTo) {
     searchParams.set("styleTo", params.styleTo);
+  }
+
+  if (params.collectionRange) {
+    searchParams.set("collectionRange", params.collectionRange);
+  }
+
+  if (params.collectionFrom) {
+    searchParams.set("collectionFrom", params.collectionFrom);
+  }
+
+  if (params.collectionTo) {
+    searchParams.set("collectionTo", params.collectionTo);
   }
 
   return `/admin?${searchParams.toString()}`;

--- a/features/admin-dashboard/lib/dashboard-tab.ts
+++ b/features/admin-dashboard/lib/dashboard-tab.ts
@@ -1,6 +1,6 @@
 import type { DashboardRange } from "./dashboard-range";
 
-export type AdminDashboardTab = "all" | "one-tap-style";
+export type AdminDashboardTab = "all" | "one-tap-style" | "collections";
 
 export const ADMIN_DASHBOARD_TAB_OPTIONS: Array<{
   value: AdminDashboardTab;
@@ -8,10 +8,13 @@ export const ADMIN_DASHBOARD_TAB_OPTIONS: Array<{
 }> = [
   { value: "all", label: "すべて" },
   { value: "one-tap-style", label: "ワンタップスタイル" },
+  { value: "collections", label: "コレクション" },
 ];
 
 export function parseAdminDashboardTab(value?: string): AdminDashboardTab {
-  return value === "one-tap-style" ? "one-tap-style" : "all";
+  if (value === "one-tap-style") return "one-tap-style";
+  if (value === "collections") return "collections";
+  return "all";
 }
 
 export function buildAdminDashboardHref(params: {

--- a/features/admin-dashboard/lib/get-collection-kpi.ts
+++ b/features/admin-dashboard/lib/get-collection-kpi.ts
@@ -1,80 +1,41 @@
 import "server-only";
 
 import { createAdminClient } from "@/lib/supabase/admin";
+import {
+  buildCollectionKpi,
+  type CollectionCompletionRow,
+  type CollectionEventRow,
+  type CollectionImageJobRow,
+  type CollectionKpi,
+} from "./build-collection-kpi";
 
-export interface OutfitGenerationCount {
-  presetId: string;
-  count: number;
-}
-
-export interface CollectionKpi {
-  categoryKey: string;
-  completions: number;
-  mountsFailed: number;
-  seriesGenerations: number;
-  outfitCounts: OutfitGenerationCount[];
-  // 企画ファネル(style_usage_events を当該シリーズの preset で絞って集計)
-  visitsMember: number;
-  visitsGuest: number;
-  generates: number;
-  downloads: number;
-  saveClicks: number;
-  signupClicks: number;
-}
-
-type AdminClient = ReturnType<typeof createAdminClient>;
-
-async function countEvents(
-  supabase: AdminClient,
-  presetIds: string[],
-  eventType: string,
-  authState?: "authenticated" | "guest",
-): Promise<number> {
-  if (presetIds.length === 0) return 0;
-  let query = supabase
-    .from("style_usage_events")
-    .select("id", { count: "exact", head: true })
-    .in("style_id", presetIds)
-    .eq("event_type", eventType);
-  if (authState) {
-    query = query.eq("auth_state", authState);
-  }
-  const { count } = await query;
-  return count ?? 0;
-}
+export type {
+  CollectionKpi,
+  CollectionKpiMetric,
+  CollectionTrendPoint,
+  OutfitGenerationCount,
+} from "./build-collection-kpi";
 
 /**
- * 指定シリーズの KPI を集計する。admin 専用。
- * - completions / mountsFailed: collection_completions(耐久データ)
- * - seriesGenerations / outfitCounts: image_jobs(成功ジョブ)
+ * 指定シリーズの KPI を期間付きで集計する。admin 専用。
+ * - 範囲 [previousStart, now] で行を取得し、純関数 buildCollectionKpi で
+ *   current / previous(前期間比) / 日別トレンド に集計する。
+ * - completions / mountsFailed: collection_completions(completed_at で範囲絞り)
+ * - seriesGenerations / outfitCounts: image_jobs(成功ジョブ・created_at で範囲絞り)
  * - ファネル: style_usage_events を当該カテゴリの preset id で絞って集計
  */
 export async function getCollectionKpi(params: {
   categoryKey: string;
   categoryId: string;
+  currentStart: Date;
+  previousStart: Date;
+  now: Date;
 }): Promise<CollectionKpi> {
   const supabase = createAdminClient();
+  const startIso = params.previousStart.toISOString();
+  const endIso = params.now.toISOString();
 
-  const [{ count: completions }, { count: mountsFailed }] = await Promise.all([
-    supabase
-      .from("collection_completions")
-      .select("id", { count: "exact", head: true })
-      .eq("category_key", params.categoryKey)
-      .eq("mount_status", "completed"),
-    supabase
-      .from("collection_completions")
-      .select("id", { count: "exact", head: true })
-      .eq("category_key", params.categoryKey)
-      .eq("mount_status", "failed"),
-  ]);
-
-  const { count: seriesGenerations } = await supabase
-    .from("image_jobs")
-    .select("id", { count: "exact", head: true })
-    .eq("style_preset_category_key", params.categoryKey)
-    .eq("status", "succeeded");
-
-  // 当該カテゴリの preset 一覧(衣装別集計 + ファネル絞り込みに使う)
+  // 当該カテゴリの preset 一覧(衣装別の表示順 + ファネル絞り込みに使う)
   const { data: presets } = await supabase
     .from("style_presets")
     .select("id, display_order")
@@ -82,44 +43,38 @@ export async function getCollectionKpi(params: {
     .order("display_order", { ascending: true });
   const presetIds = (presets ?? []).map((p) => p.id as string);
 
-  const outfitCounts: OutfitGenerationCount[] = [];
-  for (const presetId of presetIds) {
-    const { count } = await supabase
+  const [completionsResult, imageJobsResult, eventsResult] = await Promise.all([
+    supabase
+      .from("collection_completions")
+      .select("mount_status, completed_at")
+      .eq("category_key", params.categoryKey)
+      .gte("completed_at", startIso)
+      .lte("completed_at", endIso),
+    supabase
       .from("image_jobs")
-      .select("id", { count: "exact", head: true })
+      .select("created_at, generation_metadata")
       .eq("style_preset_category_key", params.categoryKey)
       .eq("status", "succeeded")
-      .eq("generation_metadata->oneTapStyle->>id", presetId);
-    outfitCounts.push({ presetId, count: count ?? 0 });
-  }
-
-  const [
-    visitsMember,
-    visitsGuest,
-    generates,
-    downloads,
-    saveClicks,
-    signupClicks,
-  ] = await Promise.all([
-    countEvents(supabase, presetIds, "visit", "authenticated"),
-    countEvents(supabase, presetIds, "visit", "guest"),
-    countEvents(supabase, presetIds, "generate"),
-    countEvents(supabase, presetIds, "download"),
-    countEvents(supabase, presetIds, "wardrobe_save_click"),
-    countEvents(supabase, presetIds, "signup_click"),
+      .gte("created_at", startIso)
+      .lte("created_at", endIso),
+    presetIds.length > 0
+      ? supabase
+          .from("style_usage_events")
+          .select("auth_state, event_type, created_at")
+          .in("style_id", presetIds)
+          .gte("created_at", startIso)
+          .lte("created_at", endIso)
+      : Promise.resolve({ data: [] as CollectionEventRow[], error: null }),
   ]);
 
-  return {
+  return buildCollectionKpi({
     categoryKey: params.categoryKey,
-    completions: completions ?? 0,
-    mountsFailed: mountsFailed ?? 0,
-    seriesGenerations: seriesGenerations ?? 0,
-    outfitCounts,
-    visitsMember,
-    visitsGuest,
-    generates,
-    downloads,
-    saveClicks,
-    signupClicks,
-  };
+    presetIds,
+    completionRows: (completionsResult.data ?? []) as CollectionCompletionRow[],
+    imageJobRows: (imageJobsResult.data ?? []) as CollectionImageJobRow[],
+    eventRows: (eventsResult.data ?? []) as CollectionEventRow[],
+    currentStart: params.currentStart,
+    previousStart: params.previousStart,
+    now: params.now,
+  });
 }

--- a/features/admin-dashboard/lib/get-collection-kpi.ts
+++ b/features/admin-dashboard/lib/get-collection-kpi.ts
@@ -43,29 +43,38 @@ export async function getCollectionKpi(params: {
     .order("display_order", { ascending: true });
   const presetIds = (presets ?? []).map((p) => p.id as string);
 
-  const [completionsResult, imageJobsResult, eventsResult] = await Promise.all([
-    supabase
-      .from("collection_completions")
-      .select("mount_status, completed_at")
-      .eq("category_key", params.categoryKey)
-      .gte("completed_at", startIso)
-      .lte("completed_at", endIso),
-    supabase
-      .from("image_jobs")
-      .select("created_at, generation_metadata")
-      .eq("style_preset_category_key", params.categoryKey)
-      .eq("status", "succeeded")
-      .gte("created_at", startIso)
-      .lte("created_at", endIso),
-    presetIds.length > 0
-      ? supabase
-          .from("style_usage_events")
-          .select("auth_state, event_type, created_at")
-          .in("style_id", presetIds)
-          .gte("created_at", startIso)
-          .lte("created_at", endIso)
-      : Promise.resolve({ data: [] as CollectionEventRow[], error: null }),
-  ]);
+  const [completionsResult, imageJobsResult, eventsResult, sharesResult] =
+    await Promise.all([
+      supabase
+        .from("collection_completions")
+        .select("mount_status, completed_at")
+        .eq("category_key", params.categoryKey)
+        .gte("completed_at", startIso)
+        .lte("completed_at", endIso),
+      supabase
+        .from("image_jobs")
+        .select("created_at, generation_metadata")
+        .eq("style_preset_category_key", params.categoryKey)
+        .eq("status", "succeeded")
+        .gte("created_at", startIso)
+        .lte("created_at", endIso),
+      presetIds.length > 0
+        ? supabase
+            .from("style_usage_events")
+            .select("auth_state, event_type, created_at")
+            .in("style_id", presetIds)
+            .gte("created_at", startIso)
+            .lte("created_at", endIso)
+        : Promise.resolve({ data: [] as CollectionEventRow[], error: null }),
+      // mount_shared は style_id を持たないため series で絞れない。
+      // 期間中の全コレクションのシェア数を取得する(稼働コレが1つなら実質その series)。
+      supabase
+        .from("style_usage_events")
+        .select("auth_state, event_type, created_at")
+        .eq("event_type", "mount_shared")
+        .gte("created_at", startIso)
+        .lte("created_at", endIso),
+    ]);
 
   return buildCollectionKpi({
     categoryKey: params.categoryKey,
@@ -73,6 +82,7 @@ export async function getCollectionKpi(params: {
     completionRows: (completionsResult.data ?? []) as CollectionCompletionRow[],
     imageJobRows: (imageJobsResult.data ?? []) as CollectionImageJobRow[],
     eventRows: (eventsResult.data ?? []) as CollectionEventRow[],
+    shareRows: (sharesResult.data ?? []) as CollectionEventRow[],
     currentStart: params.currentStart,
     previousStart: params.previousStart,
     now: params.now,

--- a/features/admin-dashboard/lib/get-collection-kpi.ts
+++ b/features/admin-dashboard/lib/get-collection-kpi.ts
@@ -8,6 +8,12 @@ import {
   type CollectionImageJobRow,
   type CollectionKpi,
 } from "./build-collection-kpi";
+import {
+  buildCollectionUuFunnel,
+  type CollectionUuFunnel,
+} from "./build-collection-uu-funnel";
+
+export type { CollectionUuFunnel } from "./build-collection-uu-funnel";
 
 export type {
   CollectionKpi,
@@ -70,12 +76,13 @@ export async function getCollectionKpi(params: {
             .gte("created_at", startIso)
             .lte("created_at", endIso)
         : Promise.resolve({ data: [] as CollectionEventRow[], error: null }),
-      // mount_shared は style_id を持たないため series で絞れない。
-      // 期間中の全コレクションのシェア数を取得する(稼働コレが1つなら実質その series)。
+      // mount_shared は category_key を style_id に格納して記録(share-event route)。
+      // series 固有のシェア数で絞る(計装変更前の旧 share は style_id=null のため対象外)。
       supabase
         .from("style_usage_events")
         .select("auth_state, event_type, created_at")
         .eq("event_type", "mount_shared")
+        .eq("style_id", params.categoryKey)
         .gte("created_at", startIso)
         .lte("created_at", endIso),
     ]);
@@ -90,5 +97,77 @@ export async function getCollectionKpi(params: {
     currentStart: params.currentStart,
     previousStart: params.previousStart,
     now: params.now,
+  });
+}
+
+type UserIdRow = { user_id: string | null };
+
+function distinctUserIds(rows: UserIdRow[] | null): string[] {
+  return (rows ?? [])
+    .map((row) => row.user_id)
+    .filter((value): value is string => Boolean(value));
+}
+
+/**
+ * 指定シリーズのユニークユーザー(UU)ファネルを取得する(現在期間のみ)。
+ * - 生成UU(ログイン) → コンプリートUU → シェアUU、および期間内登録UU → コンプリート
+ * - ゲストは user_id=NULL のため UU 計測対象外(ログイン側のみ)。admin 専用。
+ */
+export async function getCollectionUuFunnel(params: {
+  categoryKey: string;
+  categoryId: string;
+  currentStart: Date;
+  now: Date;
+}): Promise<CollectionUuFunnel> {
+  const supabase = createAdminClient();
+  const startIso = params.currentStart.toISOString();
+  const endIso = params.now.toISOString();
+
+  const { data: presetRows } = await supabase
+    .from("style_presets")
+    .select("id")
+    .eq("category_id", params.categoryId);
+  const presetIds = (presetRows ?? []).map((p) => p.id as string);
+
+  const [genResult, completedResult, shareResult, registeredResult] =
+    await Promise.all([
+      presetIds.length > 0
+        ? supabase
+            .from("style_usage_events")
+            .select("user_id")
+            .eq("event_type", "generate")
+            .eq("auth_state", "authenticated")
+            .in("style_id", presetIds)
+            .gte("created_at", startIso)
+            .lte("created_at", endIso)
+        : Promise.resolve({ data: [] as UserIdRow[], error: null }),
+      supabase
+        .from("collection_completions")
+        .select("user_id")
+        .eq("category_key", params.categoryKey)
+        .eq("mount_status", "completed")
+        .gte("completed_at", startIso)
+        .lte("completed_at", endIso),
+      supabase
+        .from("style_usage_events")
+        .select("user_id")
+        .eq("event_type", "mount_shared")
+        .eq("style_id", params.categoryKey)
+        .gte("created_at", startIso)
+        .lte("created_at", endIso),
+      supabase
+        .from("profiles")
+        .select("user_id")
+        .gte("created_at", startIso)
+        .lte("created_at", endIso),
+    ]);
+
+  return buildCollectionUuFunnel({
+    generateMemberUserIds: distinctUserIds(genResult.data as UserIdRow[] | null),
+    completerUserIds: distinctUserIds(completedResult.data as UserIdRow[] | null),
+    shareUserIds: distinctUserIds(shareResult.data as UserIdRow[] | null),
+    registeredUserIds: distinctUserIds(
+      registeredResult.data as UserIdRow[] | null,
+    ),
   });
 }

--- a/features/admin-dashboard/lib/get-collection-kpi.ts
+++ b/features/admin-dashboard/lib/get-collection-kpi.ts
@@ -35,13 +35,17 @@ export async function getCollectionKpi(params: {
   const startIso = params.previousStart.toISOString();
   const endIso = params.now.toISOString();
 
-  // 当該カテゴリの preset 一覧(衣装別の表示順 + ファネル絞り込みに使う)
-  const { data: presets } = await supabase
+  // 当該カテゴリの preset 一覧(柱名ラベル + 表示順 + ファネル絞り込みに使う)
+  const { data: presetRows } = await supabase
     .from("style_presets")
-    .select("id, display_order")
+    .select("id, display_order, title")
     .eq("category_id", params.categoryId)
     .order("display_order", { ascending: true });
-  const presetIds = (presets ?? []).map((p) => p.id as string);
+  const presets = (presetRows ?? []).map((p) => ({
+    id: p.id as string,
+    label: (p.title as string | null) ?? (p.id as string).slice(0, 8),
+  }));
+  const presetIds = presets.map((p) => p.id);
 
   const [completionsResult, imageJobsResult, eventsResult, sharesResult] =
     await Promise.all([
@@ -78,7 +82,7 @@ export async function getCollectionKpi(params: {
 
   return buildCollectionKpi({
     categoryKey: params.categoryKey,
-    presetIds,
+    presets,
     completionRows: (completionsResult.data ?? []) as CollectionCompletionRow[],
     imageJobRows: (imageJobsResult.data ?? []) as CollectionImageJobRow[],
     eventRows: (eventsResult.data ?? []) as CollectionEventRow[],

--- a/tests/unit/features/admin-dashboard/admin-csv.test.ts
+++ b/tests/unit/features/admin-dashboard/admin-csv.test.ts
@@ -1,0 +1,64 @@
+import {
+  DASHBOARD_TREND_CSV_HEADERS,
+  ONE_TAP_STYLE_TREND_CSV_HEADERS,
+  buildDashboardTrendCsv,
+  buildOneTapStyleTrendCsv,
+  csvDateSpanSuffix,
+  escapeCsvField,
+  toCsvString,
+} from "@/features/admin-dashboard/lib/admin-csv";
+
+describe("admin-csv", () => {
+  test("escapeCsvField はカンマ/引用符/改行を含む値だけ引用符で囲む", () => {
+    expect(escapeCsvField("abc")).toBe("abc");
+    expect(escapeCsvField("a,b")).toBe('"a,b"');
+    expect(escapeCsvField('a"b')).toBe('"a""b"');
+    expect(escapeCsvField("a\nb")).toBe('"a\nb"');
+  });
+
+  test("toCsvString はヘッダー + 行を CRLF で結合する", () => {
+    expect(
+      toCsvString(
+        ["x", "y"],
+        [
+          [1, 2],
+          ["a", "b,c"],
+        ],
+      ),
+    ).toBe('x,y\r\n1,2\r\na,"b,c"');
+  });
+
+  test("csvDateSpanSuffix は空配列で all、それ以外は最初_最後", () => {
+    expect(csvDateSpanSuffix([])).toBe("all");
+    expect(csvDateSpanSuffix(["2026-06-06", "2026-06-07", "2026-06-13"])).toBe(
+      "2026-06-06_2026-06-13",
+    );
+  });
+
+  test("buildDashboardTrendCsv: 日付/新規登録/生成完了", () => {
+    const csv = buildDashboardTrendCsv([
+      { bucket: "2026-06-10", label: "6/10", signups: 5, generations: 12 },
+    ]);
+    const lines = csv.split("\r\n");
+    expect(lines[0]).toBe(DASHBOARD_TREND_CSV_HEADERS.join(","));
+    expect(lines[1]).toBe("2026-06-10,5,12");
+  });
+
+  test("buildOneTapStyleTrendCsv: 訪問/生成/登録/保存の各指標", () => {
+    const csv = buildOneTapStyleTrendCsv([
+      {
+        bucket: "2026-06-10",
+        label: "6/10",
+        visits: 100,
+        generations: 40,
+        signupClicks: 9,
+        signupCompletions: 3,
+        wardrobeSaveClicks: 7,
+        wardrobeSaveCompletions: 2,
+      },
+    ]);
+    const lines = csv.split("\r\n");
+    expect(lines[0]).toBe(ONE_TAP_STYLE_TREND_CSV_HEADERS.join(","));
+    expect(lines[1]).toBe("2026-06-10,100,40,9,3,7,2");
+  });
+});

--- a/tests/unit/features/admin-dashboard/build-collection-kpi.test.ts
+++ b/tests/unit/features/admin-dashboard/build-collection-kpi.test.ts
@@ -243,6 +243,52 @@ describe("buildCollectionKpi", () => {
     const jun10 = kpi.trend.find((p) => p.bucket === "2026-06-10");
     expect(jun10?.shares).toBe(1);
   });
+
+  test("previous 期間の各イベントを previous に計上し、未知イベントは無視する", () => {
+    const prevAt = "2026-06-02T00:00:00.000Z"; // previous window
+    const kpi = build({
+      presetIds: ["preset-a"],
+      completionRows: [{ mount_status: "failed", completed_at: prevAt }],
+      eventRows: [
+        { auth_state: "authenticated", event_type: "visit", created_at: prevAt },
+        { auth_state: "guest", event_type: "visit", created_at: prevAt },
+        { auth_state: "authenticated", event_type: "generate", created_at: prevAt },
+        { auth_state: "authenticated", event_type: "download", created_at: prevAt },
+        { auth_state: "authenticated", event_type: "wardrobe_save_click", created_at: prevAt },
+        { auth_state: "guest", event_type: "signup_click", created_at: prevAt },
+        { auth_state: "authenticated", event_type: "rate_limited", created_at: prevAt }, // 未知→無視
+      ],
+      shareRows: [
+        { auth_state: "authenticated", event_type: "mount_shared", created_at: prevAt },
+      ],
+    });
+
+    expect(kpi.mountsFailed.previous).toBe(1);
+    expect(kpi.visitsMember.previous).toBe(1);
+    expect(kpi.visitsGuest.previous).toBe(1);
+    expect(kpi.generates.previous).toBe(1);
+    expect(kpi.downloads.previous).toBe(1);
+    expect(kpi.saveClicks.previous).toBe(1);
+    expect(kpi.signupClicks.previous).toBe(1);
+    expect(kpi.shares.previous).toBe(1);
+    // current は全て0(previous のみ)
+    expect(kpi.visitsMember.current).toBe(0);
+    expect(kpi.generates.current).toBe(0);
+  });
+
+  test("ダウンロードの member 内訳と日別 downloadsMember を集計する", () => {
+    const kpi = build({
+      presetIds: ["preset-a"],
+      eventRows: [
+        { auth_state: "authenticated", event_type: "download", created_at: "2026-06-10T00:00:00.000Z" },
+      ],
+    });
+
+    expect(kpi.downloads.member).toBe(1);
+    expect(kpi.downloads.guest).toBe(0);
+    const jun10 = kpi.trend.find((p) => p.bucket === "2026-06-10");
+    expect(jun10?.downloadsMember).toBe(1);
+  });
 });
 
 describe("extractOneTapStyleId", () => {

--- a/tests/unit/features/admin-dashboard/build-collection-kpi.test.ts
+++ b/tests/unit/features/admin-dashboard/build-collection-kpi.test.ts
@@ -16,6 +16,7 @@ function build(params: {
   completionRows?: CollectionCompletionRow[];
   imageJobRows?: CollectionImageJobRow[];
   eventRows?: CollectionEventRow[];
+  shareRows?: CollectionEventRow[];
 }) {
   return buildCollectionKpi({
     categoryKey: "wafer",
@@ -23,6 +24,7 @@ function build(params: {
     completionRows: params.completionRows ?? [],
     imageJobRows: params.imageJobRows ?? [],
     eventRows: params.eventRows ?? [],
+    shareRows: params.shareRows ?? [],
     currentStart: CURRENT_START,
     previousStart: PREVIOUS_START,
     now: NOW,
@@ -102,6 +104,7 @@ describe("buildCollectionKpi", () => {
       kpi.downloads,
       kpi.saveClicks,
       kpi.signupClicks,
+      kpi.shares,
     ];
     for (const metric of metrics) {
       expect(metric.current).toBe(0);
@@ -185,11 +188,53 @@ describe("buildCollectionKpi", () => {
     expect(kpi.saveClicks.current).toBe(1);
     expect(kpi.signupClicks.current).toBe(1);
 
-    // 当日(06-10)のトレンドにファネルが入る
+    // 生成/DL の member/guest 内訳(A-2 お試し / A-6 DL分離)
+    expect(kpi.generates.member).toBe(1);
+    expect(kpi.generates.guest).toBe(0);
+    expect(kpi.downloads.member).toBe(0);
+    expect(kpi.downloads.guest).toBe(1);
+
+    // 当日(06-10)のトレンドにファネルが入る(日別の訪問・分割も)
     const jun10 = kpi.trend.find((p) => p.bucket === "2026-06-10");
+    expect(jun10?.visitsMember).toBe(1);
+    expect(jun10?.visitsGuest).toBe(2);
     expect(jun10?.generates).toBe(1);
     expect(jun10?.downloads).toBe(1);
+    expect(jun10?.downloadsGuest).toBe(1);
     expect(jun10?.signupClicks).toBe(1);
+  });
+
+  test("お試し生成(ゲスト)を generatesGuest として日別にも集計する", () => {
+    const kpi = build({
+      presetIds: ["preset-a"],
+      eventRows: [
+        { auth_state: "guest", event_type: "generate", created_at: "2026-06-10T00:00:00.000Z" },
+        { auth_state: "guest", event_type: "generate", created_at: "2026-06-10T02:00:00.000Z" },
+        { auth_state: "authenticated", event_type: "generate", created_at: "2026-06-10T03:00:00.000Z" },
+      ],
+    });
+
+    expect(kpi.generates.current).toBe(3);
+    expect(kpi.generates.guest).toBe(2);
+    expect(kpi.generates.member).toBe(1);
+    const jun10 = kpi.trend.find((p) => p.bucket === "2026-06-10");
+    expect(jun10?.generatesGuest).toBe(2);
+    expect(jun10?.generates).toBe(3);
+  });
+
+  test("mount_shared(シェア)を shareRows から集計する", () => {
+    const kpi = build({
+      shareRows: [
+        { auth_state: "authenticated", event_type: "mount_shared", created_at: "2026-06-10T00:00:00.000Z" },
+        { auth_state: "authenticated", event_type: "mount_shared", created_at: "2026-06-02T00:00:00.000Z" }, // previous
+        { auth_state: "authenticated", event_type: "visit", created_at: "2026-06-10T00:00:00.000Z" }, // mount_shared 以外は無視
+      ],
+    });
+
+    expect(kpi.shares.current).toBe(1);
+    expect(kpi.shares.previous).toBe(1);
+    const jun10 = kpi.trend.find((p) => p.bucket === "2026-06-10");
+    expect(jun10?.shares).toBe(1);
   });
 });
 

--- a/tests/unit/features/admin-dashboard/build-collection-kpi.test.ts
+++ b/tests/unit/features/admin-dashboard/build-collection-kpi.test.ts
@@ -1,0 +1,212 @@
+import {
+  buildCollectionKpi,
+  extractOneTapStyleId,
+  type CollectionCompletionRow,
+  type CollectionEventRow,
+  type CollectionImageJobRow,
+} from "@/features/admin-dashboard/lib/build-collection-kpi";
+
+// 固定ウィンドウ(7d 相当): current=[06-06,06-13], previous=[05-30,06-06]
+const NOW = new Date("2026-06-13T00:00:00.000Z");
+const CURRENT_START = new Date("2026-06-06T00:00:00.000Z");
+const PREVIOUS_START = new Date("2026-05-30T00:00:00.000Z");
+
+function build(params: {
+  presetIds?: string[];
+  completionRows?: CollectionCompletionRow[];
+  imageJobRows?: CollectionImageJobRow[];
+  eventRows?: CollectionEventRow[];
+}) {
+  return buildCollectionKpi({
+    categoryKey: "wafer",
+    presetIds: params.presetIds ?? [],
+    completionRows: params.completionRows ?? [],
+    imageJobRows: params.imageJobRows ?? [],
+    eventRows: params.eventRows ?? [],
+    currentStart: CURRENT_START,
+    previousStart: PREVIOUS_START,
+    now: NOW,
+  });
+}
+
+describe("buildCollectionKpi", () => {
+  test("completed を current / previous / 範囲外に振り分ける", () => {
+    const kpi = build({
+      completionRows: [
+        { mount_status: "completed", completed_at: "2026-06-10T00:00:00.000Z" }, // current
+        { mount_status: "completed", completed_at: "2026-06-02T00:00:00.000Z" }, // previous
+        { mount_status: "completed", completed_at: "2026-05-01T00:00:00.000Z" }, // 範囲外
+      ],
+    });
+
+    expect(kpi.completions.current).toBe(1);
+    expect(kpi.completions.previous).toBe(1);
+    expect(kpi.completions.deltaPct).toBe(0);
+    expect(kpi.completions.deltaDirection).toBe("flat");
+  });
+
+  test("failed は mountsFailed に集計し completions に混ざらない", () => {
+    const kpi = build({
+      completionRows: [
+        { mount_status: "failed", completed_at: "2026-06-10T00:00:00.000Z" },
+        { mount_status: "completed", completed_at: "2026-06-10T00:00:00.000Z" },
+      ],
+    });
+
+    expect(kpi.completions.current).toBe(1);
+    expect(kpi.mountsFailed.current).toBe(1);
+  });
+
+  test("completed_at が null の行は無視する", () => {
+    const kpi = build({
+      completionRows: [{ mount_status: "completed", completed_at: null }],
+    });
+
+    expect(kpi.completions.current).toBe(0);
+    expect(kpi.completions.previous).toBe(0);
+  });
+
+  test("JST 日境界でトレンドのバケットを決める", () => {
+    const kpi = build({
+      completionRows: [
+        // 2026-06-12 15:30Z = 2026-06-13 00:30 JST → 06-13 バケット
+        { mount_status: "completed", completed_at: "2026-06-12T15:30:00.000Z" },
+      ],
+    });
+
+    const jun13 = kpi.trend.find((p) => p.bucket === "2026-06-13");
+    const jun12 = kpi.trend.find((p) => p.bucket === "2026-06-12");
+    expect(jun13?.completions).toBe(1);
+    expect(jun12?.completions).toBe(0);
+  });
+
+  test("トレンドは currentStart..now を JST 日別でゼロ埋めし昇順に並ぶ", () => {
+    const kpi = build({});
+
+    expect(kpi.trend).toHaveLength(8);
+    expect(kpi.trend[0].bucket).toBe("2026-06-06");
+    expect(kpi.trend[7].bucket).toBe("2026-06-13");
+    expect(kpi.trend.every((p) => p.completions === 0)).toBe(true);
+  });
+
+  test("空データは全メトリクス0・outfitCounts空・トレンドゼロ埋め", () => {
+    const kpi = build({});
+
+    const metrics = [
+      kpi.completions,
+      kpi.mountsFailed,
+      kpi.seriesGenerations,
+      kpi.visitsMember,
+      kpi.visitsGuest,
+      kpi.generates,
+      kpi.downloads,
+      kpi.saveClicks,
+      kpi.signupClicks,
+    ];
+    for (const metric of metrics) {
+      expect(metric.current).toBe(0);
+      expect(metric.previous).toBe(0);
+      expect(metric.deltaPct).toBe(0);
+      expect(metric.deltaDirection).toBe("flat");
+    }
+    expect(kpi.outfitCounts).toEqual([]);
+    expect(kpi.trend).toHaveLength(8);
+  });
+
+  test("previous=0 & current>0 は New(deltaPct=null, up)", () => {
+    const kpi = build({
+      completionRows: [
+        { mount_status: "completed", completed_at: "2026-06-10T00:00:00.000Z" },
+        { mount_status: "completed", completed_at: "2026-06-11T00:00:00.000Z" },
+      ],
+    });
+
+    expect(kpi.completions.current).toBe(2);
+    expect(kpi.completions.previous).toBe(0);
+    expect(kpi.completions.deltaPct).toBeNull();
+    expect(kpi.completions.deltaDirection).toBe("up");
+  });
+
+  test("image_jobs から seriesGenerations と衣装別を集計(N+1 統合)", () => {
+    const kpi = build({
+      presetIds: ["preset-a", "preset-b"],
+      imageJobRows: [
+        {
+          created_at: "2026-06-10T00:00:00.000Z",
+          generation_metadata: { oneTapStyle: { id: "preset-a" } },
+        },
+        {
+          created_at: "2026-06-10T01:00:00.000Z",
+          generation_metadata: { oneTapStyle: { id: "preset-a" } },
+        },
+        {
+          created_at: "2026-06-11T00:00:00.000Z",
+          generation_metadata: { oneTapStyle: { id: "preset-b" } },
+        },
+        {
+          created_at: "2026-06-11T00:00:00.000Z",
+          generation_metadata: { oneTapStyle: { id: "unknown-preset" } },
+        },
+        { created_at: "2026-06-11T00:00:00.000Z", generation_metadata: null },
+        {
+          created_at: "2026-06-02T00:00:00.000Z", // previous
+          generation_metadata: { oneTapStyle: { id: "preset-a" } },
+        },
+      ],
+    });
+
+    expect(kpi.seriesGenerations.current).toBe(5);
+    expect(kpi.seriesGenerations.previous).toBe(1);
+    // presetIds の順序を保ち、preset に無い id や metadata 欠落は除外
+    expect(kpi.outfitCounts).toEqual([
+      { presetId: "preset-a", count: 2 },
+      { presetId: "preset-b", count: 1 },
+    ]);
+  });
+
+  test("style_usage_events のファネルを集計(visit は auth で分割)", () => {
+    const kpi = build({
+      presetIds: ["preset-a"],
+      eventRows: [
+        { auth_state: "authenticated", event_type: "visit", created_at: "2026-06-10T00:00:00.000Z" },
+        { auth_state: "guest", event_type: "visit", created_at: "2026-06-10T00:00:00.000Z" },
+        { auth_state: "guest", event_type: "visit", created_at: "2026-06-10T01:00:00.000Z" },
+        { auth_state: "authenticated", event_type: "generate", created_at: "2026-06-10T00:00:00.000Z" },
+        { auth_state: "guest", event_type: "download", created_at: "2026-06-10T00:00:00.000Z" },
+        { auth_state: "authenticated", event_type: "wardrobe_save_click", created_at: "2026-06-10T00:00:00.000Z" },
+        { auth_state: "guest", event_type: "signup_click", created_at: "2026-06-10T00:00:00.000Z" },
+      ],
+    });
+
+    expect(kpi.visitsMember.current).toBe(1);
+    expect(kpi.visitsGuest.current).toBe(2);
+    expect(kpi.generates.current).toBe(1);
+    expect(kpi.downloads.current).toBe(1);
+    expect(kpi.saveClicks.current).toBe(1);
+    expect(kpi.signupClicks.current).toBe(1);
+
+    // 当日(06-10)のトレンドにファネルが入る
+    const jun10 = kpi.trend.find((p) => p.bucket === "2026-06-10");
+    expect(jun10?.generates).toBe(1);
+    expect(jun10?.downloads).toBe(1);
+    expect(jun10?.signupClicks).toBe(1);
+  });
+});
+
+describe("extractOneTapStyleId", () => {
+  test("null metadata → null", () => {
+    expect(extractOneTapStyleId(null)).toBeNull();
+  });
+
+  test("oneTapStyle 欠落 → null", () => {
+    expect(extractOneTapStyleId({ foo: 1 })).toBeNull();
+  });
+
+  test("id が string でない → null", () => {
+    expect(extractOneTapStyleId({ oneTapStyle: { id: 123 } })).toBeNull();
+  });
+
+  test("正常 → id を返す", () => {
+    expect(extractOneTapStyleId({ oneTapStyle: { id: "abc" } })).toBe("abc");
+  });
+});

--- a/tests/unit/features/admin-dashboard/build-collection-kpi.test.ts
+++ b/tests/unit/features/admin-dashboard/build-collection-kpi.test.ts
@@ -20,7 +20,7 @@ function build(params: {
 }) {
   return buildCollectionKpi({
     categoryKey: "wafer",
-    presetIds: params.presetIds ?? [],
+    presets: (params.presetIds ?? []).map((id) => ({ id, label: id })),
     completionRows: params.completionRows ?? [],
     imageJobRows: params.imageJobRows ?? [],
     eventRows: params.eventRows ?? [],
@@ -162,9 +162,16 @@ describe("buildCollectionKpi", () => {
     expect(kpi.seriesGenerations.previous).toBe(1);
     // presetIds の順序を保ち、preset に無い id や metadata 欠落は除外
     expect(kpi.outfitCounts).toEqual([
-      { presetId: "preset-a", count: 2 },
-      { presetId: "preset-b", count: 1 },
+      { presetId: "preset-a", label: "preset-a", count: 2 },
+      { presetId: "preset-b", label: "preset-b", count: 1 },
     ]);
+
+    // B-3: 日別 × 柱別(counts は柱順 [preset-a, preset-b])
+    const outfitJun10 = kpi.outfitDaily.find((p) => p.bucket === "2026-06-10");
+    const outfitJun11 = kpi.outfitDaily.find((p) => p.bucket === "2026-06-11");
+    expect(outfitJun10?.counts).toEqual([2, 0]);
+    expect(outfitJun11?.counts).toEqual([0, 1]);
+    expect(kpi.outfitDaily).toHaveLength(8);
   });
 
   test("style_usage_events のファネルを集計(visit は auth で分割)", () => {

--- a/tests/unit/features/admin-dashboard/build-collection-trend-csv.test.ts
+++ b/tests/unit/features/admin-dashboard/build-collection-trend-csv.test.ts
@@ -10,10 +10,16 @@ function point(overrides: Partial<CollectionTrendPoint>): CollectionTrendPoint {
     label: "6/10",
     completions: 0,
     seriesGenerations: 0,
+    visitsMember: 0,
+    visitsGuest: 0,
     generates: 0,
+    generatesGuest: 0,
     downloads: 0,
+    downloadsMember: 0,
+    downloadsGuest: 0,
     saveClicks: 0,
     signupClicks: 0,
+    shares: 0,
     ...overrides,
   };
 }
@@ -25,27 +31,32 @@ describe("buildCollectionTrendCsv", () => {
     );
   });
 
-  test("各日の指標を生値で出力し CRLF 区切りにする", () => {
+  test("各日の指標(ログイン/ゲスト内訳含む)を生値で出力し CRLF 区切りにする", () => {
     const csv = buildCollectionTrendCsv([
       point({
         bucket: "2026-06-10",
         completions: 3,
         seriesGenerations: 12,
+        visitsMember: 20,
+        visitsGuest: 30,
         generates: 8,
+        generatesGuest: 5,
         downloads: 5,
+        downloadsMember: 2,
+        downloadsGuest: 3,
         saveClicks: 2,
         signupClicks: 1,
+        shares: 4,
       }),
       point({ bucket: "2026-06-11", completions: 1000 }),
     ]);
 
     const lines = csv.split("\r\n");
     expect(lines[0]).toBe(
-      "日付,コンプリート達成数,シリーズ生成数,生成成功,ダウンロード,保存クリック,登録CTAクリック",
+      "日付,コンプリート達成数,シリーズ生成数,訪問(ログイン),訪問(ゲスト),生成成功,お試し生成(ゲスト),ダウンロード,ダウンロード(ログイン),ダウンロード(ゲスト),保存クリック,登録CTAクリック,シェア",
     );
-    expect(lines[1]).toBe("2026-06-10,3,12,8,5,2,1");
-    // 区切り記号なしの生値(スプレッドシートで数値として扱える)
-    expect(lines[2]).toBe("2026-06-11,1000,0,0,0,0,0");
+    expect(lines[1]).toBe("2026-06-10,3,12,20,30,8,5,5,2,3,2,1,4");
+    expect(lines[2]).toBe("2026-06-11,1000,0,0,0,0,0,0,0,0,0,0,0");
     expect(lines).toHaveLength(3);
   });
 });

--- a/tests/unit/features/admin-dashboard/build-collection-trend-csv.test.ts
+++ b/tests/unit/features/admin-dashboard/build-collection-trend-csv.test.ts
@@ -1,0 +1,51 @@
+import {
+  COLLECTION_TREND_CSV_HEADERS,
+  buildCollectionTrendCsv,
+} from "@/features/admin-dashboard/lib/build-collection-trend-csv";
+import type { CollectionTrendPoint } from "@/features/admin-dashboard/lib/build-collection-kpi";
+
+function point(overrides: Partial<CollectionTrendPoint>): CollectionTrendPoint {
+  return {
+    bucket: "2026-06-10",
+    label: "6/10",
+    completions: 0,
+    seriesGenerations: 0,
+    generates: 0,
+    downloads: 0,
+    saveClicks: 0,
+    signupClicks: 0,
+    ...overrides,
+  };
+}
+
+describe("buildCollectionTrendCsv", () => {
+  test("空トレンドはヘッダー行のみ", () => {
+    expect(buildCollectionTrendCsv([])).toBe(
+      COLLECTION_TREND_CSV_HEADERS.join(","),
+    );
+  });
+
+  test("各日の指標を生値で出力し CRLF 区切りにする", () => {
+    const csv = buildCollectionTrendCsv([
+      point({
+        bucket: "2026-06-10",
+        completions: 3,
+        seriesGenerations: 12,
+        generates: 8,
+        downloads: 5,
+        saveClicks: 2,
+        signupClicks: 1,
+      }),
+      point({ bucket: "2026-06-11", completions: 1000 }),
+    ]);
+
+    const lines = csv.split("\r\n");
+    expect(lines[0]).toBe(
+      "日付,コンプリート達成数,シリーズ生成数,生成成功,ダウンロード,保存クリック,登録CTAクリック",
+    );
+    expect(lines[1]).toBe("2026-06-10,3,12,8,5,2,1");
+    // 区切り記号なしの生値(スプレッドシートで数値として扱える)
+    expect(lines[2]).toBe("2026-06-11,1000,0,0,0,0,0");
+    expect(lines).toHaveLength(3);
+  });
+});

--- a/tests/unit/features/admin-dashboard/build-collection-trend-csv.test.ts
+++ b/tests/unit/features/admin-dashboard/build-collection-trend-csv.test.ts
@@ -138,4 +138,34 @@ describe("buildCollectionSummaryCsv", () => {
     expect(lines).toContain("生成UU,35,,,,");
     expect(lines).toContain("コンプリート到達率(%),28.6,,,,");
   });
+
+  test("到達率が null の場合は空欄で出力する", () => {
+    const kpi = {
+      completions: metric(0, 0),
+      seriesGenerations: metric(0, 0),
+      visitsMember: metric(0, 0),
+      visitsGuest: metric(0, 0),
+      generates: metric(0, 0, 0, 0),
+      downloads: metric(0, 0, 0, 0),
+      saveClicks: metric(0, 0),
+      signupClicks: metric(0, 0),
+      shares: metric(0, 0),
+      mountsFailed: metric(0, 0),
+    } as unknown as CollectionKpi;
+    const uuFunnel: CollectionUuFunnel = {
+      generatesUu: 0,
+      completionsUu: 0,
+      sharesUu: 0,
+      reachRatePct: null,
+      registeredUu: 0,
+      registeredCompletedUu: 0,
+      registeredReachRatePct: null,
+      registeredNotCompletedUu: 0,
+      completedNotSharedUu: 0,
+    };
+
+    const lines = buildCollectionSummaryCsv(kpi, uuFunnel).split("\r\n");
+    expect(lines).toContain("コンプリート到達率(%),,,,,");
+    expect(lines).toContain("登録→コンプリート率(%),,,,,");
+  });
 });

--- a/tests/unit/features/admin-dashboard/build-collection-trend-csv.test.ts
+++ b/tests/unit/features/admin-dashboard/build-collection-trend-csv.test.ts
@@ -1,8 +1,12 @@
 import {
   COLLECTION_TREND_CSV_HEADERS,
+  buildCollectionOutfitDailyCsv,
   buildCollectionTrendCsv,
 } from "@/features/admin-dashboard/lib/build-collection-trend-csv";
-import type { CollectionTrendPoint } from "@/features/admin-dashboard/lib/build-collection-kpi";
+import type {
+  CollectionKpi,
+  CollectionTrendPoint,
+} from "@/features/admin-dashboard/lib/build-collection-kpi";
 
 function point(overrides: Partial<CollectionTrendPoint>): CollectionTrendPoint {
   return {
@@ -58,5 +62,25 @@ describe("buildCollectionTrendCsv", () => {
     expect(lines[1]).toBe("2026-06-10,3,12,20,30,8,5,5,2,3,2,1,4");
     expect(lines[2]).toBe("2026-06-11,1000,0,0,0,0,0,0,0,0,0,0,0");
     expect(lines).toHaveLength(3);
+  });
+});
+
+describe("buildCollectionOutfitDailyCsv", () => {
+  test("日付 × 柱名 のクロス集計を出力する", () => {
+    const kpi = {
+      outfitCounts: [
+        { presetId: "a", label: "オーディン", count: 3 },
+        { presetId: "b", label: "ゼウス", count: 5 },
+      ],
+      outfitDaily: [
+        { bucket: "2026-06-10", label: "6/10", counts: [1, 2] },
+        { bucket: "2026-06-11", label: "6/11", counts: [2, 3] },
+      ],
+    } as unknown as CollectionKpi;
+
+    const lines = buildCollectionOutfitDailyCsv(kpi).split("\r\n");
+    expect(lines[0]).toBe("日付,オーディン,ゼウス");
+    expect(lines[1]).toBe("2026-06-10,1,2");
+    expect(lines[2]).toBe("2026-06-11,2,3");
   });
 });

--- a/tests/unit/features/admin-dashboard/build-collection-trend-csv.test.ts
+++ b/tests/unit/features/admin-dashboard/build-collection-trend-csv.test.ts
@@ -1,12 +1,15 @@
 import {
   COLLECTION_TREND_CSV_HEADERS,
   buildCollectionOutfitDailyCsv,
+  buildCollectionSummaryCsv,
   buildCollectionTrendCsv,
 } from "@/features/admin-dashboard/lib/build-collection-trend-csv";
 import type {
   CollectionKpi,
+  CollectionKpiMetric,
   CollectionTrendPoint,
 } from "@/features/admin-dashboard/lib/build-collection-kpi";
+import type { CollectionUuFunnel } from "@/features/admin-dashboard/lib/build-collection-uu-funnel";
 
 function point(overrides: Partial<CollectionTrendPoint>): CollectionTrendPoint {
   return {
@@ -82,5 +85,57 @@ describe("buildCollectionOutfitDailyCsv", () => {
     expect(lines[0]).toBe("日付,オーディン,ゼウス");
     expect(lines[1]).toBe("2026-06-10,1,2");
     expect(lines[2]).toBe("2026-06-11,2,3");
+  });
+});
+
+describe("buildCollectionSummaryCsv", () => {
+  function metric(
+    current: number,
+    previous: number,
+    member?: number,
+    guest?: number,
+  ): CollectionKpiMetric {
+    return {
+      current,
+      previous,
+      deltaPct: previous === 0 ? null : 0,
+      deltaDirection: "flat",
+      ...(member !== undefined ? { member } : {}),
+      ...(guest !== undefined ? { guest } : {}),
+    };
+  }
+
+  test("KPI 期間合計 + UU ファネルを 指標×値 で出力する", () => {
+    const kpi = {
+      completions: metric(10, 5),
+      seriesGenerations: metric(100, 80),
+      visitsMember: metric(50, 40),
+      visitsGuest: metric(200, 150),
+      generates: metric(60, 50, 40, 20),
+      downloads: metric(30, 20, 25, 5),
+      saveClicks: metric(8, 6),
+      signupClicks: metric(12, 10),
+      shares: metric(4, 2),
+      mountsFailed: metric(1, 0),
+    } as unknown as CollectionKpi;
+    const uuFunnel: CollectionUuFunnel = {
+      generatesUu: 35,
+      completionsUu: 10,
+      sharesUu: 4,
+      reachRatePct: 28.6,
+      registeredUu: 20,
+      registeredCompletedUu: 6,
+      registeredReachRatePct: 30,
+      registeredNotCompletedUu: 14,
+      completedNotSharedUu: 6,
+    };
+
+    const lines = buildCollectionSummaryCsv(kpi, uuFunnel).split("\r\n");
+    expect(lines[0]).toBe("指標,今期間,前期間,前期間比(%),ログイン,ゲスト");
+    expect(lines[1]).toBe("コンプリート達成数,10,5,0,,");
+    expect(lines).toContain("生成成功,60,50,0,40,20");
+    expect(lines).toContain("シェア,4,2,0,,");
+    expect(lines).toContain("生成UU,35,,,,");
+    expect(lines).toContain("コンプリート到達率(%),28.6,,,,");
   });
 });

--- a/tests/unit/features/admin-dashboard/build-collection-uu-funnel.test.ts
+++ b/tests/unit/features/admin-dashboard/build-collection-uu-funnel.test.ts
@@ -1,0 +1,49 @@
+import { buildCollectionUuFunnel } from "@/features/admin-dashboard/lib/build-collection-uu-funnel";
+
+describe("buildCollectionUuFunnel", () => {
+  test("UU の歩留まり・到達率・離脱を算出する", () => {
+    const f = buildCollectionUuFunnel({
+      generateMemberUserIds: ["u1", "u2", "u3", "u3"], // distinct 3
+      completerUserIds: ["u1", "u2"], // 2
+      shareUserIds: ["u1"], // 1
+      registeredUserIds: ["u2", "u4"], // 期間内登録 2
+    });
+
+    expect(f.generatesUu).toBe(3);
+    expect(f.completionsUu).toBe(2);
+    expect(f.sharesUu).toBe(1);
+    expect(f.reachRatePct).toBe(66.7); // 2/3
+    expect(f.registeredUu).toBe(2);
+    expect(f.registeredCompletedUu).toBe(1); // u2 ∈ completers ∩ registered
+    expect(f.registeredReachRatePct).toBe(50); // 1/2
+    expect(f.registeredNotCompletedUu).toBe(1); // u4
+    expect(f.completedNotSharedUu).toBe(1); // u2 はコンプリートしたが未シェア
+  });
+
+  test("分母0は到達率を N/A(null) にする", () => {
+    const f = buildCollectionUuFunnel({
+      generateMemberUserIds: [],
+      completerUserIds: [],
+      shareUserIds: [],
+      registeredUserIds: [],
+    });
+
+    expect(f.generatesUu).toBe(0);
+    expect(f.reachRatePct).toBeNull();
+    expect(f.registeredReachRatePct).toBeNull();
+    expect(f.registeredNotCompletedUu).toBe(0);
+    expect(f.completedNotSharedUu).toBe(0);
+  });
+
+  test("null/空文字の user_id は除外して distinct 集計する", () => {
+    const f = buildCollectionUuFunnel({
+      generateMemberUserIds: ["u1", "", "u1"],
+      completerUserIds: ["u1"],
+      shareUserIds: [],
+      registeredUserIds: [],
+    });
+
+    expect(f.generatesUu).toBe(1);
+    expect(f.completionsUu).toBe(1);
+  });
+});

--- a/tests/unit/features/admin-dashboard/dashboard-tab.test.ts
+++ b/tests/unit/features/admin-dashboard/dashboard-tab.test.ts
@@ -1,0 +1,27 @@
+import {
+  ADMIN_DASHBOARD_TAB_OPTIONS,
+  buildAdminDashboardHref,
+  parseAdminDashboardTab,
+} from "@/features/admin-dashboard/lib/dashboard-tab";
+
+describe("dashboard-tab", () => {
+  test("collections / one-tap-style / 既定 all を解釈できる", () => {
+    expect(parseAdminDashboardTab("collections")).toBe("collections");
+    expect(parseAdminDashboardTab("one-tap-style")).toBe("one-tap-style");
+    expect(parseAdminDashboardTab(undefined)).toBe("all");
+    expect(parseAdminDashboardTab("garbage")).toBe("all");
+  });
+
+  test("tab options に コレクション を含む", () => {
+    expect(ADMIN_DASHBOARD_TAB_OPTIONS).toContainEqual({
+      value: "collections",
+      label: "コレクション",
+    });
+  });
+
+  test("collections タブの href に style パラメータが混ざらない", () => {
+    expect(buildAdminDashboardHref({ range: "30d", tab: "collections" })).toBe(
+      "/admin?range=30d&tab=collections",
+    );
+  });
+});

--- a/tests/unit/features/admin-dashboard/dashboard-tab.test.ts
+++ b/tests/unit/features/admin-dashboard/dashboard-tab.test.ts
@@ -24,4 +24,18 @@ describe("dashboard-tab", () => {
       "/admin?range=30d&tab=collections",
     );
   });
+
+  test("collections の custom 期間 href に collectionRange/From/To を含む", () => {
+    const href = buildAdminDashboardHref({
+      range: "30d",
+      tab: "collections",
+      collectionRange: "custom",
+      collectionFrom: "2026-06-01T00:00:00.000Z",
+      collectionTo: "2026-06-10T00:00:00.000Z",
+    });
+    expect(href).toContain("tab=collections");
+    expect(href).toContain("collectionRange=custom");
+    expect(href).toContain("collectionFrom=");
+    expect(href).toContain("collectionTo=");
+  });
 });


### PR DESCRIPTION
### 概要
コレクションのKPIが `/admin/collections` に分かれており、全期間累計しか見られず、日別・期間比較・CSV出力ができなかった。`/admin` ダッシュボードのタブに集約し、期間フィルタ・日別トレンド・CSVエクスポートを追加した。あわせて「うちの子の神コレクション」コラボ企画の計測依頼に対応し、ログイン/ゲスト分離・お試し生成・シェア・日別×柱別・UUファネル（到達率/離脱）を実装した。

### 変更内容
- **集約**: コレクションを `/admin` の3つ目のタブに集約。旧 `/admin/collections` は `?tab=collections` へ308リダイレクト、サイドバーの重複項目を整理
- **期間**: 期間フィルタ（24h/7d/30d/90d + 任意日時 custom）・日別トレンドチャート・前期間比（delta）を追加
- **UI整理**: ワンタップ/コレクションタブで重複していた上部のグローバル期間タブを非表示にし、本文の「集計期間」に一本化
- **CSV**: すべて/ワンタップ/コレクション 各タブの日別データに CSVダウンロード/ワンタップコピーを追加（BOM付きでExcel文字化け回避）
- **計測依頼（神コレ コラボ企画）対応**:
  - A-1 日別の訪問（ログイン/ゲスト別）
  - A-2 お試し生成（未ログイン）の分離
  - A-6 ダウンロードのログイン/ゲスト分離
  - A-7 シェア（`mount_shared`）に `category_key` を付与し series 帰属で集計
  - B-1/B-3 柱名ラベル化＋日別×柱別クロス集計CSV
  - B-2/A-5/A-8 ユニークユーザー・ファネル（コンプリート到達率・登録→コンプリート率・離脱UU）
  - 期間サマリーCSV（KPI期間合計＋UUファネルを1ファイルに）
- **設計**: 集計を純関数（`buildCollectionKpi` / `buildCollectionUuFunnel` / `build-collection-trend-csv` / `admin-csv`）に分離し、ユニットテストを追加

### 実機テスト
<!-- admin 限定の分析画面。主に PC（Chrome）での確認を想定 -->
- [ ] PC（Chrome）で `/admin?tab=collections` のタブ表示・期間切替・custom期間を確認
- [ ] 各CSV（期間サマリー / 日別トレンド / 日別×柱）のダウンロード・コピーを確認
- [ ] 旧 `/admin/collections` が `?tab=collections` へリダイレクトされることを確認
- [ ] 既存の「すべて」「ワンタップスタイル」タブに無回帰
- [ ] レスポンシブ表示崩れがないことを確認

### テスト方法
- `npm run lint` / `npm run typecheck`（変更ファイルにエラーなし。既存の `tests/unit/**` 既存型エラーは対象外）
- `npm run test`（admin-dashboard スイート 54件パス。`build-collection-kpi` / `build-collection-uu-funnel` / `build-collection-trend-csv` / `admin-csv` / `dashboard-tab` 等）
- `npm run build -- --webpack` 成功（exit 0）
- dev サーバ（`localhost:3000/admin?tab=collections`）で目視確認

### 補足
- **A-4「お試し→新規登録 転換（同一人物）」と A-8「お試し止まり」は本PRに含めていません**。`style_usage_events.user_id` がゲストで NULL のため、ゲスト→登録の同一人物紐付けにはクライアント匿名トークンの計装（別案件）が必要です。
- **A-7 のシェア series 帰属は本変更デプロイ後の新規シェアから有効**です（過去シェアは `style_id=null` のため series 集計対象外）。計測期間開始前後のデプロイを推奨。UU/日別/分割集計は読み取り時集計のため、デプロイ後すぐ過去分にも反映されます。
