### PR TITLE
fix(collections): マイページの進捗モーダルがadmin設定(DB駆動レイアウト)を反映しない不具合を修正

### DIFF
--- a/features/my-page/components/MyPageCollections.tsx
+++ b/features/my-page/components/MyPageCollections.tsx
@@ -219,6 +219,15 @@ export function MyPageCollections({
       mountTemplateHeight: series.mountTemplateHeight,
       characterImageUrl: series.characterImageUrl,
       collectedImageUrls: series.collectedImageUrls ?? [],
+      // admin がカテゴリごとに設定した進捗モーダルの DB 駆動レイアウト。
+      // これを渡さないと CollectionProgressModal が MODAL_LAYOUTS(ハードコード)に
+      // フォールバックし、admin 設定のフレーム/スロット/中央画像が反映されない。
+      progressModalFrameUrl: series.progressModalFrameUrl,
+      progressModalFrameWidth: series.progressModalFrameWidth,
+      progressModalFrameHeight: series.progressModalFrameHeight,
+      progressModalSlots: series.progressModalSlots,
+      progressModalButton: series.progressModalButton,
+      progressModalCenter: series.progressModalCenter,
     });
   }
 


### PR DESCRIPTION
### 概要
マイページの「コレクション」進捗カードをタップして開く進捗モーダルで、admin がカテゴリごとに設定した進捗モーダル(フレーム画像・スロット位置・中央画像位置)が**反映されない**不具合を修正する。/style 経由では正常に反映されていたが、マイページ経由だけハードコードの台座にフォールバックしていた。

### 原因
`features/my-page/components/MyPageCollections.tsx` の `openSeriesModal` が `CollectionCelebration` を手動構築する際、`progressModalFrameUrl` / `progressModalFrameWidth` / `progressModalFrameHeight` / `progressModalSlots` / `progressModalButton` / `progressModalCenter` を渡していなかった。そのため `CollectionProgressModal` 側で DB 駆動レイアウト(dbLayout)が組み立てられず、ハードコードの `MODAL_LAYOUTS` にフォールバックしていた(中央画像が出ない・スロット位置が admin 設定とずれる)。

### 変更内容
- `openSeriesModal` の `setCelebration` に、`series`(CollectionProgress)が保持する 6 つの `progressModal*` フィールドを引き継ぐよう追加(/style 側 `useCollectionProgress` と同じ供給に統一)

### 実機テスト
- [ ] マイページのコレクション進捗カードをタップ → 進捗モーダルに admin 設定のフレーム/中央画像/スロットが反映される
- [ ] /style 経由の進捗モーダルが従来どおり正常
- [ ] DB 設定の無いカテゴリ(神コレ等)は従来の MODAL_LAYOUTS で表示(無変更)

### テスト方法
- `npm run lint` / `npm run test`(collections+my-page 197件パス)/ `npm run build -- --webpack` 緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)