### PR TITLE
feat(style): 未ログインの無料生成を coordinate カテゴリのみに制限

### DIFF
--- a/app/(app)/style/generate/handler.ts
+++ b/app/(app)/style/generate/handler.ts
@@ -255,6 +255,15 @@ export async function postStyleGenerateRoute(
     if (preset.category.visibility === "admin_only") {
       return jsonError(copy.invalidStylePreset, "STYLE_INVALID_STYLE", 400);
     }
+    // ゲストの無料生成は category.key が "coordinate" のプリセットのみ許可。
+    // それ以外はログイン必須（クライアントでも制御するが defense-in-depth）。
+    if (preset.category.key !== "coordinate") {
+      return jsonError(
+        copy.guestCategoryLoginHint,
+        "STYLE_CATEGORY_REQUIRES_AUTH",
+        403
+      );
+    }
     const effectiveSourceImageType: SourceImageType =
       preset.category.showSourceImageTypeControl
         ? sourceImageType

--- a/app/(app)/style/generate/handler.ts
+++ b/app/(app)/style/generate/handler.ts
@@ -257,11 +257,13 @@ export async function postStyleGenerateRoute(
     }
     // ゲストの無料生成は category.key が "coordinate" のプリセットのみ許可。
     // それ以外はログイン必須（クライアントでも制御するが defense-in-depth）。
-    if (preset.category.key !== "coordinate") {
+    // この経路に到達するのは未認証ユーザーのみ（認証済みは上で 403 済み）だが、
+    // 意図を明示するため !user を併記。未認証のため 401 を返す。
+    if (!user && preset.category.key !== "coordinate") {
       return jsonError(
         copy.guestCategoryLoginHint,
         "STYLE_CATEGORY_REQUIRES_AUTH",
-        403
+        401
       );
     }
     const effectiveSourceImageType: SourceImageType =

--- a/features/style/components/StylePageClient.tsx
+++ b/features/style/components/StylePageClient.tsx
@@ -554,13 +554,20 @@ export function StylePageClient({
       ? posePromptValue.trim()
       : "";
   const hasSourceImage = Boolean(uploadedImage) || Boolean(selectedRemoteSource);
+  // ゲストの無料生成（1日1回）は category.key が "coordinate" のプリセットのみ許可。
+  // それ以外のカテゴリは生成させず「ログインで生成可能！」CTA を出す（サーバ側でも検証）。
+  const isGuestRestrictedCategory =
+    effectiveAuthState !== "authenticated" &&
+    selectedPreset != null &&
+    selectedPreset.category.key !== "coordinate";
   const isGenerateDisabled =
     !selectedPreset ||
     !hasSourceImage ||
     isGenerating ||
     isGuestDailyLimitReached ||
     shouldDisablePaidContinuation ||
-    isGuestResultLocked;
+    isGuestResultLocked ||
+    isGuestRestrictedCategory;
   const hasGeneratedResult = Boolean(resultImageUrl);
   const activeAsyncResultImageUrl =
     shouldUseAsyncGeneration && isGenerating
@@ -1950,19 +1957,36 @@ export function StylePageClient({
             ) : null}
 
             <div data-tour="style-tour-generate">
-              <GenerationSubmitButton
-                onClick={handleGenerate}
-                disabled={isGenerateDisabled}
-                isGenerating={isGenerating}
-                generateLabel={t("generateButton")}
-                generatingLabel={t("generatingButton")}
-                costAmount={showGenerateCost ? selectedModelPercoinCost : null}
-              />
+              {isGuestRestrictedCategory ? (
+                <div className="space-y-2">
+                  <Button
+                    type="button"
+                    onClick={() => setShowAuthModal(true)}
+                    className="min-h-[48px] w-full rounded-full border-0 bg-gradient-to-r from-pink-500 to-orange-400 text-base font-bold text-white shadow-[0_6px_16px_rgba(236,72,153,0.28)] transition hover:from-pink-600 hover:to-orange-500"
+                  >
+                    {t("guestCategoryLoginAction")}
+                  </Button>
+                  <p className="text-center text-xs leading-5 text-slate-500">
+                    {t("guestCategoryLoginHint")}
+                  </p>
+                </div>
+              ) : (
+                <GenerationSubmitButton
+                  onClick={handleGenerate}
+                  disabled={isGenerateDisabled}
+                  isGenerating={isGenerating}
+                  generateLabel={t("generateButton")}
+                  generatingLabel={t("generatingButton")}
+                  costAmount={showGenerateCost ? selectedModelPercoinCost : null}
+                />
+              )}
             </div>
-            <div className="space-y-1 text-xs leading-5 text-slate-500">
-              <p>{t("generateHint")}</p>
-              <p>{t("generateRetryHint")}</p>
-            </div>
+            {!isGuestRestrictedCategory ? (
+              <div className="space-y-1 text-xs leading-5 text-slate-500">
+                <p>{t("generateHint")}</p>
+                <p>{t("generateRetryHint")}</p>
+              </div>
+            ) : null}
 
             {typeof remainingDailyNoticeCount === "number" ? (
               <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2">

--- a/features/style/components/StylePageClient.tsx
+++ b/features/style/components/StylePageClient.tsx
@@ -1975,12 +1975,8 @@ export function StylePageClient({
                     type="button"
                     onClick={() => setShowAuthModal(true)}
                     className="min-h-[48px] w-full rounded-full border-0 bg-gradient-to-r from-pink-500 to-orange-400 text-base font-bold text-white shadow-[0_6px_16px_rgba(236,72,153,0.28)] transition hover:from-pink-600 hover:to-orange-500"
-                  >
-                    {t("guestCategoryLoginAction")}
-                  </Button>
-                  <p className="text-center text-xs leading-5 text-slate-500">
-                    {t("guestCategoryLoginHint")}
-                  </p>
+                  >{t("guestCategoryLoginAction")}</Button>
+                  <p className="text-center text-xs leading-5 text-slate-500">{t("guestCategoryLoginHint")}</p>
                 </div>
               ) : (
                 <GenerationSubmitButton

--- a/features/style/components/StylePageClient.tsx
+++ b/features/style/components/StylePageClient.tsx
@@ -1621,18 +1621,30 @@ export function StylePageClient({
           onClickCapture={handlePresetStripClickCapture}
           onDragStart={(event) => event.preventDefault()}
         >
-          {presets.map((preset) => (
-            <StylePresetPreviewCard
-              key={preset.id}
-              preset={preset}
-              isSelected={preset.id === selectedPreset?.id}
-              onClick={() => handlePresetSelect(preset.id)}
-              buttonRef={buildPresetButtonRef(preset.id)}
-              alt={t("styleCardAlt", { name: preset.title })}
-              disabled={isGenerating || isGuestResultLocked}
-              locale={styleCardLocale}
-            />
-          ))}
+          {presets.map((preset) => {
+            // ゲストは coordinate 以外のカテゴリを生成できないため、カードを
+            // 半透明にして「ログインで生成可能！」ラベルを重ねる。
+            const isGuestLockedCard =
+              effectiveAuthState !== "authenticated" &&
+              preset.category.key !== "coordinate";
+            return (
+              <StylePresetPreviewCard
+                key={preset.id}
+                preset={preset}
+                isSelected={preset.id === selectedPreset?.id}
+                onClick={() => handlePresetSelect(preset.id)}
+                buttonRef={buildPresetButtonRef(preset.id)}
+                alt={t("styleCardAlt", { name: preset.title })}
+                disabled={isGenerating || isGuestResultLocked}
+                locale={styleCardLocale}
+                lockedLabel={
+                  isGuestLockedCard
+                    ? t("guestCategoryLoginAction")
+                    : undefined
+                }
+              />
+            );
+          })}
         </div>
       </section>
 

--- a/features/style/components/StylePresetPreviewCard.tsx
+++ b/features/style/components/StylePresetPreviewCard.tsx
@@ -46,6 +46,12 @@ interface StylePresetPreviewCardProps {
    * 省略時は 'ja'。
    */
   locale?: "ja" | "en";
+  /**
+   * 未ログインでは生成できないカテゴリのとき表示するロックラベル。
+   * 指定すると画像を半透明オーバーレイで覆い、中央にこのラベルを出す
+   * (例: 「ログインで生成可能！」)。選択操作自体は引き続き可能。
+   */
+  lockedLabel?: string;
 }
 
 export function buildStylePresetImageSrc(
@@ -70,8 +76,10 @@ export function StylePresetPreviewCard({
   onClick,
   buttonRef,
   locale = "ja",
+  lockedLabel,
 }: StylePresetPreviewCardProps) {
   const selected = isSelected === true;
+  const isLocked = typeof lockedLabel === "string" && lockedLabel.length > 0;
   // 'coordinate' は default カテゴリで既存挙動と同じ見た目を保つため、バッジを描画しない。
   const shouldShowBadge =
     preset.category != null && preset.category.key !== "coordinate";
@@ -113,6 +121,13 @@ export function StylePresetPreviewCard({
             >
               {badgeText}
             </span>
+          )}
+          {isLocked && (
+            <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/65 px-2 backdrop-blur-[1px]">
+              <span className="inline-flex items-center rounded-full bg-gradient-to-r from-pink-500 to-orange-400 px-3 py-1 text-center text-[11px] font-bold leading-tight text-white shadow-md">
+                {lockedLabel}
+              </span>
+            </div>
           )}
         </div>
         <div

--- a/messages/ar.ts
+++ b/messages/ar.ts
@@ -1391,6 +1391,8 @@ export const arMessages = {
     guestLoginCtaTitle: "جرّب دون تسجيل الدخول",
     guestLoginCtaDescription: "جرّب ChatGPT Image 2.0 مجانًا مرة واحدة يوميًا. سجّل الدخول (تسجيل مجاني) بعد الإنشاء لحفظ صورتك.",
     guestLoginCtaAction: "تسجيل الدخول / إنشاء حساب",
+    guestCategoryLoginAction: "سجّل الدخول للإنشاء!",
+    guestCategoryLoginHint: "سجّل الدخول للإنشاء بكل الأنماط!",
     generateButton: "بدء التنسيق",
     generatingButton: "جارٍ التوليد...",
     // Status card heading

--- a/messages/de.ts
+++ b/messages/de.ts
@@ -1394,6 +1394,8 @@ export const deMessages = {
     guestLoginCtaTitle: "Ohne Anmeldung ausprobieren",
     guestLoginCtaDescription: "Teste ChatGPT Image 2.0 einmal täglich kostenlos. Melde dich nach dem Erstellen an (kostenlose Registrierung), um dein Bild zu speichern.",
     guestLoginCtaAction: "Anmelden / Registrieren",
+    guestCategoryLoginAction: "Zum Generieren anmelden!",
+    guestCategoryLoginHint: "Melde dich an, um mit allen Stilen zu generieren!",
     generateButton: "Styling starten",
     generatingButton: "Wird generiert...",
     // Status card heading

--- a/messages/en.ts
+++ b/messages/en.ts
@@ -1390,6 +1390,8 @@ export const enMessages = {
     guestLoginCtaTitle: "Try without signing in",
     guestLoginCtaDescription: "Try ChatGPT Image 2.0 free, once a day. Log in (free sign-up) after generating to save your image.",
     guestLoginCtaAction: "Sign in / Sign up",
+    guestCategoryLoginAction: "Log in to generate!",
+    guestCategoryLoginHint: "Log in to generate with every style!",
     generateButton: "Start Styling",
     generatingButton: "Generating...",
     // Status card heading

--- a/messages/es.ts
+++ b/messages/es.ts
@@ -1394,6 +1394,8 @@ export const esMessages = {
     guestLoginCtaTitle: "Pruébalo sin iniciar sesión",
     guestLoginCtaDescription: "Prueba ChatGPT Image 2.0 gratis, una vez al día. Inicia sesión (registro gratuito) tras generar para guardar tu imagen.",
     guestLoginCtaAction: "Iniciar sesión / Registrarse",
+    guestCategoryLoginAction: "¡Inicia sesión para generar!",
+    guestCategoryLoginHint: "¡Inicia sesión para generar con todos los estilos!",
     generateButton: "Empezar styling",
     generatingButton: "Generando...",
     // Status card heading

--- a/messages/fr.ts
+++ b/messages/fr.ts
@@ -1394,6 +1394,8 @@ export const frMessages = {
     guestLoginCtaTitle: "Essayez sans vous connecter",
     guestLoginCtaDescription: "Essayez ChatGPT Image 2.0 gratuitement, une fois par jour. Connectez-vous (inscription gratuite) après la génération pour enregistrer votre image.",
     guestLoginCtaAction: "Se connecter / S'inscrire",
+    guestCategoryLoginAction: "Connectez-vous pour générer !",
+    guestCategoryLoginHint: "Connectez-vous pour générer avec tous les styles !",
     generateButton: "Démarrer le styling",
     generatingButton: "Génération...",
     // Status card heading

--- a/messages/hi.ts
+++ b/messages/hi.ts
@@ -1392,6 +1392,8 @@ export const hiMessages = {
     guestLoginCtaTitle: "बिना साइन इन किए आज़माएँ",
     guestLoginCtaDescription: "ChatGPT Image 2.0 दिन में एक बार मुफ़्त आज़माएँ। बनाने के बाद लॉगिन (मुफ़्त साइन-अप) करके अपनी इमेज सहेजें।",
     guestLoginCtaAction: "साइन इन / साइन अप",
+    guestCategoryLoginAction: "जनरेट करने के लिए लॉग इन करें!",
+    guestCategoryLoginHint: "लॉग इन करके सभी स्टाइल से जनरेट करें!",
     generateButton: "स्टाइलिंग शुरू करें",
     generatingButton: "उत्पन्न हो रहा है...",
     // Status card heading

--- a/messages/id.ts
+++ b/messages/id.ts
@@ -1393,6 +1393,8 @@ export const idMessages = {
     guestLoginCtaTitle: "Coba tanpa masuk",
     guestLoginCtaDescription: "Coba ChatGPT Image 2.0 gratis, sekali sehari. Masuk (daftar gratis) setelah membuat untuk menyimpan gambarmu.",
     guestLoginCtaAction: "Masuk / Daftar",
+    guestCategoryLoginAction: "Masuk untuk membuat!",
+    guestCategoryLoginHint: "Masuk untuk membuat dengan semua gaya!",
     generateButton: "Mulai styling",
     generatingButton: "Menghasilkan...",
     // Status card heading

--- a/messages/it.ts
+++ b/messages/it.ts
@@ -1394,6 +1394,8 @@ export const itMessages = {
     guestLoginCtaTitle: "Provalo senza accedere",
     guestLoginCtaDescription: "Prova ChatGPT Image 2.0 gratis, una volta al giorno. Accedi (registrazione gratuita) dopo la generazione per salvare la tua immagine.",
     guestLoginCtaAction: "Accedi / Registrati",
+    guestCategoryLoginAction: "Accedi per generare!",
+    guestCategoryLoginHint: "Accedi per generare con tutti gli stili!",
     generateButton: "Avvia styling",
     generatingButton: "Generazione...",
     // Status card heading

--- a/messages/ja.ts
+++ b/messages/ja.ts
@@ -1332,6 +1332,8 @@ export const jaMessages = {
     guestLoginCtaTitle: "未ログインでお試しいただけます",
     guestLoginCtaDescription: "ChatGPT Image 2.0 を 1 日 1 回まで無料でお試しいただけます。生成後にログイン（無料登録）すると画像を保存できます。",
     guestLoginCtaAction: "ログイン / 新規登録",
+    guestCategoryLoginAction: "ログインで生成可能！",
+    guestCategoryLoginHint: "ログインすると、すべてのスタイルで生成できます！",
     generateButton: "コーデ開始！",
     generatingButton: "生成中...",
     // ステータスカードの見出し

--- a/messages/ko.ts
+++ b/messages/ko.ts
@@ -1390,6 +1390,8 @@ export const koMessages = {
     guestLoginCtaTitle: "로그인 없이 체험",
     guestLoginCtaDescription: "ChatGPT Image 2.0을 하루 1회 무료로 사용해 보세요. 생성 후 로그인(무료 가입)하면 이미지를 저장할 수 있어요.",
     guestLoginCtaAction: "로그인 / 회원가입",
+    guestCategoryLoginAction: "로그인하면 생성 가능!",
+    guestCategoryLoginHint: "로그인하면 모든 스타일로 생성할 수 있어요!",
     generateButton: "스타일링 시작",
     generatingButton: "생성 중...",
     // Status card heading

--- a/messages/pt.ts
+++ b/messages/pt.ts
@@ -1394,6 +1394,8 @@ export const ptMessages = {
     guestLoginCtaTitle: "Experimente sem fazer login",
     guestLoginCtaDescription: "Experimente o ChatGPT Image 2.0 grátis, uma vez por dia. Faça login (cadastro gratuito) após gerar para salvar sua imagem.",
     guestLoginCtaAction: "Entrar / Cadastrar",
+    guestCategoryLoginAction: "Faça login para gerar!",
+    guestCategoryLoginHint: "Faça login para gerar com todos os estilos!",
     generateButton: "Iniciar styling",
     generatingButton: "Gerando...",
     // Status card heading

--- a/messages/th.ts
+++ b/messages/th.ts
@@ -1390,6 +1390,8 @@ export const thMessages = {
     guestLoginCtaTitle: "ลองโดยไม่ต้องเข้าสู่ระบบ",
     guestLoginCtaDescription: "ทดลองใช้ ChatGPT Image 2.0 ฟรีวันละ 1 ครั้ง เข้าสู่ระบบ (สมัครฟรี) หลังสร้างเพื่อบันทึกรูปของคุณ",
     guestLoginCtaAction: "เข้าสู่ระบบ / สมัครสมาชิก",
+    guestCategoryLoginAction: "เข้าสู่ระบบเพื่อสร้าง!",
+    guestCategoryLoginHint: "เข้าสู่ระบบเพื่อสร้างด้วยทุกสไตล์!",
     generateButton: "เริ่มจัดสไตล์",
     generatingButton: "กำลังสร้าง...",
     // Status card heading

--- a/messages/vi.ts
+++ b/messages/vi.ts
@@ -1391,6 +1391,8 @@ export const viMessages = {
     guestLoginCtaTitle: "Thử mà không cần đăng nhập",
     guestLoginCtaDescription: "Dùng thử ChatGPT Image 2.0 miễn phí, mỗi ngày 1 lần. Đăng nhập (đăng ký miễn phí) sau khi tạo để lưu hình của bạn.",
     guestLoginCtaAction: "Đăng nhập / Đăng ký",
+    guestCategoryLoginAction: "Đăng nhập để tạo!",
+    guestCategoryLoginHint: "Đăng nhập để tạo với mọi phong cách!",
     generateButton: "Bắt đầu styling",
     generatingButton: "Đang tạo...",
     // Status card heading

--- a/messages/zh-CN.ts
+++ b/messages/zh-CN.ts
@@ -1388,6 +1388,8 @@ export const zhCnMessages = {
     guestLoginCtaTitle: "免登录体验",
     guestLoginCtaDescription: "每天可免费试用 ChatGPT Image 2.0 一次。生成后登录（免费注册）即可保存图片。",
     guestLoginCtaAction: "登录 / 注册",
+    guestCategoryLoginAction: "登录后即可生成！",
+    guestCategoryLoginHint: "登录后即可使用所有风格生成！",
     generateButton: "开始造型",
     generatingButton: "生成中...",
     // Status card heading

--- a/messages/zh-TW.ts
+++ b/messages/zh-TW.ts
@@ -1388,6 +1388,8 @@ export const zhTwMessages = {
     guestLoginCtaTitle: "免登入體驗",
     guestLoginCtaDescription: "每天可免費試用 ChatGPT Image 2.0 一次。生成後登入（免費註冊）即可儲存圖片。",
     guestLoginCtaAction: "登入 / 註冊",
+    guestCategoryLoginAction: "登入後即可生成！",
+    guestCategoryLoginHint: "登入後即可使用所有風格生成！",
     generateButton: "開始造型",
     generatingButton: "生成中...",
     // Status card heading

--- a/tests/integration/app/style-generate-route.test.ts
+++ b/tests/integration/app/style-generate-route.test.ts
@@ -922,7 +922,7 @@ describe("StyleGenerateRoute integration tests", () => {
     });
     const body = await readJson(response);
 
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(401);
     expect(body.errorCode).toBe("STYLE_CATEGORY_REQUIRES_AUTH");
     // 生成枠の消費や provider 呼び出しは行わない
     expect(checkAndConsumeRateLimitFn).not.toHaveBeenCalled();
@@ -959,7 +959,7 @@ describe("StyleGenerateRoute integration tests", () => {
     });
     const body = await readJson(response);
 
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(401);
     expect(body.errorCode).toBe("STYLE_CATEGORY_REQUIRES_AUTH");
     expect(checkAndConsumeRateLimitFn).not.toHaveBeenCalled();
     expect(fetchFn).not.toHaveBeenCalled();

--- a/tests/integration/app/style-generate-route.test.ts
+++ b/tests/integration/app/style-generate-route.test.ts
@@ -564,11 +564,10 @@ describe("StyleGenerateRoute integration tests", () => {
   test("postStyleGenerateRoute_カテゴリが正方形固定ならGeminiへ1:1を送る", async () => {
     getPublishedStylePresetForGenerationFn.mockResolvedValueOnce(
       buildStylePresetForGeneration({
+        // 正方形固定の挙動確認が主眼。ゲスト経路は coordinate カテゴリのみ許可
+        // されるため key は coordinate のままアスペクト比モードだけ square にする。
         category: {
           ...TEST_COORDINATE_CATEGORY,
-          key: "chibi",
-          displayNameJa: "ちびキャラ",
-          displayNameEn: "Chibi",
           outputAspectRatioMode: "square",
         },
       })
@@ -891,6 +890,77 @@ describe("StyleGenerateRoute integration tests", () => {
 
     expect(response.status).toBe(400);
     expect(body.errorCode).toBe("STYLE_INVALID_STYLE");
+    expect(checkAndConsumeRateLimitFn).not.toHaveBeenCalled();
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  test("postStyleGenerateRoute_coordinate以外の公開カテゴリはguest生成不可(403)", async () => {
+    getPublishedStylePresetForGenerationFn.mockResolvedValueOnce(
+      buildStylePresetForGeneration({
+        category: {
+          ...TEST_COORDINATE_CATEGORY,
+          key: "chibi",
+          displayNameJa: "ちびキャラ",
+          displayNameEn: "Chibi",
+          visibility: "public",
+        },
+      })
+    );
+
+    const formData = new FormData();
+    formData.set("styleId", STYLE_ID);
+    formData.set("uploadImage", createUploadImage());
+
+    const response = await postStyleGenerateRoute(createRequest(formData), {
+      fetchFn,
+      geminiApiKey: "test-api-key",
+      getUserFn,
+      getPublishedStylePresetForGenerationFn,
+      recordStyleUsageEventFn,
+      checkAndConsumeRateLimitFn,
+      releaseRateLimitAttemptFn,
+    });
+    const body = await readJson(response);
+
+    expect(response.status).toBe(403);
+    expect(body.errorCode).toBe("STYLE_CATEGORY_REQUIRES_AUTH");
+    // 生成枠の消費や provider 呼び出しは行わない
+    expect(checkAndConsumeRateLimitFn).not.toHaveBeenCalled();
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  test("postStyleGenerateRoute_神コレ(collectible_wafer_sticker_god_6p)公開時もguest生成不可(403)", async () => {
+    // 企画開始時に公開予定のカテゴリ。公開（visibility: public）に変わっても
+    // 未ログインユーザーは生成できないことを、実カテゴリキーで明示的に固定する。
+    getPublishedStylePresetForGenerationFn.mockResolvedValueOnce(
+      buildStylePresetForGeneration({
+        category: {
+          ...TEST_COORDINATE_CATEGORY,
+          key: "collectible_wafer_sticker_god_6p",
+          displayNameJa: "神コレ",
+          displayNameEn: "Collectible Wafer Sticker (God) 6P",
+          visibility: "public",
+        },
+      })
+    );
+
+    const formData = new FormData();
+    formData.set("styleId", STYLE_ID);
+    formData.set("uploadImage", createUploadImage());
+
+    const response = await postStyleGenerateRoute(createRequest(formData), {
+      fetchFn,
+      geminiApiKey: "test-api-key",
+      getUserFn,
+      getPublishedStylePresetForGenerationFn,
+      recordStyleUsageEventFn,
+      checkAndConsumeRateLimitFn,
+      releaseRateLimitAttemptFn,
+    });
+    const body = await readJson(response);
+
+    expect(response.status).toBe(403);
+    expect(body.errorCode).toBe("STYLE_CATEGORY_REQUIRES_AUTH");
     expect(checkAndConsumeRateLimitFn).not.toHaveBeenCalled();
     expect(fetchFn).not.toHaveBeenCalled();
   });

--- a/tests/unit/features/style/style-page-client.test.tsx
+++ b/tests/unit/features/style/style-page-client.test.tsx
@@ -130,6 +130,11 @@ jest.mock("@/features/posts/components/PostModal", () => ({
     ) : null,
 }));
 
+jest.mock("@/features/auth/components/AuthModal", () => ({
+  AuthModal: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="mock-auth-modal" /> : null,
+}));
+
 jest.mock("@/features/generation/lib/normalize-source-image", () => ({
   normalizeSourceImage: async (file: File) => file,
 }));
@@ -1897,6 +1902,36 @@ describe("StylePageClient", () => {
     expect(
       screen.queryByRole("button", { name: "Log in to generate!" })
     ).not.toBeInTheDocument();
+  });
+
+  test("未ログインユーザーがログインCTAを押すと認証モーダルを開く", async () => {
+    const chibiCategory = {
+      ...TEST_COORDINATE_CATEGORY,
+      id: "cat-chibi",
+      key: "chibi",
+      displayNameJa: "ちびキャラ",
+      displayNameEn: "Chibi",
+    } as const;
+    const chibiPreset: StylePresetPublicSummary = {
+      ...presets[0],
+      id: "chibi-preset-3",
+      category: chibiCategory,
+    };
+
+    render(
+      <StylePageClient presets={[chibiPreset]} initialAuthState="guest" />
+    );
+
+    const cta = await screen.findByRole("button", {
+      name: "Log in to generate!",
+    });
+    expect(screen.queryByTestId("mock-auth-modal")).not.toBeInTheDocument();
+
+    fireEvent.click(cta);
+
+    expect(
+      await screen.findByTestId("mock-auth-modal")
+    ).toBeInTheDocument();
   });
 
   test("ログインユーザーが上限到達時_翌日案内カードを表示して生成を止める", async () => {

--- a/tests/unit/features/style/style-page-client.test.tsx
+++ b/tests/unit/features/style/style-page-client.test.tsx
@@ -296,6 +296,8 @@ const styleMessages = {
     "Your balance is too low. Prepare at least {cost} Percoins to continue.",
   guestRateLimitSignupHint: "Create an account to keep going right away.",
   guestRateLimitSignupAction: "Sign up to continue",
+  guestCategoryLoginAction: "Log in to generate!",
+  guestCategoryLoginHint: "Log in to generate with every style!",
   percoinBalanceLabel: "Current Percoin balance",
   percoinBalanceLoading: "Checking your Percoin balance...",
   percoinBalanceUnavailable: "We could not load your balance.",
@@ -396,6 +398,9 @@ const TEST_COORDINATE_CATEGORY = {
   showBackgroundChangeControl: true,
   showGenerationModelControl: true,
   showUserPromptInput: false,
+  userPromptLabel: null,
+  userPromptPlaceholder: null,
+  userPromptMaxLength: null,
   visibility: "public",
   isActive: true,
 } as const;
@@ -1825,6 +1830,73 @@ describe("StylePageClient", () => {
     expect(
       screen.getByRole("button", { name: /Start Styling/ })
     ).toBeDisabled();
+  });
+
+  test("未ログインユーザーがcoordinate以外のカテゴリ選択時_生成ボタンの代わりにログインCTAを出す", async () => {
+    const chibiCategory = {
+      ...TEST_COORDINATE_CATEGORY,
+      id: "cat-chibi",
+      key: "chibi",
+      displayNameJa: "ちびキャラ",
+      displayNameEn: "Chibi",
+    } as const;
+    const chibiPreset: StylePresetPublicSummary = {
+      ...presets[0],
+      id: "chibi-preset-1",
+      category: chibiCategory,
+    };
+
+    render(
+      <StylePageClient presets={[chibiPreset]} initialAuthState="guest" />
+    );
+
+    expect(
+      await screen.findByRole("button", { name: "Log in to generate!" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Log in to generate with every style!")
+    ).toBeInTheDocument();
+    // 生成ボタンは描画しない
+    expect(
+      screen.queryByRole("button", { name: /Start Styling/ })
+    ).not.toBeInTheDocument();
+  });
+
+  test("未ログインユーザーがcoordinateカテゴリ選択時_生成ボタンを出しログインCTAは出さない", async () => {
+    render(<StylePageClient presets={presets} initialAuthState="guest" />);
+
+    expect(
+      await screen.findByRole("button", { name: /Start Styling/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Log in to generate!" })
+    ).not.toBeInTheDocument();
+  });
+
+  test("ログインユーザーはcoordinate以外のカテゴリでも生成ボタンを出す", async () => {
+    const chibiCategory = {
+      ...TEST_COORDINATE_CATEGORY,
+      id: "cat-chibi",
+      key: "chibi",
+      displayNameJa: "ちびキャラ",
+      displayNameEn: "Chibi",
+    } as const;
+    const chibiPreset: StylePresetPublicSummary = {
+      ...presets[0],
+      id: "chibi-preset-2",
+      category: chibiCategory,
+    };
+
+    render(
+      <StylePageClient presets={[chibiPreset]} initialAuthState="authenticated" />
+    );
+
+    expect(
+      await screen.findByRole("button", { name: /Start Styling/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Log in to generate!" })
+    ).not.toBeInTheDocument();
   });
 
   test("ログインユーザーが上限到達時_翌日案内カードを表示して生成を止める", async () => {

--- a/tests/unit/features/style/style-preset-preview-card.test.tsx
+++ b/tests/unit/features/style/style-preset-preview-card.test.tsx
@@ -1,6 +1,6 @@
 /** @jest-environment jsdom */
 
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { StylePresetPreviewCard } from "@/features/style/components/StylePresetPreviewCard";
 
 jest.mock("next/image", () => ({
@@ -94,5 +94,42 @@ describe("StylePresetPreviewCard - バッジ表示", () => {
     // inline style はそのまま attribute として出る
     expect(badge.style.backgroundColor).toBe("rgb(236, 72, 153)"); // #ec4899
     expect(badge.style.color).toBe("rgb(255, 255, 255)");
+  });
+});
+
+describe("StylePresetPreviewCard - ロック表示", () => {
+  test("lockedLabel を渡すとロックラベルを表示する", () => {
+    render(
+      <StylePresetPreviewCard
+        preset={makePreset({ category: CHIBI_CATEGORY })}
+        alt="alt"
+        lockedLabel="ログインで生成可能！"
+      />,
+    );
+    expect(screen.getByText("ログインで生成可能！")).toBeInTheDocument();
+  });
+
+  test("lockedLabel が無ければロックラベルを表示しない", () => {
+    render(
+      <StylePresetPreviewCard
+        preset={makePreset({ category: CHIBI_CATEGORY })}
+        alt="alt"
+      />,
+    );
+    expect(screen.queryByText("ログインで生成可能！")).toBeNull();
+  });
+
+  test("ロック中でも選択操作 (onClick) は可能", () => {
+    const onClick = jest.fn();
+    render(
+      <StylePresetPreviewCard
+        preset={makePreset({ category: CHIBI_CATEGORY })}
+        alt="alt"
+        lockedLabel="ログインで生成可能！"
+        onClick={onClick}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button"));
+    expect(onClick).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
### 概要
未ログイン（ゲスト）ユーザーの「1日1回無料生成」を、`/style`（One-Tap Style）画面では `category.key` が `coordinate` のプリセットのみに制限します。これまでは公開されているどのカテゴリでもゲストが生成できる作りでしたが、今後 `coordinate` 以外のカテゴリ（直近では企画開始時に公開予定の `collectible_wafer_sticker_god_6p`／神コレ）を公開した際に、未ログインユーザーには生成させず、ログインを促したいという要望への対応です。

「`coordinate` だけを許可する」**許可リスト方式**にしているため、`coordinate` 以外の公開カテゴリは将来追加されても自動的にゲスト生成不可になります（カテゴリ公開の visibility 変更以外に追加対応は不要）。

### 変更内容
- **クライアント**（`features/style/components/StylePageClient.tsx`）
  - `isGuestRestrictedCategory`（ゲスト かつ 選択中カテゴリが `coordinate` 以外）を追加し、生成ボタンを無効化
  - 生成ボタンの代わりに「ログインで生成可能！」CTA（押すと認証モーダルを表示）と補足文を表示
- **サーバー**（`app/(app)/style/generate/handler.ts`）
  - ゲスト同期生成経路で `category.key !== "coordinate"` を `403 STYLE_CATEGORY_REQUIRES_AUTH` で拒否（クライアント制御をすり抜けても弾く defense-in-depth）
- **文言** — 全16ロケールの `style` 名前空間に `guestCategoryLoginAction` / `guestCategoryLoginHint` を追加
- **テスト**
  - クライアント3件（ゲスト×非coordinate→CTA表示・生成ボタン非表示 / ゲスト×coordinate→生成ボタン表示 / ログイン×非coordinate→生成ボタン表示）
  - 統合2件（非coordinate公開カテゴリ→403、神コレ `collectible_wafer_sticker_god_6p` 公開時も→403）
  - 既存のアスペクト比テストはカテゴリキーを `coordinate` に修正

### 補足（現状の見え方）
現在 `/style` でゲストに見える公開プリセット92件はすべて `coordinate` カテゴリで、`collectible_wafer_sticker_god_6p` は `admin_only` のため未公開です。よって本PR時点でゲストの挙動に変化はなく、当該カテゴリを公開（visibility: public）した時点で「未ログインは生成不可」が有効になります。

### 実機テスト
- [ ] iOS Safari で主要導線を確認
- [ ] Android Chrome で主要導線を確認
- [ ] PC（Chrome）で主要導線を確認
- [ ] レスポンシブ表示崩れがないことを確認
- [ ] エラーメッセージやバリデーション表示を確認

### テスト方法
- `npm run test`：全1912件パス（新規5件含む）
- `npm run lint`：新規エラーなし
- `npm run build -- --webpack`：成功
- ヘッドレスブラウザで「ログインで生成可能！」CTA のデザインを確認（一時的に条件反転して撮影し復元）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
