### PR TITLE
feat(creator-looks): カメラ/構図固定ルールを生成プロンプトに前置（背景アングルコピー抑制）

### DIFF
--- a/shared/generation/prompt-registry.ts
+++ b/shared/generation/prompt-registry.ts
@@ -225,6 +225,11 @@ No pose change.
 No identity change.
 No art style change.`;
 
+// Creator Looks: 生成時に hidden_prompt 冒頭へ前置するカメラ/構図固定の最優先ルール。
+// image_1(参照画像)を視覚的に渡すと構図・背景までコピーされる問題への対策。
+const CREATOR_LOOKS_CAMERA_DIRECTIVE_DEFAULT = `TOP PRIORITY RULE — image_1 is an OUTFIT-ONLY reference:
+Copy ONLY the outfit, garments, and accessories from image_1. You MUST completely ignore image_1's background, scenery, camera angle, perspective, pose, framing, and composition — never reproduce any of them. Keep image_0's exact camera angle, viewpoint, framing, crop, and pose unchanged. The background follows the separate background instruction; never copy the background or layout from image_1. Whenever anything other than the outfit conflicts between the two images, image_0 always wins.`;
+
 // ============================================================================
 // レジストリ本体
 // ============================================================================
@@ -486,6 +491,15 @@ export const PROMPT_REGISTRY = {
       "Creator Looks: クリエイター投稿画像から衣装+背景プロンプトを抽出する meta-prompt (VLM 入力)。" +
       "出力は user_style_template_secrets に保存され、通常ユーザーには公開しない。",
     defaultContent: CREATOR_LOOKS_META_EXTRACTOR_DEFAULT,
+    supportedVariables: [],
+  },
+  "creator_looks.camera_directive": {
+    category: "creator_looks",
+    description:
+      "Creator Looks: 生成時に hidden_prompt 冒頭へ前置する最優先ルール。" +
+      "image_1 を「衣装専用の参照」に限定し、背景・構図・カメラアングルは image_0 を維持させる" +
+      "(image_1 の構図がコピーされる問題への対策)。背景 ON/OFF どちらでも前置される。",
+    defaultContent: CREATOR_LOOKS_CAMERA_DIRECTIVE_DEFAULT,
     supportedVariables: [],
   },
 } as const satisfies Record<string, PromptDefinition>;

--- a/supabase/functions/image-gen-worker/creator-looks-prompt.ts
+++ b/supabase/functions/image-gen-worker/creator-looks-prompt.ts
@@ -23,21 +23,24 @@ const KEEP_BACKGROUND_DIRECTIVE = "Background: keep the original background of `
  *
  * @param hiddenPrompt VLM 抽出済みの構造化プロンプト
  * @param overrideBackground true なら Background セクション含む、false なら除去 + keep 指示
