### PR TITLE
fix(collections): マイページ進捗一覧に解放ゲートを適用し前提未完走のぷち神カードを非表示に

### DIFF
--- a/features/collections/lib/collection-progress-repository.ts
+++ b/features/collections/lib/collection-progress-repository.ts
@@ -52,7 +52,55 @@ export async function getCollectionProgressForUser(
   const rows = (data ?? []) as CollectionProgressRow[];
   const withCharacter = await attachCharacterImages(rows.map(mapProgressRow));
   const withCollected = await attachCollectedImages(withCharacter, userId);
-  return attachCompletionIds(withCollected, userId);
+  const withCompletion = await attachCompletionIds(withCollected, userId);
+  // 解放ゲート: 前提カテゴリ未完走のゲート付きカテゴリ(例: ぷち神)はここで除外する。
+  return filterLockedCategories(withCompletion, supabase);
+}
+
+/**
+ * 解放ゲート(unlock_prerequisite_key)をマイページの進捗一覧にも適用する。
+ *
+ * `/style`・ホーム(applyCollectionUnlockGating)と同じポリシーで、
+ * `unlock_prerequisite_key` が設定されたカテゴリは「前提カテゴリを完走(= 台紙 mount を
+ * 作成し is_completed=true)」したときだけ表示する。前提未完走なら一覧から除外する。
+ * admin プレビュー(admin_only の取り込み)とは独立の判定であり、admin も前提完走が必要。
+ *
+ * 前提カテゴリの完走状態は、同じ進捗配列内の該当行(神コレ等。public/series なので必ず含まれる)
+ * の isCompleted から判定する。ゲート情報の取得に失敗したときは回帰を避けるため全件返す。
+ */
+async function filterLockedCategories(
+  items: CollectionProgress[],
+  supabase: SupabaseClient,
+): Promise<CollectionProgress[]> {
+  if (items.length === 0) return items;
+  const { data, error } = await supabase
+    .from("preset_categories")
+    .select("key, unlock_prerequisite_key")
+    .in(
+      "key",
+      items.map((i) => i.categoryKey),
+    );
+  if (error) {
+    // ゲート判定不能。over-hiding を避け、従来挙動(全件)にフォールバックする。
+    console.error("[collection-progress] unlock gate query failed:", error);
+    return items;
+  }
+  const prerequisiteByKey = new Map<string, string | null>();
+  for (const row of data ?? []) {
+    prerequisiteByKey.set(
+      row.key as string,
+      (row.unlock_prerequisite_key as string | null) ?? null,
+    );
+  }
+  // 完走(台紙作成 = is_completed)済みカテゴリの key 集合。
+  const completedKeys = new Set(
+    items.filter((i) => i.isCompleted).map((i) => i.categoryKey),
+  );
+  return items.filter((item) => {
+    const prerequisite = prerequisiteByKey.get(item.categoryKey) ?? null;
+    if (!prerequisite) return true; // ゲートなし → 常に表示
+    return completedKeys.has(prerequisite); // 前提が完走済みのときだけ表示
+  });
 }
 
 function mapProgressRow(row: CollectionProgressRow): CollectionProgress {

--- a/tests/unit/features/collections/collection-progress-repository.test.ts
+++ b/tests/unit/features/collections/collection-progress-repository.test.ts
@@ -190,3 +190,129 @@ describe("getCollectionProgressForUser: progress-modal フィールド結合", (
     );
   });
 });
