### PR TITLE
fix(collections): 進捗モーダルの中央画像を丸クロップ + DB台座のオレンジボタンを非表示

### DIFF
--- a/app/api/admin/preset-categories/collection-settings-payload.ts
+++ b/app/api/admin/preset-categories/collection-settings-payload.ts
@@ -36,6 +36,10 @@ export interface CollectionSettingsPayload {
   progressModalRingColor?: string | null;
   /** %達成バッジの色(#RRGGBB)または null(デフォルト配色) */
   progressModalBadgeColor?: string | null;
+  /** %達成バッジの文字色(#RRGGBB)または null(デフォルト配色) */
+  progressModalBadgeTextColor?: string | null;
+  /** %達成バッジの背景色(#RRGGBB)または null(デフォルト配色) */
+  progressModalBadgeBgColor?: string | null;
 }
 
 export interface CollectionSettingsExisting {
@@ -327,6 +331,34 @@ export function parseCollectionSettings(
       };
     } else {
       payload.progressModalBadgeColor = v;
+    }
+  }
+
+  if (body.progress_modal_badge_text_color !== undefined) {
+    const v = body.progress_modal_badge_text_color;
+    if (v === null) {
+      payload.progressModalBadgeTextColor = null;
+    } else if (typeof v !== "string" || !HEX_COLOR_RE.test(v)) {
+      return {
+        ok: false,
+        error: "progress_modal_badge_text_color must be a #RRGGBB hex color or null",
+      };
+    } else {
+      payload.progressModalBadgeTextColor = v;
+    }
+  }
+
+  if (body.progress_modal_badge_bg_color !== undefined) {
+    const v = body.progress_modal_badge_bg_color;
+    if (v === null) {
+      payload.progressModalBadgeBgColor = null;
+    } else if (typeof v !== "string" || !HEX_COLOR_RE.test(v)) {
+      return {
+        ok: false,
+        error: "progress_modal_badge_bg_color must be a #RRGGBB hex color or null",
+      };
+    } else {
+      payload.progressModalBadgeBgColor = v;
     }
   }
 

--- a/app/api/admin/preset-categories/collection-settings-payload.ts
+++ b/app/api/admin/preset-categories/collection-settings-payload.ts
@@ -32,6 +32,10 @@ export interface CollectionSettingsPayload {
   progressModalSlots?: NormalizedSlotRect[] | null;
   progressModalButton?: NormalizedSlotRect | null;
   progressModalCenter?: NormalizedSlotRect | null;
+  /** 進捗リングの色(#RRGGBB)または null(デフォルト配色) */
+  progressModalRingColor?: string | null;
+  /** %達成バッジの色(#RRGGBB)または null(デフォルト配色) */
+  progressModalBadgeColor?: string | null;
 }
 
 export interface CollectionSettingsExisting {
@@ -291,6 +295,38 @@ export function parseCollectionSettings(
         };
       }
       payload.progressModalCenter = rect;
+    }
+  }
+
+  // 進捗モーダルの配色(任意・独立)。NULL=従来デフォルト配色。
+  // #RRGGBB の16進カラーのみ許可(DB の CHECK 制約と同等。多層防御)。
+  const HEX_COLOR_RE = /^#[0-9A-Fa-f]{6}$/;
+
+  if (body.progress_modal_ring_color !== undefined) {
+    const v = body.progress_modal_ring_color;
+    if (v === null) {
+      payload.progressModalRingColor = null;
+    } else if (typeof v !== "string" || !HEX_COLOR_RE.test(v)) {
+      return {
+        ok: false,
+        error: "progress_modal_ring_color must be a #RRGGBB hex color or null",
+      };
+    } else {
+      payload.progressModalRingColor = v;
+    }
+  }
+
+  if (body.progress_modal_badge_color !== undefined) {
+    const v = body.progress_modal_badge_color;
+    if (v === null) {
+      payload.progressModalBadgeColor = null;
+    } else if (typeof v !== "string" || !HEX_COLOR_RE.test(v)) {
+      return {
+        ok: false,
+        error: "progress_modal_badge_color must be a #RRGGBB hex color or null",
+      };
+    } else {
+      payload.progressModalBadgeColor = v;
     }
   }
 

--- a/features/collections/components/AchievementBadge.tsx
+++ b/features/collections/components/AchievementBadge.tsx
@@ -1,0 +1,113 @@
+/**
+ * スカロップ(波打ち)型のゴールドバッジ + 王冠 + 「○○%／達成!」を描く SVG。
+ * 画像素材を持たずインラインで完結し、画面幅に応じて拡縮しても崩れない。
+ *
+ * - color / textColor / bgColor が null のときは従来のデフォルト配色を使う。
+ * - animate(default true): % 数字に coll-pop アニメを付ける。静的プレビュー等で
+ *   アニメを止めたいときは false を渡す(animation/coll-pop を出力しない)。
+ *   ※ coll-pop の @keyframes は呼び出し側(モーダル)の <style> に定義がある前提。
+ */
+export function AchievementBadge({
+  percent,
+  color,
+  textColor,
+  bgColor,
+  animate = true,
+}: {
+  percent: number;
+  color?: string | null;
+  textColor?: string | null;
+  bgColor?: string | null;
+  animate?: boolean;
+}) {
+  // 10弁のスカロップを極座標で生成(内/外を交互に)
+  const cx = 50;
+  const cy = 50;
+  const petals = 10;
+  const rOuter = 44;
+  const rInner = 38;
+  const pts: string[] = [];
+  for (let i = 0; i < petals * 2; i++) {
+    const a = (i * Math.PI) / petals - Math.PI / 2;
+    const r = i % 2 === 0 ? rOuter : rInner;
+    const x = cx + r * Math.cos(a);
+    const y = cy + r * Math.sin(a);
+    pts.push(`${x.toFixed(2)},${y.toFixed(2)}`);
+  }
+  return (
+    <svg
+      viewBox="0 0 100 100"
+      className="h-full w-full drop-shadow-[0_2px_4px_rgba(180,90,20,0.35)]"
+      aria-hidden
+    >
+      <defs>
+        <radialGradient id="badgeFill" cx="50%" cy="42%" r="60%">
+          <stop offset="0%" stopColor="#FFFBEB" />
+          <stop offset="70%" stopColor="#FEF3C7" />
+          <stop offset="100%" stopColor="#FDE68A" />
+        </radialGradient>
+        <linearGradient id="badgeStroke" x1="0%" y1="0%" x2="0%" y2="100%">
+          <stop offset="0%" stopColor="#FCD34D" />
+          <stop offset="100%" stopColor="#F59E0B" />
+        </linearGradient>
+      </defs>
+      {/* 外側スカロップ(濃ゴールド)。color 指定時はその単色で塗る。 */}
+      <polygon points={pts.join(" ")} fill={color ?? "url(#badgeStroke)"} />
+      {/* 内側スカロップ(中身)。やや小さい同形で重ねて縁取りを作る */}
+      <polygon
+        points={pts
+          .map((p) => {
+            const [x, y] = p.split(",").map(Number);
+            return `${(cx + (x - cx) * 0.86).toFixed(2)},${(cy + (y - cy) * 0.86).toFixed(2)}`;
+          })
+          .join(" ")}
+        fill={bgColor ?? "url(#badgeFill)"}
+      />
+      {/* 王冠(シンプル) - %が真ん中にくるよう下にシフト。color 指定時はその色。 */}
+      <g transform="translate(50 31)">
+        <path
+          d="M -7 6 L -7 -1 L -3 3 L 0 -4 L 3 3 L 7 -1 L 7 6 Z"
+          fill={color ?? "#F59E0B"}
+          stroke="#FFFFFF"
+          strokeWidth="0.6"
+          strokeLinejoin="round"
+        />
+        <circle cx="-7" cy="-1" r="1.2" fill={color ?? "#F59E0B"} />
+        <circle cx="0" cy="-4" r="1.3" fill={color ?? "#F59E0B"} />
+        <circle cx="7" cy="-1" r="1.2" fill={color ?? "#F59E0B"} />
+      </g>
+      {/* 「○○%」(オレンジ・大きめ) - バッジ中央に配置
+            カウントアップ後半でぴょこっと拡縮(coll-pop)。SVG <text> は
+            transform-box=fill-box で自身の中心を回転原点にできる。
+            animate=false のときは coll-pop を付けない(静的プレビュー用)。 */}
+      <text
+        x="50"
+        y="57"
+        textAnchor="middle"
+        fontFamily="'Mochiy Pop One','Zen Maru Gothic',system-ui,sans-serif"
+        fontWeight="700"
+        fontSize="20"
+        fill={textColor ?? "#F97316"}
+        style={{
+          transformBox: "fill-box",
+          transformOrigin: "center",
+          animation: animate ? "coll-pop 1400ms ease-out both" : undefined,
+        }}
+      >
+        {percent}%
+      </text>
+      {/* 「達成!」 - %の直下 */}
+      <text
+        x="50"
+        y="69"
+        textAnchor="middle"
+        fontFamily="'Mochiy Pop One','Zen Maru Gothic',system-ui,sans-serif"
+        fontWeight="700"
+        fontSize="9"
+        fill={textColor ?? "#B45309"}
+      >
+        達成！
+      </text>
+    </svg>
+  );
+}