+ * @param cameraDirective 生成プロンプト管理(creator_looks.camera_directive)で編集可能な、
+ *   image_1 を「衣装専用参照」に限定しカメラ/構図を image_0 に固定する最優先ルール。
+ *   空文字なら付与しない(フォールバック)。背景 ON/OFF どちらでも冒頭に前置する。
  */
 export function composeCreatorLooksPrompt(
   hiddenPrompt: string,
   overrideBackground: boolean,
+  cameraDirective = "",
 ): string {
-  if (overrideBackground) {
-    return hiddenPrompt;
-  }
+  const body = overrideBackground
+    ? hiddenPrompt
+    : // Background セクションを除去 + 「元背景を維持」指示を末尾に追加
+      // (= 既存 Inspire の override_background=false 相当を gpt-image-2 に伝える)
+      `${stripBackgroundSection(hiddenPrompt)}\n\n${KEEP_BACKGROUND_DIRECTIVE}`;
 
-  // Background セクションを除去
-  const withoutBackground = stripBackgroundSection(hiddenPrompt);
-
-  // 末尾に「元背景を維持」指示を追加
-  // (= 既存 Inspire の override_background=false 相当を gpt-image-2 に伝える)
-  return `${withoutBackground}\n\n${KEEP_BACKGROUND_DIRECTIVE}`;
+  // カメラ/構図固定の最優先ルールを冒頭に前置する(実機テストで冒頭配置が最も効いた)。
+  const head = cameraDirective.trim();
+  return head ? `${head}\n\n${body}` : body;
 }
 
 /**

--- a/supabase/functions/image-gen-worker/index.ts
+++ b/supabase/functions/image-gen-worker/index.ts
@@ -1851,6 +1851,9 @@ Deno.serve(async () => {
                     fullPrompt = composeCreatorLooksPrompt(
                       creatorLooksHiddenPrompt,
                       job.override_background ?? true,
+                      // admin 編集可のカメラ/構図固定ルール(creator_looks.camera_directive)。
+                      // promptTemplates は default + override をマージ済みなので必ず存在する。
+                      promptTemplates["creator_looks.camera_directive"] ?? "",
                     );
                   } else if (job.generation_type === "inspire") {
                     fullPrompt = buildInspirePrompt({

--- a/tests/unit/supabase/functions/image-gen-worker/creator-looks-prompt.test.ts
+++ b/tests/unit/supabase/functions/image-gen-worker/creator-looks-prompt.test.ts
@@ -46,6 +46,38 @@ describe("composeCreatorLooksPrompt", () => {
     // Constraints セクションも残る
     expect(result).toContain("Constraints:");
   });
+
+  const CAMERA = "TOP PRIORITY RULE — image_1 is an OUTFIT-ONLY reference: ...";
+
+  test("cameraDirective を渡すと(背景ON)冒頭に前置され hidden_prompt が続く", () => {
+    const result = composeCreatorLooksPrompt(SAMPLE_HIDDEN_PROMPT, true, CAMERA);
+    expect(result.startsWith(CAMERA)).toBe(true);
+    expect(result).toContain(SAMPLE_HIDDEN_PROMPT);
+    expect(result).toBe(`${CAMERA}\n\n${SAMPLE_HIDDEN_PROMPT}`);
+  });
+
+  test("cameraDirective を渡すと(背景OFF)冒頭に前置され、背景除去+keep も両立", () => {
+    const result = composeCreatorLooksPrompt(SAMPLE_HIDDEN_PROMPT, false, CAMERA);
+    expect(result.startsWith(CAMERA)).toBe(true);
+    // 背景除去 + keep 指示は引き続き効く
+    expect(result).not.toContain(
+      "Background: spring cherry blossom park with soft sunlight",
+    );
+    expect(result).toContain(
+      "Background: keep the original background of `image_0.png` unchanged.",
+    );
+    expect(result).toContain("Styling Direction:");
+  });
+
+  test("cameraDirective が空文字なら前置しない(従来挙動)", () => {
+    expect(composeCreatorLooksPrompt(SAMPLE_HIDDEN_PROMPT, true, "")).toBe(
+      SAMPLE_HIDDEN_PROMPT,
+    );
+    // デフォルト引数(未指定)も同じ
+    expect(composeCreatorLooksPrompt(SAMPLE_HIDDEN_PROMPT, true)).toBe(
+      SAMPLE_HIDDEN_PROMPT,
+    );
+  });
 });
 
 describe("stripBackgroundSection", () => {


### PR DESCRIPTION
### 概要

Creator Looks の inspire 生成は image_1（参照画像）を**視覚入力として渡す**ため、背景・構図・カメラアングルまで image_1 からコピーされ、「**背景はクリエイターの世界観を参照しつつ、カメラアングルは image_0（うちの子写真）に合わせる**」が実現できていませんでした。

hidden_prompt の**冒頭に最優先ルール**（image_1 は衣装専用・カメラ/構図は image_0 維持）を前置して抑制します。**実機テストで冒頭配置が最も効果的**だと確認済みです。

### 変更内容
- `prompt-registry`: **`creator_looks.camera_directive`** を追加。**admin の生成プロンプト管理に `meta_extractor` と並んで表示・編集可能**（default は「image_1=衣装専用／カメラ・構図は image_0 維持／image_1 の背景・構図はコピーしない」）
- `composeCreatorLooksPrompt`: `cameraDirective` 引数を追加し、hidden_prompt の**冒頭へ前置**。背景 ON/OFF（背景セクション除去＋元背景維持）の既存分岐はそのまま
- worker（`index.ts`）: `resolveAllPromptTemplatesForWorker` の結果から `creator_looks.camera_directive` を渡す
- テスト追加（背景ON/OFFで前置される／空文字は従来挙動）

### 動作
| 背景 | 最終プロンプト |
|---|---|
| ON | `[camera_directive] + hidden_prompt(Background記述含む)` → 背景は世界観・カメラは image_0 |
| OFF | `[camera_directive] + 背景除去版 + 「元背景維持」` → 背景は image_0 維持・カメラも image_0 |

### デプロイ注意
これは **Supabase Edge Function（`image-gen-worker`）** の変更を含みます。マージ後に **`supabase functions deploy image-gen-worker`** が必要です（Vercel デプロイでは反映されません）。

### テスト方法
- `npx jest tests/unit/supabase/functions/image-gen-worker/creator-looks-prompt.test.ts` → 11 passed（前置の新規テスト含む）
- registry 依存テスト（prompt-registry / prompt-override / generation-prompts）→ 緑
- `npm run typecheck` → 本番0 / `npm run lint` → 0 / `npm run build -- --webpack` → exit=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)