### PR TITLE
feat(admin): 解放ゲート(前提カテゴリ/段階解放の単位)を管理画面で設定可能に

### DIFF
--- a/app/(app)/admin/preset-categories/[id]/page.tsx
+++ b/app/(app)/admin/preset-categories/[id]/page.tsx
@@ -2,7 +2,10 @@ import { connection } from "next/server";
 import { notFound, redirect } from "next/navigation";
 import { getUser } from "@/lib/auth";
 import { getAdminUserIds } from "@/lib/env";
-import { getPresetCategoryById } from "@/features/style-presets/lib/preset-category-repository";
+import {
+  getPresetCategoryById,
+  listPresetCategories,
+} from "@/features/style-presets/lib/preset-category-repository";
 import { AdminPresetCategoryFormClient } from "@/features/preset-categories/components/AdminPresetCategoryFormClient";
 import { formatDatetimeLocalJst } from "@/lib/datetime/format-datetime-local-jst";
 
@@ -29,6 +32,12 @@ export default async function AdminPresetCategoryEditPage({
     notFound();
   }
 
+  // 解放ゲートの前提カテゴリ候補: コレクションシリーズのみ・自分自身は除外。
+  const allCategories = await listPresetCategories({ includeInactive: false });
+  const prerequisiteOptions = allCategories
+    .filter((c) => c.isCollectionSeries && c.id !== category.id)
+    .map((c) => ({ key: c.key, displayNameJa: c.displayNameJa }));
+
   return (
     <div className="space-y-6">
       <header>
@@ -53,6 +62,7 @@ export default async function AdminPresetCategoryEditPage({
         initialCollectionDisplayEndsAtLocal={formatDatetimeLocalJst(
           category.collectionDisplayEndsAt,
         )}
+        prerequisiteOptions={prerequisiteOptions}
       />
     </div>
   );

--- a/app/(app)/admin/preset-categories/new/page.tsx
+++ b/app/(app)/admin/preset-categories/new/page.tsx
@@ -2,6 +2,7 @@ import { connection } from "next/server";
 import { redirect } from "next/navigation";
 import { getUser } from "@/lib/auth";
 import { getAdminUserIds } from "@/lib/env";
+import { listPresetCategories } from "@/features/style-presets/lib/preset-category-repository";
 import { AdminPresetCategoryFormClient } from "@/features/preset-categories/components/AdminPresetCategoryFormClient";
 
 export const metadata = {
@@ -16,6 +17,12 @@ export default async function AdminPresetCategoryNewPage() {
   if (!user || adminUserIds.length === 0 || !adminUserIds.includes(user.id)) {
     redirect("/");
   }
+
+  // 解放ゲートの前提カテゴリ候補: コレクションシリーズのみ(新規なので自身の除外は不要)。
+  const allCategories = await listPresetCategories({ includeInactive: false });
+  const prerequisiteOptions = allCategories
+    .filter((c) => c.isCollectionSeries)
+    .map((c) => ({ key: c.key, displayNameJa: c.displayNameJa }));
 
   return (
     <div className="space-y-6">
@@ -32,7 +39,10 @@ export default async function AdminPresetCategoryNewPage() {
           作成後 `key` は変更できません。slug 形式 (小文字英数字 + `_`、先頭は英字) で入力してください。
         </p>
       </header>
-      <AdminPresetCategoryFormClient mode="create" />
+      <AdminPresetCategoryFormClient
+        mode="create"
+        prerequisiteOptions={prerequisiteOptions}
+      />
     </div>
   );
 }

--- a/app/api/admin/preset-categories/collection-settings-payload.ts
+++ b/app/api/admin/preset-categories/collection-settings-payload.ts
@@ -18,6 +18,10 @@ import {
 export interface CollectionSettingsPayload {
   isCollectionSeries?: boolean;
   completionThreshold?: number | null;
+  /** 完走必須の前提カテゴリ key(完走者限定の解放ゲート)。null=ゲートなし */
+  unlockPrerequisiteKey?: string | null;
+  /** プリセットを N 体ずつ段階解放する単位(正の整数)。null=最初から全部 */
+  progressiveBatchSize?: number | null;
   mountTemplatePath?: string | null;
   mountLayout?: MountLayoutKey | null;
   mountSlots?: NormalizedSlotRect[] | null;
@@ -90,6 +94,37 @@ export function parseCollectionSettings(
       return { ok: false, error: "completion_threshold must be a positive integer" };
     } else {
       payload.completionThreshold = v;
+    }
+  }
+
+  // 解放ゲート: 完走必須の前提カテゴリ key(完走者限定)。空文字は null(ゲートなし)に正規化。
+  if (body.unlock_prerequisite_key !== undefined) {
+    const v = body.unlock_prerequisite_key;
+    if (v === null) {
+      payload.unlockPrerequisiteKey = null;
+    } else if (typeof v !== "string") {
+      return {
+        ok: false,
+        error: "unlock_prerequisite_key must be a non-empty string or null",
+      };
+    } else {
+      const trimmed = v.trim();
+      payload.unlockPrerequisiteKey = trimmed.length > 0 ? trimmed : null;
+    }
+  }
+
+  // 段階解放の単位 N(正の整数)。DB CHECK は > 0 または NULL。
+  if (body.progressive_batch_size !== undefined) {
+    const v = body.progressive_batch_size;
+    if (v === null) {
+      payload.progressiveBatchSize = null;
+    } else if (typeof v !== "number" || !Number.isInteger(v) || v < 1) {
+      return {
+        ok: false,
+        error: "progressive_batch_size must be an integer >= 1, or null",
+      };
+    } else {
+      payload.progressiveBatchSize = v;
     }
   }
 

--- a/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
+++ b/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
@@ -1231,6 +1231,8 @@ export function AdminPresetCategoryFormClient({
                 step={1}
                 value={form.progressiveBatchSize ?? ""}
                 onChange={(e) => {
+                  // 入力中に値を消さないため、任意の整数を state に許容する。
+                  // 不正値(0/負)は min={1}(ネイティブ)+ 保存時のバリデーションで弾く。
                   if (e.target.value === "") {
                     update("progressiveBatchSize", null);
                     return;
@@ -1238,7 +1240,7 @@ export function AdminPresetCategoryFormClient({
                   const n = Number.parseInt(e.target.value, 10);
                   update(
                     "progressiveBatchSize",
-                    Number.isFinite(n) && n >= 1 ? n : null,
+                    Number.isNaN(n) ? null : n,
                   );
                 }}
                 placeholder="空=一括解放"

--- a/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
+++ b/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
@@ -37,6 +37,11 @@ interface Props {
    */
   initialCollectionDisplayStartsAtLocal?: string;
   initialCollectionDisplayEndsAtLocal?: string;
+  /**
+   * 解放ゲートの「前提カテゴリ」selectで使う候補。コレクションシリーズのみ・
+   * 編集時は自身を除外したものをサーバー側で渡す。省略時は空配列(ゲートなしのみ)。
+   */
+  prerequisiteOptions?: { key: string; displayNameJa: string }[];
 }
 
 interface FormState {
@@ -60,6 +65,10 @@ interface FormState {
   visibility: "public" | "admin_only";
   isCollectionSeries: boolean;
   completionThreshold: number | null;
+  /** 解放の前提カテゴリ key(完走者限定)。null=ゲートなし */
+  unlockPrerequisiteKey: string | null;
+  /** 段階解放の単位(正の整数)。null=最初から全部解放 */
+  progressiveBatchSize: number | null;
   mountTemplatePath: string | null;
   mountLayout: "" | "grid_3" | "grid_4" | "grid_6";
   /** カスタム枠(正規化矩形配列)。null なら mountLayout プリセットを使用 */
@@ -130,6 +139,8 @@ function toFormState(
     visibility: initial?.visibility ?? "admin_only",
     isCollectionSeries: initial?.isCollectionSeries ?? false,
     completionThreshold: initial?.completionThreshold ?? null,
+    unlockPrerequisiteKey: initial?.unlockPrerequisiteKey ?? null,
+    progressiveBatchSize: initial?.progressiveBatchSize ?? null,
     mountTemplatePath: initial?.mountTemplatePath ?? null,
     mountLayout: initial?.mountLayout ?? "",
     mountSlots: initial?.mountSlots ?? null,
@@ -259,6 +270,7 @@ export function AdminPresetCategoryFormClient({
   initial,
   initialCollectionDisplayStartsAtLocal,
   initialCollectionDisplayEndsAtLocal,
+  prerequisiteOptions = [],
 }: Props) {
   const router = useRouter();
   const [form, setForm] = useState<FormState>(() =>
@@ -548,6 +560,8 @@ export function AdminPresetCategoryFormClient({
               visibility: form.visibility,
               is_collection_series: form.isCollectionSeries,
               completion_threshold: effectiveThreshold,
+              unlock_prerequisite_key: form.unlockPrerequisiteKey,
+              progressive_batch_size: form.progressiveBatchSize,
               mount_template_path: form.mountTemplatePath,
               mount_layout: form.mountLayout === "" ? null : form.mountLayout,
               mount_slots: form.mountSlots,
@@ -593,6 +607,8 @@ export function AdminPresetCategoryFormClient({
               visibility: form.visibility,
               is_collection_series: form.isCollectionSeries,
               completion_threshold: effectiveThreshold,
+              unlock_prerequisite_key: form.unlockPrerequisiteKey,
+              progressive_batch_size: form.progressiveBatchSize,
               mount_template_path: form.mountTemplatePath,
               mount_layout: form.mountLayout === "" ? null : form.mountLayout,
               mount_slots: form.mountSlots,
@@ -1177,6 +1193,62 @@ export function AdminPresetCategoryFormClient({
               での生成は終了後も可能です。
             </span>
           </label>
+        </div>
+
+        <div className="space-y-3 rounded-md border border-slate-200 bg-slate-50 p-3">
+          <p className="text-sm font-semibold text-slate-800">解放ゲート</p>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <label className="block">
+              <span className="text-sm font-medium text-slate-700">
+                解放の前提カテゴリ
+              </span>
+              <select
+                value={form.unlockPrerequisiteKey ?? ""}
+                onChange={(e) =>
+                  update("unlockPrerequisiteKey", e.target.value || null)
+                }
+                className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm"
+              >
+                <option value="">なし（ゲートなし）</option>
+                {prerequisiteOptions.map((opt) => (
+                  <option key={opt.key} value={opt.key}>
+                    {opt.displayNameJa}
+                  </option>
+                ))}
+              </select>
+              <span className="mt-1 block text-xs text-slate-500">
+                このカテゴリを完走したユーザーにのみ表示します（完走者限定）。
+              </span>
+            </label>
+
+            <label className="block">
+              <span className="text-sm font-medium text-slate-700">
+                段階解放の単位
+              </span>
+              <input
+                type="number"
+                min={1}
+                step={1}
+                value={form.progressiveBatchSize ?? ""}
+                onChange={(e) => {
+                  if (e.target.value === "") {
+                    update("progressiveBatchSize", null);
+                    return;
+                  }
+                  const n = Number.parseInt(e.target.value, 10);
+                  update(
+                    "progressiveBatchSize",
+                    Number.isFinite(n) && n >= 1 ? n : null,
+                  );
+                }}
+                placeholder="空=一括解放"
+                className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm"
+              />
+              <span className="mt-1 block text-xs text-slate-500">
+                カテゴリ内のプリセットを何体ずつ解放するか（空=最初から全部）。
+              </span>
+            </label>
+          </div>
         </div>
 
         <div className="block">

--- a/features/style-presets/lib/preset-category-repository.ts
+++ b/features/style-presets/lib/preset-category-repository.ts
@@ -48,6 +48,8 @@ export interface PresetCategoryRow {
   visibility?: StylePresetCategoryVisibility | null;
   is_collection_series?: boolean | null;
   completion_threshold?: number | null;
+  unlock_prerequisite_key?: string | null;
+  progressive_batch_size?: number | null;
   mount_template_path?: string | null;
   mount_layout?: string | null;
   mount_slots?: unknown;
@@ -96,6 +98,8 @@ export interface PresetCategoryAdmin {
   visibility: StylePresetCategoryVisibility;
   isCollectionSeries: boolean;
   completionThreshold: number | null;
+  unlockPrerequisiteKey: string | null;
+  progressiveBatchSize: number | null;
   mountTemplatePath: string | null;
   mountLayout: MountLayoutKey | null;
   mountSlots: NormalizedSlotRect[] | null;
@@ -143,6 +147,8 @@ export interface PresetCategoryInsert {
   visibility?: StylePresetCategoryVisibility;
   isCollectionSeries?: boolean;
   completionThreshold?: number | null;
+  unlockPrerequisiteKey?: string | null;
+  progressiveBatchSize?: number | null;
   mountTemplatePath?: string | null;
   mountLayout?: MountLayoutKey | null;
   mountSlots?: NormalizedSlotRect[] | null;
@@ -186,6 +192,8 @@ export interface PresetCategoryUpdate {
   visibility?: StylePresetCategoryVisibility;
   isCollectionSeries?: boolean;
   completionThreshold?: number | null;
+  unlockPrerequisiteKey?: string | null;
+  progressiveBatchSize?: number | null;
   mountTemplatePath?: string | null;
   mountLayout?: MountLayoutKey | null;
   mountSlots?: NormalizedSlotRect[] | null;
@@ -244,6 +252,8 @@ function mapRow(row: PresetCategoryRow): PresetCategoryAdmin {
     visibility: normalizeVisibility(row.visibility),
     isCollectionSeries: row.is_collection_series ?? false,
     completionThreshold: row.completion_threshold ?? null,
+    unlockPrerequisiteKey: row.unlock_prerequisite_key ?? null,
+    progressiveBatchSize: row.progressive_batch_size ?? null,
     mountTemplatePath: row.mount_template_path ?? null,
     mountLayout: isMountLayoutKey(row.mount_layout) ? row.mount_layout : null,
     mountSlots: parseNormalizedSlots(row.mount_slots),
@@ -372,6 +382,8 @@ export async function createPresetCategory(
       visibility: input.visibility ?? "admin_only",
       is_collection_series: input.isCollectionSeries ?? false,
       completion_threshold: input.completionThreshold ?? null,
+      unlock_prerequisite_key: input.unlockPrerequisiteKey ?? null,
+      progressive_batch_size: input.progressiveBatchSize ?? null,
       mount_template_path: input.mountTemplatePath ?? null,
       mount_layout: input.mountLayout ?? null,
       mount_slots: input.mountSlots ?? null,
@@ -445,6 +457,10 @@ export async function updatePresetCategory(
     payload.is_collection_series = input.isCollectionSeries;
   if (input.completionThreshold !== undefined)
     payload.completion_threshold = input.completionThreshold;
+  if (input.unlockPrerequisiteKey !== undefined)
+    payload.unlock_prerequisite_key = input.unlockPrerequisiteKey;
+  if (input.progressiveBatchSize !== undefined)
+    payload.progressive_batch_size = input.progressiveBatchSize;
   if (input.mountTemplatePath !== undefined)
     payload.mount_template_path = input.mountTemplatePath;
   if (input.mountLayout !== undefined) payload.mount_layout = input.mountLayout;

--- a/tests/unit/features/collections/collection-settings-payload.test.ts
+++ b/tests/unit/features/collections/collection-settings-payload.test.ts
@@ -271,6 +271,79 @@ describe("parseCollectionSettings", () => {
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.error).toMatch(/collection_display_ends_at/);
   });
+
+  // ---------------- 解放ゲート: unlock_prerequisite_key ----------------
+
+  test("unlock_prerequisite_key: 文字列はトリムして採用", () => {
+    const r = parseCollectionSettings(
+      { unlock_prerequisite_key: "  god_collection  " },
+      OFF,
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.payload.unlockPrerequisiteKey).toBe("god_collection");
+  });
+
+  test("unlock_prerequisite_key: 空文字は null(ゲートなし)に正規化", () => {
+    const r = parseCollectionSettings({ unlock_prerequisite_key: "  " }, OFF);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.payload.unlockPrerequisiteKey).toBeNull();
+  });
+
+  test("unlock_prerequisite_key: null はクリア(ゲートなし)", () => {
+    const r = parseCollectionSettings({ unlock_prerequisite_key: null }, OFF);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.payload.unlockPrerequisiteKey).toBeNull();
+  });
+
+  test("unlock_prerequisite_key: string/null 以外は拒否", () => {
+    const r = parseCollectionSettings({ unlock_prerequisite_key: 42 }, OFF);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/unlock_prerequisite_key/);
+  });
+
+  test("空 body は unlock_prerequisite_key を payload に含めない(no-op)", () => {
+    const r = parseCollectionSettings({}, OFF);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.payload.unlockPrerequisiteKey).toBeUndefined();
+  });
+
+  // ---------------- 段階解放: progressive_batch_size ----------------
+
+  test("progressive_batch_size: 1 以上の整数はそのまま採用", () => {
+    const r = parseCollectionSettings({ progressive_batch_size: 3 }, OFF);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.payload.progressiveBatchSize).toBe(3);
+  });
+
+  test("progressive_batch_size: null はクリア(一括解放)", () => {
+    const r = parseCollectionSettings({ progressive_batch_size: null }, OFF);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.payload.progressiveBatchSize).toBeNull();
+  });
+
+  test("progressive_batch_size: 0 / 負 / 非整数は拒否", () => {
+    expect(
+      parseCollectionSettings({ progressive_batch_size: 0 }, OFF).ok,
+    ).toBe(false);
+    expect(
+      parseCollectionSettings({ progressive_batch_size: -2 }, OFF).ok,
+    ).toBe(false);
+    expect(
+      parseCollectionSettings({ progressive_batch_size: 1.5 }, OFF).ok,
+    ).toBe(false);
+  });
+
+  test("progressive_batch_size: 数値以外は拒否", () => {
+    const r = parseCollectionSettings({ progressive_batch_size: "3" }, OFF);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/progressive_batch_size/);
+  });
+
+  test("空 body は progressive_batch_size を payload に含めない(no-op)", () => {
+    const r = parseCollectionSettings({}, OFF);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.payload.progressiveBatchSize).toBeUndefined();
+  });
 });
 
 describe("parseCollectionSettings - mount_slots(カスタム枠) / 任意N / 台紙実寸", () => {

--- a/tests/unit/lib/preset-category-repository.test.ts
+++ b/tests/unit/lib/preset-category-repository.test.ts
@@ -153,6 +153,36 @@ describe("getPresetCategoryById", () => {
     expect(result?.progressModalBadgeBgColor).toBe("#166534");
   });
 
+  test("unlock_prerequisite_key / progressive_batch_size を camelCase へマップする", async () => {
+    const row: PresetCategoryRow = {
+      ...SAMPLE_ROW,
+      unlock_prerequisite_key: "god_collection",
+      progressive_batch_size: 3,
+    };
+    createAdminClientMock.mockReturnValue({
+      from: buildSingleChain({ data: row, error: null }),
+    });
+
+    const result = await getPresetCategoryById(SAMPLE_ROW.id);
+    expect(result?.unlockPrerequisiteKey).toBe("god_collection");
+    expect(result?.progressiveBatchSize).toBe(3);
+  });
+
+  test("unlock_prerequisite_key / progressive_batch_size が null なら null にフォールバックする", async () => {
+    const row: PresetCategoryRow = {
+      ...SAMPLE_ROW,
+      unlock_prerequisite_key: null,
+      progressive_batch_size: null,
+    };
+    createAdminClientMock.mockReturnValue({
+      from: buildSingleChain({ data: row, error: null }),
+    });
+
+    const result = await getPresetCategoryById(SAMPLE_ROW.id);
+    expect(result?.unlockPrerequisiteKey).toBeNull();
+    expect(result?.progressiveBatchSize).toBeNull();
+  });
+
   test("progress_modal_* 色列が null なら null にフォールバックする", async () => {
     const row: PresetCategoryRow = {
       ...SAMPLE_ROW,


### PR DESCRIPTION
### 概要
コレクションの「解放ゲート」設定(`unlock_prerequisite_key` / `progressive_batch_size`)を**管理画面のプリセットカテゴリ編集**で行えるようにする。これにより go-live(②残りプリセットの公開・③解放ゲート・④公開範囲)を**すべて admin 画面だけで完結**できる。カラム自体は既存(マイグレ済)で、今回は admin への配線とUI追加のみ。

### 変更内容
- `preset-category-repository`: `unlock_prerequisite_key`/`progressive_batch_size` を Row/Admin/Insert/Update + `mapRow` + create/update payload に追加(SELECT は `*` のため変更不要)
- `collection-settings-payload`: `unlock_prerequisite_key`(文字列/空→null)・`progressive_batch_size`(1以上の整数/null、0・負・非整数は拒否=DB CHECK と整合)を検証
- 編集/新規ページ: `listPresetCategories` から **コレクションシリーズのみ**を取得(編集時は自分を除外)し、`prerequisiteOptions` としてフォームへ供給
- フォーム「解放ゲート」セクション: 前提カテゴリ `<select>`(なし/コレクションシリーズ)+ 段階解放の単位 number(空=一括)+ 説明文
- 単体テスト追加(バリデーション・mapRow ラウンドトリップ)

### 実機テスト
- [ ] プリセットカテゴリ編集に「解放ゲート」が表示され、前提カテゴリに「うちの子の神コレクション」等が選べる
- [ ] 段階解放の単位に 2 を入れて保存 → DB に反映
- [ ] 前提カテゴリ「なし」+ 単位空 で保存 → null(ゲート無効)
- [ ] 既存カテゴリ(神コレ等)に影響がない

### テスト方法
- `npm run lint` / `npm run test`(対象2ファイル95件パス・全2101件)/ `npm run build -- --webpack` 緑

> ⚠️ マージは作者(@3balljugglerYu)が確認後に行います。

🤖 Generated with [Claude Code](https://claude.com/claude-code)