--- a/features/collections/components/CollectionProgressModal.tsx
+++ b/features/collections/components/CollectionProgressModal.tsx
@@ -66,6 +66,12 @@ export interface CollectionCelebration {
    * characterImageUrl(= collection_character_path)を敷く。
    */
   progressModalCenter?: NormalizedSlotRect | null;
+  /**
+   * 進捗リング・%達成バッジの色(#RRGGBB)。設定があるとき、リングのアークと
+   * %達成バッジをこの色で描く。null なら従来のデフォルト配色(オレンジ/ゴールド)。
+   */
+  progressModalRingColor?: string | null;
+  progressModalBadgeColor?: string | null;
 }
 
 interface Props {
@@ -114,6 +120,16 @@ interface ModalLayout {
    * 設定があるとき、フレーム中央に characterImageUrl を敷く。
    */
   centerRect?: NormalizedSlotRect | null;
+  /**
+   * 進捗リングのアーク色(#RRGGBB)。設定があるときグラデーションの代わりに
+   * この単色を使う。null なら従来のゴールド→オレンジのグラデーション。
+   */
+  ringColor?: string | null;
+  /**
+   * %達成バッジの色(#RRGGBB)。設定があるとき外側スカロップ/王冠をこの色で塗る。
+   * null なら従来のゴールド配色。
+   */
+  badgeColor?: string | null;
 }
 
 // ready(全画像ロード完了)の保険タイムアウト。これを過ぎたら強制表示する。
@@ -167,7 +183,13 @@ const RING_C = 2 * Math.PI * RING_R;
  * スカロップ(波打ち)型のゴールドバッジ + 王冠 + 「○○%／達成！」を描く SVG。
  * 画像素材を持たずインラインで完結し、画面幅に応じて拡縮しても崩れない。
  */
-function AchievementBadge({ percent }: { percent: number }) {
+function AchievementBadge({
+  percent,
+  color,
+}: {
+  percent: number;
+  color?: string | null;
+}) {
   // 10弁のスカロップを極座標で生成(内/外を交互に)
   const cx = 50;
   const cy = 50;
@@ -199,10 +221,10 @@ function AchievementBadge({ percent }: { percent: number }) {
           <stop offset="100%" stopColor="#F59E0B" />
         </linearGradient>
       </defs>
-      {/* 外側スカロップ(濃ゴールド) */}
+      {/* 外側スカロップ(濃ゴールド)。color 指定時はその単色で塗る。 */}
       <polygon
         points={pts.join(" ")}
-        fill="url(#badgeStroke)"
+        fill={color ?? "url(#badgeStroke)"}
       />
       {/* 内側スカロップ(中身)。やや小さい同形で重ねて縁取りを作る */}
       <polygon
@@ -214,18 +236,18 @@ function AchievementBadge({ percent }: { percent: number }) {
           .join(" ")}
         fill="url(#badgeFill)"
       />
-      {/* 王冠(シンプル) - %が真ん中にくるよう下にシフト */}
+      {/* 王冠(シンプル) - %が真ん中にくるよう下にシフト。color 指定時はその色。 */}
       <g transform="translate(50 31)">
         <path
           d="M -7 6 L -7 -1 L -3 3 L 0 -4 L 3 3 L 7 -1 L 7 6 Z"
-          fill="#F59E0B"
+          fill={color ?? "#F59E0B"}
           stroke="#FFFFFF"
           strokeWidth="0.6"
           strokeLinejoin="round"
         />
-        <circle cx="-7" cy="-1" r="1.2" fill="#F59E0B" />
-        <circle cx="0" cy="-4" r="1.3" fill="#F59E0B" />
-        <circle cx="7" cy="-1" r="1.2" fill="#F59E0B" />
+        <circle cx="-7" cy="-1" r="1.2" fill={color ?? "#F59E0B"} />
+        <circle cx="0" cy="-4" r="1.3" fill={color ?? "#F59E0B"} />
+        <circle cx="7" cy="-1" r="1.2" fill={color ?? "#F59E0B"} />
       </g>
       {/* 「○○%」(オレンジ・大きめ) - バッジ中央に配置
             カウントアップ後半でぴょこっと拡縮(coll-pop)。SVG <text> は
@@ -342,6 +364,8 @@ export function CollectionProgressModal({
       centerRect,
       ring,
       badge,
+      ringColor: celebration.progressModalRingColor ?? null,
+      badgeColor: celebration.progressModalBadgeColor ?? null,
     };
   })();
   const cLayout = celebration
@@ -769,7 +793,7 @@ export function CollectionProgressModal({
                   cy="50"
                   r={RING_R}
                   fill="none"
-                  stroke="url(#collArc)"
+                  stroke={layout.ringColor ?? "url(#collArc)"}
                   strokeWidth="3.6"
                   strokeLinecap="round"
                   strokeDasharray={RING_C}
@@ -791,7 +815,10 @@ export function CollectionProgressModal({
                 aspectRatio: "1 / 1",
               }}
             >
-              <AchievementBadge percent={Math.round(ratio * 100)} />
+              <AchievementBadge
+                percent={Math.round(ratio * 100)}
+                color={layout.badgeColor}
+              />
             </div>
             ) : null}
 

--- a/features/collections/components/CollectionProgressModal.tsx
+++ b/features/collections/components/CollectionProgressModal.tsx
@@ -299,23 +299,51 @@ export function CollectionProgressModal({
   const cShowMount = cIsCompleted && !!cMountImageUrl;
   // admin がカテゴリごとに設定した DB 駆動レイアウト。フレーム画像+実寸がそろっている
   // ときだけ有効。設定が無ければ従来どおりハードコード MODAL_LAYOUTS を使う。
-  const dbLayout: ModalLayout | null =
-    celebration &&
-    celebration.progressModalFrameUrl &&
-    celebration.progressModalFrameWidth &&
-    celebration.progressModalFrameHeight
-      ? {
-          frame: celebration.progressModalFrameUrl,
-          frameAspect:
-            celebration.progressModalFrameWidth /
-            celebration.progressModalFrameHeight,
-          button: { left: 0, top: 0, width: 0, height: 0 },
-          slots: { cx: [], cy: 0, d: 0 },
-          slotRects: celebration.progressModalSlots ?? [],
-          buttonRect: celebration.progressModalButton ?? null,
-          centerRect: celebration.progressModalCenter ?? null,
-        }
-      : null;
+  const dbLayout: ModalLayout | null = (() => {
+    if (
+      !celebration ||
+      !celebration.progressModalFrameUrl ||
+      !celebration.progressModalFrameWidth ||
+      !celebration.progressModalFrameHeight
+    ) {
+      return null;
+    }
+    const frameAspect =
+      celebration.progressModalFrameWidth /
+      celebration.progressModalFrameHeight;
+    const centerRect = celebration.progressModalCenter ?? null;
+    // 中央(centerRect)から進捗リング・%達成バッジの位置を自動導出する(神コレと同じ見た目)。
+    // ring.size は幅%。縦方向は size*frameAspect で正方(=真円)になるよう換算する。
+    let ring: ModalLayout["ring"];
+    let badge: ModalLayout["badge"];
+    if (centerRect) {
+      const cxPct = (centerRect.x + centerRect.w / 2) * 100; // 横中心(幅%)
+      const cyPct = (centerRect.y + centerRect.h / 2) * 100; // 縦中心(高さ%)
+      const ringSize = centerRect.w * 100 * 1.08; // 中央円より少し大きい(幅%)
+      ring = {
+        left: cxPct - ringSize / 2,
+        top: cyPct - (ringSize * frameAspect) / 2,
+        size: ringSize,
+      };
+      const r = ringSize / 2;
+      badge = {
+        cx: cxPct + r * 0.707, // リングの右下(約45°)に配置
+        cy: cyPct + r * frameAspect * 0.707,
+        size: ringSize * 0.4,
+      };
+    }
+    return {
+      frame: celebration.progressModalFrameUrl,
+      frameAspect,
+      button: { left: 0, top: 0, width: 0, height: 0 },
+      slots: { cx: [], cy: 0, d: 0 },
+      slotRects: celebration.progressModalSlots ?? [],
+      buttonRect: celebration.progressModalButton ?? null,
+      centerRect,
+      ring,
+      badge,
+    };
+  })();
   const cLayout = celebration
     ? (dbLayout ?? MODAL_LAYOUTS[celebration.categoryKey] ?? null)
     : null;

--- a/features/collections/components/CollectionProgressModal.tsx
+++ b/features/collections/components/CollectionProgressModal.tsx
@@ -840,9 +840,11 @@ export function CollectionProgressModal({
                 onClick={() => onCreateMount(celebration)}
                 aria-label={cIsCompleted ? "台紙を更新する" : "台紙を作成する"}
                 className={
-                  layout.buttonRect
-                    ? "absolute rounded-full focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-orange-300/60"
-                    : "absolute flex items-center justify-center rounded-full bg-gradient-to-r from-amber-400 to-orange-500 px-4 text-base font-bold text-white shadow-[0_4px_0_rgba(234,88,12,0.45)] focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-orange-300/60"
+                  // 共通クラス + DB台座(buttonRect)以外はオレンジ CTA の装飾を追加。
+                  "absolute rounded-full focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-orange-300/60" +
+                  (layout.buttonRect
+                    ? ""
+                    : " flex items-center justify-center bg-gradient-to-r from-amber-400 to-orange-500 px-4 text-base font-bold text-white shadow-[0_4px_0_rgba(234,88,12,0.45)]")
                 }
                 style={{
                   left: `${buttonBox.left}%`,
@@ -854,11 +856,11 @@ export function CollectionProgressModal({
                     : "'Mochiy Pop One','Zen Maru Gothic',system-ui,sans-serif",
                 }}
               >
-                {layout.buttonRect
-                  ? null
-                  : cIsCompleted
+                {!layout.buttonRect
+                  ? cIsCompleted
                     ? "台紙を更新する →"
-                    : "台紙を作成する →"}
+                    : "台紙を作成する →"
+                  : null}
               </button>
             ) : (
               <Link

--- a/features/collections/components/CollectionProgressModal.tsx
+++ b/features/collections/components/CollectionProgressModal.tsx
@@ -659,10 +659,10 @@ export function CollectionProgressModal({
             />
 
             {/* DB 駆動: 中央画像領域(centerRect)に characterImageUrl を敷く。
-                フレームの中央四角の内側に収まるよう、フレーム描画の後に重ねる。 */}
+                神コレと同様に丸クロップ(rounded-full)。centerRect を正方にすると真円。 */}
             {layout.centerRect && characterImageUrl ? (
               <div
-                className="absolute overflow-hidden rounded-[1.2rem]"
+                className="absolute overflow-hidden rounded-full"
                 style={{
                   left: `${layout.centerRect.x * 100}%`,
                   top: `${layout.centerRect.y * 100}%`,
@@ -861,19 +861,33 @@ export function CollectionProgressModal({
                   かぶせる(土台PNGの「シールを生成する」を覆い隠す)。
                 それ以外は透明クリック領域で /style へ遷移。 */}
             {toCount >= threshold && onCreateMount ? (
+              // DB 駆動台座(buttonRect あり)は、フレームにボタンが焼き込まれているので
+              // コード側は透明クリック領域だけにする(オレンジ CTA を重ねない)。
+              // ハードコード台座(神コレ等)は従来どおりオレンジ CTA を重ねる。
               <button
                 type="button"
                 onClick={() => onCreateMount(celebration)}
-                className="absolute flex items-center justify-center rounded-full bg-gradient-to-r from-amber-400 to-orange-500 px-4 text-base font-bold text-white shadow-[0_4px_0_rgba(234,88,12,0.45)] focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-orange-300/60"
+                aria-label={cIsCompleted ? "台紙を更新する" : "台紙を作成する"}
+                className={
+                  layout.buttonRect
+                    ? "absolute rounded-full focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-orange-300/60"
+                    : "absolute flex items-center justify-center rounded-full bg-gradient-to-r from-amber-400 to-orange-500 px-4 text-base font-bold text-white shadow-[0_4px_0_rgba(234,88,12,0.45)] focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-orange-300/60"
+                }
                 style={{
                   left: `${buttonBox.left}%`,
                   top: `${buttonBox.top}%`,
                   width: `${buttonBox.width}%`,
                   height: `${buttonBox.height}%`,
-                  fontFamily: "'Mochiy Pop One','Zen Maru Gothic',system-ui,sans-serif",
+                  fontFamily: layout.buttonRect
+                    ? undefined
+                    : "'Mochiy Pop One','Zen Maru Gothic',system-ui,sans-serif",
                 }}
               >
-                {cIsCompleted ? "台紙を更新する →" : "台紙を作成する →"}
+                {layout.buttonRect
+                  ? null
+                  : cIsCompleted
+                    ? "台紙を更新する →"
+                    : "台紙を作成する →"}
               </button>
             ) : (
               <Link

--- a/features/collections/components/CollectionProgressModal.tsx
+++ b/features/collections/components/CollectionProgressModal.tsx
@@ -10,6 +10,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { ShareLinkButton } from "@/components/ShareLinkButton";
+import { AchievementBadge } from "@/features/collections/components/AchievementBadge";
 import { CollectionConfetti } from "@/features/collections/components/CollectionConfetti";
 import { CollectionSparkle } from "@/features/collections/components/CollectionSparkle";
 import { mountAspectForCategory } from "@/features/collections/lib/mount-aspects";
@@ -194,115 +195,6 @@ const MODAL_LAYOUTS: Record<string, ModalLayout> = {
 // 進捗リング(SVG)の定数
 const RING_R = 47;
 const RING_C = 2 * Math.PI * RING_R;
-
-/**
- * スカロップ(波打ち)型のゴールドバッジ + 王冠 + 「○○%／達成！」を描く SVG。
- * 画像素材を持たずインラインで完結し、画面幅に応じて拡縮しても崩れない。
- */
-function AchievementBadge({
-  percent,
-  color,
-  textColor,
-  bgColor,
-}: {
-  percent: number;
-  color?: string | null;
-  textColor?: string | null;
-  bgColor?: string | null;
-}) {
-  // 10弁のスカロップを極座標で生成(内/外を交互に)
-  const cx = 50;
-  const cy = 50;
-  const petals = 10;
-  const rOuter = 44;
-  const rInner = 38;
-  const pts: string[] = [];
-  for (let i = 0; i < petals * 2; i++) {
-    const a = (i * Math.PI) / petals - Math.PI / 2;
-    const r = i % 2 === 0 ? rOuter : rInner;
-    const x = cx + r * Math.cos(a);
-    const y = cy + r * Math.sin(a);
-    pts.push(`${x.toFixed(2)},${y.toFixed(2)}`);
-  }
-  return (
-    <svg
-      viewBox="0 0 100 100"
-      className="h-full w-full drop-shadow-[0_2px_4px_rgba(180,90,20,0.35)]"
-      aria-hidden
-    >
-      <defs>
-        <radialGradient id="badgeFill" cx="50%" cy="42%" r="60%">
-          <stop offset="0%" stopColor="#FFFBEB" />
-          <stop offset="70%" stopColor="#FEF3C7" />
-          <stop offset="100%" stopColor="#FDE68A" />
-        </radialGradient>
-        <linearGradient id="badgeStroke" x1="0%" y1="0%" x2="0%" y2="100%">
-          <stop offset="0%" stopColor="#FCD34D" />
-          <stop offset="100%" stopColor="#F59E0B" />
-        </linearGradient>
-      </defs>
-      {/* 外側スカロップ(濃ゴールド)。color 指定時はその単色で塗る。 */}
-      <polygon
-        points={pts.join(" ")}
-        fill={color ?? "url(#badgeStroke)"}
-      />
-      {/* 内側スカロップ(中身)。やや小さい同形で重ねて縁取りを作る */}
-      <polygon
-        points={pts
-          .map((p) => {
-            const [x, y] = p.split(",").map(Number);
-            return `${(cx + (x - cx) * 0.86).toFixed(2)},${(cy + (y - cy) * 0.86).toFixed(2)}`;
-          })
-          .join(" ")}
-        fill={bgColor ?? "url(#badgeFill)"}
-      />
-      {/* 王冠(シンプル) - %が真ん中にくるよう下にシフト。color 指定時はその色。 */}
-      <g transform="translate(50 31)">
-        <path
-          d="M -7 6 L -7 -1 L -3 3 L 0 -4 L 3 3 L 7 -1 L 7 6 Z"
-          fill={color ?? "#F59E0B"}
-          stroke="#FFFFFF"
-          strokeWidth="0.6"
-          strokeLinejoin="round"
-        />
-        <circle cx="-7" cy="-1" r="1.2" fill={color ?? "#F59E0B"} />
-        <circle cx="0" cy="-4" r="1.3" fill={color ?? "#F59E0B"} />
-        <circle cx="7" cy="-1" r="1.2" fill={color ?? "#F59E0B"} />
-      </g>
-      {/* 「○○%」(オレンジ・大きめ) - バッジ中央に配置
-            カウントアップ後半でぴょこっと拡縮(coll-pop)。SVG <text> は
-            transform-box=fill-box で自身の中心を回転原点にできる。 */}
-      <text
-        x="50"
-        y="57"
-        textAnchor="middle"
-        fontFamily="'Mochiy Pop One','Zen Maru Gothic',system-ui,sans-serif"
-        fontWeight="700"
-        fontSize="20"
-        fill={textColor ?? "#F97316"}
-        style={{
-          transformBox: "fill-box",
-          transformOrigin: "center",
-          animation: "coll-pop 1400ms ease-out both",
-        }}
-      >
-        {percent}%
-      </text>
-      {/* 「達成！」 - %の直下 */}
-      <text
-        x="50"
-        y="69"
-        textAnchor="middle"
-        fontFamily="'Mochiy Pop One','Zen Maru Gothic',system-ui,sans-serif"
-        fontWeight="700"
-        fontSize="9"
-        fill={textColor ?? "#B45309"}
-      >
-        達成！
-      </text>
-    </svg>
-  );
-}
 
 export function CollectionProgressModal({
   open,

--- a/features/collections/components/CollectionProgressModal.tsx
+++ b/features/collections/components/CollectionProgressModal.tsx
@@ -72,6 +72,12 @@ export interface CollectionCelebration {
    */
   progressModalRingColor?: string | null;
   progressModalBadgeColor?: string | null;
+  /**
+   * %達成バッジの文字色・内側背景色(#RRGGBB)。設定があるとき、バッジの
+   * %数字・達成！ラベルの色と内側スカロップの背景をこの色で描く。null なら従来配色。
+   */
+  progressModalBadgeTextColor?: string | null;
+  progressModalBadgeBgColor?: string | null;
 }
 
 interface Props {
@@ -130,6 +136,16 @@ interface ModalLayout {
    * null なら従来のゴールド配色。
    */
   badgeColor?: string | null;
+  /**
+   * %達成バッジの文字色(#RRGGBB)。設定があるとき % 数字・達成！ラベルをこの色で塗る。
+   * null なら従来配色(% はオレンジ #F97316 / 達成！は #B45309)。
+   */
+  badgeTextColor?: string | null;
+  /**
+   * %達成バッジの内側背景色(#RRGGBB)。設定があるとき内側スカロップをこの色で塗る。
+   * null なら従来のクリーム地グラデーション(url(#badgeFill))。
+   */
+  badgeBgColor?: string | null;
 }
 
 // ready(全画像ロード完了)の保険タイムアウト。これを過ぎたら強制表示する。
@@ -186,9 +202,13 @@ const RING_C = 2 * Math.PI * RING_R;
 function AchievementBadge({
   percent,
   color,
+  textColor,
+  bgColor,
 }: {
   percent: number;
   color?: string | null;
+  textColor?: string | null;
+  bgColor?: string | null;
 }) {
   // 10弁のスカロップを極座標で生成(内/外を交互に)
   const cx = 50;
@@ -234,7 +254,7 @@ function AchievementBadge({
             return `${(cx + (x - cx) * 0.86).toFixed(2)},${(cy + (y - cy) * 0.86).toFixed(2)}`;
           })
           .join(" ")}
-        fill="url(#badgeFill)"
+        fill={bgColor ?? "url(#badgeFill)"}
       />
       {/* 王冠(シンプル) - %が真ん中にくるよう下にシフト。color 指定時はその色。 */}
       <g transform="translate(50 31)">
@@ -259,7 +279,7 @@ function AchievementBadge({
         fontFamily="'Mochiy Pop One','Zen Maru Gothic',system-ui,sans-serif"
         fontWeight="700"
         fontSize="20"
-        fill="#F97316"
+        fill={textColor ?? "#F97316"}
         style={{
           transformBox: "fill-box",
           transformOrigin: "center",
@@ -276,7 +296,7 @@ function AchievementBadge({
         fontFamily="'Mochiy Pop One','Zen Maru Gothic',system-ui,sans-serif"
         fontWeight="700"
         fontSize="9"
-        fill="#B45309"
+        fill={textColor ?? "#B45309"}
       >
         達成！
       </text>
@@ -366,6 +386,8 @@ export function CollectionProgressModal({
       badge,
       ringColor: celebration.progressModalRingColor ?? null,
       badgeColor: celebration.progressModalBadgeColor ?? null,
+      badgeTextColor: celebration.progressModalBadgeTextColor ?? null,
+      badgeBgColor: celebration.progressModalBadgeBgColor ?? null,
     };
   })();
   const cLayout = celebration
@@ -818,6 +840,8 @@ export function CollectionProgressModal({
               <AchievementBadge
                 percent={Math.round(ratio * 100)}
                 color={layout.badgeColor}
+                textColor={layout.badgeTextColor}
+                bgColor={layout.badgeBgColor}
               />
             </div>
             ) : null}

--- a/features/collections/components/CollectionProgressRing.tsx
+++ b/features/collections/components/CollectionProgressRing.tsx
@@ -21,6 +21,7 @@ export function CollectionProgressRing({
   complete = false,
   imageUrl,
   tintByProgress = true,
+  color,
   className,
   children,
 }: {
@@ -30,6 +31,11 @@ export function CollectionProgressRing({
   imageUrl?: string | null;
   /** true: 進捗に応じて画像がグレー→カラーに変化。false: 常にフルカラー(枠だけアニメ) */
   tintByProgress?: boolean;
+  /**
+   * 進捗アークの色(#RRGGBB)。設定があるときグラデーションの代わりにこの単色を使う
+   * (進捗モーダルのリング色と揃える)。null/未指定なら従来のゴールド→オレンジのグラデ。
+   */
+  color?: string | null;
   className?: string;
   children?: ReactNode;
 }) {
@@ -63,7 +69,7 @@ export function CollectionProgressRing({
           cy={VIEWBOX / 2}
           r={R}
           fill="none"
-          stroke="url(#collRingGrad)"
+          stroke={color ?? "url(#collRingGrad)"}
           strokeWidth={STROKE}
           strokeLinecap="round"
           strokeDasharray={C}

--- a/features/collections/hooks/useCollectionProgress.ts
+++ b/features/collections/hooks/useCollectionProgress.ts
@@ -144,6 +144,8 @@ export function useCollectionProgress() {
             progressModalCenter: target.progressModalCenter,
             progressModalRingColor: target.progressModalRingColor,
             progressModalBadgeColor: target.progressModalBadgeColor,
+            progressModalBadgeTextColor: target.progressModalBadgeTextColor,
+            progressModalBadgeBgColor: target.progressModalBadgeBgColor,
             celebrationEffect: "sparkle",
           });
           return true;
@@ -186,6 +188,8 @@ export function useCollectionProgress() {
           progressModalCenter: series.progressModalCenter,
           progressModalRingColor: series.progressModalRingColor,
           progressModalBadgeColor: series.progressModalBadgeColor,
+          progressModalBadgeTextColor: series.progressModalBadgeTextColor,
+          progressModalBadgeBgColor: series.progressModalBadgeBgColor,
           // フィードの自動コンプリート祝いはダイヤのきらめき演出にする。
           celebrationEffect: "sparkle",
         });
@@ -273,6 +277,8 @@ export function useCollectionProgress() {
       progressModalCenter: null,
       progressModalRingColor: null,
       progressModalBadgeColor: null,
+      progressModalBadgeTextColor: null,
+      progressModalBadgeBgColor: null,
     });
   }, []);
 

--- a/features/collections/hooks/useCollectionProgress.ts
+++ b/features/collections/hooks/useCollectionProgress.ts
@@ -142,6 +142,8 @@ export function useCollectionProgress() {
             progressModalSlots: target.progressModalSlots,
             progressModalButton: target.progressModalButton,
             progressModalCenter: target.progressModalCenter,
+            progressModalRingColor: target.progressModalRingColor,
+            progressModalBadgeColor: target.progressModalBadgeColor,
             celebrationEffect: "sparkle",
           });
           return true;
@@ -182,6 +184,8 @@ export function useCollectionProgress() {
           progressModalSlots: series.progressModalSlots,
           progressModalButton: series.progressModalButton,
           progressModalCenter: series.progressModalCenter,
+          progressModalRingColor: series.progressModalRingColor,
+          progressModalBadgeColor: series.progressModalBadgeColor,
           // フィードの自動コンプリート祝いはダイヤのきらめき演出にする。
           celebrationEffect: "sparkle",
         });
@@ -267,6 +271,8 @@ export function useCollectionProgress() {
       progressModalSlots: null,
       progressModalButton: null,
       progressModalCenter: null,
+      progressModalRingColor: null,
+      progressModalBadgeColor: null,
     });
   }, []);
 

--- a/features/collections/lib/collection-progress-repository.ts
+++ b/features/collections/lib/collection-progress-repository.ts
@@ -80,6 +80,8 @@ function mapProgressRow(row: CollectionProgressRow): CollectionProgress {
     progressModalCenter: null,
     progressModalRingColor: null,
     progressModalBadgeColor: null,
+    progressModalBadgeTextColor: null,
+    progressModalBadgeBgColor: null,
   };
 }
 
@@ -159,7 +161,7 @@ async function attachCharacterImages(
   const { data, error } = await supabase
     .from("preset_categories")
     .select(
-      "id, collection_character_path, mount_template_width, mount_template_height, progress_modal_frame_path, progress_modal_frame_width, progress_modal_frame_height, progress_modal_slots, progress_modal_button, progress_modal_center, progress_modal_ring_color, progress_modal_badge_color",
+      "id, collection_character_path, mount_template_width, mount_template_height, progress_modal_frame_path, progress_modal_frame_width, progress_modal_frame_height, progress_modal_slots, progress_modal_button, progress_modal_center, progress_modal_ring_color, progress_modal_badge_color, progress_modal_badge_text_color, progress_modal_badge_bg_color",
     )
     .in("id", categoryIds);
   if (error) {
@@ -182,6 +184,8 @@ async function attachCharacterImages(
       center: NormalizedSlotRect | null;
       ringColor: string | null;
       badgeColor: string | null;
+      badgeTextColor: string | null;
+      badgeBgColor: string | null;
     }
   >();
   for (const row of data ?? []) {
@@ -206,6 +210,10 @@ async function attachCharacterImages(
       center: parseNormalizedRect(row.progress_modal_center),
       ringColor: (row.progress_modal_ring_color as string | null) ?? null,
       badgeColor: (row.progress_modal_badge_color as string | null) ?? null,
+      badgeTextColor:
+        (row.progress_modal_badge_text_color as string | null) ?? null,
+      badgeBgColor:
+        (row.progress_modal_badge_bg_color as string | null) ?? null,
     });
   }
   return items.map((i) => {
@@ -225,6 +233,8 @@ async function attachCharacterImages(
       progressModalCenter: modal?.center ?? null,
       progressModalRingColor: modal?.ringColor ?? null,
       progressModalBadgeColor: modal?.badgeColor ?? null,
+      progressModalBadgeTextColor: modal?.badgeTextColor ?? null,
+      progressModalBadgeBgColor: modal?.badgeBgColor ?? null,
     };
   });
 }

--- a/features/collections/lib/collection-progress-repository.ts
+++ b/features/collections/lib/collection-progress-repository.ts
@@ -78,6 +78,8 @@ function mapProgressRow(row: CollectionProgressRow): CollectionProgress {
     progressModalSlots: null,
     progressModalButton: null,
     progressModalCenter: null,
+    progressModalRingColor: null,
+    progressModalBadgeColor: null,
   };
 }
 
@@ -157,7 +159,7 @@ async function attachCharacterImages(
   const { data, error } = await supabase
     .from("preset_categories")
     .select(
-      "id, collection_character_path, mount_template_width, mount_template_height, progress_modal_frame_path, progress_modal_frame_width, progress_modal_frame_height, progress_modal_slots, progress_modal_button, progress_modal_center",
+      "id, collection_character_path, mount_template_width, mount_template_height, progress_modal_frame_path, progress_modal_frame_width, progress_modal_frame_height, progress_modal_slots, progress_modal_button, progress_modal_center, progress_modal_ring_color, progress_modal_badge_color",
     )
     .in("id", categoryIds);
   if (error) {
@@ -178,6 +180,8 @@ async function attachCharacterImages(
       slots: NormalizedSlotRect[] | null;
       button: NormalizedSlotRect | null;
       center: NormalizedSlotRect | null;
+      ringColor: string | null;
+      badgeColor: string | null;
     }
   >();
   for (const row of data ?? []) {
@@ -200,6 +204,8 @@ async function attachCharacterImages(
       slots: parseNormalizedSlots(row.progress_modal_slots),
       button: parseNormalizedRect(row.progress_modal_button),
       center: parseNormalizedRect(row.progress_modal_center),
+      ringColor: (row.progress_modal_ring_color as string | null) ?? null,
+      badgeColor: (row.progress_modal_badge_color as string | null) ?? null,
     });
   }
   return items.map((i) => {
@@ -217,6 +223,8 @@ async function attachCharacterImages(
       progressModalSlots: modal?.slots ?? null,
       progressModalButton: modal?.button ?? null,
       progressModalCenter: modal?.center ?? null,
+      progressModalRingColor: modal?.ringColor ?? null,
+      progressModalBadgeColor: modal?.badgeColor ?? null,
     };
   });
 }

--- a/features/collections/lib/collection-types.ts
+++ b/features/collections/lib/collection-types.ts
@@ -41,6 +41,12 @@ export interface CollectionProgress {
    * (= collection_character_path)を流用する。位置だけを admin がここで設定する。
    */
   progressModalCenter: NormalizedSlotRect | null;
+  /**
+   * 進捗リング・%達成バッジの色(#RRGGBB)。null なら従来デフォルト配色
+   * (オレンジのリング/ゴールドのバッジ)を使う。
+   */
+  progressModalRingColor: string | null;
+  progressModalBadgeColor: string | null;
 }
 
 /** RPC の生レスポンス行(snake_case) */

--- a/features/collections/lib/collection-types.ts
+++ b/features/collections/lib/collection-types.ts
@@ -47,6 +47,12 @@ export interface CollectionProgress {
    */
   progressModalRingColor: string | null;
   progressModalBadgeColor: string | null;
+  /**
+   * %達成バッジの文字色・内側背景色(#RRGGBB)。null なら従来デフォルト配色
+   * (% はオレンジ/達成！は茶/背景はクリーム)を使う。
+   */
+  progressModalBadgeTextColor: string | null;
+  progressModalBadgeBgColor: string | null;
 }
 
 /** RPC の生レスポンス行(snake_case) */

--- a/features/my-page/components/MyPageCollections.tsx
+++ b/features/my-page/components/MyPageCollections.tsx
@@ -230,6 +230,8 @@ export function MyPageCollections({
       progressModalCenter: series.progressModalCenter,
       progressModalRingColor: series.progressModalRingColor,
       progressModalBadgeColor: series.progressModalBadgeColor,
+      progressModalBadgeTextColor: series.progressModalBadgeTextColor,
+      progressModalBadgeBgColor: series.progressModalBadgeBgColor,
     });
   }
 
@@ -299,6 +301,7 @@ export function MyPageCollections({
                     complete={completed}
                     imageUrl={s.characterImageUrl}
                     tintByProgress={false}
+                    color={s.progressModalRingColor}
                     className="w-16 shrink-0"
                   >
                     {!s.characterImageUrl ? (

--- a/features/my-page/components/MyPageCollections.tsx
+++ b/features/my-page/components/MyPageCollections.tsx
@@ -228,6 +228,8 @@ export function MyPageCollections({
       progressModalSlots: series.progressModalSlots,
       progressModalButton: series.progressModalButton,
       progressModalCenter: series.progressModalCenter,
+      progressModalRingColor: series.progressModalRingColor,
+      progressModalBadgeColor: series.progressModalBadgeColor,
     });
   }
 

--- a/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
+++ b/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
@@ -80,6 +80,10 @@ interface FormState {
   progressModalButton: NormalizedSlotRect | null;
   /** 進捗モーダルの中央画像領域(単一の正規化矩形)。表示画像はキャラ画像を流用。 */
   progressModalCenter: NormalizedSlotRect | null;
+  /** 進捗リングの色(#RRGGBB)。null=従来デフォルト配色 */
+  progressModalRingColor: string | null;
+  /** %達成バッジの色(#RRGGBB)。null=従来デフォルト配色 */
+  progressModalBadgeColor: string | null;
   displayOrder: number;
   isActive: boolean;
 }
@@ -137,6 +141,8 @@ function toFormState(
     progressModalSlots: initial?.progressModalSlots ?? null,
     progressModalButton: initial?.progressModalButton ?? null,
     progressModalCenter: initial?.progressModalCenter ?? null,
+    progressModalRingColor: initial?.progressModalRingColor ?? null,
+    progressModalBadgeColor: initial?.progressModalBadgeColor ?? null,
     displayOrder: initial?.displayOrder ?? 0,
     isActive: initial?.isActive ?? true,
   };
@@ -473,6 +479,8 @@ export function AdminPresetCategoryFormClient({
               progress_modal_slots: form.progressModalSlots,
               progress_modal_button: form.progressModalButton,
               progress_modal_center: form.progressModalCenter,
+              progress_modal_ring_color: form.progressModalRingColor,
+              progress_modal_badge_color: form.progressModalBadgeColor,
               display_order: form.displayOrder,
               is_active: form.isActive,
             }
@@ -514,6 +522,8 @@ export function AdminPresetCategoryFormClient({
               progress_modal_slots: form.progressModalSlots,
               progress_modal_button: form.progressModalButton,
               progress_modal_center: form.progressModalCenter,
+              progress_modal_ring_color: form.progressModalRingColor,
+              progress_modal_badge_color: form.progressModalBadgeColor,
               display_order: form.displayOrder,
               is_active: form.isActive,
             };
@@ -1391,6 +1401,56 @@ export function AdminPresetCategoryFormClient({
               </button>
             </div>
           )}
+        </div>
+
+        {/* 進捗リング/%達成バッジの配色。null(未設定)なら従来デフォルト配色
+            (オレンジのリング/ゴールドのバッジ)を使う(= 厳密な no-op)。 */}
+        <div className="block">
+          <span className="text-sm font-medium text-slate-700">進捗リングの色</span>
+          <div className="mt-1 flex items-center gap-2">
+            <input
+              type="color"
+              value={form.progressModalRingColor ?? "#F97316"}
+              onChange={(e) => update("progressModalRingColor", e.target.value)}
+              className="h-10 w-16 rounded-md border border-slate-300"
+            />
+            <span className="text-xs text-slate-500">
+              {form.progressModalRingColor ?? "未設定(デフォルト配色)"}
+            </span>
+            {form.progressModalRingColor && (
+              <button
+                type="button"
+                onClick={() => update("progressModalRingColor", null)}
+                className="rounded-md border border-slate-300 px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50"
+              >
+                デフォルトに戻す
+              </button>
+            )}
+          </div>
+        </div>
+
+        <div className="block">
+          <span className="text-sm font-medium text-slate-700">%達成バッジの色</span>
+          <div className="mt-1 flex items-center gap-2">
+            <input
+              type="color"
+              value={form.progressModalBadgeColor ?? "#F59E0B"}
+              onChange={(e) => update("progressModalBadgeColor", e.target.value)}
+              className="h-10 w-16 rounded-md border border-slate-300"
+            />
+            <span className="text-xs text-slate-500">
+              {form.progressModalBadgeColor ?? "未設定(デフォルト配色)"}
+            </span>
+            {form.progressModalBadgeColor && (
+              <button
+                type="button"
+                onClick={() => update("progressModalBadgeColor", null)}
+                className="rounded-md border border-slate-300 px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50"
+              >
+                デフォルトに戻す
+              </button>
+            )}
+          </div>
         </div>
       </fieldset>
 

--- a/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
+++ b/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
@@ -84,6 +84,10 @@ interface FormState {
   progressModalRingColor: string | null;
   /** %達成バッジの色(#RRGGBB)。null=従来デフォルト配色 */
   progressModalBadgeColor: string | null;
+  /** %達成バッジの文字色(#RRGGBB)。null=従来デフォルト配色 */
+  progressModalBadgeTextColor: string | null;
+  /** %達成バッジの背景色(#RRGGBB)。null=従来デフォルト配色 */
+  progressModalBadgeBgColor: string | null;
   displayOrder: number;
   isActive: boolean;
 }
@@ -143,6 +147,8 @@ function toFormState(
     progressModalCenter: initial?.progressModalCenter ?? null,
     progressModalRingColor: initial?.progressModalRingColor ?? null,
     progressModalBadgeColor: initial?.progressModalBadgeColor ?? null,
+    progressModalBadgeTextColor: initial?.progressModalBadgeTextColor ?? null,
+    progressModalBadgeBgColor: initial?.progressModalBadgeBgColor ?? null,
     displayOrder: initial?.displayOrder ?? 0,
     isActive: initial?.isActive ?? true,
   };
@@ -481,6 +487,8 @@ export function AdminPresetCategoryFormClient({
               progress_modal_center: form.progressModalCenter,
               progress_modal_ring_color: form.progressModalRingColor,
               progress_modal_badge_color: form.progressModalBadgeColor,
+              progress_modal_badge_text_color: form.progressModalBadgeTextColor,
+              progress_modal_badge_bg_color: form.progressModalBadgeBgColor,
               display_order: form.displayOrder,
               is_active: form.isActive,
             }
@@ -524,6 +532,8 @@ export function AdminPresetCategoryFormClient({
               progress_modal_center: form.progressModalCenter,
               progress_modal_ring_color: form.progressModalRingColor,
               progress_modal_badge_color: form.progressModalBadgeColor,
+              progress_modal_badge_text_color: form.progressModalBadgeTextColor,
+              progress_modal_badge_bg_color: form.progressModalBadgeBgColor,
               display_order: form.displayOrder,
               is_active: form.isActive,
             };
@@ -1445,6 +1455,58 @@ export function AdminPresetCategoryFormClient({
               <button
                 type="button"
                 onClick={() => update("progressModalBadgeColor", null)}
+                className="rounded-md border border-slate-300 px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50"
+              >
+                デフォルトに戻す
+              </button>
+            )}
+          </div>
+        </div>
+
+        <div className="block">
+          <span className="text-sm font-medium text-slate-700">バッジの文字色</span>
+          <div className="mt-1 flex items-center gap-2">
+            <input
+              type="color"
+              value={form.progressModalBadgeTextColor ?? "#F97316"}
+              onChange={(e) =>
+                update("progressModalBadgeTextColor", e.target.value)
+              }
+              className="h-10 w-16 rounded-md border border-slate-300"
+            />
+            <span className="text-xs text-slate-500">
+              {form.progressModalBadgeTextColor ?? "未設定(デフォルト配色)"}
+            </span>
+            {form.progressModalBadgeTextColor && (
+              <button
+                type="button"
+                onClick={() => update("progressModalBadgeTextColor", null)}
+                className="rounded-md border border-slate-300 px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50"
+              >
+                デフォルトに戻す
+              </button>
+            )}
+          </div>
+        </div>
+
+        <div className="block">
+          <span className="text-sm font-medium text-slate-700">バッジの背景色</span>
+          <div className="mt-1 flex items-center gap-2">
+            <input
+              type="color"
+              value={form.progressModalBadgeBgColor ?? "#FEF3C7"}
+              onChange={(e) =>
+                update("progressModalBadgeBgColor", e.target.value)
+              }
+              className="h-10 w-16 rounded-md border border-slate-300"
+            />
+            <span className="text-xs text-slate-500">
+              {form.progressModalBadgeBgColor ?? "未設定(デフォルト配色)"}
+            </span>
+            {form.progressModalBadgeBgColor && (
+              <button
+                type="button"
+                onClick={() => update("progressModalBadgeBgColor", null)}
                 className="rounded-md border border-slate-300 px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50"
               >
                 デフォルトに戻す

--- a/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
+++ b/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
@@ -17,6 +17,7 @@ import {
   splitSlots,
 } from "@/features/collections/lib/slot-edit-geometry";
 import { MountSlotEditor } from "@/features/preset-categories/components/MountSlotEditor";
+import { ProgressModalColorPreview } from "@/features/preset-categories/components/ProgressModalColorPreview";
 
 type Mode = "create" | "edit";
 
@@ -1414,7 +1415,10 @@ export function AdminPresetCategoryFormClient({
         </div>
 
         {/* 進捗リング/%達成バッジの配色。null(未設定)なら従来デフォルト配色
-            (オレンジのリング/ゴールドのバッジ)を使う(= 厳密な no-op)。 */}
+            (オレンジのリング/ゴールドのバッジ)を使う(= 厳密な no-op)。
+            左に各色のカラー入力、右にライブプレビュー(リング + %達成バッジ)を並べる。 */}
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
+        <div className="flex-1 space-y-4">
         <div className="block">
           <span className="text-sm font-medium text-slate-700">進捗リングの色</span>
           <div className="mt-1 flex items-center gap-2">
@@ -1513,6 +1517,21 @@ export function AdminPresetCategoryFormClient({
               </button>
             )}
           </div>
+        </div>
+        </div>
+
+        {/* ライブプレビュー: 上で選んだ色がリング/バッジにどう反映されるか確認できる。 */}
+        <div className="shrink-0">
+          <span className="mb-1 block text-sm font-medium text-slate-700">
+            プレビュー
+          </span>
+          <ProgressModalColorPreview
+            ringColor={form.progressModalRingColor}
+            badgeColor={form.progressModalBadgeColor}
+            badgeTextColor={form.progressModalBadgeTextColor}
+            badgeBgColor={form.progressModalBadgeBgColor}
+          />
+        </div>
         </div>
       </fieldset>
 

--- a/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
+++ b/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
@@ -174,6 +174,86 @@ function fileToBase64(file: File): Promise<string> {
   });
 }
 
+const HEX6_RE = /^#[0-9A-Fa-f]{6}$/;
+
+/**
+ * 色入力フィールド(スウォッチ + HEX テキスト欄 + 「デフォルトに戻す」)。
+ * value=null は「未設定(デフォルト配色)」。HEX テキストは自由入力でき、
+ * 有効な #RRGGBB になったときだけ確定する(空にすると null=デフォルトに戻る)。
+ * ネイティブの type=color パレットは RGB/HEX 表記を制御できないため、
+ * HEX を直接読み書きできるテキスト欄を併設する。
+ */
+function ColorField({
+  label,
+  value,
+  defaultSwatch,
+  onChange,
+}: {
+  label: string;
+  value: string | null;
+  defaultSwatch: string;
+  onChange: (value: string | null) => void;
+}) {
+  const [text, setText] = useState(value ?? "");
+  // スウォッチ操作・リセット等で外部 value が変わったらテキストも同期する。
+  // useEffect ではなく「レンダー中に派生 state を調整」する公式パターンを使う。
+  const [lastValue, setLastValue] = useState(value);
+  if (value !== lastValue) {
+    setLastValue(value);
+    setText(value ?? "");
+  }
+
+  const handleText = (raw: string) => {
+    setText(raw);
+    const t = raw.trim();
+    if (t === "") {
+      onChange(null);
+      return;
+    }
+    const norm = (t.startsWith("#") ? t : `#${t}`).toUpperCase();
+    if (HEX6_RE.test(norm)) {
+      onChange(norm);
+    }
+    // 途中入力(無効な hex)は確定しない。確定済みの値は維持される。
+  };
+
+  return (
+    <div className="block">
+      <span className="text-sm font-medium text-slate-700">{label}</span>
+      <div className="mt-1 flex items-center gap-2">
+        <input
+          type="color"
+          value={value ?? defaultSwatch}
+          onChange={(e) => onChange(e.target.value.toUpperCase())}
+          className="h-10 w-16 rounded-md border border-slate-300"
+          aria-label={`${label}(スウォッチ)`}
+        />
+        <input
+          type="text"
+          value={text}
+          onChange={(e) => handleText(e.target.value)}
+          placeholder="#RRGGBB"
+          maxLength={7}
+          spellCheck={false}
+          className="h-10 w-28 rounded-md border border-slate-300 px-2 font-mono text-sm uppercase"
+          aria-label={`${label}(HEX)`}
+        />
+        {value == null ? (
+          <span className="text-xs text-slate-500">未設定(デフォルト配色)</span>
+        ) : (
+          <button
+            type="button"
+            onClick={() => onChange(null)}
+            className="rounded-md border border-slate-300 px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50"
+          >
+            デフォルトに戻す
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export function AdminPresetCategoryFormClient({
   mode,
   initial,
@@ -1419,105 +1499,30 @@ export function AdminPresetCategoryFormClient({
             左に各色のカラー入力、右にライブプレビュー(リング + %達成バッジ)を並べる。 */}
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
         <div className="flex-1 space-y-4">
-        <div className="block">
-          <span className="text-sm font-medium text-slate-700">進捗リングの色</span>
-          <div className="mt-1 flex items-center gap-2">
-            <input
-              type="color"
-              value={form.progressModalRingColor ?? "#F97316"}
-              onChange={(e) => update("progressModalRingColor", e.target.value)}
-              className="h-10 w-16 rounded-md border border-slate-300"
-            />
-            <span className="text-xs text-slate-500">
-              {form.progressModalRingColor ?? "未設定(デフォルト配色)"}
-            </span>
-            {form.progressModalRingColor && (
-              <button
-                type="button"
-                onClick={() => update("progressModalRingColor", null)}
-                className="rounded-md border border-slate-300 px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50"
-              >
-                デフォルトに戻す
-              </button>
-            )}
-          </div>
-        </div>
-
-        <div className="block">
-          <span className="text-sm font-medium text-slate-700">%達成バッジの色</span>
-          <div className="mt-1 flex items-center gap-2">
-            <input
-              type="color"
-              value={form.progressModalBadgeColor ?? "#F59E0B"}
-              onChange={(e) => update("progressModalBadgeColor", e.target.value)}
-              className="h-10 w-16 rounded-md border border-slate-300"
-            />
-            <span className="text-xs text-slate-500">
-              {form.progressModalBadgeColor ?? "未設定(デフォルト配色)"}
-            </span>
-            {form.progressModalBadgeColor && (
-              <button
-                type="button"
-                onClick={() => update("progressModalBadgeColor", null)}
-                className="rounded-md border border-slate-300 px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50"
-              >
-                デフォルトに戻す
-              </button>
-            )}
-          </div>
-        </div>
-
-        <div className="block">
-          <span className="text-sm font-medium text-slate-700">バッジの文字色</span>
-          <div className="mt-1 flex items-center gap-2">
-            <input
-              type="color"
-              value={form.progressModalBadgeTextColor ?? "#F97316"}
-              onChange={(e) =>
-                update("progressModalBadgeTextColor", e.target.value)
-              }
-              className="h-10 w-16 rounded-md border border-slate-300"
-            />
-            <span className="text-xs text-slate-500">
-              {form.progressModalBadgeTextColor ?? "未設定(デフォルト配色)"}
-            </span>
-            {form.progressModalBadgeTextColor && (
-              <button
-                type="button"
-                onClick={() => update("progressModalBadgeTextColor", null)}
-                className="rounded-md border border-slate-300 px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50"
-              >
-                デフォルトに戻す
-              </button>
-            )}
-          </div>
-        </div>
-
-        <div className="block">
-          <span className="text-sm font-medium text-slate-700">バッジの背景色</span>
-          <div className="mt-1 flex items-center gap-2">
-            <input
-              type="color"
-              value={form.progressModalBadgeBgColor ?? "#FEF3C7"}
-              onChange={(e) =>
-                update("progressModalBadgeBgColor", e.target.value)
-              }
-              className="h-10 w-16 rounded-md border border-slate-300"
-            />
-            <span className="text-xs text-slate-500">
-              {form.progressModalBadgeBgColor ?? "未設定(デフォルト配色)"}
-            </span>
-            {form.progressModalBadgeBgColor && (
-              <button
-                type="button"
-                onClick={() => update("progressModalBadgeBgColor", null)}
-                className="rounded-md border border-slate-300 px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50"
-              >
-                デフォルトに戻す
-              </button>
-            )}
-          </div>
-        </div>
+        <ColorField
+          label="進捗リングの色"
+          value={form.progressModalRingColor}
+          defaultSwatch="#F97316"
+          onChange={(v) => update("progressModalRingColor", v)}
+        />
+        <ColorField
+          label="%達成バッジの色"
+          value={form.progressModalBadgeColor}
+          defaultSwatch="#F59E0B"
+          onChange={(v) => update("progressModalBadgeColor", v)}
+        />
+        <ColorField
+          label="バッジの文字色"
+          value={form.progressModalBadgeTextColor}
+          defaultSwatch="#F97316"
+          onChange={(v) => update("progressModalBadgeTextColor", v)}
+        />
+        <ColorField
+          label="バッジの背景色"
+          value={form.progressModalBadgeBgColor}
+          defaultSwatch="#FEF3C7"
+          onChange={(v) => update("progressModalBadgeBgColor", v)}
+        />
         </div>
 
         {/* ライブプレビュー: 上で選んだ色がリング/バッジにどう反映されるか確認できる。 */}

--- a/features/preset-categories/components/ProgressModalColorPreview.tsx
+++ b/features/preset-categories/components/ProgressModalColorPreview.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { AchievementBadge } from "@/features/collections/components/AchievementBadge";
+
+/**
+ * 進捗モーダルの「進捗リング + %達成バッジ」を、admin が選んだ配色で
+ * 静的にプレビューする小さなコンポーネント(約 150px 角)。
+ * フレーム画像は使わず、中性的な背景の上にリングとバッジだけを描くので
+ * 色の見え方が分かりやすい。form state を直接受け取るためライブ更新される。
+ */
+
+// 進捗リング(SVG)の定数。モーダル本体(CollectionProgressModal)と同値。
+const RING_R = 47;
+const RING_C = 2 * Math.PI * RING_R;
+// プレビューのサンプル達成率(見栄え用に 66%)。
+const SAMPLE_RATIO = 0.66;
+
+export function ProgressModalColorPreview({
+  ringColor,
+  badgeColor,
+  badgeTextColor,
+  badgeBgColor,
+}: {
+  ringColor: string | null;
+  badgeColor: string | null;
+  badgeTextColor: string | null;
+  badgeBgColor: string | null;
+}) {
+  const dashoffset = RING_C * (1 - SAMPLE_RATIO);
+  return (
+    <div className="relative h-[150px] w-[150px] rounded-xl bg-slate-100">
+      {/* 中央画像のプレースホルダ(薄いグレーの円) */}
+      <div className="absolute left-1/2 top-1/2 h-[78%] w-[78%] -translate-x-1/2 -translate-y-1/2 rounded-full bg-slate-300/60" />
+
+      {/* 進捗リング(トラック + アーク)。モーダルと同じ -90° 回転 + dash 計算。 */}
+      <svg
+        viewBox="0 0 100 100"
+        className="absolute inset-0 h-full w-full -rotate-90 drop-shadow-[0_1px_2px_rgba(180,90,20,0.35)]"
+        aria-hidden
+      >
+        <defs>
+          <linearGradient
+            id="previewArc"
+            x1="0%"
+            y1="0%"
+            x2="100%"
+            y2="100%"
+          >
+            <stop offset="0%" stopColor="#FBBF24" />
+            <stop offset="100%" stopColor="#F97316" />
+          </linearGradient>
+        </defs>
+        {/* トラック(うっすら) */}
+        <circle
+          cx="50"
+          cy="50"
+          r={RING_R}
+          fill="none"
+          stroke="rgba(255,255,255,0.65)"
+          strokeWidth="3.2"
+        />
+        {/* 進捗アーク */}
+        <circle
+          cx="50"
+          cy="50"
+          r={RING_R}
+          fill="none"
+          stroke={ringColor ?? "url(#previewArc)"}
+          strokeWidth="3.6"
+          strokeLinecap="round"
+          strokeDasharray={RING_C}
+          strokeDashoffset={dashoffset}
+        />
+      </svg>
+
+      {/* %達成バッジ(リング右下)。静的プレビューなのでアニメは無効。 */}
+      <div className="pointer-events-none absolute bottom-1 right-1 h-[40%] w-[40%]">
+        <AchievementBadge
+          percent={Math.round(SAMPLE_RATIO * 100)}
+          color={badgeColor}
+          textColor={badgeTextColor}
+          bgColor={badgeBgColor}
+          animate={false}
+        />
+      </div>
+    </div>
+  );
+}

--- a/features/style-presets/lib/preset-category-repository.ts
+++ b/features/style-presets/lib/preset-category-repository.ts
@@ -62,6 +62,8 @@ export interface PresetCategoryRow {
   progress_modal_slots?: unknown;
   progress_modal_button?: unknown;
   progress_modal_center?: unknown;
+  progress_modal_ring_color?: string | null;
+  progress_modal_badge_color?: string | null;
   display_order: number;
   is_active: boolean;
   created_by: string | null;
@@ -106,6 +108,8 @@ export interface PresetCategoryAdmin {
   progressModalSlots: NormalizedSlotRect[] | null;
   progressModalButton: NormalizedSlotRect | null;
   progressModalCenter: NormalizedSlotRect | null;
+  progressModalRingColor: string | null;
+  progressModalBadgeColor: string | null;
   displayOrder: number;
   isActive: boolean;
   createdBy: string | null;
@@ -149,6 +153,8 @@ export interface PresetCategoryInsert {
   progressModalSlots?: NormalizedSlotRect[] | null;
   progressModalButton?: NormalizedSlotRect | null;
   progressModalCenter?: NormalizedSlotRect | null;
+  progressModalRingColor?: string | null;
+  progressModalBadgeColor?: string | null;
   displayOrder?: number;
   isActive?: boolean;
   createdBy?: string | null;
@@ -188,6 +194,8 @@ export interface PresetCategoryUpdate {
   progressModalSlots?: NormalizedSlotRect[] | null;
   progressModalButton?: NormalizedSlotRect | null;
   progressModalCenter?: NormalizedSlotRect | null;
+  progressModalRingColor?: string | null;
+  progressModalBadgeColor?: string | null;
   displayOrder?: number;
   isActive?: boolean;
   updatedBy?: string | null;
@@ -254,6 +262,8 @@ function mapRow(row: PresetCategoryRow): PresetCategoryAdmin {
     progressModalSlots: parseNormalizedSlots(row.progress_modal_slots),
     progressModalButton: parseNormalizedRect(row.progress_modal_button),
     progressModalCenter: parseNormalizedRect(row.progress_modal_center),
+    progressModalRingColor: row.progress_modal_ring_color ?? null,
+    progressModalBadgeColor: row.progress_modal_badge_color ?? null,
     displayOrder: row.display_order,
     isActive: row.is_active,
     createdBy: row.created_by,
@@ -366,6 +376,8 @@ export async function createPresetCategory(
       progress_modal_slots: input.progressModalSlots ?? null,
       progress_modal_button: input.progressModalButton ?? null,
       progress_modal_center: input.progressModalCenter ?? null,
+      progress_modal_ring_color: input.progressModalRingColor ?? null,
+      progress_modal_badge_color: input.progressModalBadgeColor ?? null,
       display_order: input.displayOrder ?? 0,
       is_active: input.isActive ?? true,
       created_by: input.createdBy ?? null,
@@ -447,6 +459,10 @@ export async function updatePresetCategory(
     payload.progress_modal_button = input.progressModalButton;
   if (input.progressModalCenter !== undefined)
     payload.progress_modal_center = input.progressModalCenter;
+  if (input.progressModalRingColor !== undefined)
+    payload.progress_modal_ring_color = input.progressModalRingColor;
+  if (input.progressModalBadgeColor !== undefined)
+    payload.progress_modal_badge_color = input.progressModalBadgeColor;
   if (input.displayOrder !== undefined) payload.display_order = input.displayOrder;
   if (input.isActive !== undefined) payload.is_active = input.isActive;
   if (input.updatedBy !== undefined) payload.updated_by = input.updatedBy;

--- a/features/style-presets/lib/preset-category-repository.ts
+++ b/features/style-presets/lib/preset-category-repository.ts
@@ -64,6 +64,8 @@ export interface PresetCategoryRow {
   progress_modal_center?: unknown;
   progress_modal_ring_color?: string | null;
   progress_modal_badge_color?: string | null;
+  progress_modal_badge_text_color?: string | null;
+  progress_modal_badge_bg_color?: string | null;
   display_order: number;
   is_active: boolean;
   created_by: string | null;
@@ -110,6 +112,8 @@ export interface PresetCategoryAdmin {
   progressModalCenter: NormalizedSlotRect | null;
   progressModalRingColor: string | null;
   progressModalBadgeColor: string | null;
+  progressModalBadgeTextColor: string | null;
+  progressModalBadgeBgColor: string | null;
   displayOrder: number;
   isActive: boolean;
   createdBy: string | null;
@@ -155,6 +159,8 @@ export interface PresetCategoryInsert {
   progressModalCenter?: NormalizedSlotRect | null;
   progressModalRingColor?: string | null;
   progressModalBadgeColor?: string | null;
+  progressModalBadgeTextColor?: string | null;
+  progressModalBadgeBgColor?: string | null;
   displayOrder?: number;
   isActive?: boolean;
   createdBy?: string | null;
@@ -196,6 +202,8 @@ export interface PresetCategoryUpdate {
   progressModalCenter?: NormalizedSlotRect | null;
   progressModalRingColor?: string | null;
   progressModalBadgeColor?: string | null;
+  progressModalBadgeTextColor?: string | null;
+  progressModalBadgeBgColor?: string | null;
   displayOrder?: number;
   isActive?: boolean;
   updatedBy?: string | null;
@@ -264,6 +272,8 @@ function mapRow(row: PresetCategoryRow): PresetCategoryAdmin {
     progressModalCenter: parseNormalizedRect(row.progress_modal_center),
     progressModalRingColor: row.progress_modal_ring_color ?? null,
     progressModalBadgeColor: row.progress_modal_badge_color ?? null,
+    progressModalBadgeTextColor: row.progress_modal_badge_text_color ?? null,
+    progressModalBadgeBgColor: row.progress_modal_badge_bg_color ?? null,
     displayOrder: row.display_order,
     isActive: row.is_active,
     createdBy: row.created_by,
@@ -378,6 +388,8 @@ export async function createPresetCategory(
       progress_modal_center: input.progressModalCenter ?? null,
       progress_modal_ring_color: input.progressModalRingColor ?? null,
       progress_modal_badge_color: input.progressModalBadgeColor ?? null,
+      progress_modal_badge_text_color: input.progressModalBadgeTextColor ?? null,
+      progress_modal_badge_bg_color: input.progressModalBadgeBgColor ?? null,
       display_order: input.displayOrder ?? 0,
       is_active: input.isActive ?? true,
       created_by: input.createdBy ?? null,
@@ -463,6 +475,10 @@ export async function updatePresetCategory(
     payload.progress_modal_ring_color = input.progressModalRingColor;
   if (input.progressModalBadgeColor !== undefined)
     payload.progress_modal_badge_color = input.progressModalBadgeColor;
+  if (input.progressModalBadgeTextColor !== undefined)
+    payload.progress_modal_badge_text_color = input.progressModalBadgeTextColor;
+  if (input.progressModalBadgeBgColor !== undefined)
+    payload.progress_modal_badge_bg_color = input.progressModalBadgeBgColor;
   if (input.displayOrder !== undefined) payload.display_order = input.displayOrder;
   if (input.isActive !== undefined) payload.is_active = input.isActive;
   if (input.updatedBy !== undefined) payload.updated_by = input.updatedBy;

--- a/supabase/migrations/20260616160000_add_progress_modal_colors.sql
+++ b/supabase/migrations/20260616160000_add_progress_modal_colors.sql
@@ -1,0 +1,54 @@
+-- ===============================================
+-- preset_categories に「進捗モーダルの配色(リング/バッジ)」を追加
+-- ===============================================
+-- 20260616130000 で中央画像位置(progress_modal_center)を admin から設定できるように
+-- したのに続き、進捗モーダルの「進捗リングの色」と「%達成バッジの色」も
+-- カテゴリごとに admin が指定できるようにする。
+--
+-- - progress_modal_ring_color  : 進捗リング(アーク)の色。#RRGGBB の16進文字列。
+-- - progress_modal_badge_color : %達成バッジの色。#RRGGBB の16進文字列。
+--
+-- どちらも nullable。NULL のときは従来どおりのデフォルト配色
+-- (オレンジのリング/ゴールドのバッジ)を使う。既存カテゴリ(神コレ/ウエハース/
+-- coordinate 等)や未設定の petit は NULL のまま動作不変(厳密な no-op)。
+-- ===============================================
+
+ALTER TABLE public.preset_categories
+  ADD COLUMN IF NOT EXISTS progress_modal_ring_color TEXT;
+
+ALTER TABLE public.preset_categories
+  ADD COLUMN IF NOT EXISTS progress_modal_badge_color TEXT;
+
+-- 値は NULL もしくは #RRGGBB 形式の16進カラーのみ許可する
+ALTER TABLE public.preset_categories
+  DROP CONSTRAINT IF EXISTS preset_categories_progress_modal_ring_color_hex;
+ALTER TABLE public.preset_categories
+  ADD CONSTRAINT preset_categories_progress_modal_ring_color_hex
+  CHECK (
+    progress_modal_ring_color IS NULL
+    OR progress_modal_ring_color ~ '^#[0-9A-Fa-f]{6}$'
+  );
+
+ALTER TABLE public.preset_categories
+  DROP CONSTRAINT IF EXISTS preset_categories_progress_modal_badge_color_hex;
+ALTER TABLE public.preset_categories
+  ADD CONSTRAINT preset_categories_progress_modal_badge_color_hex
+  CHECK (
+    progress_modal_badge_color IS NULL
+    OR progress_modal_badge_color ~ '^#[0-9A-Fa-f]{6}$'
+  );
+
+COMMENT ON COLUMN public.preset_categories.progress_modal_ring_color IS '進捗モーダルの進捗リング(アーク)の色。#RRGGBB。NULL=従来デフォルト配色';
+COMMENT ON COLUMN public.preset_categories.progress_modal_badge_color IS '進捗モーダルの%達成バッジの色。#RRGGBB。NULL=従来デフォルト配色';
+
+-- ===============================================
+-- DOWN:
+-- ALTER TABLE public.preset_categories
+--   DROP CONSTRAINT IF EXISTS preset_categories_progress_modal_ring_color_hex;
+-- ALTER TABLE public.preset_categories
+--   DROP CONSTRAINT IF EXISTS preset_categories_progress_modal_badge_color_hex;
+-- ALTER TABLE public.preset_categories
+--   DROP COLUMN IF EXISTS progress_modal_ring_color;
+-- ALTER TABLE public.preset_categories
+--   DROP COLUMN IF EXISTS progress_modal_badge_color;
+-- ===============================================

--- a/supabase/migrations/20260616170000_add_progress_modal_badge_text_bg_colors.sql
+++ b/supabase/migrations/20260616170000_add_progress_modal_badge_text_bg_colors.sql
@@ -1,0 +1,56 @@
+-- ===============================================
+-- preset_categories に「%達成バッジの文字色/背景色」を追加
+-- ===============================================
+-- 20260616160000 で進捗モーダルの「進捗リングの色」と「%達成バッジの色」を
+-- admin から設定できるようにしたのに続き、バッジ内部の
+-- 「文字色(% の数字・達成！ラベル)」と「背景色(内側スカロップ)」も
+-- カテゴリごとに admin が指定できるようにする。
+--
+-- - progress_modal_badge_text_color : %達成バッジの文字色(% の数字・達成！）。#RRGGBB。
+-- - progress_modal_badge_bg_color   : %達成バッジの内側背景色(クリーム地)。#RRGGBB。
+--
+-- どちらも nullable。NULL のときは従来どおりのデフォルト配色
+-- (% はオレンジ #F97316 / 達成！は #B45309 / 背景はクリームの url(#badgeFill))を使う。
+-- 既存カテゴリ(神コレ/ウエハース/coordinate 等)や未設定の petit は NULL のまま
+-- 動作不変(厳密な no-op)。
+-- ===============================================
+
+ALTER TABLE public.preset_categories
+  ADD COLUMN IF NOT EXISTS progress_modal_badge_text_color TEXT;
+
+ALTER TABLE public.preset_categories
+  ADD COLUMN IF NOT EXISTS progress_modal_badge_bg_color TEXT;
+
+-- 値は NULL もしくは #RRGGBB 形式の16進カラーのみ許可する
+ALTER TABLE public.preset_categories
+  DROP CONSTRAINT IF EXISTS preset_categories_progress_modal_badge_text_color_hex;
+ALTER TABLE public.preset_categories
+  ADD CONSTRAINT preset_categories_progress_modal_badge_text_color_hex
+  CHECK (
+    progress_modal_badge_text_color IS NULL
+    OR progress_modal_badge_text_color ~ '^#[0-9A-Fa-f]{6}$'
+  );
+
+ALTER TABLE public.preset_categories
+  DROP CONSTRAINT IF EXISTS preset_categories_progress_modal_badge_bg_color_hex;
+ALTER TABLE public.preset_categories
+  ADD CONSTRAINT preset_categories_progress_modal_badge_bg_color_hex
+  CHECK (
+    progress_modal_badge_bg_color IS NULL
+    OR progress_modal_badge_bg_color ~ '^#[0-9A-Fa-f]{6}$'
+  );
+
+COMMENT ON COLUMN public.preset_categories.progress_modal_badge_text_color IS '進捗モーダルの%達成バッジの文字色(%の数字・達成！）。#RRGGBB。NULL=従来デフォルト配色';
+COMMENT ON COLUMN public.preset_categories.progress_modal_badge_bg_color IS '進捗モーダルの%達成バッジの内側背景色(クリーム地)。#RRGGBB。NULL=従来デフォルト配色';
+
+-- ===============================================
+-- DOWN:
+-- ALTER TABLE public.preset_categories
+--   DROP CONSTRAINT IF EXISTS preset_categories_progress_modal_badge_text_color_hex;
+-- ALTER TABLE public.preset_categories
+--   DROP CONSTRAINT IF EXISTS preset_categories_progress_modal_badge_bg_color_hex;
+-- ALTER TABLE public.preset_categories
+--   DROP COLUMN IF EXISTS progress_modal_badge_text_color;
+-- ALTER TABLE public.preset_categories
+--   DROP COLUMN IF EXISTS progress_modal_badge_bg_color;
+-- ===============================================

--- a/tests/unit/features/collections/achievement-badge.test.tsx
+++ b/tests/unit/features/collections/achievement-badge.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * `AchievementBadge` の色プロップ分岐テスト。
+ *
+ * SVG をインラインで描く純コンポーネント(next/image 不要)。
+ * - color/textColor/bgColor が null(未指定)のときは従来のゴールド配色
+ *   (外側 url(#badgeStroke) / 内側 url(#badgeFill) / % 文字 #F97316)。
+ * - 指定があるときはその単色で外側スカロップ・内側背景・文字色を塗る。
+ * alt="" の SVG は role を持たないため、container.querySelectorAll で要素を引く。
+ */
+
+import { render } from "@testing-library/react";
+
+import { AchievementBadge } from "@/features/collections/components/AchievementBadge";
+
+describe("AchievementBadge: 色プロップ分岐", () => {
+  test("色プロップ未指定なら従来のゴールド配色(グラデーション参照)になる", () => {
+    const { container } = render(<AchievementBadge percent={66} />);
+
+    const polygons = container.querySelectorAll("polygon");
+    // 外側スカロップ(縁取り)= url(#badgeStroke)、内側(中身)= url(#badgeFill)
+    expect(polygons[0]).toHaveAttribute("fill", "url(#badgeStroke)");
+    expect(polygons[1]).toHaveAttribute("fill", "url(#badgeFill)");
+
+    // % 文字はオレンジ #F97316
+    const texts = container.querySelectorAll("text");
+    expect(texts[0]).toHaveAttribute("fill", "#F97316");
+    expect(texts[0]?.textContent).toBe("66%");
+    // 「達成！」ラベルは茶 #B45309
+    expect(texts[1]).toHaveAttribute("fill", "#B45309");
+  });
+
+  test("色プロップ指定時はその単色で外側/内側/文字を塗る", () => {
+    const { container } = render(
+      <AchievementBadge
+        percent={66}
+        color="#16A34A"
+        textColor="#FFFFFF"
+        bgColor="#166534"
+      />,
+    );
+
+    const polygons = container.querySelectorAll("polygon");
+    expect(polygons[0]).toHaveAttribute("fill", "#16A34A");
+    expect(polygons[1]).toHaveAttribute("fill", "#166534");
+
+    const texts = container.querySelectorAll("text");
+    // % 文字・「達成！」ともに textColor で塗る
+    expect(texts[0]).toHaveAttribute("fill", "#FFFFFF");
+    expect(texts[1]).toHaveAttribute("fill", "#FFFFFF");
+  });
+});

--- a/tests/unit/features/collections/collection-progress-modal.test.tsx
+++ b/tests/unit/features/collections/collection-progress-modal.test.tsx
@@ -381,3 +381,119 @@ describe("CollectionProgressModal: 完了時の紙吹雪は画像ロードを待
     }
   });
 });
+
+describe("CollectionProgressModal: DB 駆動レイアウト(progressModal* 設定)", () => {
+  // admin が設定する DB 駆動レイアウト。frameUrl+実寸がそろっているので
+  // MODAL_LAYOUTS より優先され、centerRect から ring/badge を自動導出する。
+  const dbProgress = (
+    overrides: Partial<CollectionCelebration> = {},
+  ): CollectionCelebration => ({
+    categoryKey: "db_driven_category",
+    displayName: "DB駆動",
+    fromCount: 0,
+    toCount: 2,
+    threshold: 6,
+    isCompleted: false,
+    mountImageUrl: null,
+    sharePath: null,
+    completionId: null,
+    characterImageUrl: "CHAR",
+    collectedImageUrls: ["S1", "S2"],
+    progressModalFrameUrl: "https://cdn.example.com/frames/frame-1.webp",
+    progressModalFrameWidth: 1086,
+    progressModalFrameHeight: 1448,
+    progressModalSlots: [
+      { x: 0.1, y: 0.7, w: 0.13, h: 0.13 },
+      { x: 0.3, y: 0.7, w: 0.13, h: 0.13 },
+    ],
+    progressModalButton: { x: 0.1, y: 0.85, w: 0.8, h: 0.09 },
+    progressModalCenter: { x: 0.3, y: 0.2, w: 0.4, h: 0.3 },
+    ...overrides,
+  });
+
+  test("DB 色設定あり: フレーム/中央/スロット画像 + リング/バッジ/%文字に指定色を反映", () => {
+    render(
+      <CollectionProgressModal
+        open
+        celebration={dbProgress({
+          progressModalRingColor: "#22C55E",
+          progressModalBadgeColor: "#16A34A",
+          progressModalBadgeTextColor: "#FFFFFF",
+          progressModalBadgeBgColor: "#166534",
+        })}
+        onClose={jest.fn()}
+      />,
+    );
+
+    const imgSrcs = Array.from(document.querySelectorAll("img")).map(
+      (img) => img.getAttribute("src") ?? "",
+    );
+    // フレーム / 中央キャラ / 集めたシール(S1/S2)が描画される
+    expect(
+      imgSrcs.some((src) => src.includes("frame-1.webp")),
+    ).toBe(true);
+    expect(imgSrcs).toContain("CHAR");
+    expect(imgSrcs).toContain("S1");
+    expect(imgSrcs).toContain("S2");
+
+    // 進捗アークの circle に ringColor が反映される
+    const arcStrokes = Array.from(
+      document.querySelectorAll("svg circle"),
+    ).map((c) => c.getAttribute("stroke"));
+    expect(arcStrokes).toContain("#22C55E");
+
+    // バッジ外側 polygon=badgeColor、内側 polygon=badgeBgColor
+    const polygonFills = Array.from(
+      document.querySelectorAll("polygon"),
+    ).map((p) => p.getAttribute("fill"));
+    expect(polygonFills).toContain("#16A34A");
+    expect(polygonFills).toContain("#166534");
+
+    // % 文字に badgeTextColor が反映される
+    const textFills = Array.from(document.querySelectorAll("text")).map((t) =>
+      t.getAttribute("fill"),
+    );
+    expect(textFills).toContain("#FFFFFF");
+  });
+
+  test("DB 色設定なし(null): リング/バッジ/%文字は従来デフォルト配色になる", () => {
+    render(
+      <CollectionProgressModal
+        open
+        celebration={dbProgress({
+          progressModalRingColor: null,
+          progressModalBadgeColor: null,
+          progressModalBadgeTextColor: null,
+          progressModalBadgeBgColor: null,
+        })}
+        onClose={jest.fn()}
+      />,
+    );
+
+    // フレームは DB 駆動のまま描画される(色だけデフォルト)
+    const imgSrcs = Array.from(document.querySelectorAll("img")).map(
+      (img) => img.getAttribute("src") ?? "",
+    );
+    expect(
+      imgSrcs.some((src) => src.includes("frame-1.webp")),
+    ).toBe(true);
+
+    // 進捗アークはグラデーション参照(デフォルト)
+    const arcStrokes = Array.from(
+      document.querySelectorAll("svg circle"),
+    ).map((c) => c.getAttribute("stroke"));
+    expect(arcStrokes).toContain("url(#collArc)");
+
+    // バッジ外側はゴールドのグラデ参照(デフォルト)
+    const polygonFills = Array.from(
+      document.querySelectorAll("polygon"),
+    ).map((p) => p.getAttribute("fill"));
+    expect(polygonFills).toContain("url(#badgeStroke)");
+
+    // % 文字はオレンジ #F97316(デフォルト)
+    const textFills = Array.from(document.querySelectorAll("text")).map((t) =>
+      t.getAttribute("fill"),
+    );
+    expect(textFills).toContain("#F97316");
+  });
+});

--- a/tests/unit/features/collections/collection-progress-repository.test.ts
+++ b/tests/unit/features/collections/collection-progress-repository.test.ts
@@ -1,0 +1,192 @@
+/** @jest-environment node */
+
+/**
+ * `collection-progress-repository` の progress-modal フィールド結合テスト。
+ *
+ * getCollectionProgressForUser は
+ *  1) RPC get_collection_progress_for_user でシリーズ進捗行を取得し mapProgressRow、
+ *  2) preset_categories から progress_modal_* / character / colors を引いて結合、
+ *  3) 集めたシール画像と completion_id を付与する。
+ * ここでは progress_modal_*(frame/slots/center/button + ring/badge/text/bg color)が
+ * CollectionProgress に正しく結合されることを検証する。
+ * 外部依存(admin client / 公開URL組立 / 代表画像)はモックする。
+ */
+
+const createAdminClientMock = jest.fn();
+jest.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => createAdminClientMock(),
+}));
+
+const buildPublicGeneratedImageUrlMock = jest.fn(
+  (path: string | null): string | null =>
+    path ? `https://cdn.example.com/public/${path}` : null,
+);
+jest.mock(
+  "@/features/collections/lib/public-mount-server-api",
+  () => ({
+    buildPublicGeneratedImageUrl: (path: string | null) =>
+      buildPublicGeneratedImageUrlMock(path),
+  }),
+);
+
+const getRepresentativeImagesForCategoryMock = jest.fn();
+jest.mock("@/features/collections/lib/representative-images", () => ({
+  getRepresentativeImagesForCategory: (...args: unknown[]) =>
+    getRepresentativeImagesForCategoryMock(...args),
+}));
+
+import { getCollectionProgressForUser } from "@/features/collections/lib/collection-progress-repository";
+
+const PROGRESS_ROW = {
+  category_id: "cat-1",
+  category_key: "db_driven_category",
+  display_name_ja: "DB駆動",
+  display_name_en: "DB Driven",
+  completion_threshold: 6,
+  unique_outfit_count: 2,
+  is_completed: false,
+  mount_status: null,
+  mount_image_path: null,
+  completed_at: null,
+};
+
+const PRESET_CATEGORY_ROW = {
+  id: "cat-1",
+  collection_character_path: "characters/char-1.png",
+  mount_template_width: 1086,
+  mount_template_height: 1448,
+  progress_modal_frame_path: "frames/frame-1.webp",
+  progress_modal_frame_width: 1086,
+  progress_modal_frame_height: 1448,
+  progress_modal_slots: [
+    { x: 0.1, y: 0.7, w: 0.13, h: 0.13 },
+    { x: 0.3, y: 0.7, w: 0.13, h: 0.13 },
+  ],
+  progress_modal_button: { x: 0.1, y: 0.85, w: 0.8, h: 0.09 },
+  progress_modal_center: { x: 0.3, y: 0.2, w: 0.4, h: 0.3 },
+  progress_modal_ring_color: "#22C55E",
+  progress_modal_badge_color: "#16A34A",
+  progress_modal_badge_text_color: "#FFFFFF",
+  progress_modal_badge_bg_color: "#166534",
+};
+
+/**
+ * createAdminClient のモック。
+ * - rpc(): 進捗行を返す
+ * - from("preset_categories").select().in(): progress_modal 列付き行を返す
+ */
+function buildAdminClient() {
+  const rpc = jest.fn().mockResolvedValue({ data: [PROGRESS_ROW], error: null });
+  const from = jest.fn((table: string) => {
+    if (table === "preset_categories") {
+      return {
+        select: jest.fn(() => ({
+          in: jest
+            .fn()
+            .mockResolvedValue({ data: [PRESET_CATEGORY_ROW], error: null }),
+        })),
+      };
+    }
+    // collection_completions(attachCompletionIds): 未完了なので呼ばれない想定
+    return {
+      select: jest.fn(() => ({
+        eq: jest.fn(() => ({
+          eq: jest.fn().mockResolvedValue({ data: [], error: null }),
+        })),
+      })),
+    };
+  });
+  return { rpc, from };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  getRepresentativeImagesForCategoryMock.mockResolvedValue([]);
+});
+
+describe("getCollectionProgressForUser: progress-modal フィールド結合", () => {
+  test("preset_categories の progress_modal_* を CollectionProgress に結合する", async () => {
+    createAdminClientMock.mockImplementation(() => buildAdminClient());
+
+    const result = await getCollectionProgressForUser("user-1", false);
+
+    expect(result).toHaveLength(1);
+    const p = result[0]!;
+    // frame は buildPublicGeneratedImageUrl で組み立てた公開URL
+    expect(p.progressModalFrameUrl).toBe(
+      "https://cdn.example.com/public/frames/frame-1.webp",
+    );
+    expect(p.progressModalFrameWidth).toBe(1086);
+    expect(p.progressModalFrameHeight).toBe(1448);
+    expect(p.progressModalSlots).toEqual([
+      { x: 0.1, y: 0.7, w: 0.13, h: 0.13 },
+      { x: 0.3, y: 0.7, w: 0.13, h: 0.13 },
+    ]);
+    expect(p.progressModalButton).toEqual({
+      x: 0.1,
+      y: 0.85,
+      w: 0.8,
+      h: 0.09,
+    });
+    expect(p.progressModalCenter).toEqual({
+      x: 0.3,
+      y: 0.2,
+      w: 0.4,
+      h: 0.3,
+    });
+    // 色 4 種が結合される
+    expect(p.progressModalRingColor).toBe("#22C55E");
+    expect(p.progressModalBadgeColor).toBe("#16A34A");
+    expect(p.progressModalBadgeTextColor).toBe("#FFFFFF");
+    expect(p.progressModalBadgeBgColor).toBe("#166534");
+    // キャラ画像も公開URLに組み立て
+    expect(p.characterImageUrl).toBe(
+      "https://cdn.example.com/public/characters/char-1.png",
+    );
+  });
+
+  test("色列が null なら null として結合する", async () => {
+    createAdminClientMock.mockImplementation(() => {
+      const client = buildAdminClient();
+      client.from = jest.fn((table: string) => {
+        if (table === "preset_categories") {
+          return {
+            select: jest.fn(() => ({
+              in: jest.fn().mockResolvedValue({
+                data: [
+                  {
+                    ...PRESET_CATEGORY_ROW,
+                    progress_modal_ring_color: null,
+                    progress_modal_badge_color: null,
+                    progress_modal_badge_text_color: null,
+                    progress_modal_badge_bg_color: null,
+                  },
+                ],
+                error: null,
+              }),
+            })),
+          };
+        }
+        return {
+          select: jest.fn(() => ({
+            eq: jest.fn(() => ({
+              eq: jest.fn().mockResolvedValue({ data: [], error: null }),
+            })),
+          })),
+        };
+      });
+      return client;
+    });
+
+    const result = await getCollectionProgressForUser("user-1", false);
+    const p = result[0]!;
+    expect(p.progressModalRingColor).toBeNull();
+    expect(p.progressModalBadgeColor).toBeNull();
+    expect(p.progressModalBadgeTextColor).toBeNull();
+    expect(p.progressModalBadgeBgColor).toBeNull();
+    // frame など他フィールドは引き続き結合される
+    expect(p.progressModalFrameUrl).toBe(
+      "https://cdn.example.com/public/frames/frame-1.webp",
+    );
+  });
+});

--- a/tests/unit/features/collections/collection-settings-payload.test.ts
+++ b/tests/unit/features/collections/collection-settings-payload.test.ts
@@ -556,4 +556,77 @@ describe("parseCollectionSettings - 進捗モーダル設定(任意・独立)", 
       ).ok,
     ).toBe(false);
   });
+
+  // ---------------- progress_modal_ring_color / progress_modal_badge_color ----------------
+
+  test("ring/badge color: 有効な #RRGGBB はそのまま採用", () => {
+    const r = parseCollectionSettings(
+      {
+        progress_modal_ring_color: "#F97316",
+        progress_modal_badge_color: "#1E90FF",
+      },
+      OFF,
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.payload.progressModalRingColor).toBe("#F97316");
+      expect(r.payload.progressModalBadgeColor).toBe("#1E90FF");
+    }
+  });
+
+  test("ring/badge color: 大文字小文字混在の hex も受理", () => {
+    const r = parseCollectionSettings(
+      { progress_modal_ring_color: "#aabBcc" },
+      OFF,
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.payload.progressModalRingColor).toBe("#aabBcc");
+  });
+
+  test("ring/badge color: null はクリア(デフォルト配色に戻す)", () => {
+    const r = parseCollectionSettings(
+      {
+        progress_modal_ring_color: null,
+        progress_modal_badge_color: null,
+      },
+      OFF,
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.payload.progressModalRingColor).toBeNull();
+      expect(r.payload.progressModalBadgeColor).toBeNull();
+    }
+  });
+
+  test("ring color: hex でない文字列は拒否", () => {
+    expect(
+      parseCollectionSettings({ progress_modal_ring_color: "orange" }, OFF).ok,
+    ).toBe(false);
+    // 3桁短縮形は許可しない
+    expect(
+      parseCollectionSettings({ progress_modal_ring_color: "#FFF" }, OFF).ok,
+    ).toBe(false);
+    // # 抜けは拒否
+    expect(
+      parseCollectionSettings({ progress_modal_ring_color: "F97316" }, OFF).ok,
+    ).toBe(false);
+  });
+
+  test("badge color: 文字列以外(数値)は拒否", () => {
+    const r = parseCollectionSettings(
+      { progress_modal_badge_color: 16711680 },
+      OFF,
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/progress_modal_badge_color/);
+  });
+
+  test("空 body は ring/badge color を payload に含めない(no-op)", () => {
+    const r = parseCollectionSettings({}, OFF);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.payload.progressModalRingColor).toBeUndefined();
+      expect(r.payload.progressModalBadgeColor).toBeUndefined();
+    }
+  });
 });

--- a/tests/unit/features/collections/collection-settings-payload.test.ts
+++ b/tests/unit/features/collections/collection-settings-payload.test.ts
@@ -629,4 +629,93 @@ describe("parseCollectionSettings - 進捗モーダル設定(任意・独立)", 
       expect(r.payload.progressModalBadgeColor).toBeUndefined();
     }
   });
+
+  // ---------------- progress_modal_badge_text_color / progress_modal_badge_bg_color ----------------
+
+  test("badge text/bg color: 有効な #RRGGBB はそのまま採用", () => {
+    const r = parseCollectionSettings(
+      {
+        progress_modal_badge_text_color: "#FF0000",
+        progress_modal_badge_bg_color: "#00FF00",
+      },
+      OFF,
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.payload.progressModalBadgeTextColor).toBe("#FF0000");
+      expect(r.payload.progressModalBadgeBgColor).toBe("#00FF00");
+    }
+  });
+
+  test("badge text/bg color: 大文字小文字混在の hex も受理", () => {
+    const r = parseCollectionSettings(
+      {
+        progress_modal_badge_text_color: "#aAbBcC",
+        progress_modal_badge_bg_color: "#DdEeFf",
+      },
+      OFF,
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.payload.progressModalBadgeTextColor).toBe("#aAbBcC");
+      expect(r.payload.progressModalBadgeBgColor).toBe("#DdEeFf");
+    }
+  });
+
+  test("badge text/bg color: null はクリア(デフォルト配色に戻す)", () => {
+    const r = parseCollectionSettings(
+      {
+        progress_modal_badge_text_color: null,
+        progress_modal_badge_bg_color: null,
+      },
+      OFF,
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.payload.progressModalBadgeTextColor).toBeNull();
+      expect(r.payload.progressModalBadgeBgColor).toBeNull();
+    }
+  });
+
+  test("badge text color: hex でない文字列は拒否", () => {
+    // 名前付き色は拒否
+    expect(
+      parseCollectionSettings(
+        { progress_modal_badge_text_color: "orange" },
+        OFF,
+      ).ok,
+    ).toBe(false);
+    // 3桁短縮形は許可しない
+    expect(
+      parseCollectionSettings(
+        { progress_modal_badge_text_color: "#FFF" },
+        OFF,
+      ).ok,
+    ).toBe(false);
+    // # 抜けは拒否
+    const r = parseCollectionSettings(
+      { progress_modal_badge_text_color: "FF0000" },
+      OFF,
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/progress_modal_badge_text_color/);
+  });
+
+  test("badge bg color: 文字列以外(数値)は拒否", () => {
+    const r = parseCollectionSettings(
+      { progress_modal_badge_bg_color: 16711680 },
+      OFF,
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/progress_modal_badge_bg_color/);
+  });
+
+  test("空 body は badge text/bg color を payload に含めない(no-op)", () => {
+    const r = parseCollectionSettings({}, OFF);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.payload.progressModalBadgeTextColor).toBeUndefined();
+      expect(r.payload.progressModalBadgeBgColor).toBeUndefined();
+    }
+  });
 });

--- a/tests/unit/lib/preset-category-repository.test.ts
+++ b/tests/unit/lib/preset-category-repository.test.ts
@@ -106,6 +106,72 @@ describe("getPresetCategoryById", () => {
     expect(result?.visibility).toBe("public");
   });
 
+  test("progress_modal_* 列を camelCase ドメインへマップする(色/中央/ボタン)", async () => {
+    const row: PresetCategoryRow = {
+      ...SAMPLE_ROW,
+      progress_modal_frame_path: "frames/frame-1.webp",
+      progress_modal_frame_width: 1086,
+      progress_modal_frame_height: 1448,
+      progress_modal_slots: [
+        { x: 0.1, y: 0.7, w: 0.13, h: 0.13 },
+        { x: 0.3, y: 0.7, w: 0.13, h: 0.13 },
+      ],
+      progress_modal_button: { x: 0.1, y: 0.85, w: 0.8, h: 0.09 },
+      progress_modal_center: { x: 0.3, y: 0.2, w: 0.4, h: 0.3 },
+      progress_modal_ring_color: "#22C55E",
+      progress_modal_badge_color: "#16A34A",
+      progress_modal_badge_text_color: "#FFFFFF",
+      progress_modal_badge_bg_color: "#166534",
+    };
+    createAdminClientMock.mockReturnValue({
+      from: buildSingleChain({ data: row, error: null }),
+    });
+
+    const result = await getPresetCategoryById(SAMPLE_ROW.id);
+    expect(result?.progressModalFramePath).toBe("frames/frame-1.webp");
+    expect(result?.progressModalFrameWidth).toBe(1086);
+    expect(result?.progressModalFrameHeight).toBe(1448);
+    expect(result?.progressModalSlots).toEqual([
+      { x: 0.1, y: 0.7, w: 0.13, h: 0.13 },
+      { x: 0.3, y: 0.7, w: 0.13, h: 0.13 },
+    ]);
+    expect(result?.progressModalButton).toEqual({
+      x: 0.1,
+      y: 0.85,
+      w: 0.8,
+      h: 0.09,
+    });
+    expect(result?.progressModalCenter).toEqual({
+      x: 0.3,
+      y: 0.2,
+      w: 0.4,
+      h: 0.3,
+    });
+    expect(result?.progressModalRingColor).toBe("#22C55E");
+    expect(result?.progressModalBadgeColor).toBe("#16A34A");
+    expect(result?.progressModalBadgeTextColor).toBe("#FFFFFF");
+    expect(result?.progressModalBadgeBgColor).toBe("#166534");
+  });
+
+  test("progress_modal_* 色列が null なら null にフォールバックする", async () => {
+    const row: PresetCategoryRow = {
+      ...SAMPLE_ROW,
+      progress_modal_ring_color: null,
+      progress_modal_badge_color: null,
+      progress_modal_badge_text_color: null,
+      progress_modal_badge_bg_color: null,
+    };
+    createAdminClientMock.mockReturnValue({
+      from: buildSingleChain({ data: row, error: null }),
+    });
+
+    const result = await getPresetCategoryById(SAMPLE_ROW.id);
+    expect(result?.progressModalRingColor).toBeNull();
+    expect(result?.progressModalBadgeColor).toBeNull();
+    expect(result?.progressModalBadgeTextColor).toBeNull();
+    expect(result?.progressModalBadgeBgColor).toBeNull();
+  });
+
   test("行が無ければ null を返す", async () => {
     createAdminClientMock.mockReturnValue({
       from: buildSingleChain({ data: null, error: null }),


### PR DESCRIPTION
### 概要
進捗モーダル(DB駆動の ぷち神 台座)の見た目を調整する。①中央画像を神コレと同様の丸クロップにする ②フレームに焼き込まれたボタンがあるので、コード側のオレンジ CTA を重ねず透明クリック領域にする。

### 変更内容
- 中央画像(`centerRect`)の `div` を `rounded-[1.2rem]` → `rounded-full`(丸クロップ)。`centerRect` を正方にすると真円
- DB 駆動台座(`buttonRect` あり)のとき、完了時のオレンジ CTA を重ねず**透明クリック領域**のみにする(焼き込みボタンを活かす)。ハードコード台座(神コレ/ウエハース)は従来どおりオレンジ CTA を表示

### 実機テスト
- [ ] ぷち神の進捗モーダル:中央画像が丸くクロップされる
- [ ] ぷち神の進捗モーダル:完了時でもオレンジボタンが出ず、焼き込みボタンが見える/タップで台紙作成が動く
- [ ] 神コレ/ウエハースの進捗モーダル:従来どおりオレンジ CTA が表示(無変更)

### テスト方法
- `npm run lint` / `npm run test`(collections 187件パス)/ `npm run build -- --webpack` 緑

> ⚠️ マージは作者(@3balljugglerYu)が実機確認後に行います。

🤖 Generated with [Claude Code](https://claude.com/claude-code)