### PR TITLE
feat(collections): 台紙の枠(スロット)ドラッグ編集UIと表示アスペクト修正 (Phase 2)

### DIFF
--- a/app/api/collections/mount/route.ts
+++ b/app/api/collections/mount/route.ts
@@ -185,7 +185,7 @@ export async function POST(request: NextRequest) {
     const { data: category, error: categoryError } = await admin
       .from("preset_categories")
       .select(
-        "id, mount_template_path, mount_layout, mount_slots, completion_threshold, visibility, display_name_ja, ogp_template_path, ogp_mount_placement",
+        "id, mount_template_path, mount_layout, mount_slots, mount_template_width, mount_template_height, completion_threshold, visibility, display_name_ja, ogp_template_path, ogp_mount_placement",
       )
       .eq("key", categoryKey)
       .eq("is_collection_series", true)
@@ -355,6 +355,10 @@ export async function POST(request: NextRequest) {
       status: "completed",
       mountImageUrl: versioned,
       sharePath,
+      mountTemplateWidth:
+        (category.mount_template_width as number | null) ?? null,
+      mountTemplateHeight:
+        (category.mount_template_height as number | null) ?? null,
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : "unknown error";

--- a/app/m/[token]/page.tsx
+++ b/app/m/[token]/page.tsx
@@ -87,7 +87,13 @@ export default async function PublicMountPage({
 
       <div
         className="relative w-full max-w-sm overflow-hidden rounded-xl border border-gray-200 shadow-md"
-        style={{ aspectRatio: mountAspectForCategory(mount.categoryKey) }}
+        style={{
+          aspectRatio: mountAspectForCategory(
+            mount.categoryKey,
+            mount.mountTemplateWidth,
+            mount.mountTemplateHeight,
+          ),
+        }}
       >
         <Image
           src={mount.mountImageUrl}

--- a/docs/planning/collection-mount-slot-editor-phase2-plan.md
+++ b/docs/planning/collection-mount-slot-editor-phase2-plan.md
@@ -1,0 +1,412 @@
+# コレクション台紙「枠(スロット)ドラッグ編集UI」 — Phase 2 実装計画
+
+> Phase 1（DB / 合成 / admin API の土台）は完了・main マージ済み・本番 migration 適用済み。
+> 本計画は **admin プリセットカテゴリ編集画面に「枠調整モード」を追加する UI フェーズ** を扱う。
+> 関連: `docs/planning/collection-mount-slot-editor-implementation-plan.md`（Phase 1, ADR-001/002）。
+
+## ゴール
+
+運営が台紙テンプレ(空PNG)をアップロードした後、その画像を背景に **N 個のスロット矩形を
+ドラッグで移動・四隅リサイズ** し、`mount_slots`(正規化矩形配列 0..1)として保存できるようにする。
+これにより「枠の位置・大きさはプログラム(コード側 `MOUNT_LAYOUTS` grid_3/4/6)固定」だった制約を外し、
+台紙デザインに合わせて運営が GUI で枠を微調整できる。
+
+**編集モデル（確定）: サイズは全枠連動・位置は枠ごと自由。** 全スロットは常に **同一サイズ**
+（共有 `{w,h}`）を持ち、どれか1枠の四隅をリサイズすると **全枠が同じサイズに追従** する。
+一方、移動(位置 `{x,y}`)は **その枠だけ** が動く。台紙の見た目の統一感（全枠同サイズ）を保ちつつ、
+配置だけ自由に置けるようにする運営の要望に基づく。
+
+到達点: `/admin/preset-categories/[id]/edit`（およびコレクション設定を持つ create）で、
+台紙アップロード → グリッド数選択で初期枠を seed → ドラッグ移動 / 四隅リサイズ（正方形・縦横比ロック可）
+→ 合成プレビュー確認 → 保存で `mount_slots` を PATCH。既存の神コレ(mount_slots=NULL)は不変。
+
+---
+
+## コードベース調査結果
+
+### 統合先 — `features/preset-categories/components/AdminPresetCategoryFormClient.tsx`（949行・"use client"）
+
+| 箇所 | 行 | Phase 2 でやること |
+|------|----|----|
+| `FormState` 型 | 29–58 | `mountSlots: NormalizedSlotRect[] \| null` と `mountTemplateWidth/Height: number \| null` を追加 |
+| `toFormState` 初期化 | 72–107 | 上記3つを `initial?.mountSlots ?? null` 等で初期化 |
+| `handleTemplateUpload` | 177–206 | API が返す `{path,width,height}` の **width/height を捨てている**。これを `update()` で取り込む |
+| `handleSubmit` body（create/edit 両方） | 218–284 | `mount_slots` / `mount_template_width` / `mount_template_height` を body に追加 |
+| コレクション設定 fieldset | 757–918 | 台紙テンプレ `<img>` プレビュー(876–883)の直後に「枠調整モード」セクションを挿入 |
+| `mountTemplatePreviewUrl(path)` | 115–117 | 背景画像URL。`/api/admin/collection-mount-template?path=...` を流用 |
+
+`PresetCategoryAdmin`（`preset-category-repository.ts:66`）は既に `mountSlots`(90) /
+`mountTemplateWidth`(91) / `mountTemplateHeight`(92) を持つ。`mapRow`(208–213) が
+`parseNormalizedSlots(row.mount_slots)` で復元済み。**ドメイン層は Phase 1 で完成しており、
+フォームへの配線だけが欠けている。**
+
+### 保存API — 変更不要（Phase 1 で完成）
+
+- `app/api/admin/preset-categories/route.ts`(POST) / `[id]/route.ts`(PATCH) →
+  `parseCollectionSettings()` → `Object.assign(payload, ...)` → repository。
+- `collection-settings-payload.ts` が `mount_slots`(0..1+`SLOT_EPS=1e-6` 範囲検証, 103–135) /
+  `mount_template_width`(137–146) / `mount_template_height`(149–158) を受理。
+  `completion_threshold === mount_slots.length` を強制（261 付近・任意N対応）。
+- repository の create(320–322) / update(384–388) も配線済み。
+
+→ **Phase 2 は API・DB・repository を一切変更しない。フォームが正しい body を送るだけ。**
+
+### 合成プレビュー — `composeMount` は使えない
+
+`features/collections/lib/compose-mount.ts` の `composeMount` は **sharp 依存(server-only)**。
+ブラウザでは動かない。よって「枠にサンプル画像を cover で重ねた見え方」のプレビューは
+**DOM/CSS（absolute 配置 + `object-fit: cover` + overflow:hidden）で再現** する。
+実合成の真値は `toPixelRect(rect, W, H)`(`mount-layouts.ts:130`, fit:"cover" と等価)であり、
+DOM プレビューはこれと同じ「正規化矩形 × 表示実寸」で配置するため見た目が一致する。
+
+### 枠データの源泉 — `features/collections/lib/mount-layouts.ts`
+
+- `NormalizedSlotRect {x,y,w,h}`(15) / `PixelSlotRect`(23) / `toPixelRect`(130)
+- `MOUNT_LAYOUTS: Record<"grid_3"|"grid_4"|"grid_6", NormalizedSlotRect[]>`(30) — 初期 seed 用
+- `slotCountForLayout`(61)
+
+### ドラッグ実装ライブラリ — `@dnd-kit` は使わない（ADR-001）
+
+`@dnd-kit/core|sortable|utilities` は導入済みだが、用途は「離散アイテムの並べ替え D&D」。
+本機能は **連続平面上の矩形を移動 + 四隅リサイズ + 縦横比ロック** であり、dnd-kit のセンサー/
+衝突判定/transform モデルとは噛み合わない（リサイズハンドルは dnd-kit のプリミティブに無い）。
+素の Pointer Events(`onPointerDown/Move/Up` + `setPointerCapture`)で move/resize を
+ピクセル空間で実装する方が単純で正確。詳細は ADR-001。
+
+### i18n
+
+このフォームは admin 専用で **全面的に日本語ハードコード**（next-intl の翻訳キーを使っていない。
+例: 757–916 の文言はすべて日本語リテラル）。Phase 2 の新規 UI 文言も **既存に倣い日本語リテラル**
+とする（en/ja の 16 ロケールファイル追加は不要）。ユーザー(エンドユーザー)向け画面ではないため。
+
+---
+
+## 概要図
+
+### ユーザー(運営)操作フロー
+
+```mermaid
+flowchart TD
+    A["コレクション設定 ON"] --> B["台紙テンプレPNGをアップロード"]
+    B --> C["API が path と実寸 width,height を返す"]
+    C --> D["枠調整モードが表示される"]
+    D --> E["グリッド数 N を選んで初期枠を seed"]
+    E --> F{"枠を編集"}
+    F -->|"枠本体をドラッグ"| G["その枠だけ移動 ピクセル空間でクランプ"]
+    F -->|"四隅ハンドルをドラッグ"| H["共有サイズ変更 全枠が同じサイズに連動 比率ロック時は正方形維持"]
+    G --> I["合成プレビューに即時反映"]
+    H --> I
+    I --> F
+    F -->|"完了"| J["更新ボタンで保存"]
+    J --> K["mount_slots を 0..1 正規化して PATCH"]
+    K --> L["API が threshold と枠数一致を検証して保存"]
+```
+
+### 保存シーケンス
+
+```mermaid
+sequenceDiagram
+    participant U as Operator
+    participant F as AdminPresetCategoryFormClient
+    participant E as MountSlotEditor
+    participant T as TemplateUploadAPI
+    participant A as PresetCategoriesAPI
+    participant DB as Supabase
+    U->>F: 台紙PNGを選択
+    F->>T: POST collection-mount-template
+    T-->>F: path, width, height
+    F->>F: mountTemplatePath, dims を state へ
+    U->>E: グリッド数を選択
+    E->>E: MOUNT_LAYOUTS から枠を seed
+    U->>E: ドラッグ移動 / 四隅リサイズ
+    E-->>F: onChange 正規化矩形配列
+    U->>F: 更新ボタン
+    F->>A: PATCH mount_slots, dims, completion_threshold
+    A->>A: 0..1 範囲検証 と threshold 一致検証
+    A->>DB: UPDATE preset_categories
+    DB-->>A: OK
+    A-->>F: 200
+```
+
+### 編集モードの状態遷移
+
+```mermaid
+stateDiagram-v2
+    [*] --> 台紙なし
+    台紙なし --> 台紙あり枠未設定: 台紙アップロード成功
+    台紙あり枠未設定 --> 編集中: グリッド数を選び seed
+    台紙あり枠未設定 --> 編集中: 既存 mount_slots を読み込み
+    編集中 --> 編集中: その枠だけ移動
+    編集中 --> 編集中: 四隅リサイズ 全枠が同サイズに連動
+    編集中 --> 保存済み: 更新ボタンで PATCH 成功
+    保存済み --> 編集中: 再編集
+```
+
+---
+
+## EARS（要件定義）
+
+### 表示・初期化
+- **When** the operator uploads a mount template successfully, **the system shall** capture the
+  returned image `width`/`height` and reveal the slot editor with the template as background.
+  運営が台紙をアップロードしたら、返却された実寸を保持し、台紙を背景にした枠エディタを表示する。
+- **When** the edited category already has `mount_slots`, **the system shall** initialize the
+  editor with those rectangles. 既存の `mount_slots` があればその矩形で初期化する。
+- **Where** no `mount_slots` exists but a grid layout is chosen, **the system shall** seed N
+  rectangles from `MOUNT_LAYOUTS`. 枠が無くグリッドを選んだ場合は `MOUNT_LAYOUTS` から N 枠を seed する。
+
+### 編集操作
+- **When** the operator drags a slot body, **the system shall** translate **only that slot** in
+  pixel space, clamped within the template bounds. 枠本体ドラッグでは **その枠だけ** を台紙内にクランプして移動する。
+- **When** the operator drags a corner handle of any slot, **the system shall** update the
+  **shared size** so that **every slot resizes to the same size**, each keeping its own center
+  fixed (so the dragged corner tracks the pointer on every corner). いずれかの枠の四隅ハンドルを
+  動かすと **共有サイズ** が変わり、**全枠が同じサイズに連動** する（各枠は自分の中心を固定して追従＝
+  どの角を引いてもその角がポインタに付いてくる）。
+- **While** ratio-lock is enabled, **the system shall** preserve the shared pixel aspect ratio
+  during resize (square stays square even on a non-square template). 比率ロック中は共有サイズの
+  ピクセル縦横比を維持する（非正方形台紙でもピクセル正方形）。
+- **When** the shared size grows such that a slot would exceed bounds, **the system shall** clamp
+  the shared size to the largest value that keeps **all** slots inside 0..1. 共有サイズ拡大で
+  どれか1枠でもはみ出す場合、**全枠が 0..1 に収まる最大サイズ** にクランプする。
+- **The system shall** enforce a minimum slot size (px). 最小サイズ(px)を下回らせない。
+
+### 保存・検証
+- **When** the operator submits, **the system shall** normalize all slots to 0..1 and send
+  `mount_slots`, `mount_template_width`, `mount_template_height`, and `completion_threshold`
+  (= slot count). 保存時に 0..1 正規化し、枠数を threshold として送る。
+- **If** the slot count does not equal `completion_threshold`, **then the system shall** block
+  submission with an inline message before calling the API. 枠数と N が不一致なら送信前にエラー表示する。
+- **If** the template has not been uploaded (no dims), **then the system shall** keep the editor
+  disabled and fall back to the existing grid-layout select. 台紙未アップロード時はエディタを無効化し従来のレイアウト選択にフォールバックする。
+
+### 後方互換
+- **Where** the operator leaves `mount_slots` untouched, **the system shall** preserve existing
+  behavior (mount_slots stays NULL, grid preset drives composition). 枠を触らなければ従来どおり NULL のまま。
+
+---
+
+## ADR（設計判断記録）
+
+### ADR-001: ドラッグ/リサイズは @dnd-kit ではなく素の Pointer Events で実装する
+
+- **Context**: リポジトリに `@dnd-kit/*` 導入済み。だが本機能は連続平面上の矩形を「移動 + 四隅
+  リサイズ + 縦横比ロック」する bounding-box エディタ。
+- **Decision**: `onPointerDown` + `setPointerCapture` + `onPointerMove`/`onPointerUp` で
+  move/resize を **ピクセル空間** で自前実装する。dnd-kit は使わない。
+- **Reason**: dnd-kit は「離散アイテムの並べ替え D&D」用でリサイズハンドルや比率ロックの
+  プリミティブを持たない。transform モデルと衝突判定を回避でき、ピクセル↔正規化の数式を
+  一箇所に集約できる。Pointer Events はタッチ/マウス両対応で外部依存ゼロ。
+- **Consequence**: ドラッグ中の境界クランプ・最小サイズ・比率ロックの算術を自前で書く必要が
+  あるが、純関数に切り出してユニットテスト可能（むしろ望ましい）。慣性/キーボード操作は範囲外。
+
+### ADR-002: 合成プレビューは composeMount ではなく DOM/CSS で再現する
+
+- **Context**: 真の合成 `composeMount` は sharp(server-only) でブラウザ実行不可。
+- **Decision**: 台紙 `<img>` の上に各枠を `position:absolute` + `object-fit:cover` +
+  `overflow:hidden` で重ね、サンプル画像を cover 配置してプレビューする。配置率は枠の正規化矩形
+  をそのまま % で適用。
+- **Reason**: `composeMount` の `toPixelRect`(fit:"cover") と同じ「正規化矩形 × 実寸」で配置する
+  ため、ピクセルパーフェクトではないが運営が枠位置を判断するには十分一致する。サーバー往復不要で
+  ドラッグ中もリアルタイム反映できる。
+- **Consequence**: 最終的な合成の厳密確認は本番の台紙生成(既存 `composeMount` 経路)で行う。
+  プレビューはあくまで枠配置の目視確認用と位置づける。
+
+### ADR-003: 編集はピクセル空間で行い、保存時にのみ正規化する
+
+- **Context**: 「正方形を維持」は台紙が非正方形でも **画面ピクセル上の正方形** を意味する。
+- **Decision**: エディタ内部状態は表示ピクセル矩形ではなく **正規化矩形(0..1)** を単一の真値
+  として保持しつつ、ドラッグ算術(比率ロック・最小サイズ)は「正規化 → ピクセル換算 → 操作 →
+  正規化」で行う。実寸 `mountTemplateWidth/Height` を換算係数に使う。
+- **Reason**: 保存形式(0..1)と表示(任意の描画幅)を分離。描画コンテナ幅が変わっても矩形は不変。
+  比率ロックだけは実寸アスペクトを使ってピクセル正方形を保証する。
+- **Consequence**: 換算ヘルパ(`normalizedToPixel`/`pixelToNormalized`/`clampRect`/
+  `resizeWithRatioLock`)を `mount-layouts.ts` 近傍に純関数で置き、テストする。
+
+### ADR-004: サイズは「共有 1 値」、位置は「枠ごと」に分離して保持する
+
+- **Context**: 全枠は常に同サイズ・位置は枠ごと自由（運営確定仕様）。`mount_slots` の保存形式は
+  従来どおり `[{x,y,w,h}]`(枠ごと)。
+- **Decision**: エディタの内部状態を **共有サイズ `size:{w,h}`(正規化) + 位置配列
+  `positions:{x,y}[]`** に分解して持つ。保存・props 受け渡し時は `joinSlots()`
+  で従来の `NormalizedSlotRect[]` に合成する。逆に既存 `mount_slots` 読み込み時は `splitSlots()` で
+  **先頭枠の w,h を共有サイズの初期値** とし（全枠同値前提・差異があれば先頭に正規化）、各枠の x,y を
+  positions に取る。リサイズは **中心固定**（各枠の中心を保ったまま新サイズへ）。
+- **Reason**: 「1枠リサイズ → 全枠連動」を状態構造で自然に表現でき、リサイズ時に全枠ループ更新する
+  命令的コードを避けられる。`mount_slots` の I/O 形式・API・DB・composeMount は一切変えずに済む。
+- **Consequence**: リサイズは `size` を1回更新するだけ。ただし共有サイズ拡大時は **全 positions が
+  0..1 に収まる最大値** にクランプする必要があり、その判定(`maxUniformSizeWithin(positions, ...)`)を
+  純関数化してテストする。既存 mount_slots が（理論上）枠ごと別サイズだった場合は先頭サイズに揃うが、
+  Phase 1 までは grid プリセット由来＝全枠同サイズのため実害なし。
+
+---
+
+## 実装計画（フェーズ＋TODO）
+
+### フェーズ間の依存関係
+
+```mermaid
+flowchart LR
+    P1["Phase 1: 幾何ヘルパ 純関数"] --> P2["Phase 2: エディタComponent"]
+    P2 --> P3["Phase 3: フォーム配線 保存"]
+    P3 --> P4["Phase 4: プレビュー"]
+    P4 --> P5["Phase 5: テスト 仕上げ"]
+```
+
+> 各フェーズ終了時に `npm run build -- --webpack` が通ること。
+
+### Phase 1: 幾何ヘルパ（純関数・テスト容易）
+目的: ドラッグ/リサイズ/クランプ/比率ロックの算術を UI から分離。
+ビルド確認: 既存利用者がいないので型のみ。lint/typecheck 緑。
+
+- [ ] `features/collections/lib/slot-edit-geometry.ts`（新規）に純関数を追加。状態は
+      **共有サイズ `size:{w,h}` + 位置 `positions:{x,y}[]`**(ADR-004)を前提:
+  - [ ] `clampPositionWithin(pos, size): {x,y}` — 1枠を 0..1 内へ位置クランプ（移動用）
+  - [ ] `movePosition(pos, size, dxNorm, dyNorm): {x,y}` — その枠だけ移動 + クランプ
+  - [ ] `resizeSharedSize(size, corner, dxNorm, dyNorm, opts): {w,h}` — **共有サイズ** を更新。
+        `opts.lockRatio` 時は実寸アスペクト(`templateW/H`)でピクセル正方形/比率維持、
+        `opts.minPx` で最小サイズ(px)を下限クランプ
+  - [ ] `maxUniformSizeWithin(positions, desiredSize, templateW, templateH): {w,h}` —
+        全 positions を 0..1 に収める **最大共有サイズ** にクランプ（拡大時のはみ出し防止）
+  - [ ] `splitSlots(slots): { size, positions }` / `joinSlots(size, positions): NormalizedSlotRect[]`
+        — 既存 `mount_slots` ↔ エディタ内部状態の相互変換（先頭枠 w,h を共有サイズに採用）
+  - [ ] `seedSlots(layout): NormalizedSlotRect[]` — `MOUNT_LAYOUTS` の薄いラッパ（N 変更時の再 seed 用）
+- [ ] `toPixelRect`(既存) は再利用。`PixelSlotRect`/`NormalizedSlotRect` を import。
+
+### Phase 2: 枠エディタ Component
+目的: 台紙背景 + ドラッグ可能な N 枠 + 四隅ハンドル + 比率ロックトグル。
+ビルド確認: 単体で import してもビルドが通る（フォーム未配線でも可）。
+
+- [ ] `features/preset-categories/components/MountSlotEditor.tsx`（新規・"use client"）:
+  - [ ] props: `{ templateUrl, templateWidth, templateHeight, slots, ratioLock, onChange }`
+        （`slots: NormalizedSlotRect[]`。内部で `splitSlots` → `{size, positions}` に分解）
+  - [ ] 背景 `<img src={templateUrl}>` を実寸アスペクトで描画（`aspect-ratio` CSS）
+  - [ ] 各枠を `position:absolute`（left/top を positions、width/height を **共有 size**・%）で重ねる
+  - [ ] 枠本体 `onPointerDown` → **その枠だけ** move（`movePosition`）
+  - [ ] 四隅 4 ハンドル `onPointerDown` → **共有サイズ** resize（`resizeSharedSize` →
+        `maxUniformSizeWithin` でクランプ → **全枠の width/height が連動**）
+        （`setPointerCapture`、`onPointerMove` で Phase 1 ヘルパ、`onPointerUp` で解放）
+  - [ ] 変更のたび `onChange(joinSlots(size, positions))` で親へ `NormalizedSlotRect[]` を返す
+  - [ ] コンテナの実描画幅は `ref` + `getBoundingClientRect()` で取得しピクセル換算に使用
+  - [ ] 比率ロック(正方形維持) ON/OFF トグル、共有サイズ(w/h %)と各枠位置(x/y %)の数値表示
+
+### Phase 3: フォーム配線と保存
+目的: アップロード実寸の取り込み・エディタ表示・PATCH body 拡張。
+ビルド確認: edit 画面で枠を動かして更新 → 再読込で保持。
+
+- [ ] `FormState`(29–58) に `mountSlots` / `mountTemplateWidth` / `mountTemplateHeight` を追加
+- [ ] `toFormState`(72–107) で `initial?.mountSlots ?? null` 等を初期化
+- [ ] `handleTemplateUpload`(177–206) のレスポンス型に `width?/height?` を足し、成功時に
+      `update("mountTemplateWidth", ...)` / `update("mountTemplateHeight", ...)` を実行
+- [ ] コレクション fieldset（台紙 `<img>` プレビュー 876–883 の直後）に:
+  - [ ] グリッド数選択(既存 `mountLayout` select)変更時に「枠を seed し直す」導線
+        （`seedSlotsForLayout` + `completionThreshold` を枠数へ同期）
+  - [ ] `mountTemplatePath` と dims が揃った時のみ `<MountSlotEditor>` を描画。
+        未アップロード時は従来の grid 選択にフォールバック（後方互換）
+- [ ] `handleSubmit` body（create 220–252 / edit 253–284 の両方）に追加:
+  - [ ] `mount_slots: form.mountSlots`（未編集 = null のまま送らない or null 送出で従来動作）
+  - [ ] `mount_template_width: form.mountTemplateWidth`
+  - [ ] `mount_template_height: form.mountTemplateHeight`
+  - [ ] `completion_threshold` を `mountSlots` があれば枠数に同期
+- [ ] 送信前バリデーション: `mountSlots` があり `mountSlots.length !== completionThreshold`
+      なら `setError(...)` して中断（API 検証の先回り・UX 向上）
+
+### Phase 4: 合成プレビュー（ADR-002）
+目的: 枠にサンプル画像を cover で重ねた見えを即時表示。
+ビルド確認: ドラッグに追従してプレビューが動く。
+
+- [ ] エディタ内 or 隣接に「プレビュー」トグル。各枠に固定サンプル画像（または現在のキャラ画像）を
+      `object-fit:cover` + `overflow:hidden` で配置、`composeMount` と同じ正規化矩形で % 配置
+- [ ] 空データ/未アップロード時はプレビューを出さない
+
+### Phase 5: テストと仕上げ
+目的: 幾何ヘルパのユニットテスト・回帰確認。
+ビルド確認: lint / typecheck / test / build すべて緑。
+
+- [ ] `tests/unit/features/collections/slot-edit-geometry.test.ts`（新規）
+- [ ] 既存 `mount-layouts.test.ts` / `collection-settings-payload.test.ts` の無回帰確認
+- [ ] 既存 admin フォーム（コレクション以外）の無回帰目視
+- [ ] 4 検証コマンドを通す
+
+---
+
+## 修正対象ファイル一覧
+
+| ファイル | 操作 | 変更内容 |
+|----------|------|----------|
+| features/collections/lib/slot-edit-geometry.ts | 新規 | move/resize/clamp/ratio-lock/seed 純関数 |
+| features/preset-categories/components/MountSlotEditor.tsx | 新規 | 枠ドラッグ/リサイズ/プレビュー Component |
+| features/preset-categories/components/AdminPresetCategoryFormClient.tsx | 修正 | FormState/toFormState 拡張、アップロード実寸取込、エディタ配線、submit body 拡張、送信前検証 |
+| tests/unit/features/collections/slot-edit-geometry.test.ts | 新規 | 幾何ヘルパのユニットテスト |
+| app/api/admin/preset-categories/collection-settings-payload.ts | 変更なし | Phase 1 で mount_slots/dims/任意N を受理済み |
+| app/api/admin/preset-categories/route.ts, [id]/route.ts | 変更なし | Phase 1 で配線済み |
+| features/style-presets/lib/preset-category-repository.ts | 変更なし | mountSlots/dims 配線済み |
+| supabase/migrations/* | 変更なし | DB 変更なし |
+| messages/ja.ts, en.ts ほか | 変更なし | admin フォームは日本語リテラル運用（i18n 追加不要） |
+
+---
+
+## 品質・テスト観点
+
+### 品質チェックリスト
+- [ ] **エラーハンドリング**: アップロード失敗時の既存挙動を壊さない。送信前に枠数⁄N 不一致を検出
+- [ ] **権限制御**: API は `requireAdmin`、ページは layout ガード（既存・変更なし）
+- [ ] **データ整合性**: 保存は 0..1 正規化 + `SLOT_EPS` 内。`threshold === slots.length` を UI/API 二重で担保
+- [ ] **後方互換**: 枠未編集なら `mount_slots` は NULL のまま、神コレ等は不変
+- [ ] **i18n**: admin 専用日本語リテラル運用に一致（追加なし）
+
+### テスト観点
+| カテゴリ | テスト内容 |
+|----------|-----------|
+| 正常系 | move はその枠のみ移動、resize は共有サイズ変更で全枠が同サイズに連動。比率ロックで正方形維持（非正方形台紙でも） |
+| 境界 | `maxUniformSizeWithin` が全枠を 0..1 に収める最大共有サイズへクランプ、最小サイズ下限、x+w/y+h が 1 を超えない |
+| 連動 | `splitSlots`/`joinSlots` の往復が同値、リサイズ後に全枠の w,h が一致 |
+| 異常系 | 枠数 ≠ N で送信ブロック、台紙未アップロードでエディタ無効 |
+| 無回帰 | grid_3/4/6 の seed が `MOUNT_LAYOUTS` と一致、既存 mount-layouts テスト緑 |
+| 実機 | edit 画面で枠移動 → 更新 → 再読込で保持、本番台紙生成で合成確認 |
+
+recharts 等を含まない純関数中心のため、RTL ではなく **幾何ヘルパのユニットテスト** に注力
+（リポジトリの既存カバレッジ方針＝純関数優先に一致）。
+
+---
+
+## 検証（順番に全てパス）
+
+```
+npm run lint
+npm run typecheck
+npm run test
+npm run build -- --webpack
+```
+
+`--webpack` 必須（`codex-webpack-build` スキル: サンドボックスで Turbopack ビルドが stall しうる）。
+
+手動E2E（任意・dev サーバ）: コレクション設定 ON → 台紙PNGアップロード → 枠エディタ表示 →
+グリッド数で seed → ドラッグ移動/四隅リサイズ（比率ロック ON で正方形維持を確認）→ プレビュー追従 →
+更新 → 再読込で枠保持 → 既存の神コレ(mount_slots=NULL)が無回帰。
+
+---
+
+## リスク / ロールバック
+
+低〜中。DB/API/repository は不変（Phase 1 完了済み）で、変更は admin フォーム + 新規 2 ファイルに
+閉じる。最大の不確実性はポインタ算術（クランプ/比率ロック）だが純関数化してテストで担保する。
+
+- **Git**: フェーズごとにコミットし revert 可能に。
+- **部分ロールバック**: `MountSlotEditor` を非表示にすれば従来の grid 選択にフォールバックする
+  （`mountTemplatePath` と dims が揃った時のみ描画する条件分岐で制御）。
+- **機能フラグ不要**: admin 限定・追加的。必要なら描画条件 1 行のコメントアウトで無効化できる。
+
+> 注: グローバル gitignore が `*.md` を無視するため、本計画書のコミットには `git add -f` が必要
+> （[[global-gitignore-md-files]]）。**ただし本計画はユーザー承認まではコミットしない。**
+
+---
+
+## 使用スキル
+
+| スキル | 用途 | フェーズ |
+|--------|------|----------|
+| `/test-generate` | 幾何ヘルパのテスト生成 | Phase 5 |
+| `/git-create-branch` 相当 | （本ブランチ継続 or 新規） | 実装開始時 |
+| `/git-create-pr` | PR 作成 | 実装完了時 |
+| `/resolve-gemini-review` | Gemini/Codecov 対応 | PR 後 |

--- a/features/collections/components/CollectionMountComposer.tsx
+++ b/features/collections/components/CollectionMountComposer.tsx
@@ -31,6 +31,8 @@ export interface MountGeneratedResult {
   mountImageUrl: string;
   sharePath: string | null;
   completionId: string | null;
+  mountTemplateWidth: number | null;
+  mountTemplateHeight: number | null;
 }
 
 interface Props {
@@ -74,6 +76,8 @@ export function CollectionMountComposer({
           status?: string;
           mountImageUrl?: string;
           sharePath?: string;
+          mountTemplateWidth?: number | null;
+          mountTemplateHeight?: number | null;
           error?: string;
         };
         if (res.ok && data.status === "completed" && data.mountImageUrl) {
@@ -84,6 +88,8 @@ export function CollectionMountComposer({
             completionId: data.sharePath
               ? data.sharePath.replace("/m/", "")
               : null,
+            mountTemplateWidth: data.mountTemplateWidth ?? null,
+            mountTemplateHeight: data.mountTemplateHeight ?? null,
           });
           return;
         }

--- a/features/collections/components/CollectionProgressModal.tsx
+++ b/features/collections/components/CollectionProgressModal.tsx
@@ -29,6 +29,9 @@ export interface CollectionCelebration {
   threshold: number;
   isCompleted: boolean;
   mountImageUrl: string | null;
+  /** 台紙テンプレ実寸(px)。表示アスペクト算出用。無ければ null(従来表にフォールバック) */
+  mountTemplateWidth?: number | null;
+  mountTemplateHeight?: number | null;
   sharePath: string | null;
   /** 公開ページ token(= collection_completions.id)。シェアに使う */
   completionId: string | null;
@@ -499,7 +502,13 @@ export function CollectionProgressModal({
               />
               <div
                 className="relative overflow-hidden rounded-2xl border border-amber-100 shadow-[0_6px_18px_rgba(120,90,50,0.18)]"
-                style={{ aspectRatio: mountAspectForCategory(celebration.categoryKey) }}
+                style={{
+                  aspectRatio: mountAspectForCategory(
+                    celebration.categoryKey,
+                    celebration.mountTemplateWidth,
+                    celebration.mountTemplateHeight,
+                  ),
+                }}
               >
                 <Image
                   src={mountImageUrl ?? ""}

--- a/features/collections/hooks/useCollectionProgress.ts
+++ b/features/collections/hooks/useCollectionProgress.ts
@@ -129,6 +129,8 @@ export function useCollectionProgress() {
                 ? `/m/${target.completionId}`
                 : null,
             completionId: completed ? target.completionId : null,
+            mountTemplateWidth: target.mountTemplateWidth,
+            mountTemplateHeight: target.mountTemplateHeight,
             characterImageUrl: target.characterImageUrl,
             collectedImageUrls: (target.collectedImageUrls ?? []).slice(
               0,
@@ -164,6 +166,8 @@ export function useCollectionProgress() {
           // マイページの完了サムネタップ(openMountModal)と同じ挙動に揃える。
           sharePath: series.completionId ? `/m/${series.completionId}` : null,
           completionId: series.completionId,
+          mountTemplateWidth: series.mountTemplateWidth,
+          mountTemplateHeight: series.mountTemplateHeight,
           characterImageUrl: series.characterImageUrl,
           collectedImageUrls: series.collectedImageUrls ?? [],
           // フィードの自動コンプリート祝いはダイヤのきらめき演出にする。
@@ -240,6 +244,8 @@ export function useCollectionProgress() {
       mountImageUrl: result.mountImageUrl,
       sharePath: result.sharePath,
       completionId: result.completionId,
+      mountTemplateWidth: result.mountTemplateWidth,
+      mountTemplateHeight: result.mountTemplateHeight,
       characterImageUrl: target?.characterImageUrl ?? null,
       collectedImageUrls: [],
     });

--- a/features/collections/lib/collection-progress-repository.ts
+++ b/features/collections/lib/collection-progress-repository.ts
@@ -65,6 +65,8 @@ function mapProgressRow(row: CollectionProgressRow): CollectionProgress {
     characterImageUrl: null,
     collectedImageUrls: [],
     completionId: null,
+    mountTemplateWidth: null,
+    mountTemplateHeight: null,
   };
 }
 
@@ -143,23 +145,35 @@ async function attachCharacterImages(
   const categoryIds = items.map((i) => i.categoryId);
   const { data, error } = await supabase
     .from("preset_categories")
-    .select("id, collection_character_path")
+    .select(
+      "id, collection_character_path, mount_template_width, mount_template_height",
+    )
     .in("id", categoryIds);
   if (error) {
     // キャラ画像の付与失敗は致命ではない(リングはテキスト表示にフォールバック)
     return items;
   }
   const pathById = new Map<string, string | null>();
+  const dimsById = new Map<
+    string,
+    { width: number | null; height: number | null }
+  >();
   for (const row of data ?? []) {
     pathById.set(
       row.id as string,
       (row.collection_character_path as string | null) ?? null,
     );
+    dimsById.set(row.id as string, {
+      width: (row.mount_template_width as number | null) ?? null,
+      height: (row.mount_template_height as number | null) ?? null,
+    });
   }
   return items.map((i) => ({
     ...i,
     characterImageUrl: buildPublicGeneratedImageUrl(
       pathById.get(i.categoryId) ?? null,
     ),
+    mountTemplateWidth: dimsById.get(i.categoryId)?.width ?? null,
+    mountTemplateHeight: dimsById.get(i.categoryId)?.height ?? null,
   }));
 }

--- a/features/collections/lib/collection-types.ts
+++ b/features/collections/lib/collection-types.ts
@@ -23,6 +23,9 @@ export interface CollectionProgress {
    * フィード側の完了モーダルでシェア導線(台紙シェア/シェアページ)を出すのに使う。
    */
   completionId: string | null;
+  /** 台紙テンプレ実寸(px)。完了モーダルの表示アスペクト算出用。無ければ null */
+  mountTemplateWidth: number | null;
+  mountTemplateHeight: number | null;
 }
 
 /** RPC の生レスポンス行(snake_case) */

--- a/features/collections/lib/mount-aspects.ts
+++ b/features/collections/lib/mount-aspects.ts
@@ -14,6 +14,24 @@ const MOUNT_ASPECTS: Record<string, string> = {
   collectible_wafer_sticker_god_6p: "1024 / 1608",
 };
 
-export function mountAspectForCategory(categoryKey: string): string {
+/**
+ * 台紙の表示アスペクト比(CSS aspect-ratio 文字列)を返す。
+ * 1. DB に保存された台紙テンプレ実寸(width/height)があればそれを最優先で使う
+ *    (運営が任意サイズの台紙をアップロードしてもクロップされない)。
+ * 2. 無ければカテゴリ別のハードコード表 → 既定値にフォールバック(後方互換)。
+ */
+export function mountAspectForCategory(
+  categoryKey: string,
+  width?: number | null,
+  height?: number | null,
+): string {
+  if (
+    typeof width === "number" &&
+    typeof height === "number" &&
+    width > 0 &&
+    height > 0
+  ) {
+    return `${width} / ${height}`;
+  }
   return MOUNT_ASPECTS[categoryKey] ?? DEFAULT_MOUNT_ASPECT;
 }

--- a/features/collections/lib/public-mount-server-api.ts
+++ b/features/collections/lib/public-mount-server-api.ts
@@ -22,6 +22,9 @@ export interface PublicMount {
   displayNameEn: string;
   mountImageUrl: string;
   completedAt: string | null;
+  /** 台紙テンプレ実寸(px)。表示アスペクト算出用。無ければ null */
+  mountTemplateWidth: number | null;
+  mountTemplateHeight: number | null;
 }
 
 /**
@@ -39,7 +42,7 @@ export async function getPublicMountByToken(
   const { data, error } = await supabase
     .from("collection_completions")
     .select(
-      "id, user_id, category_key, mount_image_path, completed_at, preset_categories(display_name_ja, display_name_en)",
+      "id, user_id, category_key, mount_image_path, completed_at, preset_categories(display_name_ja, display_name_en, mount_template_width, mount_template_height)",
     )
     .eq("id", token)
     .eq("mount_status", "completed")
@@ -61,6 +64,8 @@ export async function getPublicMountByToken(
   const catRecord = (cat ?? {}) as {
     display_name_ja?: string;
     display_name_en?: string;
+    mount_template_width?: number | null;
+    mount_template_height?: number | null;
   };
 
   return {
@@ -71,5 +76,7 @@ export async function getPublicMountByToken(
     displayNameEn: catRecord.display_name_en ?? "",
     mountImageUrl,
     completedAt: (data.completed_at as string | null) ?? null,
+    mountTemplateWidth: catRecord.mount_template_width ?? null,
+    mountTemplateHeight: catRecord.mount_template_height ?? null,
   };
 }

--- a/features/collections/lib/slot-edit-geometry.ts
+++ b/features/collections/lib/slot-edit-geometry.ts
@@ -170,6 +170,34 @@ export function resizeShared(
   return { size: { w, h }, positions: newPositions };
 }
 
+/**
+ * 枠の数を targetCount に合わせる(共有サイズは維持)。
+ * - 減らす場合: 末尾の枠を削除
+ * - 増やす場合: 既存枠はそのまま、足りない分をデフォルト位置(少しずつずらした左上)に追加
+ * 既存枠の位置・サイズは保持する。
+ */
+export function setSlotCount(
+  state: EditorSlots,
+  targetCount: number,
+): EditorSlots {
+  const { size, positions } = state;
+  if (targetCount <= 0) {
+    return { size, positions: [] };
+  }
+  if (targetCount === positions.length) {
+    return state;
+  }
+  if (targetCount < positions.length) {
+    return { size, positions: positions.slice(0, targetCount) };
+  }
+  const next = positions.map((p) => ({ ...p }));
+  for (let k = positions.length; k < targetCount; k++) {
+    const offset = 0.04 * (k - positions.length + 1);
+    next.push(clampPosition({ x: 0.1 + offset, y: 0.1 + offset }, size));
+  }
+  return { size, positions: next };
+}
+
 /** 横方向の整列 */
 export type HAlign = "left" | "center" | "right";
 /** 縦方向の整列 */

--- a/features/collections/lib/slot-edit-geometry.ts
+++ b/features/collections/lib/slot-edit-geometry.ts
@@ -46,11 +46,35 @@ export interface ResizeOptions {
   templateHeight: number;
   /** 1枠の最小辺(px) */
   minPx: number;
+  /** true なら全枠が 0..1 に収まるよう上限クランプ。false なら台紙外も許可(確定時に判定) */
+  bounded: boolean;
 }
+
+/** 枠が台紙(0..1)からはみ出している判定の許容誤差。API の SLOT_EPS と一致させる。 */
+export const BOUNDS_EPS = 1e-6;
 
 function clamp(value: number, min: number, max: number): number {
   if (max < min) return min;
   return Math.min(Math.max(value, min), max);
+}
+
+/** 台紙(0..1)からはみ出している枠のインデックス一覧を返す。 */
+export function outOfBoundsIndices(
+  slots: NormalizedSlotRect[],
+  eps: number = BOUNDS_EPS,
+): number[] {
+  const result: number[] = [];
+  slots.forEach((s, i) => {
+    if (
+      s.x < -eps ||
+      s.y < -eps ||
+      s.x + s.w > 1 + eps ||
+      s.y + s.h > 1 + eps
+    ) {
+      result.push(i);
+    }
+  });
+  return result;
 }
 
 /**
@@ -93,14 +117,19 @@ export function clampPosition(pos: Point, size: Size): Point {
   };
 }
 
-/** その枠だけを移動する(共有サイズは不変)。台紙内にクランプ。 */
+/**
+ * その枠だけを移動する(共有サイズは不変)。
+ * bounded=true なら台紙内にクランプ、false なら台紙外も許可(確定時に判定)。
+ */
 export function movePosition(
   pos: Point,
   size: Size,
   dxNorm: number,
   dyNorm: number,
+  bounded: boolean = true,
 ): Point {
-  return clampPosition({ x: pos.x + dxNorm, y: pos.y + dyNorm }, size);
+  const moved = { x: pos.x + dxNorm, y: pos.y + dyNorm };
+  return bounded ? clampPosition(moved, size) : moved;
 }
 
 /** snapPosition の結果。x/y は吸着後の左上、guideX/Y は表示するガイド線(正規化, 無ければ null)。 */
@@ -209,14 +238,19 @@ export function resizeShared(
   // 各枠でアンカー(対角)を固定したまま 0..1 に収まる最大サイズ。
   // 西アンカー(右辺固定): 左辺が 0 まで → maxW = 右辺座標(x+w)
   // 東アンカー(左辺固定): 右辺が 1 まで → maxW = 1 - x
-  let maxW = 1;
-  let maxH = 1;
-  for (const p of positions) {
-    maxW = Math.min(maxW, isWest ? p.x + size.w : 1 - p.x);
-    maxH = Math.min(maxH, isNorth ? p.y + size.h : 1 - p.y);
+  // bounded=false のときは上限なし(台紙外まで許可・確定時に判定)。
+  let maxW = Number.POSITIVE_INFINITY;
+  let maxH = Number.POSITIVE_INFINITY;
+  if (opts.bounded) {
+    maxW = 1;
+    maxH = 1;
+    for (const p of positions) {
+      maxW = Math.min(maxW, isWest ? p.x + size.w : 1 - p.x);
+      maxH = Math.min(maxH, isNorth ? p.y + size.h : 1 - p.y);
+    }
+    maxW = Math.max(maxW, 0);
+    maxH = Math.max(maxH, 0);
   }
-  maxW = Math.max(maxW, 0);
-  maxH = Math.max(maxH, 0);
 
   let w: number;
   let h: number;

--- a/features/collections/lib/slot-edit-geometry.ts
+++ b/features/collections/lib/slot-edit-geometry.ts
@@ -118,6 +118,18 @@ export function clampPosition(pos: Point, size: Size): Point {
 }
 
 /**
+ * 移動の上限を「枠が台紙から完全に離れる位置まで」に緩くクランプする。
+ * 近い辺が台紙の反対側の辺に達するまで動かせる(=完全に外へ出せるが無限には飛ばない)。
+ * x: -w(右辺が台紙左端0)〜1(左辺が台紙右端1) / y: -h〜1。
+ */
+export function clampPositionLoose(pos: Point, size: Size): Point {
+  return {
+    x: clamp(pos.x, -size.w, 1),
+    y: clamp(pos.y, -size.h, 1),
+  };
+}
+
+/**
  * その枠だけを移動する(共有サイズは不変)。
  * bounded=true なら台紙内にクランプ、false なら台紙外も許可(確定時に判定)。
  */

--- a/features/collections/lib/slot-edit-geometry.ts
+++ b/features/collections/lib/slot-edit-geometry.ts
@@ -1,0 +1,240 @@
+/**
+ * 台紙スロット(枠)エディタの幾何計算(純関数)。
+ *
+ * 編集モデル(運営確定仕様):
+ * - サイズは全枠で共有(`size:{w,h}`)。どれか1枠をリサイズすると全枠が同じサイズに連動。
+ * - 位置は枠ごと自由(`positions:{x,y}[]`、各枠の左上)。移動はその枠だけ動く。
+ *
+ * 座標はすべて正規化(0..1)。リサイズ時の「正方形維持(比率ロック)」だけは台紙実寸
+ * (templateWidth/Height)を使ってピクセル空間でのアスペクトを保つ。
+ *
+ * 保存形式は従来どおり NormalizedSlotRect[]([{x,y,w,h}])。本モジュールの
+ * split/join で「共有サイズ+位置配列」と相互変換する(ADR-004)。
+ * UI から切り離した純関数なのでユニットテスト可能。
+ */
+
+import {
+  MOUNT_LAYOUTS,
+  type MountLayoutKey,
+  type NormalizedSlotRect,
+} from "@/features/collections/lib/mount-layouts";
+
+export interface Size {
+  w: number;
+  h: number;
+}
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+/** 四隅ハンドルの識別子(n=上, s=下, w=左, e=右) */
+export type Corner = "nw" | "ne" | "sw" | "se";
+
+/** エディタ内部状態: 共有サイズ + 枠ごとの左上位置 */
+export interface EditorSlots {
+  size: Size;
+  positions: Point[];
+}
+
+export interface ResizeOptions {
+  /** 比率ロック(正方形維持): ピクセル空間で現在のアスペクトを保つ */
+  lockRatio: boolean;
+  /** 台紙テンプレ実寸(px)。ピクセル換算・最小サイズ・比率ロックに使用 */
+  templateWidth: number;
+  templateHeight: number;
+  /** 1枠の最小辺(px) */
+  minPx: number;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (max < min) return min;
+  return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * NormalizedSlotRect[] を「共有サイズ + 位置配列」へ分解する。
+ * 共有サイズは先頭枠の w,h を採用(全枠同サイズ前提。差異があれば先頭に揃う)。
+ * 空配列なら size は 0、positions も空。
+ */
+export function splitSlots(slots: NormalizedSlotRect[]): EditorSlots {
+  if (slots.length === 0) {
+    return { size: { w: 0, h: 0 }, positions: [] };
+  }
+  const first = slots[0];
+  return {
+    size: { w: first.w, h: first.h },
+    positions: slots.map((s) => ({ x: s.x, y: s.y })),
+  };
+}
+
+/** 「共有サイズ + 位置配列」を NormalizedSlotRect[] へ合成する(保存形式) */
+export function joinSlots(state: EditorSlots): NormalizedSlotRect[] {
+  return state.positions.map((p) => ({
+    x: p.x,
+    y: p.y,
+    w: state.size.w,
+    h: state.size.h,
+  }));
+}
+
+/** グリッドレイアウトから初期枠を seed する(N 変更時の再 seed 用) */
+export function seedSlots(layout: MountLayoutKey): NormalizedSlotRect[] {
+  // 参照を共有しないようコピーを返す
+  return MOUNT_LAYOUTS[layout].map((s) => ({ ...s }));
+}
+
+/** 1枠の左上位置を 0..1 内(右端/下端が共有サイズ分はみ出さない範囲)へクランプ */
+export function clampPosition(pos: Point, size: Size): Point {
+  return {
+    x: clamp(pos.x, 0, 1 - size.w),
+    y: clamp(pos.y, 0, 1 - size.h),
+  };
+}
+
+/** その枠だけを移動する(共有サイズは不変)。台紙内にクランプ。 */
+export function movePosition(
+  pos: Point,
+  size: Size,
+  dxNorm: number,
+  dyNorm: number,
+): Point {
+  return clampPosition({ x: pos.x + dxNorm, y: pos.y + dyNorm }, size);
+}
+
+/**
+ * いずれかの枠の四隅ハンドルをドラッグして「共有サイズ」を変更する。
+ * 対角固定: ドラッグした角の **対角を固定** したまま新サイズへ全枠が連動する
+ * (例: 左上を引くと各枠の右下が固定されたままサイズが変わる)。
+ * 比率ロック時はピクセル空間のアスペクトを維持。各枠はアンカー(対角)を固定したまま
+ * 0..1 に収まる最大サイズへクランプする。
+ */
+export function resizeShared(
+  state: EditorSlots,
+  corner: Corner,
+  dxNorm: number,
+  dyNorm: number,
+  opts: ResizeOptions,
+): EditorSlots {
+  const { size, positions } = state;
+  // 動く辺の符号(東=右辺が動く/西=左辺が動く, 南=下辺が動く/北=上辺が動く)
+  const sx = corner === "ne" || corner === "se" ? 1 : -1;
+  const sy = corner === "sw" || corner === "se" ? 1 : -1;
+  // 西(左上/左下)は左辺が動く=右辺がアンカー。北(左上/右上)は上辺が動く=下辺がアンカー。
+  const isWest = corner === "nw" || corner === "sw";
+  const isNorth = corner === "nw" || corner === "ne";
+
+  let desiredW = size.w + sx * dxNorm;
+  const desiredH = size.h + sy * dyNorm;
+
+  const minW = opts.minPx / opts.templateWidth;
+  const minH = opts.minPx / opts.templateHeight;
+
+  // 各枠でアンカー(対角)を固定したまま 0..1 に収まる最大サイズ。
+  // 西アンカー(右辺固定): 左辺が 0 まで → maxW = 右辺座標(x+w)
+  // 東アンカー(左辺固定): 右辺が 1 まで → maxW = 1 - x
+  let maxW = 1;
+  let maxH = 1;
+  for (const p of positions) {
+    maxW = Math.min(maxW, isWest ? p.x + size.w : 1 - p.x);
+    maxH = Math.min(maxH, isNorth ? p.y + size.h : 1 - p.y);
+  }
+  maxW = Math.max(maxW, 0);
+  maxH = Math.max(maxH, 0);
+
+  let w: number;
+  let h: number;
+  if (opts.lockRatio) {
+    // 現在のアスペクト(h/w)を保つ。ポインタ移動の大きい軸を主軸にする。
+    const ratio = size.w > 0 ? size.h / size.w : 1;
+    if (Math.abs(dyNorm) > Math.abs(dxNorm)) {
+      desiredW = ratio > 0 ? desiredH / ratio : desiredW;
+    }
+    const lowW = Math.max(minW, minH / (ratio || 1));
+    const highW = Math.min(maxW, ratio > 0 ? maxH / ratio : maxW);
+    w = clamp(desiredW, lowW, highW);
+    h = w * ratio;
+  } else {
+    w = clamp(desiredW, minW, maxW);
+    h = clamp(desiredH, minH, maxH);
+  }
+
+  // 各枠はアンカー(対角)を固定したまま新サイズへ。
+  // 西アンカーなら右辺(x+size.w)を保つ → x = (x+size.w) - w
+  // 北アンカーなら下辺(y+size.h)を保つ → y = (y+size.h) - h
+  const newPositions = positions.map((p) => ({
+    x: isWest ? p.x + size.w - w : p.x,
+    y: isNorth ? p.y + size.h - h : p.y,
+  }));
+  return { size: { w, h }, positions: newPositions };
+}
+
+/** 共有サイズのピクセル比 (w_px / h_px) を返す。生成側の比率(3:4 等)と同じ尺度。 */
+export function pixelAspectRatio(
+  size: Size,
+  templateWidth: number,
+  templateHeight: number,
+): number {
+  const wPx = size.w * templateWidth;
+  const hPx = size.h * templateHeight;
+  return hPx > 0 ? wPx / hPx : 1;
+}
+
+/**
+ * 共有サイズを指定の **ピクセル比(ratioPx = w_px / h_px)** にそろえる。
+ * 例: ratioPx = 3/4 で枠を 3:4(縦長) に。生成の GEMINI_SUPPORTED_ASPECT_RATIOS と
+ * 同じ尺度。各枠は左上(位置)を保ったまま幅基準で高さを決め、はみ出す場合は比率を
+ * 保ったまま全枠が 0..1 に収まる最大サイズへ縮める。最小サイズも比率を保って適用。
+ */
+export function applyAspect(
+  state: EditorSlots,
+  ratioPx: number,
+  templateWidth: number,
+  templateHeight: number,
+  minPx: number,
+): EditorSlots {
+  const { size, positions } = state;
+  if (positions.length === 0 || ratioPx <= 0) {
+    return state;
+  }
+  // 左上固定で各枠が収まる上限(幅/高さ)
+  let maxW = 1;
+  let maxH = 1;
+  for (const p of positions) {
+    maxW = Math.min(maxW, 1 - p.x);
+    maxH = Math.min(maxH, 1 - p.y);
+  }
+  const minW = minPx / templateWidth;
+  const minH = minPx / templateHeight;
+
+  // ピクセル比 R = (w*tW)/(h*tH) より h = w*tW/(R*tH), w = h*R*tH/tW
+  const hFromW = (w: number) => (w * templateWidth) / (ratioPx * templateHeight);
+  const wFromH = (h: number) => (h * ratioPx * templateHeight) / templateWidth;
+
+  // 現在の幅を起点に、比率を保ったまま max/min に収める
+  let w = size.w;
+  let h = hFromW(w);
+  if (h > maxH) {
+    h = maxH;
+    w = wFromH(h);
+  }
+  if (w > maxW) {
+    w = maxW;
+    h = hFromW(w);
+  }
+  if (w < minW) {
+    w = minW;
+    h = hFromW(w);
+  }
+  if (h < minH) {
+    h = minH;
+    w = wFromH(h);
+  }
+  // 最小が最大を超える極端なケースの安全クランプ(比率は崩れうる)
+  w = Math.min(w, maxW);
+  h = Math.min(h, maxH);
+
+  // 左上は保持(位置不変)
+  return { size: { w, h }, positions: positions.map((p) => ({ ...p })) };
+}

--- a/features/collections/lib/slot-edit-geometry.ts
+++ b/features/collections/lib/slot-edit-geometry.ts
@@ -170,6 +170,66 @@ export function resizeShared(
   return { size: { w, h }, positions: newPositions };
 }
 
+/** 横方向の整列 */
+export type HAlign = "left" | "center" | "right";
+/** 縦方向の整列 */
+export type VAlign = "top" | "middle" | "bottom";
+
+/**
+ * 全枠の「辺」をそろえる(デザインツールの整列と同じ)。グループ全体を動かすのではなく、
+ * 各枠の端を枠群の端にそろえる。全枠は同サイズなので結果は重なる(例: 左寄せ=全枠が同じ
+ * 左端の縦並びになる)。
+ * - 横: left=一番左の枠の左端, right=一番右の枠の右端, center=枠群の水平中央
+ * - 縦: top=一番上の枠の上端, bottom=一番下の枠の下端, middle=枠群の垂直中央
+ * hAlign / vAlign を null にするとその軸は動かさない(片軸だけの整列が可能)。
+ */
+export function alignGroup(
+  state: EditorSlots,
+  hAlign: HAlign | null,
+  vAlign: VAlign | null,
+): EditorSlots {
+  const { size, positions } = state;
+  if (positions.length === 0) {
+    return state;
+  }
+  let minX = Number.POSITIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let maxX = Number.NEGATIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+  for (const p of positions) {
+    minX = Math.min(minX, p.x);
+    minY = Math.min(minY, p.y);
+    maxX = Math.max(maxX, p.x);
+    maxY = Math.max(maxY, p.y);
+  }
+  // 全枠同サイズなので右端そろえ=最大x、中央そろえ=左端の中点に揃う
+  const centerX = (minX + maxX) / 2;
+  const centerY = (minY + maxY) / 2;
+
+  const targetX = (): number | null => {
+    if (hAlign === "left") return minX;
+    if (hAlign === "right") return maxX;
+    if (hAlign === "center") return centerX;
+    return null;
+  };
+  const targetY = (): number | null => {
+    if (vAlign === "top") return minY;
+    if (vAlign === "bottom") return maxY;
+    if (vAlign === "middle") return centerY;
+    return null;
+  };
+  const tx = targetX();
+  const ty = targetY();
+
+  return {
+    size,
+    positions: positions.map((p) => ({
+      x: tx === null ? p.x : tx,
+      y: ty === null ? p.y : ty,
+    })),
+  };
+}
+
 /** 共有サイズのピクセル比 (w_px / h_px) を返す。生成側の比率(3:4 等)と同じ尺度。 */
 export function pixelAspectRatio(
   size: Size,

--- a/features/collections/lib/slot-edit-geometry.ts
+++ b/features/collections/lib/slot-edit-geometry.ts
@@ -277,20 +277,26 @@ export type DistributeAxis = "horizontal" | "vertical";
 /**
  * 枠を等間隔に分布する(デザインツールの「分布」と同じ)。
  * 指定軸の両端の枠は動かさず、間の枠を等間隔に並べ直す。全枠同サイズなので
- * 位置(左端/上端)を等間隔にすれば枠間のすき間も均等になる。枠が2つ以下なら何もしない。
+ * 位置(左端/上端)を等間隔にすれば枠間のすき間も均等になる。対象が3つ未満なら何もしない。
+ * indices を渡すとその枠だけを対象に分布する(複数選択での部分分布)。省略時は全枠。
  */
 export function distributeEvenly(
   state: EditorSlots,
   axis: DistributeAxis,
+  indices?: number[],
 ): EditorSlots {
   const { size, positions } = state;
-  const n = positions.length;
+  const targetIdx =
+    indices && indices.length > 0 ? indices : positions.map((_, i) => i);
+  const n = targetIdx.length;
   if (n < 3) {
     return state;
   }
   const key: keyof Point = axis === "horizontal" ? "x" : "y";
-  // 指定軸の値でソートした順序(元のインデックスを保持)
-  const order = positions.map((_, i) => i).sort((a, b) => positions[a][key] - positions[b][key]);
+  // 対象枠を指定軸の値でソート(元のインデックスを保持)
+  const order = targetIdx
+    .slice()
+    .sort((a, b) => positions[a][key] - positions[b][key]);
   const lo = positions[order[0]][key];
   const hi = positions[order[n - 1]][key];
   const step = (hi - lo) / (n - 1);

--- a/features/collections/lib/slot-edit-geometry.ts
+++ b/features/collections/lib/slot-edit-geometry.ts
@@ -230,6 +230,37 @@ export function alignGroup(
   };
 }
 
+/** 均等配置(分布)の方向 */
+export type DistributeAxis = "horizontal" | "vertical";
+
+/**
+ * 枠を等間隔に分布する(デザインツールの「分布」と同じ)。
+ * 指定軸の両端の枠は動かさず、間の枠を等間隔に並べ直す。全枠同サイズなので
+ * 位置(左端/上端)を等間隔にすれば枠間のすき間も均等になる。枠が2つ以下なら何もしない。
+ */
+export function distributeEvenly(
+  state: EditorSlots,
+  axis: DistributeAxis,
+): EditorSlots {
+  const { size, positions } = state;
+  const n = positions.length;
+  if (n < 3) {
+    return state;
+  }
+  const key: keyof Point = axis === "horizontal" ? "x" : "y";
+  // 指定軸の値でソートした順序(元のインデックスを保持)
+  const order = positions.map((_, i) => i).sort((a, b) => positions[a][key] - positions[b][key]);
+  const lo = positions[order[0]][key];
+  const hi = positions[order[n - 1]][key];
+  const step = (hi - lo) / (n - 1);
+
+  const newPositions = positions.map((p) => ({ ...p }));
+  order.forEach((origIndex, sortedPos) => {
+    newPositions[origIndex][key] = lo + step * sortedPos;
+  });
+  return { size, positions: newPositions };
+}
+
 /** 共有サイズのピクセル比 (w_px / h_px) を返す。生成側の比率(3:4 等)と同じ尺度。 */
 export function pixelAspectRatio(
   size: Size,

--- a/features/collections/lib/slot-edit-geometry.ts
+++ b/features/collections/lib/slot-edit-geometry.ts
@@ -103,6 +103,81 @@ export function movePosition(
   return clampPosition({ x: pos.x + dxNorm, y: pos.y + dyNorm }, size);
 }
 
+/** snapPosition の結果。x/y は吸着後の左上、guideX/Y は表示するガイド線(正規化, 無ければ null)。 */
+export interface SnapResult {
+  x: number;
+  y: number;
+  guideX: number | null;
+  guideY: number | null;
+}
+
+/**
+ * ドラッグ中の枠を他の枠の辺(左/中央/右・上/中央/下)に吸着させる(スマートガイド)。
+ * しきい値(正規化)以内に近づいたら、その辺へ位置を合わせる。x/y は独立に判定する。
+ * 全枠同サイズ前提。閾値は画面px換算した正規化値を渡す。
+ */
+export function snapPosition(
+  pos: Point,
+  size: Size,
+  others: Point[],
+  thresholdX: number,
+  thresholdY: number,
+): SnapResult {
+  // ドラッグ枠の候補辺(左上からのオフセット付き)
+  const draggedX = [
+    { off: 0, v: pos.x },
+    { off: size.w / 2, v: pos.x + size.w / 2 },
+    { off: size.w, v: pos.x + size.w },
+  ];
+  const draggedY = [
+    { off: 0, v: pos.y },
+    { off: size.h / 2, v: pos.y + size.h / 2 },
+    { off: size.h, v: pos.y + size.h },
+  ];
+  const otherX: number[] = [];
+  const otherY: number[] = [];
+  for (const o of others) {
+    otherX.push(o.x, o.x + size.w / 2, o.x + size.w);
+    otherY.push(o.y, o.y + size.h / 2, o.y + size.h);
+  }
+
+  let bestX: number | null = null;
+  let guideX: number | null = null;
+  let bestXDist = thresholdX;
+  for (const d of draggedX) {
+    for (const ov of otherX) {
+      const dist = Math.abs(d.v - ov);
+      // より近いものだけ採用(同距離は先勝ち=左/中央/右の順で intent に近い辺を優先)
+      if (dist < bestXDist) {
+        bestXDist = dist;
+        bestX = ov - d.off;
+        guideX = ov;
+      }
+    }
+  }
+
+  let bestY: number | null = null;
+  let guideY: number | null = null;
+  let bestYDist = thresholdY;
+  for (const d of draggedY) {
+    for (const ov of otherY) {
+      const dist = Math.abs(d.v - ov);
+      if (dist < bestYDist) {
+        bestYDist = dist;
+        bestY = ov - d.off;
+        guideY = ov;
+      }
+    }
+  }
+
+  return {
+    x: bestX ?? pos.x,
+    y: bestY ?? pos.y,
+    guideX,
+    guideY,
+  };
+}
+
 /**
  * いずれかの枠の四隅ハンドルをドラッグして「共有サイズ」を変更する。
  * 対角固定: ドラッグした角の **対角を固定** したまま新サイズへ全枠が連動する

--- a/features/collections/lib/slot-edit-geometry.ts
+++ b/features/collections/lib/slot-edit-geometry.ts
@@ -204,57 +204,70 @@ export type HAlign = "left" | "center" | "right";
 export type VAlign = "top" | "middle" | "bottom";
 
 /**
- * 全枠の「辺」をそろえる(デザインツールの整列と同じ)。グループ全体を動かすのではなく、
- * 各枠の端を枠群の端にそろえる。全枠は同サイズなので結果は重なる(例: 左寄せ=全枠が同じ
+ * 枠の「辺」をそろえる(デザインツールの整列と同じ)。グループ全体を動かすのではなく、
+ * 各枠の端を(対象枠群の)端にそろえる。全枠は同サイズなので結果は重なる(例: 左寄せ=同じ
  * 左端の縦並びになる)。
- * - 横: left=一番左の枠の左端, right=一番右の枠の右端, center=枠群の水平中央
- * - 縦: top=一番上の枠の上端, bottom=一番下の枠の下端, middle=枠群の垂直中央
+ * - 横: left=一番左の左端, right=一番右の右端, center=対象群の水平中央
+ * - 縦: top=一番上の上端, bottom=一番下の下端, middle=対象群の垂直中央
  * hAlign / vAlign を null にするとその軸は動かさない(片軸だけの整列が可能)。
+ * indices を渡すとその枠だけを対象に整列する(複数選択での部分整列)。省略時は全枠。
  */
 export function alignGroup(
   state: EditorSlots,
   hAlign: HAlign | null,
   vAlign: VAlign | null,
+  indices?: number[],
 ): EditorSlots {
   const { size, positions } = state;
   if (positions.length === 0) {
     return state;
   }
+  const targetSet =
+    indices && indices.length > 0
+      ? new Set(indices)
+      : new Set(positions.map((_, i) => i));
+
   let minX = Number.POSITIVE_INFINITY;
   let minY = Number.POSITIVE_INFINITY;
   let maxX = Number.NEGATIVE_INFINITY;
   let maxY = Number.NEGATIVE_INFINITY;
-  for (const p of positions) {
+  positions.forEach((p, i) => {
+    if (!targetSet.has(i)) return;
     minX = Math.min(minX, p.x);
     minY = Math.min(minY, p.y);
     maxX = Math.max(maxX, p.x);
     maxY = Math.max(maxY, p.y);
-  }
+  });
   // 全枠同サイズなので右端そろえ=最大x、中央そろえ=左端の中点に揃う
   const centerX = (minX + maxX) / 2;
   const centerY = (minY + maxY) / 2;
 
-  const targetX = (): number | null => {
-    if (hAlign === "left") return minX;
-    if (hAlign === "right") return maxX;
-    if (hAlign === "center") return centerX;
-    return null;
-  };
-  const targetY = (): number | null => {
-    if (vAlign === "top") return minY;
-    if (vAlign === "bottom") return maxY;
-    if (vAlign === "middle") return centerY;
-    return null;
-  };
-  const tx = targetX();
-  const ty = targetY();
+  const tx =
+    hAlign === "left"
+      ? minX
+      : hAlign === "right"
+        ? maxX
+        : hAlign === "center"
+          ? centerX
+          : null;
+  const ty =
+    vAlign === "top"
+      ? minY
+      : vAlign === "bottom"
+        ? maxY
+        : vAlign === "middle"
+          ? centerY
+          : null;
 
   return {
     size,
-    positions: positions.map((p) => ({
-      x: tx === null ? p.x : tx,
-      y: ty === null ? p.y : ty,
-    })),
+    positions: positions.map((p, i) => {
+      if (!targetSet.has(i)) return p;
+      return {
+        x: tx === null ? p.x : tx,
+        y: ty === null ? p.y : ty,
+      };
+    }),
   };
 }
 

--- a/features/my-page/components/CachedMyPageCollections.tsx
+++ b/features/my-page/components/CachedMyPageCollections.tsx
@@ -19,7 +19,7 @@ export async function CachedMyPageCollections({ userId }: { userId: string }) {
   const { data } = await supabase
     .from("collection_completions")
     .select(
-      "id, category_key, mount_image_path, completed_at, preset_categories(display_name_ja)",
+      "id, category_key, mount_image_path, completed_at, preset_categories(display_name_ja, mount_template_width, mount_template_height)",
     )
     .eq("user_id", userId)
     .eq("mount_status", "completed")
@@ -33,13 +33,19 @@ export async function CachedMyPageCollections({ userId }: { userId: string }) {
       if (!mountImageUrl) return null;
       const cat = (row as { preset_categories?: unknown }).preset_categories;
       const catRecord = (Array.isArray(cat) ? cat[0] : cat) as
-        | { display_name_ja?: string }
+        | {
+            display_name_ja?: string;
+            mount_template_width?: number | null;
+            mount_template_height?: number | null;
+          }
         | undefined;
       return {
         completionId: row.id as string,
         categoryKey: row.category_key as string,
         displayName: catRecord?.display_name_ja ?? "",
         mountImageUrl,
+        mountTemplateWidth: catRecord?.mount_template_width ?? null,
+        mountTemplateHeight: catRecord?.mount_template_height ?? null,
       } satisfies CompletedMountView;
     })
     .filter((m): m is CompletedMountView => m !== null);

--- a/features/my-page/components/MyPageCollections.tsx
+++ b/features/my-page/components/MyPageCollections.tsx
@@ -27,6 +27,8 @@ export interface CompletedMountView {
   categoryKey: string;
   displayName: string;
   mountImageUrl: string;
+  mountTemplateWidth: number | null;
+  mountTemplateHeight: number | null;
 }
 
 /**
@@ -138,6 +140,8 @@ export function MyPageCollections({
         mountImageUrl: result.mountImageUrl,
         sharePath: result.sharePath,
         completionId: result.completionId,
+        mountTemplateWidth: result.mountTemplateWidth,
+        mountTemplateHeight: result.mountTemplateHeight,
         characterImageUrl: null,
         collectedImageUrls: [],
       });
@@ -172,6 +176,8 @@ export function MyPageCollections({
       mountImageUrl: m.mountImageUrl,
       sharePath: `/m/${m.completionId}`,
       completionId: m.completionId,
+      mountTemplateWidth: m.mountTemplateWidth,
+      mountTemplateHeight: m.mountTemplateHeight,
       characterImageUrl: null,
       collectedImageUrls: [],
       canRecompose: cached?.canRecompose ?? false,
@@ -209,6 +215,8 @@ export function MyPageCollections({
       mountImageUrl: null,
       sharePath: null,
       completionId: null,
+      mountTemplateWidth: series.mountTemplateWidth,
+      mountTemplateHeight: series.mountTemplateHeight,
       characterImageUrl: series.characterImageUrl,
       collectedImageUrls: series.collectedImageUrls ?? [],
     });
@@ -239,7 +247,13 @@ export function MyPageCollections({
               type="button"
               onClick={() => openMountModal(m)}
               className="relative w-24 overflow-hidden rounded-md border border-gray-200"
-              style={{ aspectRatio: mountAspectForCategory(m.categoryKey) }}
+              style={{
+                aspectRatio: mountAspectForCategory(
+                  m.categoryKey,
+                  m.mountTemplateWidth,
+                  m.mountTemplateHeight,
+                ),
+              }}
               aria-label={`${m.displayName} の台紙を表示`}
             >
               <Image

--- a/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
+++ b/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
@@ -9,7 +9,12 @@ import {
   isMountLayoutKey,
   type NormalizedSlotRect,
 } from "@/features/collections/lib/mount-layouts";
-import { seedSlots } from "@/features/collections/lib/slot-edit-geometry";
+import {
+  joinSlots,
+  seedSlots,
+  setSlotCount,
+  splitSlots,
+} from "@/features/collections/lib/slot-edit-geometry";
 import { MountSlotEditor } from "@/features/preset-categories/components/MountSlotEditor";
 
 type Mode = "create" | "edit";
@@ -248,6 +253,52 @@ export function AdminPresetCategoryFormClient({
   /** カスタム枠を破棄し、レイアウトのプリセットに戻す。 */
   function handleClearSlots() {
     update("mountSlots", null);
+  }
+
+  /**
+   * 台紙レイアウト変更。既存の枠調整があれば確認のうえ、そのレイアウトで枠を再生成する
+   * (枠数=N も同期)。キャンセル時は選択を元に戻す(form.mountLayout を変えない)。
+   * 調整がまだ無ければ即座に seed して枠エディタを表示する。
+   */
+  function handleLayoutChange(value: FormState["mountLayout"]) {
+    if (value === "") {
+      update("mountLayout", "");
+      return;
+    }
+    const hasCustom = !!form.mountSlots && form.mountSlots.length > 0;
+    if (
+      hasCustom &&
+      !confirm(`現在の枠調整を破棄して ${value} で枠を作り直しますか?`)
+    ) {
+      return; // 選択は据え置き(controlled なので元に戻る)
+    }
+    const seeded = seedSlots(value);
+    setForm((prev) => ({
+      ...prev,
+      mountLayout: value,
+      mountSlots: seeded,
+      completionThreshold: seeded.length,
+    }));
+  }
+
+  /**
+   * コンプリート数 N 変更。カスタム枠があるときは枠の数を N に増減する
+   * (既存枠は保持・増加分はデフォルト位置に追加・減少分は末尾を削除)。
+   * カスタム枠がまだ無ければ数値だけ更新する。
+   */
+  function handleThresholdChange(raw: string) {
+    const n = raw === "" ? null : Math.floor(Number(raw));
+    const hasCustom = !!form.mountSlots && form.mountSlots.length > 0;
+    if (n === null || !Number.isFinite(n) || n < 1 || !hasCustom) {
+      update("completionThreshold", n);
+      return;
+    }
+    const resized = joinSlots(setSlotCount(splitSlots(form.mountSlots!), n));
+    setForm((prev) => ({
+      ...prev,
+      completionThreshold: n,
+      mountSlots: resized,
+    }));
   }
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
@@ -845,12 +896,7 @@ export function AdminPresetCategoryFormClient({
               min={1}
               step={1}
               value={form.completionThreshold ?? ""}
-              onChange={(e) =>
-                update(
-                  "completionThreshold",
-                  e.target.value === "" ? null : Math.floor(Number(e.target.value)),
-                )
-              }
+              onChange={(e) => handleThresholdChange(e.target.value)}
               className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm"
               placeholder="4"
             />
@@ -863,10 +909,7 @@ export function AdminPresetCategoryFormClient({
             <select
               value={form.mountLayout}
               onChange={(e) =>
-                update(
-                  "mountLayout",
-                  e.target.value as FormState["mountLayout"],
-                )
+                handleLayoutChange(e.target.value as FormState["mountLayout"])
               }
               className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm"
             >
@@ -876,7 +919,7 @@ export function AdminPresetCategoryFormClient({
               <option value="grid_6">grid_6（6枠・2×3）</option>
             </select>
             <span className="mt-1 block text-xs text-slate-500">
-              スロット数（=枠数）は N と一致させてください。
+              レイアウトを変えると枠が作り直されます（調整済みなら確認します）。N を変えると枠数も増減します。
             </span>
           </label>
         </div>

--- a/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
+++ b/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
@@ -5,6 +5,12 @@ import { useState, type FormEvent } from "react";
 import type { PresetCategoryAdmin } from "@/features/style-presets/lib/preset-category-repository";
 import { DEFAULT_GENERATION_MODEL } from "@/features/generation/types";
 import { getModelDisplayInfo } from "@/features/generation/lib/model-display";
+import {
+  isMountLayoutKey,
+  type NormalizedSlotRect,
+} from "@/features/collections/lib/mount-layouts";
+import { seedSlots } from "@/features/collections/lib/slot-edit-geometry";
+import { MountSlotEditor } from "@/features/preset-categories/components/MountSlotEditor";
 
 type Mode = "create" | "edit";
 
@@ -49,6 +55,11 @@ interface FormState {
   completionThreshold: number | null;
   mountTemplatePath: string | null;
   mountLayout: "" | "grid_3" | "grid_4" | "grid_6";
+  /** カスタム枠(正規化矩形配列)。null なら mountLayout プリセットを使用 */
+  mountSlots: NormalizedSlotRect[] | null;
+  /** 台紙テンプレ実寸(px)。アップロード時に取得。枠エディタのアスペクト換算に使う */
+  mountTemplateWidth: number | null;
+  mountTemplateHeight: number | null;
   collectionCharacterPath: string | null;
   /** datetime-local 形式("YYYY-MM-DDTHH:mm")。空文字 = 未設定 */
   collectionDisplayStartsAt: string;
@@ -96,6 +107,9 @@ function toFormState(
     completionThreshold: initial?.completionThreshold ?? null,
     mountTemplatePath: initial?.mountTemplatePath ?? null,
     mountLayout: initial?.mountLayout ?? "",
+    mountSlots: initial?.mountSlots ?? null,
+    mountTemplateWidth: initial?.mountTemplateWidth ?? null,
+    mountTemplateHeight: initial?.mountTemplateHeight ?? null,
     collectionCharacterPath: initial?.collectionCharacterPath ?? null,
     // Hydration Mismatch を避けるため、サーバー側で JST 変換済みの文字列を
     // props 経由で受け取る (props が無いケース = create mode のため空文字)。
@@ -190,13 +204,21 @@ export function AdminPresetCategoryFormClient({
       });
       const payload = (await res.json().catch(() => ({}))) as {
         path?: string;
+        width?: number;
+        height?: number;
         error?: string;
       };
       if (!res.ok || !payload.path) {
         setError(payload.error ?? "台紙テンプレのアップロードに失敗しました");
         return;
       }
-      update("mountTemplatePath", payload.path);
+      // path と実寸をまとめて反映(実寸は枠エディタのアスペクト換算に使う)
+      setForm((prev) => ({
+        ...prev,
+        mountTemplatePath: payload.path ?? null,
+        mountTemplateWidth: payload.width ?? prev.mountTemplateWidth,
+        mountTemplateHeight: payload.height ?? prev.mountTemplateHeight,
+      }));
     } catch (err) {
       console.error("[AdminPresetCategoryFormClient] template upload failed:", err);
       setError("台紙テンプレのアップロードに失敗しました");
@@ -209,12 +231,52 @@ export function AdminPresetCategoryFormClient({
     setForm((prev) => ({ ...prev, [field]: value }));
   }
 
+  /** 選択中のグリッドレイアウトから枠を seed し、N(threshold)も枠数に合わせる。 */
+  function handleSeedSlots() {
+    if (!isMountLayoutKey(form.mountLayout)) {
+      setError("枠を初期化する前に台紙レイアウトを選択してください");
+      return;
+    }
+    const seeded = seedSlots(form.mountLayout);
+    setForm((prev) => ({
+      ...prev,
+      mountSlots: seeded,
+      completionThreshold: seeded.length,
+    }));
+  }
+
+  /** カスタム枠を破棄し、レイアウトのプリセットに戻す。 */
+  function handleClearSlots() {
+    update("mountSlots", null);
+  }
+
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setBusy(true);
     setError(null);
 
     try {
+      // カスタム枠がある場合、枠数とコンプリート必要数 N を一致させる(API も検証する)。
+      // 枠数を真値とし threshold を同期する。
+      const effectiveThreshold =
+        form.mountSlots && form.mountSlots.length > 0
+          ? form.mountSlots.length
+          : form.completionThreshold;
+
+      if (
+        form.isCollectionSeries &&
+        form.mountSlots &&
+        form.mountSlots.length > 0 &&
+        form.completionThreshold !== null &&
+        form.completionThreshold !== form.mountSlots.length
+      ) {
+        setError(
+          `枠の数(${form.mountSlots.length})とコンプリート必要数 N(${form.completionThreshold})が一致していません`,
+        );
+        setBusy(false);
+        return;
+      }
+
       const body =
         mode === "create"
           ? {
@@ -237,9 +299,12 @@ export function AdminPresetCategoryFormClient({
               user_prompt_max_length: form.userPromptMaxLength,
               visibility: form.visibility,
               is_collection_series: form.isCollectionSeries,
-              completion_threshold: form.completionThreshold,
+              completion_threshold: effectiveThreshold,
               mount_template_path: form.mountTemplatePath,
               mount_layout: form.mountLayout === "" ? null : form.mountLayout,
+              mount_slots: form.mountSlots,
+              mount_template_width: form.mountTemplateWidth,
+              mount_template_height: form.mountTemplateHeight,
               collection_character_path: form.collectionCharacterPath,
               collection_display_starts_at: datetimeLocalToIso(
                 form.collectionDisplayStartsAt,
@@ -269,9 +334,12 @@ export function AdminPresetCategoryFormClient({
               user_prompt_max_length: form.userPromptMaxLength,
               visibility: form.visibility,
               is_collection_series: form.isCollectionSeries,
-              completion_threshold: form.completionThreshold,
+              completion_threshold: effectiveThreshold,
               mount_template_path: form.mountTemplatePath,
               mount_layout: form.mountLayout === "" ? null : form.mountLayout,
+              mount_slots: form.mountSlots,
+              mount_template_width: form.mountTemplateWidth,
+              mount_template_height: form.mountTemplateHeight,
               collection_character_path: form.collectionCharacterPath,
               collection_display_starts_at: datetimeLocalToIso(
                 form.collectionDisplayStartsAt,
@@ -881,6 +949,64 @@ export function AdminPresetCategoryFormClient({
               className="mt-2 max-h-56 w-auto rounded-md border border-slate-200 bg-slate-50"
             />
           ) : null}
+        </div>
+
+        {/* 枠(スロット)の調整。台紙テンプレと実寸が揃っているときだけ操作可能。 */}
+        <div className="block">
+          <span className="text-sm font-medium text-slate-700">
+            枠（スロット）の調整
+          </span>
+          {!form.mountTemplatePath ? (
+            <p className="mt-1 text-xs text-slate-500">
+              台紙テンプレをアップロードすると、枠をドラッグで調整できます。未調整なら台紙レイアウト（grid_3/4/6）のプリセット枠が使われます。
+            </p>
+          ) : form.mountTemplateWidth === null ||
+            form.mountTemplateHeight === null ? (
+            <p className="mt-1 text-xs text-amber-600">
+              この台紙には実寸情報がありません。台紙テンプレをもう一度アップロードすると枠調整が有効になります（既存の台紙は再アップロード不要・プリセット枠で動作します）。
+            </p>
+          ) : form.mountSlots && form.mountSlots.length > 0 ? (
+            <div className="mt-2 space-y-2">
+              <MountSlotEditor
+                templateUrl={mountTemplatePreviewUrl(form.mountTemplatePath)}
+                templateWidth={form.mountTemplateWidth}
+                templateHeight={form.mountTemplateHeight}
+                slots={form.mountSlots}
+                onChange={(slots) => update("mountSlots", slots)}
+              />
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={handleSeedSlots}
+                  disabled={!isMountLayoutKey(form.mountLayout)}
+                  className="rounded-md border border-slate-300 px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+                >
+                  選択中レイアウトから枠を再生成
+                </button>
+                <button
+                  type="button"
+                  onClick={handleClearSlots}
+                  className="rounded-md border border-slate-300 px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50"
+                >
+                  カスタム枠を破棄（プリセットに戻す）
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="mt-2 space-y-2">
+              <p className="text-xs text-slate-500">
+                台紙レイアウト（grid_3/4/6）を選んで「枠を初期化」すると、その配置を元に枠をドラッグ調整できます。
+              </p>
+              <button
+                type="button"
+                onClick={handleSeedSlots}
+                disabled={!isMountLayoutKey(form.mountLayout)}
+                className="rounded-md border border-slate-300 px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+              >
+                選択中レイアウトから枠を初期化
+              </button>
+            </div>
+          )}
         </div>
 
         <div className="block">

--- a/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
+++ b/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
@@ -218,12 +218,13 @@ export function AdminPresetCategoryFormClient({
         setError(payload.error ?? "台紙テンプレのアップロードに失敗しました");
         return;
       }
-      // path と実寸をまとめて反映(実寸は枠エディタのアスペクト換算に使う)
+      // path と実寸をまとめて反映(実寸は枠エディタのアスペクト換算に使う)。
+      // 台紙差し替え時に別アスペクトの旧寸法が残らないよう、取得できなければ null にする。
       setForm((prev) => ({
         ...prev,
         mountTemplatePath: payload.path ?? null,
-        mountTemplateWidth: payload.width ?? prev.mountTemplateWidth,
-        mountTemplateHeight: payload.height ?? prev.mountTemplateHeight,
+        mountTemplateWidth: payload.width ?? null,
+        mountTemplateHeight: payload.height ?? null,
       }));
     } catch (err) {
       console.error("[AdminPresetCategoryFormClient] template upload failed:", err);

--- a/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
+++ b/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/features/collections/lib/mount-layouts";
 import {
   joinSlots,
+  outOfBoundsIndices,
   seedSlots,
   setSlotCount,
   splitSlots,
@@ -326,6 +327,18 @@ export function AdminPresetCategoryFormClient({
         );
         setBusy(false);
         return;
+      }
+
+      // 枠が台紙からはみ出している場合は保存しない(枠調整で台紙内に収める)
+      if (form.isCollectionSeries && form.mountSlots) {
+        const oob = outOfBoundsIndices(form.mountSlots);
+        if (oob.length > 0) {
+          setError(
+            `枠 ${oob.map((i) => i + 1).join(", ")} が台紙からはみ出しています。枠調整で台紙内に収めてから保存してください。`,
+          );
+          setBusy(false);
+          return;
+        }
       }
 
       const body =

--- a/features/preset-categories/components/MountSlotEditor.tsx
+++ b/features/preset-categories/components/MountSlotEditor.tsx
@@ -174,7 +174,8 @@ export function MountSlotEditor({
       startY: e.clientY,
       start: splitSlots(slots),
     };
-    e.currentTarget.setPointerCapture(e.pointerId);
+    // キャプチャの設定/解除先をコンテナに統一する(解除は endDrag=コンテナの onPointerUp)
+    containerRef.current?.setPointerCapture(e.pointerId);
   }
 
   function beginResize(e: ReactPointerEvent, corner: Corner) {
@@ -188,7 +189,8 @@ export function MountSlotEditor({
       startY: e.clientY,
       start: splitSlots(slots),
     };
-    e.currentTarget.setPointerCapture(e.pointerId);
+    // キャプチャの設定/解除先をコンテナに統一する(解除は endDrag=コンテナの onPointerUp)
+    containerRef.current?.setPointerCapture(e.pointerId);
   }
 
   function handlePointerMove(e: ReactPointerEvent) {

--- a/features/preset-categories/components/MountSlotEditor.tsx
+++ b/features/preset-categories/components/MountSlotEditor.tsx
@@ -5,11 +5,13 @@ import type { NormalizedSlotRect } from "@/features/collections/lib/mount-layout
 import {
   alignGroup,
   applyAspect,
+  clampPosition,
   distributeEvenly,
   joinSlots,
   movePosition,
   pixelAspectRatio,
   resizeShared,
+  snapPosition,
   splitSlots,
   type Corner,
   type DistributeAxis,
@@ -21,6 +23,9 @@ import { GEMINI_SUPPORTED_ASPECT_RATIOS } from "@/shared/generation/gemini-aspec
 
 /** 1枠の最小辺(px)。これ以下にはリサイズできない。 */
 const MIN_SLOT_PX = 24;
+
+/** 他の枠の辺にスナップする閾値(画面px)。 */
+const SNAP_PX = 5;
 
 /** 比率が未検出のときの既定ラベル */
 const DEFAULT_ASPECT = "1:1";
@@ -88,6 +93,11 @@ export function MountSlotEditor({
   const [selection, setSelection] = useState<number[]>([0]);
   // スマホ用の複数選択モード(ON 中はタップで選択の追加/解除)
   const [multiSelectMode, setMultiSelectMode] = useState(false);
+  // ドラッグ中に表示するスナップガイド線(正規化位置, 無ければ null)
+  const [guides, setGuides] = useState<{ x: number | null; y: number | null }>({
+    x: null,
+    y: null,
+  });
 
   // 比率は常に固定(リサイズで比率を維持する)
   const lockRatio = true;
@@ -149,12 +159,27 @@ export function MountSlotEditor({
     const { dxNorm, dyNorm } = toNorm(e.clientX - drag.startX, e.clientY - drag.startY);
 
     if (drag.kind === "move") {
+      const moved = movePosition(
+        drag.start.positions[drag.index],
+        drag.start.size,
+        dxNorm,
+        dyNorm,
+      );
+      // 他の枠の辺へスナップ(5px を正規化換算)
+      const rect = containerRef.current?.getBoundingClientRect();
+      const thX = SNAP_PX / (rect?.width ?? 1);
+      const thY = SNAP_PX / (rect?.height ?? 1);
+      const others = drag.start.positions.filter((_, i) => i !== drag.index);
+      const snapped = snapPosition(moved, drag.start.size, others, thX, thY);
+      const finalPos = clampPosition(
+        { x: snapped.x, y: snapped.y },
+        drag.start.size,
+      );
+      setGuides({ x: snapped.guideX, y: snapped.guideY });
       const next: EditorSlots = {
         size: drag.start.size,
         positions: drag.start.positions.map((p, i) =>
-          i === drag.index
-            ? movePosition(p, drag.start.size, dxNorm, dyNorm)
-            : p,
+          i === drag.index ? finalPos : p,
         ),
       };
       onChange(joinSlots(next));
@@ -199,6 +224,7 @@ export function MountSlotEditor({
   function endDrag(e: ReactPointerEvent) {
     if (dragRef.current) {
       dragRef.current = null;
+      setGuides({ x: null, y: null });
       if (e.currentTarget.hasPointerCapture(e.pointerId)) {
         e.currentTarget.releasePointerCapture(e.pointerId);
       }
@@ -290,6 +316,20 @@ export function MountSlotEditor({
             ))}
           </div>
         ))}
+
+        {/* スナップガイド線(ドラッグ中に他の枠の辺と一致したとき表示) */}
+        {guides.x !== null ? (
+          <div
+            className="pointer-events-none absolute top-0 bottom-0 w-px bg-rose-500"
+            style={{ left: pct(guides.x) }}
+          />
+        ) : null}
+        {guides.y !== null ? (
+          <div
+            className="pointer-events-none absolute left-0 right-0 h-px bg-rose-500"
+            style={{ top: pct(guides.y) }}
+          />
+        ) : null}
       </div>
 
       {/* 枠全体(グループ)の整列。相対配置・サイズは保ったまま平行移動する。 */}

--- a/features/preset-categories/components/MountSlotEditor.tsx
+++ b/features/preset-categories/components/MountSlotEditor.tsx
@@ -3,6 +3,7 @@
 import { useRef, useState, type PointerEvent as ReactPointerEvent } from "react";
 import type { NormalizedSlotRect } from "@/features/collections/lib/mount-layouts";
 import {
+  alignGroup,
   applyAspect,
   joinSlots,
   movePosition,
@@ -11,6 +12,8 @@ import {
   splitSlots,
   type Corner,
   type EditorSlots,
+  type HAlign,
+  type VAlign,
 } from "@/features/collections/lib/slot-edit-geometry";
 import { GEMINI_SUPPORTED_ASPECT_RATIOS } from "@/shared/generation/gemini-aspect-ratio";
 
@@ -164,6 +167,10 @@ export function MountSlotEditor({
     onChange(joinSlots(next));
   }
 
+  function handleAlign(hAlign: HAlign | null, vAlign: VAlign | null) {
+    onChange(joinSlots(alignGroup(splitSlots(slots), hAlign, vAlign)));
+  }
+
   function endDrag(e: ReactPointerEvent) {
     if (dragRef.current) {
       dragRef.current = null;
@@ -248,6 +255,58 @@ export function MountSlotEditor({
             ))}
           </div>
         ))}
+      </div>
+
+      {/* 枠全体(グループ)の整列。相対配置・サイズは保ったまま平行移動する。 */}
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-slate-600">
+        <div className="flex items-center gap-1">
+          <span className="text-slate-500">横:</span>
+          <button
+            type="button"
+            onClick={() => handleAlign("left", null)}
+            className="rounded-md border border-slate-300 px-2 py-1 hover:bg-slate-50"
+          >
+            左寄せ
+          </button>
+          <button
+            type="button"
+            onClick={() => handleAlign("center", null)}
+            className="rounded-md border border-slate-300 px-2 py-1 hover:bg-slate-50"
+          >
+            中央
+          </button>
+          <button
+            type="button"
+            onClick={() => handleAlign("right", null)}
+            className="rounded-md border border-slate-300 px-2 py-1 hover:bg-slate-50"
+          >
+            右寄せ
+          </button>
+        </div>
+        <div className="flex items-center gap-1">
+          <span className="text-slate-500">縦:</span>
+          <button
+            type="button"
+            onClick={() => handleAlign(null, "top")}
+            className="rounded-md border border-slate-300 px-2 py-1 hover:bg-slate-50"
+          >
+            上寄せ
+          </button>
+          <button
+            type="button"
+            onClick={() => handleAlign(null, "middle")}
+            className="rounded-md border border-slate-300 px-2 py-1 hover:bg-slate-50"
+          >
+            中央
+          </button>
+          <button
+            type="button"
+            onClick={() => handleAlign(null, "bottom")}
+            className="rounded-md border border-slate-300 px-2 py-1 hover:bg-slate-50"
+          >
+            下寄せ
+          </button>
+        </div>
       </div>
 
       <div className="rounded-md bg-slate-50 px-3 py-2 text-xs text-slate-600">

--- a/features/preset-categories/components/MountSlotEditor.tsx
+++ b/features/preset-categories/components/MountSlotEditor.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import { useRef, useState, type PointerEvent as ReactPointerEvent } from "react";
+import type { NormalizedSlotRect } from "@/features/collections/lib/mount-layouts";
+import {
+  applyAspect,
+  joinSlots,
+  movePosition,
+  pixelAspectRatio,
+  resizeShared,
+  splitSlots,
+  type Corner,
+  type EditorSlots,
+} from "@/features/collections/lib/slot-edit-geometry";
+import { GEMINI_SUPPORTED_ASPECT_RATIOS } from "@/shared/generation/gemini-aspect-ratio";
+
+/** 1枠の最小辺(px)。これ以下にはリサイズできない。 */
+const MIN_SLOT_PX = 24;
+
+/** アスペクト比セレクタの「自由(ロック解除)」を表す番兵値 */
+const FREE_ASPECT = "free";
+
+/** 現在のピクセル比に最も近いプリセット比を許容誤差内で検出。無ければ "free"。 */
+function detectAspectLabel(
+  slots: NormalizedSlotRect[],
+  templateWidth: number,
+  templateHeight: number,
+): string {
+  if (slots.length === 0) return FREE_ASPECT;
+  const ratio = pixelAspectRatio(
+    { w: slots[0].w, h: slots[0].h },
+    templateWidth,
+    templateHeight,
+  );
+  let best = FREE_ASPECT;
+  let bestDiff = Number.POSITIVE_INFINITY;
+  for (const entry of GEMINI_SUPPORTED_ASPECT_RATIOS) {
+    const diff = Math.abs(entry.value - ratio) / entry.value;
+    if (diff < bestDiff) {
+      bestDiff = diff;
+      best = entry.label;
+    }
+  }
+  // 相対誤差 2% 以内なら一致とみなす。それ以外は自由。
+  return bestDiff <= 0.02 ? best : FREE_ASPECT;
+}
+
+const CORNERS: { corner: Corner; className: string; cursor: string }[] = [
+  { corner: "nw", className: "left-0 top-0 -translate-x-1/2 -translate-y-1/2", cursor: "nwse-resize" },
+  { corner: "ne", className: "right-0 top-0 translate-x-1/2 -translate-y-1/2", cursor: "nesw-resize" },
+  { corner: "sw", className: "left-0 bottom-0 -translate-x-1/2 translate-y-1/2", cursor: "nesw-resize" },
+  { corner: "se", className: "right-0 bottom-0 translate-x-1/2 translate-y-1/2", cursor: "nwse-resize" },
+];
+
+interface Props {
+  /** 台紙テンプレ画像のプレビューURL(admin API 経由) */
+  templateUrl: string;
+  /** 台紙テンプレ実寸(px)。アスペクト比・ピクセル換算に使う */
+  templateWidth: number;
+  templateHeight: number;
+  /** 現在の枠(正規化矩形配列)。全枠同サイズ前提。 */
+  slots: NormalizedSlotRect[];
+  /** 枠が変化したら呼ばれる(正規化矩形配列) */
+  onChange: (slots: NormalizedSlotRect[]) => void;
+}
+
+type DragState =
+  | { kind: "move"; index: number; startX: number; startY: number; start: EditorSlots }
+  | { kind: "resize"; corner: Corner; startX: number; startY: number; start: EditorSlots };
+
+export function MountSlotEditor({
+  templateUrl,
+  templateWidth,
+  templateHeight,
+  slots,
+  onChange,
+}: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const dragRef = useRef<DragState | null>(null);
+  const [aspectLabel, setAspectLabel] = useState(() =>
+    detectAspectLabel(slots, templateWidth, templateHeight),
+  );
+  const [selected, setSelected] = useState(0);
+
+  // 比率プリセットが選ばれている間はリサイズで比率を維持する
+  const lockRatio = aspectLabel !== FREE_ASPECT;
+  const state = splitSlots(slots);
+
+  /** ポインタ移動量(px)を正規化(0..1)へ換算する。コンテナ実描画寸法で割る。 */
+  function toNorm(dxPx: number, dyPx: number): { dxNorm: number; dyNorm: number } {
+    const rect = containerRef.current?.getBoundingClientRect();
+    const w = rect?.width ?? 1;
+    const h = rect?.height ?? 1;
+    return { dxNorm: dxPx / w, dyNorm: dyPx / h };
+  }
+
+  function beginMove(e: ReactPointerEvent, index: number) {
+    e.preventDefault();
+    e.stopPropagation();
+    setSelected(index);
+    dragRef.current = {
+      kind: "move",
+      index,
+      startX: e.clientX,
+      startY: e.clientY,
+      start: splitSlots(slots),
+    };
+    e.currentTarget.setPointerCapture(e.pointerId);
+  }
+
+  function beginResize(e: ReactPointerEvent, corner: Corner, index: number) {
+    e.preventDefault();
+    e.stopPropagation();
+    setSelected(index);
+    dragRef.current = {
+      kind: "resize",
+      corner,
+      startX: e.clientX,
+      startY: e.clientY,
+      start: splitSlots(slots),
+    };
+    e.currentTarget.setPointerCapture(e.pointerId);
+  }
+
+  function handlePointerMove(e: ReactPointerEvent) {
+    const drag = dragRef.current;
+    if (!drag) return;
+    const { dxNorm, dyNorm } = toNorm(e.clientX - drag.startX, e.clientY - drag.startY);
+
+    if (drag.kind === "move") {
+      const next: EditorSlots = {
+        size: drag.start.size,
+        positions: drag.start.positions.map((p, i) =>
+          i === drag.index
+            ? movePosition(p, drag.start.size, dxNorm, dyNorm)
+            : p,
+        ),
+      };
+      onChange(joinSlots(next));
+      return;
+    }
+
+    const next = resizeShared(drag.start, drag.corner, dxNorm, dyNorm, {
+      lockRatio,
+      templateWidth,
+      templateHeight,
+      minPx: MIN_SLOT_PX,
+    });
+    onChange(joinSlots(next));
+  }
+
+  function handleAspectChange(label: string) {
+    setAspectLabel(label);
+    if (label === FREE_ASPECT) return; // 自由: 比率ロックを外すだけ
+    const entry = GEMINI_SUPPORTED_ASPECT_RATIOS.find((r) => r.label === label);
+    if (!entry) return;
+    const next = applyAspect(
+      splitSlots(slots),
+      entry.value,
+      templateWidth,
+      templateHeight,
+      MIN_SLOT_PX,
+    );
+    onChange(joinSlots(next));
+  }
+
+  function endDrag(e: ReactPointerEvent) {
+    if (dragRef.current) {
+      dragRef.current = null;
+      if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+        e.currentTarget.releasePointerCapture(e.pointerId);
+      }
+    }
+  }
+
+  const pct = (v: number) => `${(v * 100).toFixed(1)}%`;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <span className="text-sm font-medium text-slate-700">枠調整モード</span>
+        <label className="flex items-center gap-2 text-xs text-slate-600">
+          <span>枠の比率</span>
+          <select
+            value={aspectLabel}
+            onChange={(e) => handleAspectChange(e.target.value)}
+            className="rounded-md border border-slate-300 px-2 py-1 text-xs"
+          >
+            <option value={FREE_ASPECT}>自由（ロック解除）</option>
+            {GEMINI_SUPPORTED_ASPECT_RATIOS.map((r) => (
+              <option key={r.label} value={r.label}>
+                {r.label}
+                {r.label === "1:1"
+                  ? "（正方形）"
+                  : r.value < 1
+                    ? "（縦長）"
+                    : "（横長）"}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <div
+        ref={containerRef}
+        className="relative w-full max-w-md select-none overflow-hidden rounded-md border border-slate-300 bg-slate-100"
+        style={{ aspectRatio: `${templateWidth} / ${templateHeight}`, touchAction: "none" }}
+        onPointerMove={handlePointerMove}
+        onPointerUp={endDrag}
+        onPointerCancel={endDrag}
+      >
+        {/* 台紙背景 */}
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={templateUrl}
+          alt="台紙テンプレ"
+          className="pointer-events-none absolute inset-0 h-full w-full object-contain"
+          draggable={false}
+        />
+
+        {/* 枠 */}
+        {state.positions.map((pos, index) => (
+          <div
+            key={index}
+            onPointerDown={(e) => beginMove(e, index)}
+            className={`absolute cursor-move border-2 ${
+              index === selected
+                ? "border-sky-500 bg-sky-500/10"
+                : "border-slate-400/80 bg-slate-400/5"
+            }`}
+            style={{
+              left: pct(pos.x),
+              top: pct(pos.y),
+              width: pct(state.size.w),
+              height: pct(state.size.h),
+            }}
+          >
+            <span className="absolute left-1 top-1 rounded bg-slate-900/70 px-1 text-[10px] font-medium leading-tight text-white">
+              {index + 1}
+            </span>
+            {CORNERS.map(({ corner, className, cursor }) => (
+              <span
+                key={corner}
+                onPointerDown={(e) => beginResize(e, corner, index)}
+                className={`absolute h-3 w-3 rounded-sm border border-white bg-sky-500 ${className}`}
+                style={{ cursor }}
+              />
+            ))}
+          </div>
+        ))}
+      </div>
+
+      <div className="rounded-md bg-slate-50 px-3 py-2 text-xs text-slate-600">
+        <p>
+          共有サイズ: 幅 {pct(state.size.w)} × 高さ {pct(state.size.h)}
+          （1枠をリサイズすると全 {state.positions.length} 枠が同じサイズに連動します）
+        </p>
+        <p className="mt-1">
+          枠 {selected + 1} の位置: x {pct(state.positions[selected]?.x ?? 0)}, y{" "}
+          {pct(state.positions[selected]?.y ?? 0)}
+        </p>
+        <p className="mt-1 text-slate-400">
+          枠の中央をドラッグで移動、四隅の青ハンドルでサイズ変更。
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/features/preset-categories/components/MountSlotEditor.tsx
+++ b/features/preset-categories/components/MountSlotEditor.tsx
@@ -5,10 +5,10 @@ import type { NormalizedSlotRect } from "@/features/collections/lib/mount-layout
 import {
   alignGroup,
   applyAspect,
-  clampPosition,
   distributeEvenly,
   joinSlots,
   movePosition,
+  outOfBoundsIndices,
   pixelAspectRatio,
   resizeShared,
   snapPosition,
@@ -102,12 +102,18 @@ export function MountSlotEditor({
     x: null,
     y: null,
   });
+  // 「確定」押下時の判定結果(null=未判定)
+  const [confirmResult, setConfirmResult] = useState<
+    null | { ok: boolean; idx: number[] }
+  >(null);
 
   // 比率は常に固定(リサイズで比率を維持する)
   const lockRatio = true;
   const state = splitSlots(slots);
   // 数値表示用の代表枠(最後に触れた枠)
   const primary = selection[selection.length - 1] ?? 0;
+  // 台紙からはみ出している枠(赤表示・確定不可の対象)
+  const oobSet = new Set(outOfBoundsIndices(slots));
 
   function toggleSelection(index: number) {
     setSelection((prev) =>
@@ -134,6 +140,12 @@ export function MountSlotEditor({
     if (prev) {
       onChange(prev);
     }
+  }
+
+  /** 確定: 全枠が台紙(0..1)内かを判定して結果を表示する。 */
+  function handleConfirm() {
+    const idx = outOfBoundsIndices(slots);
+    setConfirmResult({ ok: idx.length === 0, idx });
   }
 
   /** ポインタ移動量(px)を正規化(0..1)へ換算する。コンテナ実描画寸法で割る。 */
@@ -189,11 +201,13 @@ export function MountSlotEditor({
     }
 
     if (drag.kind === "move") {
+      // 台紙外も許可(bounded=false)。確定/送信時にはみ出しを判定する。
       const moved = movePosition(
         drag.start.positions[drag.index],
         drag.start.size,
         dxNorm,
         dyNorm,
+        false,
       );
       // 他の枠の辺へスナップ(5px を正規化換算)
       const rect = containerRef.current?.getBoundingClientRect();
@@ -201,15 +215,11 @@ export function MountSlotEditor({
       const thY = SNAP_PX / (rect?.height ?? 1);
       const others = drag.start.positions.filter((_, i) => i !== drag.index);
       const snapped = snapPosition(moved, drag.start.size, others, thX, thY);
-      const finalPos = clampPosition(
-        { x: snapped.x, y: snapped.y },
-        drag.start.size,
-      );
       setGuides({ x: snapped.guideX, y: snapped.guideY });
       const next: EditorSlots = {
         size: drag.start.size,
         positions: drag.start.positions.map((p, i) =>
-          i === drag.index ? finalPos : p,
+          i === drag.index ? { x: snapped.x, y: snapped.y } : p,
         ),
       };
       onChange(joinSlots(next));
@@ -221,6 +231,7 @@ export function MountSlotEditor({
       templateWidth,
       templateHeight,
       minPx: MIN_SLOT_PX,
+      bounded: false,
     });
     onChange(joinSlots(next));
   }
@@ -274,7 +285,7 @@ export function MountSlotEditor({
       <div className="flex flex-col gap-3 lg:flex-row lg:items-start">
       <div
         ref={containerRef}
-        className="relative w-full max-w-md select-none overflow-hidden rounded-md border border-slate-300 bg-slate-100 lg:shrink-0"
+        className="relative w-full max-w-md select-none overflow-visible rounded-md border border-slate-300 bg-slate-100 lg:shrink-0"
         style={{ aspectRatio: `${templateWidth} / ${templateHeight}`, touchAction: "none" }}
         onPointerMove={handlePointerMove}
         onPointerUp={endDrag}
@@ -295,9 +306,11 @@ export function MountSlotEditor({
             key={index}
             onPointerDown={(e) => beginMove(e, index)}
             className={`absolute cursor-move border-2 ${
-              selection.includes(index)
-                ? "border-sky-500 bg-sky-500/10"
-                : "border-slate-400/80 bg-slate-400/5"
+              oobSet.has(index)
+                ? "border-rose-500 bg-rose-500/10"
+                : selection.includes(index)
+                  ? "border-sky-500 bg-sky-500/10"
+                  : "border-slate-400/80 bg-slate-400/5"
             }`}
             style={{
               left: pct(pos.x),
@@ -440,6 +453,27 @@ export function MountSlotEditor({
             縦を等間隔
           </button>
         </div>
+        <div className="flex flex-col gap-1">
+          <button
+            type="button"
+            onClick={handleConfirm}
+            className="self-start rounded-md bg-slate-900 px-3 py-1.5 font-medium text-white hover:bg-slate-800"
+          >
+            チェック（はみ出し判定）
+          </button>
+          {confirmResult ? (
+            confirmResult.ok ? (
+              <p className="font-medium text-emerald-600">
+                OK: すべての枠が台紙内に収まっています。
+              </p>
+            ) : (
+              <p className="font-medium text-rose-600">
+                枠 {confirmResult.idx.map((i) => i + 1).join(", ")}{" "}
+                が台紙からはみ出しています。
+              </p>
+            )
+          ) : null}
+        </div>
       </div>
       </div>
 
@@ -458,8 +492,14 @@ export function MountSlotEditor({
           枠 {primary + 1} の位置: x {pct(state.positions[primary]?.x ?? 0)}, y{" "}
           {pct(state.positions[primary]?.y ?? 0)}
         </p>
+        {oobSet.size > 0 ? (
+          <p className="mt-1 font-medium text-rose-600">
+            台紙からはみ出している枠があります（枠{" "}
+            {[...oobSet].map((i) => i + 1).join(", ")}）。台紙内に収めてから保存してください。
+          </p>
+        ) : null}
         <p className="mt-1 text-slate-400">
-          枠の中央をドラッグで移動、四隅の青ハンドルでサイズ変更。複数選択は PC=Shift+クリック / スマホ=複数選択モードをON。
+          枠の中央をドラッグで移動、四隅の青ハンドルでサイズ変更。台紙外まで自由に調整できます。「チェック」で台紙内かを判定します。複数選択は PC=Shift+クリック / スマホ=複数選択モードをON。
         </p>
       </div>
     </div>

--- a/features/preset-categories/components/MountSlotEditor.tsx
+++ b/features/preset-categories/components/MountSlotEditor.tsx
@@ -22,22 +22,22 @@ import { GEMINI_SUPPORTED_ASPECT_RATIOS } from "@/shared/generation/gemini-aspec
 /** 1枠の最小辺(px)。これ以下にはリサイズできない。 */
 const MIN_SLOT_PX = 24;
 
-/** アスペクト比セレクタの「自由(ロック解除)」を表す番兵値 */
-const FREE_ASPECT = "free";
+/** 比率が未検出のときの既定ラベル */
+const DEFAULT_ASPECT = "1:1";
 
-/** 現在のピクセル比に最も近いプリセット比を許容誤差内で検出。無ければ "free"。 */
+/** 現在のピクセル比に最も近いプリセット比のラベルを返す。 */
 function detectAspectLabel(
   slots: NormalizedSlotRect[],
   templateWidth: number,
   templateHeight: number,
 ): string {
-  if (slots.length === 0) return FREE_ASPECT;
+  if (slots.length === 0) return DEFAULT_ASPECT;
   const ratio = pixelAspectRatio(
     { w: slots[0].w, h: slots[0].h },
     templateWidth,
     templateHeight,
   );
-  let best = FREE_ASPECT;
+  let best = DEFAULT_ASPECT;
   let bestDiff = Number.POSITIVE_INFINITY;
   for (const entry of GEMINI_SUPPORTED_ASPECT_RATIOS) {
     const diff = Math.abs(entry.value - ratio) / entry.value;
@@ -46,8 +46,7 @@ function detectAspectLabel(
       best = entry.label;
     }
   }
-  // 相対誤差 2% 以内なら一致とみなす。それ以外は自由。
-  return bestDiff <= 0.02 ? best : FREE_ASPECT;
+  return best;
 }
 
 const CORNERS: { corner: Corner; className: string; cursor: string }[] = [
@@ -90,8 +89,8 @@ export function MountSlotEditor({
   // スマホ用の複数選択モード(ON 中はタップで選択の追加/解除)
   const [multiSelectMode, setMultiSelectMode] = useState(false);
 
-  // 比率プリセットが選ばれている間はリサイズで比率を維持する
-  const lockRatio = aspectLabel !== FREE_ASPECT;
+  // 比率は常に固定(リサイズで比率を維持する)
+  const lockRatio = true;
   const state = splitSlots(slots);
   // 数値表示用の代表枠(最後に触れた枠)
   const primary = selection[selection.length - 1] ?? 0;
@@ -173,7 +172,6 @@ export function MountSlotEditor({
 
   function handleAspectChange(label: string) {
     setAspectLabel(label);
-    if (label === FREE_ASPECT) return; // 自由: 比率ロックを外すだけ
     const entry = GEMINI_SUPPORTED_ASPECT_RATIOS.find((r) => r.label === label);
     if (!entry) return;
     const next = applyAspect(
@@ -193,7 +191,9 @@ export function MountSlotEditor({
   }
 
   function handleDistribute(axis: DistributeAxis) {
-    onChange(joinSlots(distributeEvenly(splitSlots(slots), axis)));
+    // 2つ以上選択されていればその枠だけを対象に、そうでなければ全枠を分布する
+    const indices = selection.length >= 2 ? selection : undefined;
+    onChange(joinSlots(distributeEvenly(splitSlots(slots), axis, indices)));
   }
 
   function endDrag(e: ReactPointerEvent) {
@@ -228,7 +228,6 @@ export function MountSlotEditor({
               onChange={(e) => handleAspectChange(e.target.value)}
               className="rounded-md border border-slate-300 px-2 py-1 text-xs"
             >
-              <option value={FREE_ASPECT}>自由（ロック解除）</option>
               {GEMINI_SUPPORTED_ASPECT_RATIOS.map((r) => (
                 <option key={r.label} value={r.label}>
                   {r.label}
@@ -371,7 +370,9 @@ export function MountSlotEditor({
         </p>
         <p className="mt-1">
           選択中: {selection.length >= 1 ? `枠 ${selection.map((i) => i + 1).join(", ")}` : "なし"}
-          {selection.length >= 2 ? "（整列は選択枠だけに効きます）" : "（整列は全枠に効きます）"}
+          {selection.length >= 2
+            ? "（整列・均等は選択枠だけに効きます）"
+            : "（整列・均等は全枠に効きます）"}
         </p>
         <p className="mt-1">
           枠 {primary + 1} の位置: x {pct(state.positions[primary]?.x ?? 0)}, y{" "}

--- a/features/preset-categories/components/MountSlotEditor.tsx
+++ b/features/preset-categories/components/MountSlotEditor.tsx
@@ -86,6 +86,10 @@ export function MountSlotEditor({
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const dragRef = useRef<DragState | null>(null);
+  // 操作前のスナップショット履歴(元に戻す用)。1ドラッグにつき1件だけ積む。
+  const historyRef = useRef<NormalizedSlotRect[][]>([]);
+  const dragPushedRef = useRef(false);
+  const [historyLen, setHistoryLen] = useState(0);
   const [aspectLabel, setAspectLabel] = useState(() =>
     detectAspectLabel(slots, templateWidth, templateHeight),
   );
@@ -113,6 +117,25 @@ export function MountSlotEditor({
     );
   }
 
+  /** 操作前の slots をスナップショットして履歴に積む。 */
+  function pushHistory(prev: NormalizedSlotRect[]) {
+    historyRef.current.push(prev.map((s) => ({ ...s })));
+    if (historyRef.current.length > 50) historyRef.current.shift();
+    setHistoryLen(historyRef.current.length);
+  }
+
+  function handleUndo() {
+    // 枠数が外部(レイアウト/N変更)で変わった後の古い履歴は破棄しながら戻す
+    let prev = historyRef.current.pop();
+    while (prev && prev.length !== slots.length) {
+      prev = historyRef.current.pop();
+    }
+    setHistoryLen(historyRef.current.length);
+    if (prev) {
+      onChange(prev);
+    }
+  }
+
   /** ポインタ移動量(px)を正規化(0..1)へ換算する。コンテナ実描画寸法で割る。 */
   function toNorm(dxPx: number, dyPx: number): { dxNorm: number; dyNorm: number } {
     const rect = containerRef.current?.getBoundingClientRect();
@@ -130,6 +153,7 @@ export function MountSlotEditor({
       return;
     }
     setSelection([index]);
+    dragPushedRef.current = false;
     dragRef.current = {
       kind: "move",
       index,
@@ -143,6 +167,7 @@ export function MountSlotEditor({
   function beginResize(e: ReactPointerEvent, corner: Corner) {
     e.preventDefault();
     e.stopPropagation();
+    dragPushedRef.current = false;
     dragRef.current = {
       kind: "resize",
       corner,
@@ -157,6 +182,11 @@ export function MountSlotEditor({
     const drag = dragRef.current;
     if (!drag) return;
     const { dxNorm, dyNorm } = toNorm(e.clientX - drag.startX, e.clientY - drag.startY);
+    // ドラッグで実際に動いた最初の1回だけ、操作前の状態を履歴に積む
+    if (!dragPushedRef.current) {
+      pushHistory(joinSlots(drag.start));
+      dragPushedRef.current = true;
+    }
 
     if (drag.kind === "move") {
       const moved = movePosition(
@@ -199,6 +229,7 @@ export function MountSlotEditor({
     setAspectLabel(label);
     const entry = GEMINI_SUPPORTED_ASPECT_RATIOS.find((r) => r.label === label);
     if (!entry) return;
+    pushHistory(slots);
     const next = applyAspect(
       splitSlots(slots),
       entry.value,
@@ -212,12 +243,14 @@ export function MountSlotEditor({
   function handleAlign(hAlign: HAlign | null, vAlign: VAlign | null) {
     // 2つ以上選択されていればその枠だけを対象に、そうでなければ全枠を整列する
     const indices = selection.length >= 2 ? selection : undefined;
+    pushHistory(slots);
     onChange(joinSlots(alignGroup(splitSlots(slots), hAlign, vAlign, indices)));
   }
 
   function handleDistribute(axis: DistributeAxis) {
     // 2つ以上選択されていればその枠だけを対象に、そうでなければ全枠を分布する
     const indices = selection.length >= 2 ? selection : undefined;
+    pushHistory(slots);
     onChange(joinSlots(distributeEvenly(splitSlots(slots), axis, indices)));
   }
 
@@ -235,43 +268,13 @@ export function MountSlotEditor({
 
   return (
     <div className="space-y-3">
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <span className="text-sm font-medium text-slate-700">枠調整モード</span>
-        <div className="flex flex-wrap items-center gap-3">
-          <label className="flex items-center gap-2 text-xs text-slate-600">
-            <input
-              type="checkbox"
-              checked={multiSelectMode}
-              onChange={(e) => setMultiSelectMode(e.target.checked)}
-              className="h-4 w-4 rounded border-slate-300"
-            />
-            複数選択モード（スマホ用・タップで追加）
-          </label>
-          <label className="flex items-center gap-2 text-xs text-slate-600">
-            <span>枠の比率</span>
-            <select
-              value={aspectLabel}
-              onChange={(e) => handleAspectChange(e.target.value)}
-              className="rounded-md border border-slate-300 px-2 py-1 text-xs"
-            >
-              {GEMINI_SUPPORTED_ASPECT_RATIOS.map((r) => (
-                <option key={r.label} value={r.label}>
-                  {r.label}
-                  {r.label === "1:1"
-                    ? "（正方形）"
-                    : r.value < 1
-                      ? "（縦長）"
-                      : "（横長）"}
-                </option>
-              ))}
-            </select>
-          </label>
-        </div>
-      </div>
+      <span className="block text-sm font-medium text-slate-700">枠調整モード</span>
 
+      {/* PC では画像の右にボタンを並べる。スマホ(lg 未満)では縦積み。 */}
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start">
       <div
         ref={containerRef}
-        className="relative w-full max-w-md select-none overflow-hidden rounded-md border border-slate-300 bg-slate-100"
+        className="relative w-full max-w-md select-none overflow-hidden rounded-md border border-slate-300 bg-slate-100 lg:shrink-0"
         style={{ aspectRatio: `${templateWidth} / ${templateHeight}`, touchAction: "none" }}
         onPointerMove={handlePointerMove}
         onPointerUp={endDrag}
@@ -333,7 +336,43 @@ export function MountSlotEditor({
       </div>
 
       {/* 枠全体(グループ)の整列。相対配置・サイズは保ったまま平行移動する。 */}
-      <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-slate-600">
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-slate-600 lg:flex-col lg:flex-nowrap lg:items-start lg:gap-y-3">
+        <button
+          type="button"
+          onClick={handleUndo}
+          disabled={historyLen === 0}
+          className="rounded-md border border-slate-300 px-2 py-1 hover:bg-slate-50 disabled:opacity-40"
+        >
+          ← 元に戻す{historyLen > 0 ? `（${historyLen}）` : ""}
+        </button>
+        <label className="flex items-center gap-2">
+          <span className="text-slate-500">比率:</span>
+          <select
+            value={aspectLabel}
+            onChange={(e) => handleAspectChange(e.target.value)}
+            className="rounded-md border border-slate-300 px-2 py-1 text-xs"
+          >
+            {GEMINI_SUPPORTED_ASPECT_RATIOS.map((r) => (
+              <option key={r.label} value={r.label}>
+                {r.label}
+                {r.label === "1:1"
+                  ? "（正方形）"
+                  : r.value < 1
+                    ? "（縦長）"
+                    : "（横長）"}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={multiSelectMode}
+            onChange={(e) => setMultiSelectMode(e.target.checked)}
+            className="h-4 w-4 rounded border-slate-300"
+          />
+          複数選択モード（スマホ用・タップで追加）
+        </label>
         <div className="flex items-center gap-1">
           <span className="text-slate-500">横:</span>
           <button
@@ -401,6 +440,7 @@ export function MountSlotEditor({
             縦を等間隔
           </button>
         </div>
+      </div>
       </div>
 
       <div className="rounded-md bg-slate-50 px-3 py-2 text-xs text-slate-600">

--- a/features/preset-categories/components/MountSlotEditor.tsx
+++ b/features/preset-categories/components/MountSlotEditor.tsx
@@ -85,11 +85,24 @@ export function MountSlotEditor({
   const [aspectLabel, setAspectLabel] = useState(() =>
     detectAspectLabel(slots, templateWidth, templateHeight),
   );
-  const [selected, setSelected] = useState(0);
+  // 選択中の枠(複数選択可)。整列は選択枠が2つ以上ならその枠だけに効く。
+  const [selection, setSelection] = useState<number[]>([0]);
+  // スマホ用の複数選択モード(ON 中はタップで選択の追加/解除)
+  const [multiSelectMode, setMultiSelectMode] = useState(false);
 
   // 比率プリセットが選ばれている間はリサイズで比率を維持する
   const lockRatio = aspectLabel !== FREE_ASPECT;
   const state = splitSlots(slots);
+  // 数値表示用の代表枠(最後に触れた枠)
+  const primary = selection[selection.length - 1] ?? 0;
+
+  function toggleSelection(index: number) {
+    setSelection((prev) =>
+      prev.includes(index)
+        ? prev.filter((i) => i !== index)
+        : [...prev, index],
+    );
+  }
 
   /** ポインタ移動量(px)を正規化(0..1)へ換算する。コンテナ実描画寸法で割る。 */
   function toNorm(dxPx: number, dyPx: number): { dxNorm: number; dyNorm: number } {
@@ -102,7 +115,12 @@ export function MountSlotEditor({
   function beginMove(e: ReactPointerEvent, index: number) {
     e.preventDefault();
     e.stopPropagation();
-    setSelected(index);
+    // Shift/Cmd(PC) または 複数選択モード(スマホ) のときは選択トグルのみ(移動しない)
+    if (e.shiftKey || e.metaKey || multiSelectMode) {
+      toggleSelection(index);
+      return;
+    }
+    setSelection([index]);
     dragRef.current = {
       kind: "move",
       index,
@@ -113,10 +131,9 @@ export function MountSlotEditor({
     e.currentTarget.setPointerCapture(e.pointerId);
   }
 
-  function beginResize(e: ReactPointerEvent, corner: Corner, index: number) {
+  function beginResize(e: ReactPointerEvent, corner: Corner) {
     e.preventDefault();
     e.stopPropagation();
-    setSelected(index);
     dragRef.current = {
       kind: "resize",
       corner,
@@ -170,7 +187,9 @@ export function MountSlotEditor({
   }
 
   function handleAlign(hAlign: HAlign | null, vAlign: VAlign | null) {
-    onChange(joinSlots(alignGroup(splitSlots(slots), hAlign, vAlign)));
+    // 2つ以上選択されていればその枠だけを対象に、そうでなければ全枠を整列する
+    const indices = selection.length >= 2 ? selection : undefined;
+    onChange(joinSlots(alignGroup(splitSlots(slots), hAlign, vAlign, indices)));
   }
 
   function handleDistribute(axis: DistributeAxis) {
@@ -192,26 +211,37 @@ export function MountSlotEditor({
     <div className="space-y-3">
       <div className="flex flex-wrap items-center justify-between gap-2">
         <span className="text-sm font-medium text-slate-700">枠調整モード</span>
-        <label className="flex items-center gap-2 text-xs text-slate-600">
-          <span>枠の比率</span>
-          <select
-            value={aspectLabel}
-            onChange={(e) => handleAspectChange(e.target.value)}
-            className="rounded-md border border-slate-300 px-2 py-1 text-xs"
-          >
-            <option value={FREE_ASPECT}>自由（ロック解除）</option>
-            {GEMINI_SUPPORTED_ASPECT_RATIOS.map((r) => (
-              <option key={r.label} value={r.label}>
-                {r.label}
-                {r.label === "1:1"
-                  ? "（正方形）"
-                  : r.value < 1
-                    ? "（縦長）"
-                    : "（横長）"}
-              </option>
-            ))}
-          </select>
-        </label>
+        <div className="flex flex-wrap items-center gap-3">
+          <label className="flex items-center gap-2 text-xs text-slate-600">
+            <input
+              type="checkbox"
+              checked={multiSelectMode}
+              onChange={(e) => setMultiSelectMode(e.target.checked)}
+              className="h-4 w-4 rounded border-slate-300"
+            />
+            複数選択モード（スマホ用・タップで追加）
+          </label>
+          <label className="flex items-center gap-2 text-xs text-slate-600">
+            <span>枠の比率</span>
+            <select
+              value={aspectLabel}
+              onChange={(e) => handleAspectChange(e.target.value)}
+              className="rounded-md border border-slate-300 px-2 py-1 text-xs"
+            >
+              <option value={FREE_ASPECT}>自由（ロック解除）</option>
+              {GEMINI_SUPPORTED_ASPECT_RATIOS.map((r) => (
+                <option key={r.label} value={r.label}>
+                  {r.label}
+                  {r.label === "1:1"
+                    ? "（正方形）"
+                    : r.value < 1
+                      ? "（縦長）"
+                      : "（横長）"}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
       </div>
 
       <div
@@ -237,7 +267,7 @@ export function MountSlotEditor({
             key={index}
             onPointerDown={(e) => beginMove(e, index)}
             className={`absolute cursor-move border-2 ${
-              index === selected
+              selection.includes(index)
                 ? "border-sky-500 bg-sky-500/10"
                 : "border-slate-400/80 bg-slate-400/5"
             }`}
@@ -254,7 +284,7 @@ export function MountSlotEditor({
             {CORNERS.map(({ corner, className, cursor }) => (
               <span
                 key={corner}
-                onPointerDown={(e) => beginResize(e, corner, index)}
+                onPointerDown={(e) => beginResize(e, corner)}
                 className={`absolute h-3 w-3 rounded-sm border border-white bg-sky-500 ${className}`}
                 style={{ cursor }}
               />
@@ -340,11 +370,15 @@ export function MountSlotEditor({
           （1枠をリサイズすると全 {state.positions.length} 枠が同じサイズに連動します）
         </p>
         <p className="mt-1">
-          枠 {selected + 1} の位置: x {pct(state.positions[selected]?.x ?? 0)}, y{" "}
-          {pct(state.positions[selected]?.y ?? 0)}
+          選択中: {selection.length >= 1 ? `枠 ${selection.map((i) => i + 1).join(", ")}` : "なし"}
+          {selection.length >= 2 ? "（整列は選択枠だけに効きます）" : "（整列は全枠に効きます）"}
+        </p>
+        <p className="mt-1">
+          枠 {primary + 1} の位置: x {pct(state.positions[primary]?.x ?? 0)}, y{" "}
+          {pct(state.positions[primary]?.y ?? 0)}
         </p>
         <p className="mt-1 text-slate-400">
-          枠の中央をドラッグで移動、四隅の青ハンドルでサイズ変更。
+          枠の中央をドラッグで移動、四隅の青ハンドルでサイズ変更。複数選択は PC=Shift+クリック / スマホ=複数選択モードをON。
         </p>
       </div>
     </div>

--- a/features/preset-categories/components/MountSlotEditor.tsx
+++ b/features/preset-categories/components/MountSlotEditor.tsx
@@ -5,6 +5,7 @@ import type { NormalizedSlotRect } from "@/features/collections/lib/mount-layout
 import {
   alignGroup,
   applyAspect,
+  clampPositionLoose,
   distributeEvenly,
   joinSlots,
   movePosition,
@@ -215,11 +216,16 @@ export function MountSlotEditor({
       const thY = SNAP_PX / (rect?.height ?? 1);
       const others = drag.start.positions.filter((_, i) => i !== drag.index);
       const snapped = snapPosition(moved, drag.start.size, others, thX, thY);
+      // 移動は「完全に台紙から離れる位置まで」に制限(無限に飛ばさない)
+      const finalPos = clampPositionLoose(
+        { x: snapped.x, y: snapped.y },
+        drag.start.size,
+      );
       setGuides({ x: snapped.guideX, y: snapped.guideY });
       const next: EditorSlots = {
         size: drag.start.size,
         positions: drag.start.positions.map((p, i) =>
-          i === drag.index ? { x: snapped.x, y: snapped.y } : p,
+          i === drag.index ? finalPos : p,
         ),
       };
       onChange(joinSlots(next));

--- a/features/preset-categories/components/MountSlotEditor.tsx
+++ b/features/preset-categories/components/MountSlotEditor.tsx
@@ -5,12 +5,14 @@ import type { NormalizedSlotRect } from "@/features/collections/lib/mount-layout
 import {
   alignGroup,
   applyAspect,
+  distributeEvenly,
   joinSlots,
   movePosition,
   pixelAspectRatio,
   resizeShared,
   splitSlots,
   type Corner,
+  type DistributeAxis,
   type EditorSlots,
   type HAlign,
   type VAlign,
@@ -171,6 +173,10 @@ export function MountSlotEditor({
     onChange(joinSlots(alignGroup(splitSlots(slots), hAlign, vAlign)));
   }
 
+  function handleDistribute(axis: DistributeAxis) {
+    onChange(joinSlots(distributeEvenly(splitSlots(slots), axis)));
+  }
+
   function endDrag(e: ReactPointerEvent) {
     if (dragRef.current) {
       dragRef.current = null;
@@ -305,6 +311,25 @@ export function MountSlotEditor({
             className="rounded-md border border-slate-300 px-2 py-1 hover:bg-slate-50"
           >
             下寄せ
+          </button>
+        </div>
+        <div className="flex items-center gap-1">
+          <span className="text-slate-500">均等:</span>
+          <button
+            type="button"
+            onClick={() => handleDistribute("horizontal")}
+            disabled={state.positions.length < 3}
+            className="rounded-md border border-slate-300 px-2 py-1 hover:bg-slate-50 disabled:opacity-40"
+          >
+            横を等間隔
+          </button>
+          <button
+            type="button"
+            onClick={() => handleDistribute("vertical")}
+            disabled={state.positions.length < 3}
+            className="rounded-md border border-slate-300 px-2 py-1 hover:bg-slate-50 disabled:opacity-40"
+          >
+            縦を等間隔
           </button>
         </div>
       </div>

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,10 @@ const withNextIntl = createNextIntlPlugin("./i18n/request.ts");
 
 const nextConfig: NextConfig = {
   cacheComponents: true,
+  // dev サーバへ LAN 内の別端末(スマホ実機確認など)からアクセスする際の
+  // クロスオリジン保護を許可する。production では無視される dev 専用設定。
+  // 個人IPは埋め込まずプライベートレンジのワイルドカードのみ許可する。
+  allowedDevOrigins: ["192.168.*.*", "10.*.*.*", "172.16.*.*"],
   async redirects() {
     return [
       {

--- a/tests/unit/features/collections/mount-aspects.test.ts
+++ b/tests/unit/features/collections/mount-aspects.test.ts
@@ -1,0 +1,38 @@
+import {
+  DEFAULT_MOUNT_ASPECT,
+  mountAspectForCategory,
+} from "@/features/collections/lib/mount-aspects";
+
+describe("mountAspectForCategory", () => {
+  test("dims(実寸)が有効ならそれを最優先で使う", () => {
+    expect(mountAspectForCategory("any_key", 1054, 1492)).toBe("1054 / 1492");
+    // ハードコード表に在るカテゴリでも dims を優先
+    expect(
+      mountAspectForCategory("collectible_wafer_sticker_god_6p", 800, 600),
+    ).toBe("800 / 600");
+  });
+
+  test("dims が無効/未指定ならハードコード表 → 既定値にフォールバック", () => {
+    // 表に在るカテゴリ
+    expect(mountAspectForCategory("collectible_wafer_sticker_god_6p")).toBe(
+      "1024 / 1608",
+    );
+    // 表に無いカテゴリ → 既定値
+    expect(mountAspectForCategory("unknown_key")).toBe(DEFAULT_MOUNT_ASPECT);
+  });
+
+  test("0/負/null/NaN の dims は無効として扱いフォールバックする", () => {
+    expect(mountAspectForCategory("unknown_key", 0, 600)).toBe(
+      DEFAULT_MOUNT_ASPECT,
+    );
+    expect(mountAspectForCategory("unknown_key", 800, -1)).toBe(
+      DEFAULT_MOUNT_ASPECT,
+    );
+    expect(mountAspectForCategory("unknown_key", null, null)).toBe(
+      DEFAULT_MOUNT_ASPECT,
+    );
+    expect(mountAspectForCategory("unknown_key", 800, undefined)).toBe(
+      DEFAULT_MOUNT_ASPECT,
+    );
+  });
+});

--- a/tests/unit/features/collections/slot-edit-geometry.test.ts
+++ b/tests/unit/features/collections/slot-edit-geometry.test.ts
@@ -1,0 +1,193 @@
+import {
+  applyAspect,
+  clampPosition,
+  joinSlots,
+  movePosition,
+  pixelAspectRatio,
+  resizeShared,
+  seedSlots,
+  splitSlots,
+  type EditorSlots,
+} from "@/features/collections/lib/slot-edit-geometry";
+import { MOUNT_LAYOUTS } from "@/features/collections/lib/mount-layouts";
+
+describe("splitSlots / joinSlots", () => {
+  test("共有サイズと位置に分解し、合成で往復する", () => {
+    const slots = [
+      { x: 0.1, y: 0.1, w: 0.2, h: 0.2 },
+      { x: 0.6, y: 0.6, w: 0.2, h: 0.2 },
+    ];
+    const state = splitSlots(slots);
+    expect(state.size).toEqual({ w: 0.2, h: 0.2 });
+    expect(state.positions).toEqual([
+      { x: 0.1, y: 0.1 },
+      { x: 0.6, y: 0.6 },
+    ]);
+    expect(joinSlots(state)).toEqual(slots);
+  });
+
+  test("共有サイズは先頭枠の w,h を採用する", () => {
+    const state = splitSlots([
+      { x: 0, y: 0, w: 0.3, h: 0.25 },
+      { x: 0.5, y: 0.5, w: 0.9, h: 0.9 },
+    ]);
+    expect(state.size).toEqual({ w: 0.3, h: 0.25 });
+    // join すると全枠が先頭サイズに揃う
+    expect(joinSlots(state).every((s) => s.w === 0.3 && s.h === 0.25)).toBe(true);
+  });
+
+  test("空配列は size 0 / positions 空", () => {
+    expect(splitSlots([])).toEqual({ size: { w: 0, h: 0 }, positions: [] });
+  });
+});
+
+describe("seedSlots", () => {
+  test("MOUNT_LAYOUTS と同値のコピーを返す(参照は別)", () => {
+    const seeded = seedSlots("grid_4");
+    expect(seeded).toEqual(MOUNT_LAYOUTS.grid_4);
+    expect(seeded[0]).not.toBe(MOUNT_LAYOUTS.grid_4[0]);
+  });
+});
+
+describe("clampPosition / movePosition", () => {
+  test("位置を 0..1(共有サイズ分の余白)内へクランプ", () => {
+    const size = { w: 0.3, h: 0.3 };
+    expect(clampPosition({ x: -0.5, y: 1.2 }, size)).toEqual({ x: 0, y: 0.7 });
+  });
+
+  test("movePosition はその枠だけ移動しクランプする", () => {
+    const size = { w: 0.2, h: 0.2 };
+    expect(movePosition({ x: 0.1, y: 0.1 }, size, 0.05, -0.05)).toEqual({
+      x: 0.15000000000000002,
+      y: 0.05,
+    });
+    // 端を超える移動はクランプ
+    expect(movePosition({ x: 0.7, y: 0.7 }, size, 0.5, 0.5)).toEqual({
+      x: 0.8,
+      y: 0.8,
+    });
+  });
+});
+
+describe("resizeShared (対角固定・全枠連動)", () => {
+  const base: EditorSlots = {
+    size: { w: 0.2, h: 0.2 },
+    positions: [
+      { x: 0.1, y: 0.1 },
+      { x: 0.6, y: 0.6 },
+    ],
+  };
+  const sq = { lockRatio: false, templateWidth: 1000, templateHeight: 1000, minPx: 24 };
+
+  test("se を引くと左上が固定されたまま全枠が同じ新サイズになる", () => {
+    const next = resizeShared(base, "se", 0.05, 0.05, sq);
+    expect(next.size.w).toBeCloseTo(0.25, 6);
+    expect(next.size.h).toBeCloseTo(0.25, 6);
+    // 左上(対角=nw)は固定 → 位置不変
+    expect(next.positions[0]).toEqual({ x: 0.1, y: 0.1 });
+    expect(next.positions[1]).toEqual({ x: 0.6, y: 0.6 });
+    // 全枠同サイズ
+    const joined = joinSlots(next);
+    expect(joined.every((s) => s.w === next.size.w && s.h === next.size.h)).toBe(true);
+  });
+
+  test("nw を引くと各枠の右下が固定されたままサイズが変わる", () => {
+    const next = resizeShared(base, "nw", -0.05, -0.05, sq);
+    expect(next.size.w).toBeCloseTo(0.25, 6);
+    expect(next.size.h).toBeCloseTo(0.25, 6);
+    // 右下(対角=se)は固定: 枠0 右下 = (0.3,0.3), 枠1 = (0.8,0.8)
+    expect(next.positions[0].x + next.size.w).toBeCloseTo(0.3, 6);
+    expect(next.positions[0].y + next.size.h).toBeCloseTo(0.3, 6);
+    expect(next.positions[1].x + next.size.w).toBeCloseTo(0.8, 6);
+    expect(next.positions[1].y + next.size.h).toBeCloseTo(0.8, 6);
+  });
+
+  test("拡大しすぎは各枠が対角固定で 0..1 に収まる最大サイズへクランプ", () => {
+    // se 拡大 → 左上固定。枠1(0.6,0.6)の右辺が 1 まで → maxW = 1-0.6 = 0.4
+    const next = resizeShared(base, "se", 0.5, 0.5, sq);
+    expect(next.size.w).toBeCloseTo(0.4, 6);
+    expect(next.size.h).toBeCloseTo(0.4, 6);
+  });
+
+  test("nw 拡大は右下固定で左辺が 0 まで → maxW = 右辺座標(0.3)", () => {
+    const next = resizeShared(base, "nw", -0.5, -0.5, sq);
+    // 枠0 右辺=0.3, 枠1 右辺=0.8 → min=0.3
+    expect(next.size.w).toBeCloseTo(0.3, 6);
+    expect(next.size.h).toBeCloseTo(0.3, 6);
+    // 枠0 は左辺 0 まで拡大
+    expect(next.positions[0].x).toBeCloseTo(0, 6);
+  });
+
+  test("最小サイズ(px)を下回らない", () => {
+    const next = resizeShared(base, "se", -0.5, -0.5, sq);
+    // minPx 24 / 1000 = 0.024
+    expect(next.size.w).toBeCloseTo(0.024, 6);
+    expect(next.size.h).toBeCloseTo(0.024, 6);
+  });
+
+  test("比率ロック: 非正方形台紙でもピクセル正方形を維持する", () => {
+    // template 1000x500。ピクセル正方形 = w*1000 == h*500
+    const start: EditorSlots = {
+      size: { w: 0.2, h: 0.4 }, // px 200x200
+      positions: [{ x: 0.1, y: 0.1 }],
+    };
+    const next = resizeShared(start, "se", 0.05, 0.0, {
+      lockRatio: true,
+      templateWidth: 1000,
+      templateHeight: 500,
+      minPx: 24,
+    });
+    // ピクセル正方形不変
+    expect(next.size.w * 1000).toBeCloseTo(next.size.h * 500, 4);
+  });
+});
+
+describe("pixelAspectRatio", () => {
+  test("正方形台紙では正規化比そのまま", () => {
+    expect(pixelAspectRatio({ w: 0.3, h: 0.4 }, 1000, 1000)).toBeCloseTo(0.75, 6);
+  });
+
+  test("非正方形台紙では実寸を反映する", () => {
+    // 1000x500: w_px=0.2*1000=200, h_px=0.4*500=200 → 1:1
+    expect(pixelAspectRatio({ w: 0.2, h: 0.4 }, 1000, 500)).toBeCloseTo(1, 6);
+  });
+});
+
+describe("applyAspect (指定ピクセル比にそろえる)", () => {
+  test("正方形台紙で 3:4 にそろえる(幅基準で高さ決定)", () => {
+    const state: EditorSlots = {
+      size: { w: 0.3, h: 0.3 },
+      positions: [{ x: 0.1, y: 0.1 }],
+    };
+    const next = applyAspect(state, 3 / 4, 1000, 1000, 24);
+    // ピクセル比 = 3/4
+    expect(pixelAspectRatio(next.size, 1000, 1000)).toBeCloseTo(0.75, 6);
+    // 幅維持・高さ拡張 (h = w / (3/4) = 0.4)
+    expect(next.size.w).toBeCloseTo(0.3, 6);
+    expect(next.size.h).toBeCloseTo(0.4, 6);
+    // 左上は不変
+    expect(next.positions[0]).toEqual({ x: 0.1, y: 0.1 });
+  });
+
+  test("はみ出す場合は比率を保ったまま全枠が収まるよう縮める", () => {
+    // 枠が下端付近: y=0.8 で 3:4(縦長) にすると h が 1-0.8=0.2 を超える
+    const state: EditorSlots = {
+      size: { w: 0.3, h: 0.1 },
+      positions: [{ x: 0.1, y: 0.8 }],
+    };
+    const next = applyAspect(state, 3 / 4, 1000, 1000, 24);
+    // 比率は維持
+    expect(pixelAspectRatio(next.size, 1000, 1000)).toBeCloseTo(0.75, 6);
+    // 高さは余白 0.2 に収まる
+    expect(next.size.h).toBeLessThanOrEqual(0.2 + 1e-9);
+  });
+
+  test("非正方形台紙でも指定比を維持する", () => {
+    const state: EditorSlots = {
+      size: { w: 0.3, h: 0.3 },
+      positions: [{ x: 0.1, y: 0.1 }],
+    };
+    const next = applyAspect(state, 16 / 9, 1000, 500, 24);
+    expect(pixelAspectRatio(next.size, 1000, 500)).toBeCloseTo(16 / 9, 4);
+  });
+});

--- a/tests/unit/features/collections/slot-edit-geometry.test.ts
+++ b/tests/unit/features/collections/slot-edit-geometry.test.ts
@@ -226,6 +226,16 @@ describe("alignGroup (辺そろえ・全枠が端に揃う)", () => {
       expect(p.y).toBeCloseTo(0.1, 6);
     });
   });
+
+  test("indices を渡すと選択枠だけ整列し、他は不変", () => {
+    // 枠0(y=0.1) と 枠1(y=0.3) だけ上そろえ → 両方 y=0.1。枠2 は不変。
+    const next = alignGroup(base, null, "top", [0, 1]);
+    expect(next.positions[0].y).toBeCloseTo(0.1, 6);
+    expect(next.positions[1].y).toBeCloseTo(0.1, 6);
+    expect(next.positions[2].y).toBeCloseTo(0.6, 6); // 不変
+    // x は全て不変
+    expect(next.positions.map((p) => p.x)).toEqual([0.2, 0.5, 0.8]);
+  });
 });
 
 describe("distributeEvenly (両端固定・等間隔)", () => {

--- a/tests/unit/features/collections/slot-edit-geometry.test.ts
+++ b/tests/unit/features/collections/slot-edit-geometry.test.ts
@@ -177,6 +177,24 @@ describe("resizeShared (対角固定・全枠連動)", () => {
     expect(next.size.w).toBeCloseTo(0.7, 6);
     expect(next.size.h).toBeCloseTo(0.7, 6);
   });
+
+  test("比率ロック: 縦移動が主軸のとき高さ起点で比率維持する", () => {
+    // 正方形台紙・正方形枠。dy が dx より大きい → 高さ起点で w を算出
+    const start: EditorSlots = {
+      size: { w: 0.2, h: 0.2 },
+      positions: [{ x: 0.1, y: 0.1 }],
+    };
+    const next = resizeShared(start, "se", 0.0, 0.1, {
+      lockRatio: true,
+      templateWidth: 1000,
+      templateHeight: 1000,
+      minPx: 24,
+      bounded: false,
+    });
+    // 正方形(ratio=1)を維持し、高さ起点で拡大
+    expect(next.size.w).toBeCloseTo(next.size.h, 6);
+    expect(next.size.h).toBeGreaterThan(0.2);
+  });
 });
 
 describe("outOfBoundsIndices", () => {
@@ -465,5 +483,26 @@ describe("applyAspect (指定ピクセル比にそろえる)", () => {
     };
     const next = applyAspect(state, 16 / 9, 1000, 500, 24);
     expect(pixelAspectRatio(next.size, 1000, 500)).toBeCloseTo(16 / 9, 4);
+  });
+
+  test("空配列 / ratioPx<=0 はそのまま返す(ガード)", () => {
+    const empty: EditorSlots = { size: { w: 0, h: 0 }, positions: [] };
+    expect(applyAspect(empty, 0.75, 1000, 1000, 24)).toBe(empty);
+    const state: EditorSlots = {
+      size: { w: 0.3, h: 0.3 },
+      positions: [{ x: 0.1, y: 0.1 }],
+    };
+    expect(applyAspect(state, 0, 1000, 1000, 24)).toBe(state);
+  });
+
+  test("極端に縦長の比率は最小幅(minPx)が効く", () => {
+    // ratioPx=0.01(極端縦長) → 幅が minW を下回るので minW に張り付く
+    const state: EditorSlots = {
+      size: { w: 0.05, h: 0.3 },
+      positions: [{ x: 0.1, y: 0.1 }],
+    };
+    const next = applyAspect(state, 0.01, 1000, 1000, 24);
+    // minW = 24/1000 = 0.024 以上
+    expect(next.size.w).toBeGreaterThanOrEqual(0.024 - 1e-9);
   });
 });

--- a/tests/unit/features/collections/slot-edit-geometry.test.ts
+++ b/tests/unit/features/collections/slot-edit-geometry.test.ts
@@ -2,6 +2,7 @@ import {
   alignGroup,
   applyAspect,
   clampPosition,
+  clampPositionLoose,
   distributeEvenly,
   joinSlots,
   movePosition,
@@ -58,6 +59,22 @@ describe("clampPosition / movePosition", () => {
   test("位置を 0..1(共有サイズ分の余白)内へクランプ", () => {
     const size = { w: 0.3, h: 0.3 };
     expect(clampPosition({ x: -0.5, y: 1.2 }, size)).toEqual({ x: 0, y: 0.7 });
+  });
+
+  test("clampPositionLoose は完全に離れる位置まで許容する", () => {
+    const size = { w: 0.3, h: 0.2 };
+    // 右/下へは x:1, y:1 まで(左辺/上辺が台紙の反対端)
+    expect(clampPositionLoose({ x: 5, y: 5 }, size)).toEqual({ x: 1, y: 1 });
+    // 左/上へは x:-w, y:-h まで(右辺/下辺が台紙の手前端0)
+    expect(clampPositionLoose({ x: -5, y: -5 }, size)).toEqual({
+      x: -0.3,
+      y: -0.2,
+    });
+    // 範囲内はそのまま
+    expect(clampPositionLoose({ x: 0.5, y: 0.4 }, size)).toEqual({
+      x: 0.5,
+      y: 0.4,
+    });
   });
 
   test("movePosition はその枠だけ移動しクランプする", () => {

--- a/tests/unit/features/collections/slot-edit-geometry.test.ts
+++ b/tests/unit/features/collections/slot-edit-geometry.test.ts
@@ -2,6 +2,7 @@ import {
   alignGroup,
   applyAspect,
   clampPosition,
+  distributeEvenly,
   joinSlots,
   movePosition,
   pixelAspectRatio,
@@ -188,6 +189,68 @@ describe("alignGroup (辺そろえ・全枠が端に揃う)", () => {
       expect(p.x).toBeCloseTo(0.2, 6);
       expect(p.y).toBeCloseTo(0.1, 6);
     });
+  });
+});
+
+describe("distributeEvenly (両端固定・等間隔)", () => {
+  test("横: 両端固定で間の枠を等間隔にする", () => {
+    const state: EditorSlots = {
+      size: { w: 0.1, h: 0.1 },
+      positions: [
+        { x: 0.0, y: 0.1 }, // 左端
+        { x: 0.1, y: 0.2 }, // 偏った中間
+        { x: 0.15, y: 0.3 },
+        { x: 0.6, y: 0.4 }, // 右端
+      ],
+    };
+    const next = distributeEvenly(state, "horizontal");
+    // lo=0, hi=0.6, step=0.2 → 0, 0.2, 0.4, 0.6
+    [0, 0.2, 0.4, 0.6].forEach((expected, i) =>
+      expect(next.positions[i].x).toBeCloseTo(expected, 6),
+    );
+    // y は不変
+    expect(next.positions.map((p) => p.y)).toEqual([0.1, 0.2, 0.3, 0.4]);
+  });
+
+  test("縦: 両端固定で間の枠を等間隔にする", () => {
+    const state: EditorSlots = {
+      size: { w: 0.1, h: 0.1 },
+      positions: [
+        { x: 0.1, y: 0.0 },
+        { x: 0.2, y: 0.05 },
+        { x: 0.3, y: 0.9 },
+      ],
+    };
+    const next = distributeEvenly(state, "vertical");
+    // lo=0, hi=0.9, step=0.45 → 0, 0.45, 0.9
+    expect(next.positions.map((p) => p.y)).toEqual([0, 0.45, 0.9]);
+  });
+
+  test("順序が入れ替わっていても元のインデックスを保持して等間隔化", () => {
+    const state: EditorSlots = {
+      size: { w: 0.1, h: 0.1 },
+      positions: [
+        { x: 0.6, y: 0 }, // 実は右端
+        { x: 0.0, y: 0 }, // 実は左端
+        { x: 0.5, y: 0 },
+      ],
+    };
+    const next = distributeEvenly(state, "horizontal");
+    // ソート: idx1(0), idx2(0.5→0.3), idx0(0.6) → step=0.3
+    expect(next.positions[1].x).toBeCloseTo(0, 6);
+    expect(next.positions[2].x).toBeCloseTo(0.3, 6);
+    expect(next.positions[0].x).toBeCloseTo(0.6, 6);
+  });
+
+  test("枠が2つ以下なら変化しない", () => {
+    const state: EditorSlots = {
+      size: { w: 0.1, h: 0.1 },
+      positions: [
+        { x: 0.1, y: 0.1 },
+        { x: 0.5, y: 0.5 },
+      ],
+    };
+    expect(distributeEvenly(state, "horizontal")).toEqual(state);
   });
 });
 

--- a/tests/unit/features/collections/slot-edit-geometry.test.ts
+++ b/tests/unit/features/collections/slot-edit-geometry.test.ts
@@ -5,6 +5,7 @@ import {
   distributeEvenly,
   joinSlots,
   movePosition,
+  outOfBoundsIndices,
   pixelAspectRatio,
   resizeShared,
   seedSlots,
@@ -81,7 +82,13 @@ describe("resizeShared (対角固定・全枠連動)", () => {
       { x: 0.6, y: 0.6 },
     ],
   };
-  const sq = { lockRatio: false, templateWidth: 1000, templateHeight: 1000, minPx: 24 };
+  const sq = {
+    lockRatio: false,
+    templateWidth: 1000,
+    templateHeight: 1000,
+    minPx: 24,
+    bounded: true,
+  };
 
   test("se を引くと左上が固定されたまま全枠が同じ新サイズになる", () => {
     const next = resizeShared(base, "se", 0.05, 0.05, sq);
@@ -140,9 +147,35 @@ describe("resizeShared (対角固定・全枠連動)", () => {
       templateWidth: 1000,
       templateHeight: 500,
       minPx: 24,
+      bounded: true,
     });
     // ピクセル正方形不変
     expect(next.size.w * 1000).toBeCloseTo(next.size.h * 500, 4);
+  });
+
+  test("bounded=false なら台紙外まで拡大できる(クランプしない)", () => {
+    // 通常(bounded)なら maxW=0.4 でクランプされる大きな拡大量
+    const next = resizeShared(base, "se", 0.5, 0.5, { ...sq, bounded: false });
+    // 0.4 を超えて 0.2+0.5=0.7 まで拡大
+    expect(next.size.w).toBeCloseTo(0.7, 6);
+    expect(next.size.h).toBeCloseTo(0.7, 6);
+  });
+});
+
+describe("outOfBoundsIndices", () => {
+  test("台紙外の枠インデックスを返す", () => {
+    const slots = [
+      { x: 0.1, y: 0.1, w: 0.2, h: 0.2 }, // 内
+      { x: 0.9, y: 0.1, w: 0.2, h: 0.2 }, // 右はみ出し(1.1)
+      { x: -0.05, y: 0.5, w: 0.2, h: 0.2 }, // 左はみ出し
+    ];
+    expect(outOfBoundsIndices(slots)).toEqual([1, 2]);
+  });
+
+  test("全て内側なら空配列", () => {
+    expect(
+      outOfBoundsIndices([{ x: 0, y: 0, w: 1, h: 1 }]),
+    ).toEqual([]);
   });
 });
 

--- a/tests/unit/features/collections/slot-edit-geometry.test.ts
+++ b/tests/unit/features/collections/slot-edit-geometry.test.ts
@@ -1,4 +1,5 @@
 import {
+  alignGroup,
   applyAspect,
   clampPosition,
   joinSlots,
@@ -139,6 +140,54 @@ describe("resizeShared (対角固定・全枠連動)", () => {
     });
     // ピクセル正方形不変
     expect(next.size.w * 1000).toBeCloseTo(next.size.h * 500, 4);
+  });
+});
+
+describe("alignGroup (辺そろえ・全枠が端に揃う)", () => {
+  // 3枠: x[0.2,0.5,0.8], y[0.1,0.3,0.6], size 0.1
+  const base: EditorSlots = {
+    size: { w: 0.1, h: 0.1 },
+    positions: [
+      { x: 0.2, y: 0.1 },
+      { x: 0.5, y: 0.3 },
+      { x: 0.8, y: 0.6 },
+    ],
+  };
+
+  test("左寄せ: 全枠の x が一番左(0.2)に揃う。y は不変", () => {
+    const next = alignGroup(base, "left", null);
+    expect(next.positions.map((p) => p.x)).toEqual([0.2, 0.2, 0.2]);
+    // y は変わらない
+    expect(next.positions.map((p) => p.y)).toEqual([0.1, 0.3, 0.6]);
+  });
+
+  test("右寄せ: 全枠の x が一番右(0.8)に揃う", () => {
+    const next = alignGroup(base, "right", null);
+    expect(next.positions.map((p) => p.x)).toEqual([0.8, 0.8, 0.8]);
+  });
+
+  test("水平中央: 全枠の x が中点(0.5)に揃う", () => {
+    const next = alignGroup(base, "center", null);
+    next.positions.forEach((p) => expect(p.x).toBeCloseTo(0.5, 6));
+  });
+
+  test("上寄せ: 全枠の y が一番上(0.1)に揃う。x は不変", () => {
+    const next = alignGroup(base, null, "top");
+    expect(next.positions.map((p) => p.y)).toEqual([0.1, 0.1, 0.1]);
+    expect(next.positions.map((p) => p.x)).toEqual([0.2, 0.5, 0.8]);
+  });
+
+  test("下寄せ: 全枠の y が一番下(0.6)に揃う", () => {
+    const next = alignGroup(base, null, "bottom");
+    expect(next.positions.map((p) => p.y)).toEqual([0.6, 0.6, 0.6]);
+  });
+
+  test("横と縦を同時に指定すると全枠が1点(左上端)に重なる", () => {
+    const next = alignGroup(base, "left", "top");
+    next.positions.forEach((p) => {
+      expect(p.x).toBeCloseTo(0.2, 6);
+      expect(p.y).toBeCloseTo(0.1, 6);
+    });
   });
 });
 

--- a/tests/unit/features/collections/slot-edit-geometry.test.ts
+++ b/tests/unit/features/collections/slot-edit-geometry.test.ts
@@ -9,6 +9,7 @@ import {
   resizeShared,
   seedSlots,
   setSlotCount,
+  snapPosition,
   splitSlots,
   type EditorSlots,
 } from "@/features/collections/lib/slot-edit-geometry";
@@ -328,6 +329,42 @@ describe("distributeEvenly (両端固定・等間隔)", () => {
       ],
     };
     expect(distributeEvenly(state, "horizontal", [0, 1])).toBe(state);
+  });
+});
+
+describe("snapPosition (他の枠の辺へ吸着)", () => {
+  const size = { w: 0.2, h: 0.2 };
+  const others = [{ x: 0.5, y: 0.3 }]; // 上端 0.3
+
+  test("上端が他枠の上端付近(閾値内)なら吸着しガイドを返す", () => {
+    // y=0.31, 他枠上端0.3, 閾値0.02 → 吸着して y=0.3
+    const r = snapPosition({ x: 0.1, y: 0.31 }, size, others, 0.02, 0.02);
+    expect(r.y).toBeCloseTo(0.3, 6);
+    expect(r.guideY).toBeCloseTo(0.3, 6);
+  });
+
+  test("閾値外なら吸着しない(ガイドなし)", () => {
+    const r = snapPosition({ x: 0.1, y: 0.36 }, size, others, 0.02, 0.02);
+    expect(r.y).toBeCloseTo(0.36, 6);
+    expect(r.guideY).toBeNull();
+  });
+
+  test("左端が他枠の左端付近なら吸着する", () => {
+    const r = snapPosition({ x: 0.49, y: 0.7 }, size, others, 0.02, 0.02);
+    expect(r.x).toBeCloseTo(0.5, 6);
+    expect(r.guideX).toBeCloseTo(0.5, 6);
+  });
+
+  test("ドラッグ枠の中央が他枠の中央に吸着する", () => {
+    // 他枠中央 x = 0.5+0.1 = 0.6。ドラッグ枠中央(x+0.1)が0.6付近 → x=0.5
+    const r = snapPosition({ x: 0.505, y: 0.7 }, size, others, 0.02, 0.02);
+    // 左端0.505は他枠左端0.5に近いので左端吸着 → x=0.5
+    expect(r.x).toBeCloseTo(0.5, 6);
+  });
+
+  test("他枠が無ければ素通り", () => {
+    const r = snapPosition({ x: 0.1, y: 0.31 }, size, [], 0.02, 0.02);
+    expect(r).toEqual({ x: 0.1, y: 0.31, guideX: null, guideY: null });
   });
 });
 

--- a/tests/unit/features/collections/slot-edit-geometry.test.ts
+++ b/tests/unit/features/collections/slot-edit-geometry.test.ts
@@ -8,6 +8,7 @@ import {
   pixelAspectRatio,
   resizeShared,
   seedSlots,
+  setSlotCount,
   splitSlots,
   type EditorSlots,
 } from "@/features/collections/lib/slot-edit-geometry";
@@ -141,6 +142,41 @@ describe("resizeShared (対角固定・全枠連動)", () => {
     });
     // ピクセル正方形不変
     expect(next.size.w * 1000).toBeCloseTo(next.size.h * 500, 4);
+  });
+});
+
+describe("setSlotCount (枠数の増減)", () => {
+  const base: EditorSlots = {
+    size: { w: 0.2, h: 0.2 },
+    positions: [
+      { x: 0.1, y: 0.1 },
+      { x: 0.5, y: 0.5 },
+    ],
+  };
+
+  test("増やすと既存枠は保持し不足分を追加する", () => {
+    const next = setSlotCount(base, 4);
+    expect(next.positions).toHaveLength(4);
+    // 既存2枠は不変
+    expect(next.positions[0]).toEqual({ x: 0.1, y: 0.1 });
+    expect(next.positions[1]).toEqual({ x: 0.5, y: 0.5 });
+    // 追加枠は共有サイズ・0..1内
+    next.positions.slice(2).forEach((p) => {
+      expect(p.x).toBeGreaterThanOrEqual(0);
+      expect(p.x).toBeLessThanOrEqual(1 - base.size.w);
+    });
+    // サイズは維持
+    expect(next.size).toEqual({ w: 0.2, h: 0.2 });
+  });
+
+  test("減らすと末尾を削除する", () => {
+    const next = setSlotCount(base, 1);
+    expect(next.positions).toEqual([{ x: 0.1, y: 0.1 }]);
+  });
+
+  test("同数なら変化なし、0以下は空", () => {
+    expect(setSlotCount(base, 2)).toBe(base);
+    expect(setSlotCount(base, 0).positions).toEqual([]);
   });
 });
 

--- a/tests/unit/features/collections/slot-edit-geometry.test.ts
+++ b/tests/unit/features/collections/slot-edit-geometry.test.ts
@@ -298,6 +298,37 @@ describe("distributeEvenly (両端固定・等間隔)", () => {
     };
     expect(distributeEvenly(state, "horizontal")).toEqual(state);
   });
+
+  test("indices を渡すと選択枠だけ等間隔にし、他は不変", () => {
+    const state: EditorSlots = {
+      size: { w: 0.1, h: 0.1 },
+      positions: [
+        { x: 0.0, y: 0 }, // 対象(端)
+        { x: 0.9, y: 0 }, // 非対象(動かない)
+        { x: 0.1, y: 0 }, // 対象(中間)
+        { x: 0.6, y: 0 }, // 対象(端)
+      ],
+    };
+    // 対象 = idx0(0), idx2(0.1), idx3(0.6) → lo=0,hi=0.6,step=0.3 → 0,0.3,0.6
+    const next = distributeEvenly(state, "horizontal", [0, 2, 3]);
+    expect(next.positions[0].x).toBeCloseTo(0, 6);
+    expect(next.positions[2].x).toBeCloseTo(0.3, 6);
+    expect(next.positions[3].x).toBeCloseTo(0.6, 6);
+    // 非対象は不変
+    expect(next.positions[1].x).toBeCloseTo(0.9, 6);
+  });
+
+  test("対象(選択)が3未満なら変化しない", () => {
+    const state: EditorSlots = {
+      size: { w: 0.1, h: 0.1 },
+      positions: [
+        { x: 0.1, y: 0 },
+        { x: 0.5, y: 0 },
+        { x: 0.9, y: 0 },
+      ],
+    };
+    expect(distributeEvenly(state, "horizontal", [0, 1])).toBe(state);
+  });
 });
 
 describe("pixelAspectRatio", () => {


### PR DESCRIPTION
### 概要
コレクション台紙の枠(スロット)を、admin プリセットカテゴリ編集画面でドラッグ調整できる「枠調整モード」を追加する Phase 2。これまで枠の位置・大きさはコード側プリセット(grid_3/4/6)固定だったが、台紙デザインに合わせて運営が GUI で自由に調整・保存(`mount_slots`)できるようにした。あわせて、完成台紙の表示が一部カテゴリで上下に見切れていた不具合(表示アスペクト)も修正した。

土台(DB/合成/admin API)は Phase 1(#335)で実装済み。本PRは UI と表示まわり。計画書: `docs/planning/collection-mount-slot-editor-phase2-plan.md`

### 変更内容
- **枠調整モード(MountSlotEditor)** を admin 編集画面に追加(台紙を背景にドラッグ操作)
  - サイズは全枠連動・位置は枠ごと自由(共有size + 位置配列モデル)
  - リサイズは対角固定(左上を引くと右下が固定)、四隅ハンドル
  - 枠の比率セレクタ(生成の `GEMINI_SUPPORTED_ASPECT_RATIOS` 9段階)。選択でピクセル空間にスナップし比率を維持
  - 整列(左右上下・中央)/均等配置(等間隔)。複数選択(PC=Shift / スマホ=複数選択モード)時は選択枠だけに適用
  - ドラッグ時のスナップ(他の枠の辺に5px以内で吸着・ガイド線表示)
  - 元に戻す(Undo)
  - 台紙外まで自由に調整可・移動は「完全に離れる位置まで」で上限。はみ出しは赤表示＋「チェック」ボタンで判定、保存時もブロック
  - 台紙レイアウト/コンプリート数Nの変更を即時反映(編集破棄は確認)
  - PC では操作群を画像の右に集約(スマホは下)
- **保存配線**: フォームに `mount_slots`/`mount_template_width`/`mount_template_height` を追加し既存 collection-settings API へ PATCH(API/DB/composeMount は不変)
- **表示アスペクト修正**: 保存済みの `mount_template_width/height` から表示アスペクトを算出(`mountAspectForCategory`)。完成モーダル/マイページ/共有ページに dims を伝搬し、object-cover による上下クロップを解消。dims が無いカテゴリ(神コレ god_6p 等)は従来のハードコード表にフォールバック(無回帰)
- **幾何計算は純関数化**(`features/collections/lib/slot-edit-geometry.ts`)しユニットテスト追加(42ケース)
- dev: LAN実機確認用に `allowedDevOrigins`(プライベートレンジ)を追加

DBマイグレーション/RPC変更なし。

### 実機テスト
- [x] iOS Safari で主要導線を確認(枠ドラッグ・整列・均等・スナップ・保存)
- [ ] Android Chrome で主要導線を確認
- [x] PC（Chrome）で主要導線を確認
- [x] レスポンシブ表示崩れがないことを確認(PC=画像横/スマホ=下)
- [x] エラーメッセージやバリデーション表示を確認(はみ出しチェック・枠数N不一致)

### テスト方法
- `npm run lint` / `npm run typecheck` / `npm run test` / `npm run build -- --webpack` すべてパス
- ユニットテスト: `tests/unit/features/collections/slot-edit-geometry.test.ts`(42ケース)、collections 全体 139件パス、admin preset-categories API 統合テスト 12件パス
- 本番DB(admin_only の `collectible_wafer_sticker`, 1054x1492)で保存→`mount_slots`(6枠・全枠同サイズ)・dims が正しく保存されることを確認
- 完成台紙の表示が登録テンプレと同じ縦横比で見切れないことを確認。神コレ god_6p の無回帰を確認