### PR TITLE
feat(i18n): style段階解放ロックの文言を「あとで登場」→「生成すると開放」に変更

### DIFF
--- a/messages/ar.ts
+++ b/messages/ar.ts
@@ -1396,7 +1396,7 @@ export const arMessages = {
     guestLoginCtaDescription: "جرّب ChatGPT Image 2.0 مجانًا مرة واحدة يوميًا. سجّل الدخول (تسجيل مجاني) بعد الإنشاء لحفظ صورتك.",
     guestLoginCtaAction: "تسجيل الدخول / إنشاء حساب",
     guestCategoryLoginAction: "سجّل الدخول للإنشاء!",
-    styleDripLockedLabel: "قريبًا",
+    styleDripLockedLabel: "أنشئ لإلغاء القفل",
     guestCategoryLoginHint: "سجّل الدخول للإنشاء بكل الأنماط!",
     generateButton: "بدء التنسيق",
     generatingButton: "جارٍ التوليد...",

--- a/messages/de.ts
+++ b/messages/de.ts
@@ -1399,7 +1399,7 @@ export const deMessages = {
     guestLoginCtaDescription: "Teste ChatGPT Image 2.0 einmal täglich kostenlos. Melde dich nach dem Erstellen an (kostenlose Registrierung), um dein Bild zu speichern.",
     guestLoginCtaAction: "Anmelden / Registrieren",
     guestCategoryLoginAction: "Zum Generieren anmelden!",
-    styleDripLockedLabel: "Bald verfügbar",
+    styleDripLockedLabel: "Zum Freischalten generieren",
     guestCategoryLoginHint: "Melde dich an, um mit allen Stilen zu generieren!",
     generateButton: "Styling starten",
     generatingButton: "Wird generiert...",

--- a/messages/en.ts
+++ b/messages/en.ts
@@ -1395,7 +1395,7 @@ export const enMessages = {
     guestLoginCtaDescription: "Try ChatGPT Image 2.0 free, once a day. Log in (free sign-up) after generating to save your image.",
     guestLoginCtaAction: "Sign in / Sign up",
     guestCategoryLoginAction: "Log in to generate!",
-    styleDripLockedLabel: "Coming soon",
+    styleDripLockedLabel: "Generate to unlock",
     guestCategoryLoginHint: "Log in to generate with every style!",
     generateButton: "Start Styling",
     generatingButton: "Generating...",

--- a/messages/es.ts
+++ b/messages/es.ts
@@ -1399,7 +1399,7 @@ export const esMessages = {
     guestLoginCtaDescription: "Prueba ChatGPT Image 2.0 gratis, una vez al día. Inicia sesión (registro gratuito) tras generar para guardar tu imagen.",
     guestLoginCtaAction: "Iniciar sesión / Registrarse",
     guestCategoryLoginAction: "¡Inicia sesión para generar!",
-    styleDripLockedLabel: "Próximamente",
+    styleDripLockedLabel: "Genera para desbloquear",
     guestCategoryLoginHint: "¡Inicia sesión para generar con todos los estilos!",
     generateButton: "Empezar styling",
     generatingButton: "Generando...",

--- a/messages/fr.ts
+++ b/messages/fr.ts
@@ -1399,7 +1399,7 @@ export const frMessages = {
     guestLoginCtaDescription: "Essayez ChatGPT Image 2.0 gratuitement, une fois par jour. Connectez-vous (inscription gratuite) après la génération pour enregistrer votre image.",
     guestLoginCtaAction: "Se connecter / S'inscrire",
     guestCategoryLoginAction: "Connectez-vous pour générer !",
-    styleDripLockedLabel: "Bientôt disponible",
+    styleDripLockedLabel: "Générer pour débloquer",
     guestCategoryLoginHint: "Connectez-vous pour générer avec tous les styles !",
     generateButton: "Démarrer le styling",
     generatingButton: "Génération...",

--- a/messages/hi.ts
+++ b/messages/hi.ts
@@ -1397,7 +1397,7 @@ export const hiMessages = {
     guestLoginCtaDescription: "ChatGPT Image 2.0 दिन में एक बार मुफ़्त आज़माएँ। बनाने के बाद लॉगिन (मुफ़्त साइन-अप) करके अपनी इमेज सहेजें।",
     guestLoginCtaAction: "साइन इन / साइन अप",
     guestCategoryLoginAction: "जनरेट करने के लिए लॉग इन करें!",
-    styleDripLockedLabel: "जल्द आ रहा है",
+    styleDripLockedLabel: "जनरेट करके अनलॉक करें",
     guestCategoryLoginHint: "लॉग इन करके सभी स्टाइल से जनरेट करें!",
     generateButton: "स्टाइलिंग शुरू करें",
     generatingButton: "उत्पन्न हो रहा है...",

--- a/messages/id.ts
+++ b/messages/id.ts
@@ -1398,7 +1398,7 @@ export const idMessages = {
     guestLoginCtaDescription: "Coba ChatGPT Image 2.0 gratis, sekali sehari. Masuk (daftar gratis) setelah membuat untuk menyimpan gambarmu.",
     guestLoginCtaAction: "Masuk / Daftar",
     guestCategoryLoginAction: "Masuk untuk membuat!",
-    styleDripLockedLabel: "Segera hadir",
+    styleDripLockedLabel: "Buat untuk membuka",
     guestCategoryLoginHint: "Masuk untuk membuat dengan semua gaya!",
     generateButton: "Mulai styling",
     generatingButton: "Menghasilkan...",

--- a/messages/it.ts
+++ b/messages/it.ts
@@ -1399,7 +1399,7 @@ export const itMessages = {
     guestLoginCtaDescription: "Prova ChatGPT Image 2.0 gratis, una volta al giorno. Accedi (registrazione gratuita) dopo la generazione per salvare la tua immagine.",
     guestLoginCtaAction: "Accedi / Registrati",
     guestCategoryLoginAction: "Accedi per generare!",
-    styleDripLockedLabel: "In arrivo",
+    styleDripLockedLabel: "Genera per sbloccare",
     guestCategoryLoginHint: "Accedi per generare con tutti gli stili!",
     generateButton: "Avvia styling",
     generatingButton: "Generazione...",

--- a/messages/ja.ts
+++ b/messages/ja.ts
@@ -1337,7 +1337,7 @@ export const jaMessages = {
     guestLoginCtaDescription: "ChatGPT Image 2.0 を 1 日 1 回まで無料でお試しいただけます。生成後にログイン（無料登録）すると画像を保存できます。",
     guestLoginCtaAction: "ログイン / 新規登録",
     guestCategoryLoginAction: "ログインで生成可能！",
-    styleDripLockedLabel: "あとで とうじょう",
+    styleDripLockedLabel: "生成すると開放",
     guestCategoryLoginHint: "ログインすると、すべてのスタイルで生成できます！",
     generateButton: "コーデ開始！",
     generatingButton: "生成中...",

--- a/messages/ko.ts
+++ b/messages/ko.ts
@@ -1395,7 +1395,7 @@ export const koMessages = {
     guestLoginCtaDescription: "ChatGPT Image 2.0을 하루 1회 무료로 사용해 보세요. 생성 후 로그인(무료 가입)하면 이미지를 저장할 수 있어요.",
     guestLoginCtaAction: "로그인 / 회원가입",
     guestCategoryLoginAction: "로그인하면 생성 가능!",
-    styleDripLockedLabel: "곧 등장",
+    styleDripLockedLabel: "생성하면 해제",
     guestCategoryLoginHint: "로그인하면 모든 스타일로 생성할 수 있어요!",
     generateButton: "스타일링 시작",
     generatingButton: "생성 중...",

--- a/messages/pt.ts
+++ b/messages/pt.ts
@@ -1399,7 +1399,7 @@ export const ptMessages = {
     guestLoginCtaDescription: "Experimente o ChatGPT Image 2.0 grátis, uma vez por dia. Faça login (cadastro gratuito) após gerar para salvar sua imagem.",
     guestLoginCtaAction: "Entrar / Cadastrar",
     guestCategoryLoginAction: "Faça login para gerar!",
-    styleDripLockedLabel: "Em breve",
+    styleDripLockedLabel: "Gere para desbloquear",
     guestCategoryLoginHint: "Faça login para gerar com todos os estilos!",
     generateButton: "Iniciar styling",
     generatingButton: "Gerando...",

--- a/messages/th.ts
+++ b/messages/th.ts
@@ -1395,7 +1395,7 @@ export const thMessages = {
     guestLoginCtaDescription: "ทดลองใช้ ChatGPT Image 2.0 ฟรีวันละ 1 ครั้ง เข้าสู่ระบบ (สมัครฟรี) หลังสร้างเพื่อบันทึกรูปของคุณ",
     guestLoginCtaAction: "เข้าสู่ระบบ / สมัครสมาชิก",
     guestCategoryLoginAction: "เข้าสู่ระบบเพื่อสร้าง!",
-    styleDripLockedLabel: "เร็ว ๆ นี้",
+    styleDripLockedLabel: "สร้างเพื่อปลดล็อก",
     guestCategoryLoginHint: "เข้าสู่ระบบเพื่อสร้างด้วยทุกสไตล์!",
     generateButton: "เริ่มจัดสไตล์",
     generatingButton: "กำลังสร้าง...",

--- a/messages/vi.ts
+++ b/messages/vi.ts
@@ -1396,7 +1396,7 @@ export const viMessages = {
     guestLoginCtaDescription: "Dùng thử ChatGPT Image 2.0 miễn phí, mỗi ngày 1 lần. Đăng nhập (đăng ký miễn phí) sau khi tạo để lưu hình của bạn.",
     guestLoginCtaAction: "Đăng nhập / Đăng ký",
     guestCategoryLoginAction: "Đăng nhập để tạo!",
-    styleDripLockedLabel: "Sắp ra mắt",
+    styleDripLockedLabel: "Tạo để mở khóa",
     guestCategoryLoginHint: "Đăng nhập để tạo với mọi phong cách!",
     generateButton: "Bắt đầu styling",
     generatingButton: "Đang tạo...",

--- a/messages/zh-CN.ts
+++ b/messages/zh-CN.ts
@@ -1393,7 +1393,7 @@ export const zhCnMessages = {
     guestLoginCtaDescription: "每天可免费试用 ChatGPT Image 2.0 一次。生成后登录（免费注册）即可保存图片。",
     guestLoginCtaAction: "登录 / 注册",
     guestCategoryLoginAction: "登录后即可生成！",
-    styleDripLockedLabel: "敬请期待",
+    styleDripLockedLabel: "生成后解锁",
     guestCategoryLoginHint: "登录后即可使用所有风格生成！",
     generateButton: "开始造型",
     generatingButton: "生成中...",

--- a/messages/zh-TW.ts
+++ b/messages/zh-TW.ts
@@ -1393,7 +1393,7 @@ export const zhTwMessages = {
     guestLoginCtaDescription: "每天可免費試用 ChatGPT Image 2.0 一次。生成後登入（免費註冊）即可儲存圖片。",
     guestLoginCtaAction: "登入 / 註冊",
     guestCategoryLoginAction: "登入後即可生成！",
-    styleDripLockedLabel: "敬請期待",
+    styleDripLockedLabel: "生成後解鎖",
     guestCategoryLoginHint: "登入後即可使用所有風格生成！",
     generateButton: "開始造型",
     generatingButton: "生成中...",


### PR DESCRIPTION
### 概要

style 画面で、段階解放（drip）によりまだ解放されていないプリセットの中央に表示される文言が、受動的な「あとで とうじょう」（= Coming soon 相当）でした。これを**行動喚起の「生成すると開放」（= Generate to unlock 相当）**に変更し、「生成すると次のスタイルが解放される」導線をユーザーに明示します。

この文言は段階解放ロック（前提カテゴリ完走済み・このプリセットは次バッチ）でのみ表示されるため、「生成すると開放」は文脈的に正確です。

### 変更内容
- i18n キー `styleDripLockedLabel` を **全16ロケール**で「生成すると開放 = Generate to unlock」相当に統一
  - ja「生成すると開放」/ en「Generate to unlock」/ ko「생성하면 해제」/ zh-CN「生成后解锁」/ zh-TW「生成後解鎖」/ es「Genera para desbloquear」/ fr「Générer pour débloquer」/ de「Zum Freischalten generieren」/ it「Genera per sbloccare」/ pt「Gere para desbloquear」/ id「Buat untuk membuka」/ vi「Tạo để mở khóa」/ th「สร้างเพื่อปลดล็อก」/ hi「जनरेट करके अनलॉक करें」/ ar「أنشئ لإلغاء القفل」
- **文言のみの変更**（表示条件・ロジックは一切変更なし）

> 注: ja 以外の翻訳はアシスタントによる訳案です。各言語の最終ニュアンスは必要に応じてご確認ください。

### 実機テスト
- [ ] iOS Safari で主要導線を確認
- [ ] Android Chrome で主要導線を確認
- [ ] PC（Chrome）で主要導線を確認
- [ ] レスポンシブ表示崩れがないことを確認
- [ ] style 画面の段階解放ロックカードに「生成すると開放」が表示されること
- [ ] 言語切替で各ロケールの文言が表示されること

### テスト方法
- `npm run typecheck` → messages 型エラーなし
- `npm run lint` → 変更ファイル0エラー
- `npm run build -- --webpack` → exit=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)