+
+describe("getCollectionProgressForUser: 解放ゲート(unlock_prerequisite_key)適用", () => {
+  const GOD = {
+    category_id: "god-id",
+    category_key: "god",
+    display_name_ja: "神コレ",
+    display_name_en: "God",
+    completion_threshold: 6,
+    unique_outfit_count: 6,
+    is_completed: false,
+    mount_status: null,
+    mount_image_path: null,
+    completed_at: null,
+  };
+  const PETIT = {
+    category_id: "petit-id",
+    category_key: "petit",
+    display_name_ja: "ぷち神",
+    display_name_en: "Petit",
+    completion_threshold: 6,
+    unique_outfit_count: 2,
+    is_completed: false,
+    mount_status: null,
+    mount_image_path: null,
+    completed_at: null,
+  };
+
+  /**
+   * RPC は [神コレ, ぷち神] を返す(admin プレビュー想定)。
+   * preset_categories は key と unlock_prerequisite_key を返す。
+   * 神コレの完走状態(godCompleted)で台紙作成済みかを切り替える。
+   */
+  function buildGateClient(godCompleted: boolean) {
+    const rpc = jest.fn().mockResolvedValue({
+      data: [{ ...GOD, is_completed: godCompleted }, PETIT],
+      error: null,
+    });
+    const categoryRows = [
+      { id: "god-id", key: "god", unlock_prerequisite_key: null },
+      { id: "petit-id", key: "petit", unlock_prerequisite_key: "god" },
+    ];
+    const from = jest.fn((table: string) => {
+      if (table === "preset_categories") {
+        return {
+          select: jest.fn(() => ({
+            in: jest
+              .fn()
+              .mockResolvedValue({ data: categoryRows, error: null }),
+          })),
+        };
+      }
+      return {
+        select: jest.fn(() => ({
+          eq: jest.fn(() => ({
+            eq: jest.fn().mockResolvedValue({ data: [], error: null }),
+          })),
+        })),
+      };
+    });
+    return { rpc, from };
+  }
+
+  test("前提(神コレ)が未完走ならゲート付きカテゴリ(ぷち神)を除外する", async () => {
+    createAdminClientMock.mockImplementation(() => buildGateClient(false));
+
+    const result = await getCollectionProgressForUser("user-1", true);
+
+    const keys = result.map((r) => r.categoryKey);
+    expect(keys).toContain("god");
+    expect(keys).not.toContain("petit");
+  });
+
+  test("前提(神コレ)が完走済みならゲート付きカテゴリ(ぷち神)を表示する", async () => {
+    createAdminClientMock.mockImplementation(() => buildGateClient(true));
+
+    const result = await getCollectionProgressForUser("user-1", true);
+
+    const keys = result.map((r) => r.categoryKey);
+    expect(keys).toContain("god");
+    expect(keys).toContain("petit");
+  });
+
+  test("ゲートなしカテゴリ(神コレ)は前提に関係なく常に表示する", async () => {
+    createAdminClientMock.mockImplementation(() => buildGateClient(false));
+
+    const result = await getCollectionProgressForUser("user-1", true);
+
+    expect(result.some((r) => r.categoryKey === "god")).toBe(true);
+  });
+
+  test("ゲート情報の取得に失敗したら回帰回避で全件返す(over-hiding しない)", async () => {
+    createAdminClientMock.mockImplementation(() => {
+      const client = buildGateClient(false);
+      client.from = jest.fn((table: string) => {
+        if (table === "preset_categories") {
+          return {
+            select: jest.fn(() => ({
+              in: jest
+                .fn()
+                .mockResolvedValue({ data: null, error: { message: "boom" } }),
+            })),
+          };
+        }
+        return {
+          select: jest.fn(() => ({
+            eq: jest.fn(() => ({
+              eq: jest.fn().mockResolvedValue({ data: [], error: null }),
+            })),
+          })),
+        };
+      });
+      return client;
+    });
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const result = await getCollectionProgressForUser("user-1", true);
+
+    // ゲート判定不能 → 全件(神コレ + ぷち神)返す
+    const keys = result.map((r) => r.categoryKey);
+    expect(keys).toContain("god");
+    expect(keys).toContain("petit");
+    consoleError.mockRestore();
+  });
+});


### PR DESCRIPTION
### 概要

マイページのコレクション進捗一覧（`/api/collections/progress`）が**解放ゲート（`unlock_prerequisite_key`）を考慮しておらず**、前提カテゴリ「神コレ」の台紙（コンプリートシート／mount）を作成していない＝**未完走の状態でも、ゲート付きカテゴリ「ぷち神コレ」のカードが表示され進捗モーダルが開けてしまう**不具合を修正します。

`/style`・ホーム（`applyCollectionUnlockGating`、#342）には解放ゲートが入っているのに、**マイページだけ適用漏れ**でした。本来「神コレの台紙を作成して初めてぷち神が解放される」仕様に揃えます。

#### 影響範囲
- **現状**: ぷち神は `visibility=admin_only` のため一般ユーザーには出ず、admin プレビューでのみ顕在化（＝今はマスクされている）。
- **go-live 時**: ぷち神を `public` にした瞬間、ゲートが無いと**前提未完走の全ユーザーにぷち神カードが出てしまう** → 本対応で予防。

### 変更内容
- `getCollectionProgressForUser()` に `filterLockedCategories()` を追加（`features/collections/lib/collection-progress-repository.ts`）
- `unlock_prerequisite_key` が設定されたカテゴリは、**前提カテゴリの `is_completed`（= 台紙 mount 作成済み）が true のときだけ表示**。未完走なら一覧から除外
- 前提の完走状態は**同じ進捗配列内の神コレ行**から判定（`preset_categories` から `unlock_prerequisite_key` を引くのみ・**マイグレーション不要**）
- **admin も前提完走が必要**（admin プレビューの admin_only 取り込みとは独立の判定。`/style` と同一ポリシー）
- ゲート情報の取得に失敗した場合は **over-hiding を避けて全件返す**（回帰防止・ログのみ）
- 単体テスト4件追加（前提未完走で除外／完走で表示／ゲートなしは常時表示／取得失敗で全件フォールバック）

### 実機テスト
- [ ] iOS Safari で主要導線を確認
- [ ] Android Chrome で主要導線を確認
- [ ] PC（Chrome）で主要導線を確認
- [ ] レスポンシブ表示崩れがないことを確認
- [ ] エラーメッセージやバリデーション表示を確認
- [ ] 神コレ100%生成・台紙未作成の状態でマイページにぷち神カードが出ないこと
- [ ] 神コレの台紙作成後はマイページにぷち神カードが出ること
- [ ] 神コレ（ゲートなし）は前提に関係なく常に表示されること

### テスト方法
- `npx jest tests/unit/features/collections tests/unit/features/my-page` → 260 passed（新規ゲート4件含む）
- `npm run typecheck` → 本対象ファイル0エラー
- `npm run lint` → 変更ファイル0エラー
- `npm run build -- --webpack` → exit=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)