### PR TITLE
fix(collections): 達成前の進捗モーダルCTAが透明で見えない不具合を修正

### DIFF
--- a/features/collections/components/CollectionProgressModal.tsx
+++ b/features/collections/components/CollectionProgressModal.tsx
@@ -887,14 +887,27 @@ export function CollectionProgressModal({
                   href="/style"
                   aria-label="シールを生成する"
                   onClick={onClose}
-                  className="absolute rounded-full focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-orange-300/60"
+                  className={
+                    "absolute flex items-center justify-center rounded-full px-4 text-base font-bold focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-orange-300/60" +
+                    (layout.buttonColor
+                      ? ""
+                      : " bg-gradient-to-r from-amber-400 to-orange-500 shadow-[0_4px_0_rgba(234,88,12,0.45)]")
+                  }
                   style={{
                     left: `${buttonBox.left}%`,
                     top: `${buttonBox.top}%`,
                     width: `${buttonBox.width}%`,
                     height: `${buttonBox.height}%`,
+                    color: layout.buttonTextColor ?? "#ffffff",
+                    fontFamily:
+                      "'Mochiy Pop One','Zen Maru Gothic',system-ui,sans-serif",
+                    ...(layout.buttonColor
+                      ? { backgroundColor: layout.buttonColor }
+                      : {}),
                   }}
-                />
+                >
+                  シールを生成する
+                </Link>
               )
             ) : null}
           </div>

--- a/tests/unit/features/collections/collection-progress-modal.test.tsx
+++ b/tests/unit/features/collections/collection-progress-modal.test.tsx
@@ -562,7 +562,7 @@ describe("CollectionProgressModal: 達成後 CTA の文言と配色", () => {
     expect(onCreateMount).toHaveBeenCalledTimes(1);
   });
 
-  test("達成前(未コンプリート)・ボタン領域あり: フレーム上に「シールを生成する」リンク(/style)", () => {
+  test("達成前(未コンプリート)・ボタン領域あり: 「シールを生成する」が文字付きで表示され /style へ", () => {
     render(
       <CollectionProgressModal
         open
@@ -573,6 +573,12 @@ describe("CollectionProgressModal: 達成後 CTA の文言と配色", () => {
     );
     const link = screen.getByRole("link", { name: "シールを生成する" });
     expect(link).toHaveAttribute("href", "/style");
+    // 透明ではなく文字が表示される(達成前で何も見えない不具合の回帰防止)
+    expect(link).toHaveTextContent("シールを生成する");
+    // admin のボタン色が反映される
+    expect(link.getAttribute("style")).toContain(
+      "background-color: rgb(198, 112, 255)",
+    );
   });
 
   test("達成前(未コンプリート)・ボタン領域なし: フレーム下に「シールを生成する」リンク(/style)", () => {


### PR DESCRIPTION
### 概要

ボタン領域(`progress_modal_button`)が設定された DB 駆動台座(ぷち神)で、**達成前(未コンプリート)のCTAが透明クリック領域のまま**描画され、フレームPNGに文言の焼き込みが無いカテゴリでは「シールを生成する」が何も見えませんでした（タップすると `/style` には遷移する）。達成前のCTAも達成後と同様にコード描画(文言+色)へ統一します。

### 変更内容
- 達成前の絶対配置CTAを、達成後と同じくコード描画(テキスト「シールを生成する」+ admin色/未設定はオレンジ)に統一
- 神コレ等の焼き込みボタンは同位置のコードボタンで覆い隠す（達成後と同じ挙動で一貫・回帰なし）
- フレーム下配置(ボタン領域なし)は前回対応済みで変更なし
- テスト: 達成前に文字付きCTAが表示され admin色が反映されることを検証(回帰防止)

### 実機テスト
- [ ] ぷち神(達成前/0種)で「シールを生成する」が表示され /style へ遷移する
- [ ] 達成後は「カードを作成/更新する」が表示されカード生成される
- [ ] 神コレの従来表示が崩れていない

### テスト方法
- `npx jest tests/unit/features/collections/collection-progress-modal.test.tsx` → 19 passed
- `npm run typecheck` → 本番0エラー / `npm run lint` → 0 / `npm run build -- --webpack` → exit=0
- マイグレーションなし(コードのみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)