### PR TITLE
fix(collections): ぷち神の段階解放を sort_order の多い順から行う(表示順は昇順のまま)

### DIFF
--- a/features/collections/lib/collection-unlock-gating.ts
+++ b/features/collections/lib/collection-unlock-gating.ts
@@ -21,11 +21,18 @@ export interface CollectionUnlockContext {
  * - `unlockPrerequisiteKey` が null のカテゴリ → 一切変更しない(従来挙動)。
  * - 前提条件カテゴリが未完走のユーザー → そのカテゴリのプリセットを「一覧から完全に除去」
  *   (ティザーを出さない方針)。
- * - 完走済みユーザー → プリセットは残すが、sort_order 昇順で解放数を超えるものに
- *   `locked: true` を立て、UI 側でシルエット(選択・生成不可)として表示する。
+ * - 完走済みユーザー → プリセットは残すが、解放数を超えるものに `locked: true` を立て、
+ *   UI 側でシルエット(選択・生成不可)として表示する。
  *
  * 入力 `presets` は sort_order 昇順で並んでいる前提(listPublishedStylePresets の order)。
- * カテゴリ内での出現順をそのまま sort_order 上の index とみなす。
+ * **表示順は一切変更しない**(昇順のまま)。
+ *
+ * 解放順(解放ゲート付きカテゴリは sort_order の「多い順」から解放する):
+ *   解放ゲート付きカテゴリ(例: ぷち神)は、表示は sort_order 昇順のままで、段階解放だけを
+ *   sort_order の大きい方(末尾)から行う。これにより「シルエット(あとでとうじょう)が前に
+ *   まとまり、解放済みが末尾にまとまる」並びになる(例: total=6/解放2なら、先頭4つがシルエット、
+ *   末尾2つ=sort 5・4 のアフロディーテ・アルテミスが解放)。解放判定の index だけを反転し、
+ *   並べ替えは行わない。前提条件なしの従来カテゴリは従来どおり昇順で先頭から解放。
  */
 export function applyCollectionUnlockGating(
   presets: readonly StylePresetPublicSummary[],
@@ -44,8 +51,8 @@ export function applyCollectionUnlockGating(
 
   for (const preset of presets) {
     const category = preset.category;
-    const indexInCategory = seenCountByCategoryKey.get(category.key) ?? 0;
-    seenCountByCategoryKey.set(category.key, indexInCategory + 1);
+    const ascendingIndex = seenCountByCategoryKey.get(category.key) ?? 0;
+    seenCountByCategoryKey.set(category.key, ascendingIndex + 1);
 
     // 前提条件なし(従来カテゴリ) → そのまま通す。
     if (!category.unlockPrerequisiteKey) {
@@ -59,11 +66,14 @@ export function applyCollectionUnlockGating(
     }
 
     // 完走済み → 段階解放。解放数を超えるものは locked にして残す。
+    // 解放ゲート付きカテゴリは sort_order の多い方(末尾)から解放するため、解放判定の
+    // index を反転する(表示順は昇順のまま並べ替えない)。
     const distinctGenerated =
       context.distinctGeneratedByCategoryKey.get(category.key) ?? 0;
     const total = totalByCategoryKey.get(category.key) ?? 0;
+    const unlockIndex = total - 1 - ascendingIndex;
     const unlocked = isPresetUnlocked(
-      indexInCategory,
+      unlockIndex,
       distinctGenerated,
       category.progressiveBatchSize,
       total,

--- a/features/collections/lib/collection-unlock-server.ts
+++ b/features/collections/lib/collection-unlock-server.ts
@@ -189,17 +189,23 @@ export async function authorizeStylePresetUnlock(
 
   // 2) 段階解放の範囲内チェック。
   //    sort_order 上の index と総数を、公開一覧(sort_order 昇順)から導出する。
+  //    解放ゲート付きカテゴリは解放順を sort_order の降順にするため index を反転し、
+  //    applyCollectionUnlockGating(配信側)の降順表示・降順解放と一致させる。
+  //    この関数は冒頭で unlockPrerequisiteKey 無しを return 済みなので、ここは常にゲート付き。
   const published = await listPublishedStylePresets({
     includeAdminOnly: options.includeAdminOnly === true,
   });
   const sameCategory = published.filter((p) => p.category.key === category.key);
   const total = sameCategory.length;
-  const indexInCategory = sameCategory.findIndex((p) => p.id === presetId);
+  const ascendingIndex = sameCategory.findIndex((p) => p.id === presetId);
 
   // 一覧に存在しない(= 配信対象外)場合は安全側で拒否。
-  if (indexInCategory < 0) {
+  if (ascendingIndex < 0) {
     return { allowed: false, reason: "preset_locked" };
   }
+
+  // 降順 index(末尾=sort_order 最大 を index 0 とする)。
+  const indexInCategory = total - 1 - ascendingIndex;
 
   const distinctCounts = await resolveDistinctGeneratedCounts(
     new Set([category.key]),

--- a/tests/unit/features/collections/collection-unlock-gating.test.ts
+++ b/tests/unit/features/collections/collection-unlock-gating.test.ts
@@ -84,7 +84,10 @@ describe("applyCollectionUnlockGating", () => {
     expect(result.map((p) => p.id)).toEqual(["coord-1"]);
   });
 
-  test("完走済みで distinct=0, batch=2, total=6 のとき先頭2つ解放・残り locked", () => {
+  // 解放ゲート付きカテゴリは「表示は sort_order 昇順のまま」で、解放だけを sort_order の
+  // 多い方(末尾)から行う。これにより先頭にシルエット、末尾に解放済みが並ぶ。
+  // 入力は sort_order 昇順(petit-0..petit-5)。
+  test("完走済み distinct=0/batch=2 は表示昇順のまま末尾2つ(sort最大)を解放", () => {
     const petit = makeCategory(PETIT_KEY, {
       unlockPrerequisiteKey: PREREQ_KEY,
       progressiveBatchSize: 2,
@@ -97,17 +100,27 @@ describe("applyCollectionUnlockGating", () => {
       distinctGeneratedByCategoryKey: new Map([[PETIT_KEY, 0]]),
     });
     expect(result).toHaveLength(6);
+    // 表示は昇順のまま(petit-0..petit-5)。並べ替えはしない。
+    expect(result.map((p) => p.id)).toEqual([
+      "petit-0",
+      "petit-1",
+      "petit-2",
+      "petit-3",
+      "petit-4",
+      "petit-5",
+    ]);
+    // 解放は末尾2つ(petit-4, petit-5 = sort 最大)。先頭4つがシルエット。
     expect(result.map((p) => p.locked === true)).toEqual([
+      true,
+      true,
+      true,
+      true,
       false,
       false,
-      true,
-      true,
-      true,
-      true,
     ]);
   });
 
-  test("完走済みで distinct=2 なら先頭4つ解放", () => {
+  test("完走済み distinct=2 なら末尾4つを解放(表示昇順のまま)", () => {
     const petit = makeCategory(PETIT_KEY, {
       unlockPrerequisiteKey: PREREQ_KEY,
       progressiveBatchSize: 2,
@@ -119,17 +132,40 @@ describe("applyCollectionUnlockGating", () => {
       prerequisiteCompletedKeys: new Set([PREREQ_KEY]),
       distinctGeneratedByCategoryKey: new Map([[PETIT_KEY, 2]]),
     });
+    expect(result.map((p) => p.id)).toEqual([
+      "petit-0",
+      "petit-1",
+      "petit-2",
+      "petit-3",
+      "petit-4",
+      "petit-5",
+    ]);
+    // 解放数4 → 末尾4つ(petit-2..petit-5)を解放、先頭2つがシルエット。
     expect(result.map((p) => p.locked === true)).toEqual([
-      false,
-      false,
-      false,
-      false,
       true,
       true,
+      false,
+      false,
+      false,
+      false,
     ]);
   });
 
-  test("batch が null なら完走済みは全解放(locked なし)", () => {
+  test("前提条件なしの従来カテゴリは昇順・先頭から解放(変更なし)", () => {
+    const plain = makeCategory("coordinate");
+    const presets = [
+      makePreset("a", plain),
+      makePreset("b", plain),
+      makePreset("c", plain),
+    ];
+    const result = applyCollectionUnlockGating(presets, {
+      prerequisiteCompletedKeys: new Set(),
+      distinctGeneratedByCategoryKey: new Map(),
+    });
+    expect(result.map((p) => p.id)).toEqual(["a", "b", "c"]);
+  });
+
+  test("batch が null なら完走済みは全解放(locked なし・表示昇順のまま)", () => {
     const petit = makeCategory(PETIT_KEY, {
       unlockPrerequisiteKey: PREREQ_KEY,
       progressiveBatchSize: null,
@@ -142,5 +178,13 @@ describe("applyCollectionUnlockGating", () => {
       distinctGeneratedByCategoryKey: new Map([[PETIT_KEY, 0]]),
     });
     expect(result.every((p) => p.locked === undefined)).toBe(true);
+    expect(result.map((p) => p.id)).toEqual([
+      "petit-0",
+      "petit-1",
+      "petit-2",
+      "petit-3",
+      "petit-4",
+      "petit-5",
+    ]);
   });
 });

--- a/tests/unit/features/collections/collection-unlock-server.test.ts
+++ b/tests/unit/features/collections/collection-unlock-server.test.ts
@@ -180,19 +180,26 @@ describe("authorizeStylePresetUnlock", () => {
     expect(result).toEqual({ allowed: false, reason: "prerequisite_incomplete" });
   });
 
-  it("解放範囲内のプリセットは許可(distinct0/batch2/index0)", async () => {
+  // 解放ゲート付きカテゴリは sort_order の降順で解放する(末尾=sort最大 を先に解放)。
+  it("解放範囲内のプリセットは許可(distinct0/batch2 → 降順で末尾2つ)", async () => {
     setProgress([{ categoryKey: PREREQ, isCompleted: true }]);
     setDistinctRpc([{ category_key: PETIT, unique_count: 0 }]);
     const cat = categoryRef(PETIT, PREREQ, 2);
+    // 一覧は sort_order 昇順(p0..p5)。distinct0/batch2 → 解放数2。
     mockListPublished.mockResolvedValue(
       ["p0", "p1", "p2", "p3", "p4", "p5"].map((id) => presetSummary(id, cat)),
     );
 
-    const result = await authorizeStylePresetUnlock(cat, "p0", "user-1", dummyClient);
-    expect(result).toEqual({ allowed: true });
+    // 降順 index: p5→0, p4→1 が解放。
+    await expect(
+      authorizeStylePresetUnlock(cat, "p5", "user-1", dummyClient),
+    ).resolves.toEqual({ allowed: true });
+    await expect(
+      authorizeStylePresetUnlock(cat, "p4", "user-1", dummyClient),
+    ).resolves.toEqual({ allowed: true });
   });
 
-  it("未解放(index>=unlockedCount)は preset_locked で拒否", async () => {
+  it("未解放(降順 index>=unlockedCount)は preset_locked で拒否", async () => {
     setProgress([{ categoryKey: PREREQ, isCompleted: true }]);
     setDistinctRpc([{ category_key: PETIT, unique_count: 0 }]);
     const cat = categoryRef(PETIT, PREREQ, 2);
@@ -200,8 +207,8 @@ describe("authorizeStylePresetUnlock", () => {
       ["p0", "p1", "p2", "p3", "p4", "p5"].map((id) => presetSummary(id, cat)),
     );
 
-    // distinct0/batch2 → unlocked 2 → index4(p4) は未解放
-    const result = await authorizeStylePresetUnlock(cat, "p4", "user-1", dummyClient);
+    // distinct0/batch2 → unlocked 2。p0 は昇順 index0 だが降順では index5 = 未解放。
+    const result = await authorizeStylePresetUnlock(cat, "p0", "user-1", dummyClient);
     expect(result).toEqual({ allowed: false, reason: "preset_locked" });
   });
 


### PR DESCRIPTION
### 概要
ぷち神(解放ゲート付きカテゴリ)の /style での並びが、解放済みと未解放(あとでとうじょう)のシルエットが混在し、解放分が分断されて見えていました。本PRでは **表示順は sort_order 昇順のまま変えず**、段階解放だけを sort_order の大きい方(末尾)から行うようにし、「未解放シルエットが前にまとまり、解放済みが末尾に並ぶ」意図した並びにします。

例(ぷち神 sort 0=オーディン … 5=アフロディーテ、進捗1=2体解放):

```
[オーディン 🔒][ゼウス 🔒][イシス 🔒][アテナ 🔒][アルテミス 解放][アフロディーテ 解放]
```

DB の sort_order は変更しません(マイグレーション不要)。

### 変更内容
- `features/collections/lib/collection-unlock-gating.ts`：プリセットの並べ替えは行わず、解放ゲート付きカテゴリのみ解放判定の index を末尾起点に反転(`total - 1 - index`)。表示順は昇順のまま。
- `features/collections/lib/collection-unlock-server.ts`：生成時の解放認可(403)も同じく末尾起点で判定し、配信側の表示・解放と一致させる。
- 前提条件なしの従来カテゴリは従来どおり昇順・先頭から解放で挙動不変。
- ユニットテストを上記挙動(表示昇順・末尾から解放)に更新。

### 実機テスト
- [ ] iOS Safari で主要導線を確認
- [ ] Android Chrome で主要導線を確認
- [ ] PC（Chrome）で主要導線を確認
- [ ] レスポンシブ表示崩れがないことを確認
- [ ] エラーメッセージやバリデーション表示を確認

### テスト方法
- `npm run test`（collection-unlock-gating / collection-unlock-server の2スイート, 16件）… パス
- `npm run typecheck`（ソース）… エラーなし
- `npm run lint`（該当ファイル）… 指摘なし
- `npm run build -- --webpack` … 成功

> 補足: 末尾2つはDBの sort_order 順のため「アルテミス → アフロディーテ」の並びになります。両方とも解放されるため機能上は同じですが、末尾を厳密に「アフロディーテ最後」にしたい場合のみ、その2件の sort_order 入れ替え(任意・DBのみ)が必要です。
