### PR TITLE
fix(home): ホームのプリセットセクションにも解放ゲートを適用

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -166,7 +166,10 @@ export default async function LocaleHome({
         <CachedHomeBannerSection />
       </Suspense>
       <Suspense fallback={<HomeStylePresetCarouselSkeleton />}>
-        <CachedHomeStylePresetSection isAdminViewer={isAdminViewer} />
+        <CachedHomeStylePresetSection
+          isAdminViewer={isAdminViewer}
+          userId={currentUser?.id ?? null}
+        />
       </Suspense>
       {/*
         Inspire ホームカルーセル（ADR-013）。

--- a/features/home/components/CachedHomeStylePresetSection.tsx
+++ b/features/home/components/CachedHomeStylePresetSection.tsx
@@ -38,17 +38,15 @@ export async function CachedHomeStylePresetSection({
   const hasGatedCategory = cachedPresets.some(
     (preset) => preset.category.unlockPrerequisiteKey != null,
   );
-  const gated =
-    userId && hasGatedCategory
-      ? applyCollectionUnlockGating(
-          cachedPresets,
-          await resolveCollectionUnlockContext(
-            cachedPresets,
-            userId,
-            await createClient(),
-          ),
-        )
-      : applyCollectionUnlockGating(cachedPresets, EMPTY_UNLOCK_CONTEXT);
+  let unlockContext: CollectionUnlockContext = EMPTY_UNLOCK_CONTEXT;
+  if (userId && hasGatedCategory) {
+    unlockContext = await resolveCollectionUnlockContext(
+      cachedPresets,
+      userId,
+      await createClient(),
+    );
+  }
+  const gated = applyCollectionUnlockGating(cachedPresets, unlockContext);
 
   // ホームは locked(未解放=シルエット)に未対応のため、未解放分は出さない。
   const presets = gated.filter((preset) => !preset.locked);

--- a/features/home/components/CachedHomeStylePresetSection.tsx
+++ b/features/home/components/CachedHomeStylePresetSection.tsx
@@ -1,19 +1,57 @@
 import { getPublishedStylePresets } from "@/features/style-presets/lib/get-public-style-presets";
+import {
+  applyCollectionUnlockGating,
+  type CollectionUnlockContext,
+} from "@/features/collections/lib/collection-unlock-gating";
+import { resolveCollectionUnlockContext } from "@/features/collections/lib/collection-unlock-server";
+import { createClient } from "@/lib/supabase/server";
 import { HomeStylePresetCarousel } from "./HomeStylePresetCarousel";
+
+// 解放ゲート対象が無い/未ログイン時に使う空コンテキスト(除去・解放判定とも no-op)。
+const EMPTY_UNLOCK_CONTEXT: CollectionUnlockContext = {
+  prerequisiteCompletedKeys: new Set(),
+  distinctGeneratedByCategoryKey: new Map(),
+};
 
 /**
  * ホームの Style プリセットセクション。
  * admin は admin_only カテゴリも(公開前プレビュー用に)併せて表示する。
- * isAdminViewer は呼び出し側で判定して渡す(ホーム page.tsx で getUser → isAdminViewer)。
+ * isAdminViewer / userId は呼び出し側で判定して渡す(ホーム page.tsx で getUser)。
+ *
+ * 解放ゲート(unlock gating)は /style と同様にここでも適用する。これをしないと、
+ * 完走者限定・段階解放のカテゴリ(例: ぷち神)がホームでは全件表示され、ゲートが
+ * 効かなくなる。ホームのカルーセルは locked 表示に未対応なので、未解放(locked)分は
+ * 一覧から除外し、解放済みのプリセットだけを並べる。
  */
 export async function CachedHomeStylePresetSection({
   isAdminViewer = false,
+  userId = null,
 }: {
   isAdminViewer?: boolean;
+  userId?: string | null;
 }) {
-  const presets = await getPublishedStylePresets({
+  const cachedPresets = await getPublishedStylePresets({
     includeAdminOnly: isAdminViewer,
   });
+
+  // 解放ルール付きカテゴリが無ければ完全 no-op(authed client も作らない)。
+  const hasGatedCategory = cachedPresets.some(
+    (preset) => preset.category.unlockPrerequisiteKey != null,
+  );
+  const gated =
+    userId && hasGatedCategory
+      ? applyCollectionUnlockGating(
+          cachedPresets,
+          await resolveCollectionUnlockContext(
+            cachedPresets,
+            userId,
+            await createClient(),
+          ),
+        )
+      : applyCollectionUnlockGating(cachedPresets, EMPTY_UNLOCK_CONTEXT);
+
+  // ホームは locked(未解放=シルエット)に未対応のため、未解放分は出さない。
+  const presets = gated.filter((preset) => !preset.locked);
 
   return <HomeStylePresetCarousel presets={presets} />;
 }


### PR DESCRIPTION
### 概要
解放ゲート(完走者限定 + 段階解放)が `/style`(StylePageBody)だけに適用され、**ホーム画面(CachedHomeStylePresetSection)には未適用**だった。そのため ぷち神 のようなゲート付きカテゴリがホームでは全件表示され、**公開(visibility=public)後に「全ユーザーに全件見えてしまう」**不具合があった(完走者ゲート・段階解放がホームで無効)。go-live 前に必須の修正。

### 再現
- ぷち神に `unlock_prerequisite_key`(神コレ)+ `progressive_batch_size=2` を設定しても、ホームでは6体すべて表示された(/style では正しく 0/2 件に制御されていた)。

### 変更内容
- `CachedHomeStylePresetSection` に `userId` を渡し、`/style` と同じく `applyCollectionUnlockGating` + `resolveCollectionUnlockContext` を適用
- ホームのカルーセルは locked(シルエット)非対応のため、**未解放分は一覧から除外**し解放済みのみ表示
- 解放ゲート対象カテゴリが無ければ完全 no-op(従来カテゴリ・神コレ等は不変)

### 実機テスト(検証済み)
- [x] 神コレ未完走ユーザー → ホームに ぷち神 が **0件**(修正前は全件)
- [x] 神コレ完走者 + ぷち神 進捗1 → ホームに ぷち神 **2件(最初の2体)**だけ表示(段階解放)
- [x] 既存カテゴリ(神コレ/ウエハース)は無変更

### テスト方法
- `npm run lint` / `npm run test`(home+collections 213件パス)/ `npm run build -- --webpack` 緑
- Playwright でテスト垢にて 0件→(完走を一時付与)→2件 を確認

> ⚠️ マージは作者(@3balljugglerYu)が確認後に行います。

🤖 Generated with [Claude Code](https://claude.com/claude-code)