### PR TITLE
feat(collections): 進捗モーダルを閉じた直後に段階解放モーダルを即表示

### DIFF
--- a/app/api/collections/unlock-announcements/route.ts
+++ b/app/api/collections/unlock-announcements/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { isAdminViewer } from "@/lib/env";
+import { getPublishedStylePresets } from "@/features/style-presets/lib/get-public-style-presets";
+import { resolveCollectionUnlockContext } from "@/features/collections/lib/collection-unlock-server";
+import { buildCollectionUnlockAnnouncements } from "@/features/collections/lib/collection-unlock-announcement";
+
+/**
+ * GET /api/collections/unlock-announcements
+ *
+ * ログインユーザーの「解放お知らせ」サマリ(解放数・総数・解放順サムネ・前提カテゴリ)を返す。
+ * 生成直後(進捗モーダルを閉じた直後)に最新の解放状況を取得して段階解放モーダルを出す
+ * `CollectionUnlockDripListener` から呼ばれる。
+ *
+ * - 未ログインは空配列(解放はログイン前提)。
+ * - admin は admin_only カテゴリも対象(公開前プレビュー用)。
+ * - 解放ゲート付きカテゴリが無ければ即空配列(RPC を叩かない)。
+ */
+export async function GET() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ announcements: [] });
+  }
+
+  const isAdmin = isAdminViewer(user.id);
+
+  try {
+    const presets = await getPublishedStylePresets({ includeAdminOnly: isAdmin });
+    const hasGatedCategory = presets.some(
+      (preset) => preset.category.unlockPrerequisiteKey != null,
+    );
+    if (!hasGatedCategory) {
+      return NextResponse.json({ announcements: [] });
+    }
+
+    const context = await resolveCollectionUnlockContext(
+      presets,
+      user.id,
+      supabase,
+    );
+    const announcements = buildCollectionUnlockAnnouncements(presets, context);
+    return NextResponse.json({ announcements });
+  } catch (error) {
+    console.error("[collections unlock-announcements GET] failed:", error);
+    return NextResponse.json({ announcements: [] }, { status: 500 });
+  }
+}

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -8,6 +8,7 @@ import { StickyHeader } from "@/features/posts/components/StickyHeader";
 import { AppSidebar } from "@/components/AppSidebar";
 import { GeneratedImageNotificationChecker } from "@/components/GeneratedImageNotificationChecker";
 import { CollectionProgressChecker } from "@/components/CollectionProgressChecker";
+import { CollectionUnlockDripListener } from "@/features/collections/components/CollectionUnlockDripListener";
 import { BonusNotificationToastListener } from "@/features/notifications/components/BonusNotificationToastListener";
 import { TutorialTourProvider } from "@/features/tutorial/components/TutorialTourProvider";
 import { stripLocalePrefix } from "@/i18n/config";
@@ -64,6 +65,9 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       </Suspense>
       <Suspense fallback={null}>
         <CollectionProgressChecker />
+      </Suspense>
+      <Suspense fallback={null}>
+        <CollectionUnlockDripListener />
       </Suspense>
       <Suspense fallback={null}>
         <BonusNotificationToastListener />

