### PR TITLE
feat(collections): OGPテンプレ未設定時のデフォルトをブランドOGP画像に変更

### DIFF
--- a/app/api/collections/mount/route.ts
+++ b/app/api/collections/mount/route.ts
@@ -10,6 +10,8 @@ import { composeMount } from "@/features/collections/lib/compose-mount";
 import {
   composeMountOgp,
   composeMountOgpFromTemplate,
+  composeDefaultOgp,
+  DEFAULT_OGP_TEMPLATE_PATH,
   ogpPathFromMountPath,
   parseOgpMountPlacement,
 } from "@/features/collections/lib/compose-mount-ogp";
@@ -259,6 +261,7 @@ export async function POST(request: NextRequest) {
         const ogpTemplatePath = category.ogp_template_path as string | null;
         let ogpPng: Buffer | null = null;
         if (ogpTemplatePath) {
+          // カテゴリ専用テンプレートあり: テンプレに台紙(カード)を合成する。
           try {
             const ogpTemplatePng = await downloadBuffer(
               admin,
@@ -272,11 +275,28 @@ export async function POST(request: NextRequest) {
             });
           } catch (templateError) {
             console.error(
-              "collection mount OGP template compose failed (fallback to default design):",
+              "collection mount OGP template compose failed (fallback to default image):",
               templateError,
             );
           }
+        } else {
+          // テンプレート未設定カテゴリのデフォルト: 共通のブランドOGP画像を
+          // そのまま使う(カード合成なし)。SVG プログラム生成は最終フォールバックに残す。
+          try {
+            const defaultPng = await downloadBuffer(
+              admin,
+              TEMPLATE_BUCKET,
+              DEFAULT_OGP_TEMPLATE_PATH,
+            );
+            ogpPng = await composeDefaultOgp(defaultPng);
+          } catch (defaultError) {
+            console.error(
+              "collection mount default OGP image failed (fallback to programmatic design):",
+              defaultError,
+            );
+          }
         }
+        // テンプレ/デフォルト画像とも取得失敗した場合の最終フォールバック(OGP 無しを避ける)。
         ogpPng ??= await composeMountOgp({
           mountPng,
           displayName: (category.display_name_ja as string | null) ?? "",

--- a/features/collections/lib/compose-mount-ogp.ts
+++ b/features/collections/lib/compose-mount-ogp.ts
@@ -239,6 +239,24 @@ export const DEFAULT_OGP_MOUNT_PLACEMENT: OgpMountPlacement = {
 };
 
 /**
+ * カテゴリに OGP テンプレート(ogp_template_path)が無いときに使う、共通デフォルト
+ * OGP 画像の保存パス(collection-mount-templates bucket)。
+ * カード(台紙)は重ねず、この画像をそのまま 1200x630 にして OGP とする。
+ */
+export const DEFAULT_OGP_TEMPLATE_PATH = "_default/ogp-default.png";
+
+/**
+ * デフォルト OGP 画像を 1200x630 に整えて返す(カード合成なし)。
+ * テンプレート未設定カテゴリのフォールバックで使う。
+ */
+export async function composeDefaultOgp(defaultPng: Buffer): Promise<Buffer> {
+  return sharp(defaultPng)
+    .resize(1200, 630, { fit: "cover" })
+    .png()
+    .toBuffer();
+}
+
+/**
  * preset_categories.ogp_mount_placement(JSONB) を検証して返す。
  * 不正・欠損フィールドは既定値で補う。
  */

--- a/tests/unit/features/collections/compose-mount-ogp.test.ts
+++ b/tests/unit/features/collections/compose-mount-ogp.test.ts
@@ -2,6 +2,8 @@ import sharp from "sharp";
 
 import {
   DEFAULT_OGP_MOUNT_PLACEMENT,
+  DEFAULT_OGP_TEMPLATE_PATH,
+  composeDefaultOgp,
   composeMountOgpFromTemplate,
   ogpPathFromMountPath,
   parseOgpMountPlacement,
@@ -49,6 +51,29 @@ describe("parseOgpMountPlacement", () => {
         rotate: Number.NaN,
       }),
     ).toEqual(DEFAULT_OGP_MOUNT_PLACEMENT);
+  });
+});
+
+describe("composeDefaultOgp", () => {
+  test("デフォルト画像を 1200x630 の PNG にして返す(カード合成なし)", async () => {
+    // 1731x909 のデフォルト画像を想定
+    const defaultPng = await solidPng(1731, 909, [120, 200, 160]);
+    const out = await composeDefaultOgp(defaultPng);
+    const meta = await sharp(out).metadata();
+    expect(meta.format).toBe("png");
+    expect(meta.width).toBe(1200);
+    expect(meta.height).toBe(630);
+    // 元画像の色(カード等を重ねていない)がそのまま出る
+    const { data } = await sharp(out)
+      .extract({ left: 600, top: 315, width: 4, height: 4 })
+      .removeAlpha()
+      .raw()
+      .toBuffer({ resolveWithObject: true });
+    expect(data[1]).toBeGreaterThan(150); // G が支配的(元画像の色)
+  });
+
+  test("デフォルトOGPテンプレのパスは _default 配下", () => {
+    expect(DEFAULT_OGP_TEMPLATE_PATH).toBe("_default/ogp-default.png");
   });
 });
 


### PR DESCRIPTION
### 概要

`ogp_template_path` が未設定のカテゴリの共有OGPは、これまで `composeMountOgp`（SVGプログラム生成のデフォルトデザイン）にフォールバックしていました。これを、**共通のデフォルト画像（Persta.AI ブランドOGP）をそのまま使う**方式に変更します。デフォルトでは**カード（台紙）を重ねません**。

### 変更内容
- `compose-mount-ogp.ts`:
  - `DEFAULT_OGP_TEMPLATE_PATH`（`_default/ogp-default.png`）を追加
  - `composeDefaultOgp()`（1200×630 にリサイズ・カード合成なし）を追加
- `app/api/collections/mount/route.ts`:
  - テンプレ未設定カテゴリは `collection-mount-templates/_default/ogp-default.png` をダウンロードして使用（カード合成なし）
  - SVGプログラム生成（`composeMountOgp`）は「テンプレ／デフォルト画像とも取得失敗時」の**最終フォールバック**として残す
- デフォルト画像（1200×630 PNG, Persta.AI ブランドOGP）は `collection-mount-templates/_default/ogp-default.png` に**配置済み**

### 影響範囲
- `ogp_template_path` 設定済み（神コレ・ぷち神）→ 変更なし（従来どおりテンプレ合成）
- 未設定カテゴリ → デフォルトのブランドOGP画像になる（旧: プログラム生成デザイン）
- OGPは**カード作成/更新時に生成**されるため、反映は以降の生成分から

### 実機テスト
- [ ] テンプレ未設定カテゴリのカードを作成 → 共有OGPがブランドデフォルト画像になる
- [ ] 神コレ・ぷち神のOGPは従来どおり（カード合成あり）
- [ ] レスポンシブ/各SNSプレビュー

### テスト方法
- `npx jest tests/unit/features/collections/compose-mount-ogp.test.ts` → 7 passed（composeDefaultOgp の新規テスト含む）
- `npm run typecheck` → 本番0 / `npm run lint` → 0 / `npm run build -- --webpack` → exit=0
- デフォルト画像はストレージ配置済み（コード差分のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)