### PR TITLE
feat(style): プロンプト入力ラベルのスマホ折返し対策と改行表示に対応

### DIFF
--- a/app/api/admin/preset-categories/[id]/route.ts
+++ b/app/api/admin/preset-categories/[id]/route.ts
@@ -17,7 +17,7 @@ import { GENERATION_PROMPT_MAX_LENGTH } from "@/lib/generation/prompt-validation
 const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
 const MAX_DISPLAY_NAME_LENGTH = 60;
 const MAX_USER_GUIDANCE_LENGTH = 1000;
-const MAX_USER_PROMPT_LABEL_LENGTH = 80;
+const MAX_USER_PROMPT_LABEL_LENGTH = 120;
 const MAX_USER_PROMPT_PLACEHOLDER_LENGTH = 200;
 
 function revalidatePresetCategoriesCache(id: string): void {

--- a/app/api/admin/preset-categories/route.ts
+++ b/app/api/admin/preset-categories/route.ts
@@ -18,7 +18,7 @@ const KEY_PATTERN = /^[a-z][a-z0-9_]{1,49}$/;
 const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
 const MAX_DISPLAY_NAME_LENGTH = 60;
 const MAX_USER_GUIDANCE_LENGTH = 1000;
-const MAX_USER_PROMPT_LABEL_LENGTH = 80;
+const MAX_USER_PROMPT_LABEL_LENGTH = 120;
 const MAX_USER_PROMPT_PLACEHOLDER_LENGTH = 200;
 
 function revalidatePresetCategoriesCache(): void {

--- a/features/generation/components/PromptInputField.tsx
+++ b/features/generation/components/PromptInputField.tsx
@@ -75,9 +75,7 @@ export function PromptInputField({
         <Label
           htmlFor={id}
           className="whitespace-pre-line text-base font-medium leading-snug"
-        >
-          {label}
-        </Label>
+        >{label}</Label>
         {showClearButton && (
           <Button
             type="button"

--- a/features/generation/components/PromptInputField.tsx
+++ b/features/generation/components/PromptInputField.tsx
@@ -64,8 +64,18 @@ export function PromptInputField({
 
   return (
     <div {...containerProps}>
-      <div className="flex items-center justify-between gap-2">
-        <Label htmlFor={id} className="text-base font-medium">
+      {/*
+        ラベルが長い場合 (例: /style のカテゴリ別ガイド文) でも、スマホで
+        「クリア」ボタンが折り返しテキストの脇に窮屈に挟まらないよう、
+        モバイルはラベルの下にボタンを配置し、sm 以上で従来の横並びに戻す。
+      */}
+      <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between sm:gap-2">
+        {/* 管理画面で改行を入れたラベルをそのまま反映する (whitespace-pre-line)。
+            複数行でも詰まりすぎないよう leading-none を leading-snug で上書き。 */}
+        <Label
+          htmlFor={id}
+          className="whitespace-pre-line text-base font-medium leading-snug"
+        >
           {label}
         </Label>
         {showClearButton && (
@@ -73,7 +83,7 @@ export function PromptInputField({
             type="button"
             size="sm"
             variant="ghost"
-            className="h-7 px-2 text-xs text-gray-600 hover:text-gray-900"
+            className="h-7 self-end px-2 text-xs text-gray-600 hover:text-gray-900 sm:self-auto"
             onClick={() => onChange("")}
             disabled={value.length === 0 || disabled}
             aria-label={clearLabel}

--- a/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
+++ b/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
@@ -686,16 +686,16 @@ export function AdminPresetCategoryFormClient({
               <span className="text-sm font-medium text-slate-700">
                 ラベル(textarea の見出し)
               </span>
-              <input
-                type="text"
+              <textarea
                 value={form.userPromptLabel}
                 onChange={(e) => update("userPromptLabel", e.target.value)}
-                maxLength={80}
-                placeholder="例: 追加スタイルの指示(任意)"
+                maxLength={120}
+                rows={2}
+                placeholder={"例: 名前を記載してください(任意)\n【神の名前＋名前】になります"}
                 className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm"
               />
               <span className="mt-1 block text-xs text-slate-500">
-                最大 80 文字
+                最大 120 文字。改行を入れるとユーザー画面でもそのまま改行表示されます(本文と説明文を分けたいときに利用)。
               </span>
             </label>
             <label className="block">


### PR DESCRIPTION
### 概要
`/style`（One-Tap Style）のプロンプト入力欄で、カテゴリ別ラベル（textarea の見出し）が長い場合にスマホで見づらくなる問題への対応です。神コレ系カテゴリのように「本文＋補足説明」を1つのラベルに詰め込むと、折り返したテキストの脇に「クリア」ボタンが窮屈に挟まり、説明も一続きで読みにくくなっていました。

最小限の対策として、(1) スマホではラベルの下に「クリア」を配置、(2) ラベルに改行を入れられるようにして本文と説明を行で分けられるようにしました。`PromptInputField` は `/coordinate` 画面とも共有していますが、そちらはラベルが短く、デスクトップの見た目は変わりません。

### 変更内容
- **PromptInputField（ヘッダー配置）**: ラベルと「クリア」ボタンの行を、モバイルは縦積み（ラベルの下にクリア・右寄せ）、`sm`(640px) 以上では従来どおり横並び（`justify-between`）にする responsive 対応
- **PromptInputField（ラベル改行）**: ラベルに `whitespace-pre-line` と `leading-snug` を付与し、管理画面で入れた改行をユーザー画面でもそのまま表示
- **管理画面（AdminPresetCategoryFormClient）**: カテゴリ編集のラベル入力を `input` → `textarea`(2行) に変更し、改行を入力可能に。補足説明も追記
- **文字数上限**: 改行込みで本文＋説明を入れられるよう、クライアントとサーバー（`preset-categories` の作成/更新 API）双方の上限を 80→120 に統一

### 実機テスト
- [ ] iOS Safari で主要導線を確認
- [ ] Android Chrome で主要導線を確認
- [ ] PC（Chrome）で主要導線を確認
- [ ] レスポンシブ表示崩れがないことを確認
- [ ] 管理画面でラベルに改行を入れて保存→ユーザー画面で改行表示を確認

### テスト方法
- `npm run test`（generation / style / preset-categories / app）：447件パス
- `npm run lint` / `npm run typecheck`：新規エラーなし
- `npm run build -- --webpack`：成功
- ヘッドレスブラウザでモバイル/デスクトップのクリア配置と、改行入りラベルの表示を確認

### 補足
今回は軽量対応のため本文と説明は同じ文字サイズです（改行で区切るのみ）。将来「説明だけ小さいグレー文字」にしたい場合は、専用の説明フィールド新設で対応できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