--- a/features/collections/components/CollectionUnlockDripListener.tsx
+++ b/features/collections/components/CollectionUnlockDripListener.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { UnlockDripModal } from "@/features/collections/components/UnlockModals";
 import {
@@ -33,6 +33,9 @@ interface ActiveDrip {
  */
 export function CollectionUnlockDripListener() {
   const [active, setActive] = useState<ActiveDrip | null>(null);
+  // フェッチ中フラグ(同期的に重複フェッチを防ぐ)。短時間に dismiss が連続発火しても、
+  // API 解決前は active がまだ null のため、ref で弾く必要がある。
+  const fetchingRef = useRef(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -43,9 +46,10 @@ export function CollectionUnlockDripListener() {
         | undefined;
       const categoryKey = detail?.categoryKey;
       if (!categoryKey) return;
-      // 既に何か表示中なら多重表示しない。
-      if (active) return;
+      // 既に表示中、またはフェッチ中なら多重フェッチしない。
+      if (active || fetchingRef.current) return;
 
+      fetchingRef.current = true;
       try {
         const res = await fetch("/api/collections/unlock-announcements", {
           cache: "no-store",
@@ -73,6 +77,8 @@ export function CollectionUnlockDripListener() {
         setActive({ announcement, newlyUnlocked });
       } catch {
         // 取得失敗は無視(致命ではない。次の機会に出る)。
+      } finally {
+        fetchingRef.current = false;
       }
     }
 

--- a/features/collections/components/CollectionUnlockDripListener.tsx
+++ b/features/collections/components/CollectionUnlockDripListener.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { UnlockDripModal } from "@/features/collections/components/UnlockModals";
+import {
+  decideUnlockAnnouncement,
+  type CollectionUnlockAnnouncement,
+} from "@/features/collections/lib/collection-unlock-announcement";
+import {
+  getUnlockSeen,
+  writeUnlockSeen,
+} from "@/features/collections/lib/collection-unlock-seen";
+import { setUnlockAnnouncerActive } from "@/features/collections/lib/unlock-announcer-signal";
+import { COLLECTION_PROGRESS_DISMISSED_EVENT } from "@/features/collections/hooks/useCollectionProgress";
+
+interface ActiveDrip {
+  announcement: CollectionUnlockAnnouncement;
+  newlyUnlocked: CollectionUnlockAnnouncement["unlockedPresets"];
+}
+
+/**
+ * 進捗モーダルを閉じた直後に、段階解放(B)モーダルを「新たに解放された分」のサムネ付きで出す常駐リスナ。
+ *
+ * - `CollectionProgressChecker`(AppShell 常駐)が進捗モーダルを閉じると
+ *   `COLLECTION_PROGRESS_DISMISSED_EVENT`(detail.categoryKey)を発火する。
+ * - 本リスナはそれを受け、`/api/collections/unlock-announcements` で最新の解放状況を取得し、
+ *   当該カテゴリの解放数が「前回見た数(localStorage)」より増えていれば B を即表示する。
+ * - 初回(seen が無い)の場合はホームの初回モーダル(A)に委ねるため、ここでは出さない。
+ *
+ * これにより「生成 → 進捗モーダル → 閉じる → 段階解放モーダル(B)」の順序になる
+ * (進捗モーダルが出るのはコレクションシリーズが public のとき = go-live 後)。
+ */
+export function CollectionUnlockDripListener() {
+  const [active, setActive] = useState<ActiveDrip | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function handleDismissed(event: Event) {
+      const detail = (event as CustomEvent).detail as
+        | { categoryKey?: string }
+        | undefined;
+      const categoryKey = detail?.categoryKey;
+      if (!categoryKey) return;
+      // 既に何か表示中なら多重表示しない。
+      if (active) return;
+
+      try {
+        const res = await fetch("/api/collections/unlock-announcements", {
+          cache: "no-store",
+        });
+        if (!res.ok || cancelled) return;
+        const data = (await res.json()) as {
+          announcements?: CollectionUnlockAnnouncement[];
+        };
+        const announcement = (data.announcements ?? []).find(
+          (a) => a.categoryKey === categoryKey,
+        );
+        if (!announcement) return;
+
+        const seen = getUnlockSeen(announcement.categoryKey);
+        const mode = decideUnlockAnnouncement(seen, announcement.unlockedCount);
+        // 段階解放(drip)のみ担当。初回(seen===null)はホームの A に委ねる。
+        if (mode !== "drip" || seen === null) return;
+
+        const newlyUnlocked = announcement.unlockedPresets.slice(
+          seen,
+          announcement.unlockedCount,
+        );
+        if (newlyUnlocked.length === 0 || cancelled) return;
+
+        setActive({ announcement, newlyUnlocked });
+      } catch {
+        // 取得失敗は無視(致命ではない。次の機会に出る)。
+      }
+    }
+
+    window.addEventListener(COLLECTION_PROGRESS_DISMISSED_EVENT, handleDismissed);
+    return () => {
+      cancelled = true;
+      window.removeEventListener(
+        COLLECTION_PROGRESS_DISMISSED_EVENT,
+        handleDismissed,
+      );
+    };
+  }, [active]);
+
+  // 表示中はポップアップバナーを抑止する(解放お知らせ優先)。
+  const isVisible = !!active;
+  useEffect(() => {
+    setUnlockAnnouncerActive(isVisible);
+    return () => setUnlockAnnouncerActive(false);
+  }, [isVisible]);
+
+  function close() {
+    if (active) {
+      writeUnlockSeen(
+        active.announcement.categoryKey,
+        active.announcement.unlockedCount,
+      );
+    }
+    setActive(null);
+  }
+
+  if (!active || typeof document === "undefined") return null;
+
+  return createPortal(
+    <UnlockDripModal
+      title={active.announcement.categoryDisplayName}
+      newlyUnlocked={active.newlyUnlocked}
+      onClose={close}
+    />,
+    document.body,
+  );
+}

--- a/features/collections/components/PetitUnlockAnnouncer.tsx
+++ b/features/collections/components/PetitUnlockAnnouncer.tsx
@@ -2,52 +2,27 @@
 
 import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import { createPortal } from "react-dom";
-import Image from "next/image";
-import Link from "next/link";
 import {
   decideUnlockAnnouncement,
   type CollectionUnlockAnnouncement,
   type UnlockAnnouncementMode,
 } from "@/features/collections/lib/collection-unlock-announcement";
 import { getCollectionAck } from "@/features/collections/lib/collection-ack";
+import {
+  getUnlockSeen,
+  writeUnlockSeen,
+} from "@/features/collections/lib/collection-unlock-seen";
 import { setUnlockAnnouncerActive } from "@/features/collections/lib/unlock-announcer-signal";
+import {
+  InitialUnlockModal,
+  UnlockDripModal,
+} from "@/features/collections/components/UnlockModals";
 
 // クライアントでのみ true を返す SSR セーフなゲート(setState-in-effect を避けるため
 // useSyncExternalStore を使う)。サーバー/ハイドレーション中は false で何も描画しない。
 const noopSubscribe = () => () => {};
 const getClientSnapshot = () => true;
 const getServerSnapshot = () => false;
-
-const STORAGE_KEY = "persta:collection-unlock-seen-v1";
-
-/** カテゴリ key -> 「前回お知らせ時の解放数」。 */
-type SeenMap = Record<string, number>;
-
-function readSeenMap(): SeenMap {
-  if (typeof window === "undefined") return {};
-  try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
-    if (!raw) return {};
-    const parsed = JSON.parse(raw) as unknown;
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      return parsed as SeenMap;
-    }
-    return {};
-  } catch {
-    return {};
-  }
-}
-
-function writeSeen(categoryKey: string, unlockedCount: number) {
-  if (typeof window === "undefined") return;
-  try {
-    const map = readSeenMap();
-    map[categoryKey] = unlockedCount;
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
-  } catch {
-    // localStorage 不可(プライベートモード等)でも致命ではない。お知らせは出ないだけ。
-  }
-}
 
 interface ActiveAnnouncement {
   mode: Exclude<UnlockAnnouncementMode, "none">;
@@ -63,7 +38,6 @@ interface ActiveAnnouncement {
 function resolveActiveAnnouncement(
   announcements: CollectionUnlockAnnouncement[],
 ): ActiveAnnouncement | null {
-  const seenMap = readSeenMap();
   for (const announcement of announcements) {
     // 前提カテゴリ(神コレ)のコンプリート演出が「まだ確認されていない」間はお知らせを出さない。
     // コンプリート演出は表示時に collection-ack を現在のユニーク数へ進めるため、
@@ -77,11 +51,7 @@ function resolveActiveAnnouncement(
       continue;
     }
 
-    const hasSeen = Object.prototype.hasOwnProperty.call(
-      seenMap,
-      announcement.categoryKey,
-    );
-    const seen = hasSeen ? seenMap[announcement.categoryKey] : null;
+    const seen = getUnlockSeen(announcement.categoryKey);
     const mode = decideUnlockAnnouncement(seen, announcement.unlockedCount);
     if (mode === "none") continue;
 
@@ -103,6 +73,9 @@ function resolveActiveAnnouncement(
  *
  * 「前回見た解放数」は localStorage に保存し、表示後に現在値へ更新する(=同じ解放では再表示しない)。
  * サーバー側の判定(可視性 admin_only / 前提完走)を通った announcements だけが渡る前提。
+ *
+ * なお、生成直後(進捗モーダルを閉じた直後)の段階解放(B)は `CollectionUnlockDripListener`
+ * (AppShell 常駐)が担当する。本コンポーネントはホームでの初回/再訪時表示を担う。
  */
 export function PetitUnlockAnnouncer({
   announcements,
@@ -163,7 +136,7 @@ export function PetitUnlockAnnouncer({
       return;
     }
     if (!visible) return;
-    writeSeen(
+    writeUnlockSeen(
       visible.announcement.categoryKey,
       visible.announcement.unlockedCount,
     );
@@ -192,7 +165,7 @@ export function PetitUnlockAnnouncer({
         onClose={acknowledge}
       />
     ) : (
-      <DripModal
+      <UnlockDripModal
         title={visible.announcement.categoryDisplayName}
         newlyUnlocked={visible.newlyUnlocked}
         onClose={acknowledge}
@@ -200,175 +173,4 @@ export function PetitUnlockAnnouncer({
     );
 
   return createPortal(node, document.body);
-}
-
-// ぷち神の進捗モーダル(#C670FF / #F3E0FF)に合わせた爽やかな紫基調の配色。
-// ボタン背景/hover は Tailwind の arbitrary class(bg-[#C670FF] hover:bg-[#B14DF0])で指定する。
-const ACCENT_HOVER = "#B14DF0";
-const ACCENT_TEXT = "#8B3DC9";
-const ACCENT_SOFT_BG = "#F3E0FF";
-
-/** モーダル右上の閉じる(×)ボタン。 */
-function CloseButton({ onClose }: { onClose: () => void }) {
-  return (
-    <button
-      type="button"
-      onClick={onClose}
-      aria-label="閉じる"
-      className="absolute right-3 top-3 rounded-full p-1.5 text-[#B388D9] transition hover:bg-[#F3E0FF]"
-    >
-      <svg width="18" height="18" viewBox="0 0 16 16" fill="none" aria-hidden>
-        <path
-          d="M4 4l8 8M12 4l-8 8"
-          stroke="currentColor"
-          strokeWidth="1.8"
-          strokeLinecap="round"
-        />
-      </svg>
-    </button>
-  );
-}
-
-/** A: 初回解放モーダル(解放キャラのステッカー画像を見せる)。 */
-function InitialUnlockModal({
-  title,
-  onClose,
-}: {
-  title: string;
-  onClose: () => void;
-}) {
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4"
-      role="dialog"
-      aria-modal="true"
-      onClick={onClose}
-    >
-      <div
-        className="relative w-full max-w-sm overflow-hidden rounded-3xl bg-gradient-to-b from-[#F8EEFF] to-white p-6 text-center shadow-2xl"
-        onClick={(event) => event.stopPropagation()}
-      >
-        <CloseButton onClose={onClose} />
-        <span
-          className="inline-block rounded-full px-3 py-1 text-xs font-bold tracking-wide"
-          style={{ backgroundColor: ACCENT_SOFT_BG, color: ACCENT_HOVER }}
-        >
-          NEW
-        </span>
-        <h2 className="mt-2 text-lg font-bold" style={{ color: ACCENT_TEXT }}>
-          {title}が解放されました！
-        </h2>
-
-        <div className="mx-auto mt-4 w-52 overflow-hidden rounded-2xl shadow-md ring-1 ring-[#E6C8FF]">
-          <Image
-            src="/collections/petit-unlock-hero.png"
-            alt={title}
-            width={600}
-            height={600}
-            className="h-auto w-full"
-            priority
-          />
-        </div>
-
-        <p className="mt-4 text-sm text-[#7A5A93]">
-          コンプリート報酬の新しいスタイルが登場。さっそく作ってみましょう。
-        </p>
-
-        <div className="mt-6 flex flex-col gap-2">
-          <Link
-            href="/style"
-            onClick={onClose}
-            className="rounded-full bg-[#C670FF] px-4 py-2.5 text-sm font-bold text-white transition hover:bg-[#B14DF0]"
-          >
-            つくりに行く
-          </Link>
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-full px-4 py-2 text-sm font-medium text-[#9B7AB5] transition hover:bg-[#F3E0FF]"
-          >
-            あとで
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-/** B: 段階解放のお祝いモーダル(新たに解放されたサムネを表示)。 */
-function DripModal({
-  title,
-  newlyUnlocked,
-  onClose,
-}: {
-  title: string;
-  newlyUnlocked: CollectionUnlockAnnouncement["unlockedPresets"];
-  onClose: () => void;
-}) {
-  const count = newlyUnlocked.length;
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4"
-      role="dialog"
-      aria-modal="true"
-      onClick={onClose}
-    >
-      <div
-        className="relative w-full max-w-sm overflow-hidden rounded-3xl bg-gradient-to-b from-[#F8EEFF] to-white p-6 text-center shadow-2xl"
-        onClick={(event) => event.stopPropagation()}
-      >
-        <CloseButton onClose={onClose} />
-        <span
-          className="inline-block rounded-full px-3 py-1 text-xs font-bold tracking-wide"
-          style={{ backgroundColor: ACCENT_SOFT_BG, color: ACCENT_HOVER }}
-        >
-          NEW
-        </span>
-        <h2 className="mt-2 text-lg font-bold" style={{ color: ACCENT_TEXT }}>
-          新たに{count}体 解放！
-        </h2>
-        <p className="mt-1 text-sm text-[#7A5A93]">
-          {title}の続きが登場しました。
-        </p>
-
-        {count > 0 && (
-          <div className="mt-4 flex flex-wrap justify-center gap-3">
-            {newlyUnlocked.map((preset) => (
-              <div key={preset.id} className="w-20">
-                <div className="relative aspect-square overflow-hidden rounded-xl bg-[#F8EEFF] ring-1 ring-[#E6C8FF]">
-                  <Image
-                    src={preset.thumbnailUrl}
-                    alt={preset.title}
-                    fill
-                    sizes="80px"
-                    className="object-cover"
-                  />
-                </div>
-                <p className="mt-1 truncate text-[11px] text-[#7A5A93]">
-                  {preset.title}
-                </p>
-              </div>
-            ))}
-          </div>
-        )}
-
-        <div className="mt-6 flex flex-col gap-2">
-          <Link
-            href="/style"
-            onClick={onClose}
-            className="rounded-full bg-[#C670FF] px-4 py-2.5 text-sm font-bold text-white transition hover:bg-[#B14DF0]"
-          >
-            つくりに行く
-          </Link>
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-full px-4 py-2 text-sm font-medium text-[#9B7AB5] transition hover:bg-[#F3E0FF]"
-          >
-            あとで
-          </button>
-        </div>
-      </div>
-    </div>
-  );
 }

--- a/features/collections/components/UnlockModals.tsx
+++ b/features/collections/components/UnlockModals.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import type { CollectionUnlockAnnouncement } from "@/features/collections/lib/collection-unlock-announcement";
+
+// ぷち神の進捗モーダル(#C670FF / #F3E0FF)に合わせた爽やかな紫基調の配色。
+// ボタン背景/hover は Tailwind の arbitrary class(bg-[#C670FF] hover:bg-[#B14DF0])で指定する。
+const ACCENT_HOVER = "#B14DF0";
+const ACCENT_TEXT = "#8B3DC9";
+const ACCENT_SOFT_BG = "#F3E0FF";
+
+/** モーダル右上の閉じる(×)ボタン。 */
+function CloseButton({ onClose }: { onClose: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClose}
+      aria-label="閉じる"
+      className="absolute right-3 top-3 rounded-full p-1.5 text-[#B388D9] transition hover:bg-[#F3E0FF]"
+    >
+      <svg width="18" height="18" viewBox="0 0 16 16" fill="none" aria-hidden>
+        <path
+          d="M4 4l8 8M12 4l-8 8"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          strokeLinecap="round"
+        />
+      </svg>
+    </button>
+  );
+}
+
+/** NEW ピル(紫)。 */
+function NewPill() {
+  return (
+    <span
+      className="inline-block rounded-full px-3 py-1 text-xs font-bold tracking-wide"
+      style={{ backgroundColor: ACCENT_SOFT_BG, color: ACCENT_HOVER }}
+    >
+      NEW
+    </span>
+  );
+}
+
+/** 「つくりに行く」/「あとで」の CTA。 */
+function UnlockModalActions({ onClose }: { onClose: () => void }) {
+  return (
+    <div className="mt-6 flex flex-col gap-2">
+      <Link
+        href="/style"
+        onClick={onClose}
+        className="rounded-full bg-[#C670FF] px-4 py-2.5 text-sm font-bold text-white transition hover:bg-[#B14DF0]"
+      >
+        つくりに行く
+      </Link>
+      <button
+        type="button"
+        onClick={onClose}
+        className="rounded-full px-4 py-2 text-sm font-medium text-[#9B7AB5] transition hover:bg-[#F3E0FF]"
+      >
+        あとで
+      </button>
+    </div>
+  );
+}
+
+/** A: 初回解放モーダル(解放キャラのステッカー画像を見せる)。 */
+export function InitialUnlockModal({
+  title,
+  onClose,
+}: {
+  title: string;
+  onClose: () => void;
+}) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4"
+      role="dialog"
+      aria-modal="true"
+      onClick={onClose}
+    >
+      <div
+        className="relative w-full max-w-sm overflow-hidden rounded-3xl bg-gradient-to-b from-[#F8EEFF] to-white p-6 text-center shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <CloseButton onClose={onClose} />
+        <NewPill />
+        <h2 className="mt-2 text-lg font-bold" style={{ color: ACCENT_TEXT }}>
+          {title}が解放されました！
+        </h2>
+
+        <div className="mx-auto mt-4 w-52 overflow-hidden rounded-2xl shadow-md ring-1 ring-[#E6C8FF]">
+          <Image
+            src="/collections/petit-unlock-hero.png"
+            alt={title}
+            width={600}
+            height={600}
+            className="h-auto w-full"
+            priority
+          />
+        </div>
+
+        <p className="mt-4 text-sm text-[#7A5A93]">
+          コンプリート報酬の新しいスタイルが登場。さっそく作ってみましょう。
+        </p>
+
+        <UnlockModalActions onClose={onClose} />
+      </div>
+    </div>
+  );
+}
+
+/** B: 段階解放のお祝いモーダル(新たに解放されたサムネを表示)。 */
+export function UnlockDripModal({
+  title,
+  newlyUnlocked,
+  onClose,
+}: {
+  title: string;
+  newlyUnlocked: CollectionUnlockAnnouncement["unlockedPresets"];
+  onClose: () => void;
+}) {
+  const count = newlyUnlocked.length;
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4"
+      role="dialog"
+      aria-modal="true"
+      onClick={onClose}
+    >
+      <div
+        className="relative w-full max-w-sm overflow-hidden rounded-3xl bg-gradient-to-b from-[#F8EEFF] to-white p-6 text-center shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <CloseButton onClose={onClose} />
+        <NewPill />
+        <h2 className="mt-2 text-lg font-bold" style={{ color: ACCENT_TEXT }}>
+          新たに{count}体 解放！
+        </h2>
+        <p className="mt-1 text-sm text-[#7A5A93]">
+          {title}の続きが登場しました。
+        </p>
+
+        {count > 0 && (
+          <div className="mt-4 flex flex-wrap justify-center gap-3">
+            {newlyUnlocked.map((preset) => (
+              <div key={preset.id} className="w-20">
+                <div className="relative aspect-square overflow-hidden rounded-xl bg-[#F8EEFF] ring-1 ring-[#E6C8FF]">
+                  <Image
+                    src={preset.thumbnailUrl}
+                    alt={preset.title}
+                    fill
+                    sizes="80px"
+                    className="object-cover"
+                  />
+                </div>
+                <p className="mt-1 truncate text-[11px] text-[#7A5A93]">
+                  {preset.title}
+                </p>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <UnlockModalActions onClose={onClose} />
+      </div>
+    </div>
+  );
+}

--- a/features/collections/hooks/useCollectionProgress.ts
+++ b/features/collections/hooks/useCollectionProgress.ts
@@ -12,6 +12,12 @@ import {
 const POLL_INTERVAL_MS = 10000;
 /** style 画面などからの即時再チェック用イベント */
 export const COLLECTION_PROGRESS_REFRESH_EVENT = "collection-progress-refresh";
+/**
+ * 進捗モーダルを閉じたときに発火するイベント。detail.categoryKey に閉じたカテゴリを載せる。
+ * 段階解放モーダル(B)を進捗モーダルのクローズ直後に出すため CollectionUnlockDripListener が購読する。
+ */
+export const COLLECTION_PROGRESS_DISMISSED_EVENT =
+  "collection-progress-dismissed";
 
 function buildPublicMountUrl(path: string | null): string | null {
   if (!path) return null;
@@ -217,7 +223,16 @@ export function useCollectionProgress() {
   }, [evaluate]);
 
   const dismiss = useCallback(() => {
+    // 閉じたカテゴリ key を控えてからモーダルを閉じ、段階解放モーダル(B)の判定用に通知する。
+    const dismissedKey = celebrationRef.current?.categoryKey ?? null;
     setCelebration(null);
+    if (dismissedKey && typeof window !== "undefined") {
+      window.dispatchEvent(
+        new CustomEvent(COLLECTION_PROGRESS_DISMISSED_EVENT, {
+          detail: { categoryKey: dismissedKey },
+        }),
+      );
+    }
     window.setTimeout(() => {
       void evaluate();
     }, 300);

--- a/features/collections/lib/collection-unlock-seen.ts
+++ b/features/collections/lib/collection-unlock-seen.ts
@@ -1,0 +1,45 @@
+/**
+ * 解放お知らせ(初回モーダル/段階解放モーダル)の「前回見た解放数」を localStorage で管理する。
+ *
+ * カテゴリ key ごとに「最後に表示した解放数」を保存し、現在の解放数がそれを上回ったときだけ
+ * お知らせを出す(= 同じ解放では再表示しない)。ホームの `PetitUnlockAnnouncer` と、進捗モーダル
+ * クローズ後に出す `CollectionUnlockDripListener` の双方で共有する。
+ */
+const STORAGE_KEY = "persta:collection-unlock-seen-v1";
+
+type SeenMap = Record<string, number>;
+
+function readSeenMap(): SeenMap {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as SeenMap;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+/** 前回見た解放数を返す。未記録は null(= 初回)。 */
+export function getUnlockSeen(categoryKey: string): number | null {
+  const map = readSeenMap();
+  return Object.prototype.hasOwnProperty.call(map, categoryKey)
+    ? map[categoryKey]
+    : null;
+}
+
+/** 表示後に「見た解放数」を現在値へ更新する。 */
+export function writeUnlockSeen(categoryKey: string, unlockedCount: number): void {
+  if (typeof window === "undefined") return;
+  try {
+    const map = readSeenMap();
+    map[categoryKey] = unlockedCount;
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    // localStorage 不可(プライベートモード等)でも致命ではない。お知らせは出ないだけ。
+  }
+}

--- a/tests/unit/features/collections/use-collection-progress.test.tsx
+++ b/tests/unit/features/collections/use-collection-progress.test.tsx
@@ -1,5 +1,6 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import {
+  COLLECTION_PROGRESS_DISMISSED_EVENT,
   COLLECTION_PROGRESS_REFRESH_EVENT,
   useCollectionProgress,
 } from "@/features/collections/hooks/useCollectionProgress";
@@ -135,6 +136,43 @@ describe("useCollectionProgress の admin プレビュー", () => {
     const { result } = renderHook(() => useCollectionProgress());
 
     await new Promise((r) => setTimeout(r, 50));
+    expect(result.current.celebration).toBeNull();
+  });
+
+  it("dismiss すると COLLECTION_PROGRESS_DISMISSED_EVENT を categoryKey 付きで発火する", async () => {
+    // ack=0 + 進捗(uniqueOutfitCount=1)で celebration を出す。
+    mockProgressResponse({
+      items: [
+        makeSeries({
+          uniqueOutfitCount: 1,
+          isCompleted: false,
+          mountStatus: null,
+          mountImagePath: null,
+          completionId: null,
+          collectedImageUrls: [],
+        }),
+      ],
+      isAdminViewer: false,
+    });
+    window.localStorage.setItem(`collection-ack:${WAFER_KEY}`, "0");
+    setUrl("/ja");
+
+    const { result } = renderHook(() => useCollectionProgress());
+    await waitFor(() => expect(result.current.celebration).not.toBeNull());
+
+    const handler = jest.fn();
+    window.addEventListener(COLLECTION_PROGRESS_DISMISSED_EVENT, handler);
+    act(() => {
+      result.current.dismiss();
+    });
+    window.removeEventListener(COLLECTION_PROGRESS_DISMISSED_EVENT, handler);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    const event = handler.mock.calls[0][0] as CustomEvent<{
+      categoryKey: string;
+    }>;
+    expect(event.detail.categoryKey).toBe(WAFER_KEY);
+    // モーダルは閉じている。
     expect(result.current.celebration).toBeNull();
   });
 


### PR DESCRIPTION
### 概要
ぷち神(段階解放カテゴリ)で、生成 → 進捗モーダル → 閉じる の直後に「新たに2体 解放!」モーダル(B、サムネ付き)を**即表示**する導線を追加します。従来は段階解放お知らせがホーム再訪時のみだったのを、生成直後にも出せるようにします。

進捗モーダルが出るのはコレクションシリーズが `public` のとき(= go-live 後)のため、本導線も **go-live 後に有効**になります(実装は先行投入)。

### 動作フロー
1. ぷち神を生成 → 進捗モーダル(○/6)が表示
2. ユーザーが進捗モーダルを閉じる
3. その直後、解放数が増えていれば B「新たに2体 解放!」モーダルを次の2体のサムネ付きで即表示
4. 初回(まだ A を見ていない)場合はホームの初回モーダル(A)に委ね、ここでは出さない

### 変更内容
- **API** `GET /api/collections/unlock-announcements`: 現在の解放状況(解放数・総数・解放順サムネ・前提カテゴリ)を返す。未ログイン/ゲート無しは空配列。
- **`CollectionUnlockDripListener`**(AppShell 常駐): 進捗モーダルのクローズ event を購読し、最新の解放状況を取得して段階解放(drip)なら B を即表示。表示中はポップアップバナーを抑止。
- **`useCollectionProgress.dismiss`**: `COLLECTION_PROGRESS_DISMISSED_EVENT`(detail.categoryKey)を発火。
- リファクタ: 解放お知らせの「見た」記録(`collection-unlock-seen`)とモーダル UI(`UnlockModals`)を共有 lib/部品へ切り出し、`PetitUnlockAnnouncer` と共用。二重表示は localStorage の seen 共有で防止。

### 検証
- `CollectionUnlockDripListener` をブラウザで実動作確認(dismiss event → API 取得 → drip 判定 → B モーダルが次の2体サムネ付きで表示)。
- collections ユニットテスト 225 件 / typecheck / lint / `build --webpack` すべて緑。

### 注意
- 進捗モーダル発火条件(コレクションシリーズ public)を満たす go-live 後に有効。
- 初回(A)はホーム、段階解放(B)は「ホーム再訪時」+「進捗モーダルのクローズ直後」の両方で出る(seen 共有で重複表示なし)。

### 実機テスト
- [ ] (要 go-live 後)ぷち神を2体生成 → 進捗モーダルを閉じる → B モーダルが出ることを確認
- [ ] B を閉じた後、再度同じ解放では出ないことを確認
