### PR TITLE
feat(creator-looks): 生成モード(衣装のみ/衣装＋背景2段階/背景のみ)を追加

### DIFF
--- a/app/(app)/admin/admin-nav-items.ts
+++ b/app/(app)/admin/admin-nav-items.ts
@@ -116,6 +116,12 @@ export const adminNavItems: AdminNavItem[] = [
     iconKey: "image",
   },
   {
+    path: "/admin/creator-looks-two-stage",
+    label: "Creator Looks設定",
+    description: "衣装＋背景の2段階生成モードの公開レベルを管理",
+    iconKey: "file-text",
+  },
+  {
     path: "/admin/style-templates",
     label: "スタイルテンプレート審査",
     description: "ユーザー投稿テンプレを審査・管理",

--- a/app/(app)/admin/creator-looks-two-stage/CreatorLooksTwoStageForm.tsx
+++ b/app/(app)/admin/creator-looks-two-stage/CreatorLooksTwoStageForm.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/use-toast";
+import type { TwoStageVisibility } from "@/features/inspire/lib/creator-looks-two-stage";
+
+interface Props {
+  initialVisibility: TwoStageVisibility;
+}
+
+const OPTIONS: Array<{
+  value: TwoStageVisibility;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: "admin_only",
+    label: "運営のみ（未公開）",
+    description:
+      "admin / プレビュー権限のユーザーにのみ「衣装＋背景」モードを表示します（既定）。",
+  },
+  {
+    value: "public",
+    label: "全員に公開",
+    description:
+      "Creator Looks を利用できるユーザー全員に「衣装＋背景」モードを表示します。",
+  },
+];
+
+export function CreatorLooksTwoStageForm({ initialVisibility }: Props) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [visibility, setVisibility] =
+    useState<TwoStageVisibility>(initialVisibility);
+  const [isPending, setIsPending] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsPending(true);
+    try {
+      const response = await fetch("/api/admin/creator-looks-two-stage", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ visibility }),
+      });
+      const data = await response.json().catch(() => null);
+      if (!response.ok) {
+        toast({
+          title: "更新に失敗しました",
+          description: data?.error ?? "しばらくしてから再度お試しください",
+          variant: "destructive",
+        });
+        return;
+      }
+      toast({ title: "保存しました", description: "公開レベルを更新しました" });
+      router.refresh();
+    } catch (err) {
+      console.error("[CreatorLooksTwoStageForm] error:", err);
+      toast({
+        title: "更新に失敗しました",
+        description: "ネットワークエラーが発生しました",
+        variant: "destructive",
+      });
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <fieldset className="space-y-3" disabled={isPending}>
+        <legend className="mb-2 text-sm font-medium text-slate-700">
+          公開レベル
+        </legend>
+        {OPTIONS.map((opt) => (
+          <label
+            key={opt.value}
+            className={`flex cursor-pointer items-start gap-3 rounded-lg border px-4 py-3 ${
+              visibility === opt.value
+                ? "border-primary bg-primary/5"
+                : "border-slate-200 bg-slate-50"
+            }`}
+          >
+            <input
+              type="radio"
+              name="visibility"
+              value={opt.value}
+              checked={visibility === opt.value}
+              onChange={() => setVisibility(opt.value)}
+              className="mt-1 h-4 w-4"
+            />
+            <span className="min-w-0 space-y-1">
+              <span className="block text-sm font-medium text-slate-800">
+                {opt.label}
+              </span>
+              <span className="block text-xs leading-5 text-slate-500">
+                {opt.description}
+              </span>
+            </span>
+          </label>
+        ))}
+      </fieldset>
+
+      <Button type="submit" disabled={isPending}>
+        {isPending ? "保存中..." : "保存"}
+      </Button>
+    </form>
+  );
+}

--- a/app/(app)/admin/creator-looks-two-stage/page.tsx
+++ b/app/(app)/admin/creator-looks-two-stage/page.tsx
@@ -1,0 +1,40 @@
+import { connection } from "next/server";
+import { Card, CardContent } from "@/components/ui/card";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getCreatorLooksTwoStageVisibility } from "@/features/inspire/lib/creator-looks-two-stage";
+import { CreatorLooksTwoStageForm } from "./CreatorLooksTwoStageForm";
+
+export const metadata = {
+  title: "Creator Looks 2段階モード設定 | Admin",
+};
+
+/**
+ * Creator Looks「2段階(衣装＋背景)生成モード」の公開レベルを管理する admin 設定ページ。
+ * admin 認可は app/(app)/admin/layout.tsx で一括(非 admin は / へ redirect)。
+ */
+export default async function AdminCreatorLooksTwoStagePage() {
+  await connection();
+
+  const visibility = await getCreatorLooksTwoStageVisibility(
+    createAdminClient(),
+  );
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-bold tracking-tight text-slate-900 sm:text-3xl">
+          Creator Looks 2段階モード設定
+        </h1>
+        <p className="text-slate-600">
+          「衣装＋背景」の2段階生成モードを、ユーザーに表示するかどうかを切り替えます。
+        </p>
+      </header>
+
+      <Card>
+        <CardContent className="p-6 sm:p-8">
+          <CreatorLooksTwoStageForm initialVisibility={visibility} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/api/admin/creator-looks-two-stage/route.ts
+++ b/app/api/admin/creator-looks-two-stage/route.ts
@@ -1,0 +1,77 @@
+import { connection, NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/auth";
+import { ensureSameOrigin } from "@/lib/security/same-origin";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logAdminAction } from "@/lib/admin-audit";
+import { TWO_STAGE_VISIBILITY_KEY } from "@/features/inspire/lib/creator-looks-two-stage";
+
+/**
+ * PATCH /api/admin/creator-looks-two-stage
+ * Creator Looks「2段階(衣装＋背景)生成モード」の公開レベルを更新する。
+ * app_settings.key='creator_looks_two_stage_visibility' を upsert。
+ * 値は 'admin_only' | 'public'。admin のみ実行可。
+ */
+export async function PATCH(request: NextRequest) {
+  await connection();
+
+  // CSRF 防御 (cookie 認証 mutation route)
+  const originGuard = ensureSameOrigin(request);
+  if (originGuard) return originGuard;
+
+  let admin;
+  try {
+    admin = await requireAdmin();
+  } catch (error) {
+    if (error instanceof NextResponse) {
+      return error;
+    }
+    throw error;
+  }
+
+  let body: unknown = null;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const raw =
+    body && typeof body === "object"
+      ? (body as Record<string, unknown>).visibility
+      : null;
+  if (raw !== "admin_only" && raw !== "public") {
+    return NextResponse.json(
+      { error: "visibility must be 'admin_only' or 'public'" },
+      { status: 400 },
+    );
+  }
+  const visibility = raw;
+
+  const supabase = createAdminClient();
+  const { error } = await supabase.from("app_settings").upsert(
+    {
+      key: TWO_STAGE_VISIBILITY_KEY,
+      value: visibility,
+      updated_by: admin.id,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: "key" },
+  );
+
+  if (error) {
+    console.error("[creator-looks-two-stage PATCH] upsert error:", error);
+    return NextResponse.json(
+      { error: "公開設定の更新に失敗しました" },
+      { status: 500 },
+    );
+  }
+
+  await logAdminAction({
+    adminUserId: admin.id,
+    actionType: "creator_looks_two_stage_visibility_update",
+    targetType: "app_settings",
+    metadata: { key: TWO_STAGE_VISIBILITY_KEY, visibility },
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/app/api/generate-async/handler.ts
+++ b/app/api/generate-async/handler.ts
@@ -9,8 +9,18 @@ import { ensureSameOrigin } from "@/lib/security/same-origin";
 import type { ImageJobCreateInput } from "@/features/generation/lib/job-types";
 import {
   getPercoinCost,
+  creatorLooksCost,
   isModelAvailableForGeneration,
 } from "@/features/generation/lib/model-config";
+import {
+  type CreatorLooksMode,
+  overridesForCreatorLooksMode,
+  maxStagesForCreatorLooksMode,
+} from "@/shared/generation/creator-looks-mode";
+import {
+  getCreatorLooksTwoStageVisibility,
+  isTwoStageModeAvailable,
+} from "@/features/inspire/lib/creator-looks-two-stage";
 import {
   DEFAULT_GENERATION_MODEL,
   isOpenAIImageModel,
@@ -134,8 +144,12 @@ export async function postGenerateAsyncRoute(
       styleTemplateId,
       overrides,
       framingMode,
+      creatorLooksMode,
     } = validationResult.data;
     const effectiveModel = model || DEFAULT_GENERATION_MODEL;
+    // Creator Looks 投稿テンプレ(is_creator_looks)に対してのみ有効な生成モード。
+    // 一般 inspire には適用しない。inspire 検証ブロックで template 確認後に確定する。
+    let effectiveCreatorLooksMode: CreatorLooksMode | null = null;
     if (!isModelAvailableForGeneration(effectiveModel)) {
       return jsonError(
         copy.modelTemporarilyUnavailable,
@@ -202,6 +216,24 @@ export async function postGenerateAsyncRoute(
             "CREATOR_LOOKS_NOT_AVAILABLE",
             403
           );
+        }
+
+        // 生成モードを確定(未指定は衣装のみ)。
+        effectiveCreatorLooksMode = creatorLooksMode ?? "outfit_only";
+
+        // 2段階(衣装＋背景)モードの公開ガード。
+        // admin_only のときは admin/プレビュー権限ユーザー以外には許可しない
+        // (UI 非表示はセキュリティではないためサーバでも遮断)。
+        if (effectiveCreatorLooksMode === "outfit_and_background") {
+          const visibility =
+            await getCreatorLooksTwoStageVisibility(adminClient);
+          if (!isTwoStageModeAvailable(visibility, isAdminViewer(user.id))) {
+            return jsonError(
+              "この生成モードは現在利用できません",
+              "CREATOR_LOOKS_TWO_STAGE_NOT_AVAILABLE",
+              403
+            );
+          }
         }
       }
 
@@ -397,7 +429,11 @@ export async function postGenerateAsyncRoute(
       : "single_job";
 
     // ペルコイン残高チェック
-    const percoinCost = getPercoinCost(effectiveModel);
+    // Creator Looks はモード別コスト(衣装＋背景=ceil(モデルコスト×2×0.9))。
+    // 実消費(worker)も同じ creatorLooksCost を使うこと(不整合防止)。
+    const percoinCost = effectiveCreatorLooksMode
+      ? creatorLooksCost(effectiveModel, effectiveCreatorLooksMode)
+      : getPercoinCost(effectiveModel);
     const requiredPercoinCost = percoinCost * acceptedImageCount;
 
     // 現在の残高を取得
@@ -419,6 +455,24 @@ export async function postGenerateAsyncRoute(
         copy.insufficientBalance(requiredPercoinCost, currentBalance),
         "GENERATION_INSUFFICIENT_BALANCE",
         400
+      );
+    }
+
+    // Creator Looks 生成モードが指定されていれば override_* をモードから導出する
+    // (overrides より優先)。それ以外は従来の overrides をそのまま使う。
+    const resolvedOverrides = effectiveCreatorLooksMode
+      ? overridesForCreatorLooksMode(effectiveCreatorLooksMode)
+      : overrides;
+
+    // generation_metadata: framingMode(locked 以外)と Creator Looks モード/段階数を統合。
+    const generationMetadata: Record<string, unknown> = {};
+    if (effectiveFramingMode !== "locked") {
+      generationMetadata.framingMode = effectiveFramingMode;
+    }
+    if (effectiveCreatorLooksMode) {
+      generationMetadata.creatorLooksMode = effectiveCreatorLooksMode;
+      generationMetadata.creatorLooksMaxStages = maxStagesForCreatorLooksMode(
+        effectiveCreatorLooksMode,
       );
     }
 
@@ -444,15 +498,17 @@ export async function postGenerateAsyncRoute(
         : null,
       // Inspire override の 4 bool。未指定時は「すべて維持」のデフォルトを入れる。
       // 整合性は schema 側の superRefine で「1 つ以上 true」をバリデーション済み。
-      override_outfit: isInspireRequest ? overrides?.outfit ?? true : null,
-      override_angle: isInspireRequest ? overrides?.angle ?? true : null,
-      override_pose: isInspireRequest ? overrides?.pose ?? true : null,
-      override_background: isInspireRequest ? overrides?.background ?? true : null,
-      // locked 以外 (free_pose / ai_pose) のみ記録 (locked はキーなし = 既存レコードと一貫)。
-      // worker がプロンプト構築・リトライ強化の prefix 選択に使い、完了 RPC 経由で
+      override_outfit: isInspireRequest ? resolvedOverrides?.outfit ?? true : null,
+      override_angle: isInspireRequest ? resolvedOverrides?.angle ?? true : null,
+      override_pose: isInspireRequest ? resolvedOverrides?.pose ?? true : null,
+      override_background: isInspireRequest
+        ? resolvedOverrides?.background ?? true
+        : null,
+      // generation_metadata: framingMode(locked 以外) と Creator Looks モード/段階数。
+      // worker がプロンプト構築・2段階生成判定に使い、完了 RPC 経由で
       // generated_images.generation_metadata へコピーされて品質比較にも使える。
-      ...(effectiveFramingMode !== "locked"
-        ? { generation_metadata: { framingMode: effectiveFramingMode } }
+      ...(Object.keys(generationMetadata).length > 0
+        ? { generation_metadata: generationMetadata }
         : {}),
     };
 

--- a/features/generation/lib/model-config.ts
+++ b/features/generation/lib/model-config.ts
@@ -10,6 +10,7 @@ import {
   type GeminiModel,
 } from "../types";
 import { GPT_IMAGE_2_PERCOIN_COSTS } from "@/shared/generation/openai-image-model";
+import type { CreatorLooksMode } from "@/shared/generation/creator-looks-mode";
 
 export { DEFAULT_GENERATION_MODEL };
 
@@ -171,6 +172,26 @@ export function resolveEffectiveModelForAuthState(
 export function getPercoinCost(model: string | null | undefined): number {
   const normalized = normalizeModelName(model);
   return MODEL_PERCOIN_COSTS[normalized as keyof typeof MODEL_PERCOIN_COSTS] ?? 10;
+}
+
+/** Creator Looks の2段階(衣装＋背景)生成の割引率(1回ぶん×2に対して 10% 引き)。 */
+export const CREATOR_LOOKS_TWO_STAGE_DISCOUNT = 0.9;
+
+/**
+ * Creator Looks 生成のモード別ペルコイン消費量。
+ * - 衣装のみ / 背景のみ(1回): モデルコスト
+ * - 衣装＋背景(2段階): ceil(モデルコスト × 2 × 0.9)
+ * 残高チェック(API)と実消費(worker)で必ずこの関数を共用すること(不整合防止)。
+ */
+export function creatorLooksCost(
+  model: string | null | undefined,
+  mode: CreatorLooksMode,
+): number {
+  const base = getPercoinCost(model);
+  if (mode === "outfit_and_background") {
+    return Math.ceil(base * 2 * CREATOR_LOOKS_TWO_STAGE_DISCOUNT);
+  }
+  return base;
 }
 
 /**

--- a/features/generation/lib/schema.ts
+++ b/features/generation/lib/schema.ts
@@ -10,6 +10,7 @@ import {
 } from "../types";
 import { GENERATION_PROMPT_MAX_LENGTH } from "./prompt-validation";
 import { FRAMING_MODES } from "@/shared/generation/framing-mode";
+import { CREATOR_LOOKS_MODES } from "@/shared/generation/creator-looks-mode";
 
 /**
  * 画像生成機能のZodスキーマ
@@ -114,6 +115,9 @@ export const generationRequestSchema = z.object({
       background: z.boolean(),
     })
     .optional(),
+  // Creator Looks 専用: 生成モード(衣装のみ/衣装＋背景2段階/背景のみ)。
+  // 指定時は handler 側で overrides より優先して override_* を導出する。
+  creatorLooksMode: z.enum(CREATOR_LOOKS_MODES).optional(),
 }).superRefine((data, ctx) => {
   const hasSourceImageStockId =
     typeof data.sourceImageStockId === "string" &&

--- a/features/inspire/components/CreatorLooksDetailClient.tsx
+++ b/features/inspire/components/CreatorLooksDetailClient.tsx
@@ -204,9 +204,14 @@ export function CreatorLooksDetailClient({
             const id = `creator-looks-mode-${opt.mode}`;
             const selected = creatorLooksMode === opt.mode;
             return (
-              <Label
+              // label 内に RadioGroupItem(button) をネストすると invalid HTML になるため、
+              // div をカード枠にして RadioGroupItem を外出しし、Label は text に htmlFor で紐付ける。
+              // カード全体クリックでの選択は onClick で維持する。
+              <div
                 key={opt.mode}
-                htmlFor={id}
+                onClick={() => {
+                  if (!submitting) setCreatorLooksMode(opt.mode);
+                }}
                 className={`flex cursor-pointer items-start gap-3 rounded-lg border px-4 py-3 ${
                   selected
                     ? "border-primary bg-primary/5"
@@ -214,18 +219,21 @@ export function CreatorLooksDetailClient({
                 }`}
               >
                 <RadioGroupItem id={id} value={opt.mode} className="mt-0.5" />
-                <div className="min-w-0 flex-1 space-y-1">
-                  <div className="flex items-center justify-between gap-2">
+                <Label
+                  htmlFor={id}
+                  className="min-w-0 flex-1 cursor-pointer space-y-1"
+                >
+                  <span className="flex items-center justify-between gap-2">
                     <span className="text-sm font-medium">{opt.label}</span>
                     <span className="shrink-0 text-xs font-medium text-muted-foreground">
                       {t("modeCost", { cost })}
                     </span>
-                  </div>
-                  <p className="text-xs leading-5 text-muted-foreground">
+                  </span>
+                  <span className="block text-xs leading-5 text-muted-foreground">
                     {opt.description}
-                  </p>
-                </div>
-              </Label>
+                  </span>
+                </Label>
+              </div>
             );
           })}
         </RadioGroup>

--- a/features/inspire/components/CreatorLooksDetailClient.tsx
+++ b/features/inspire/components/CreatorLooksDetailClient.tsx
@@ -4,17 +4,18 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { Card } from "@/components/ui/card";
-import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { useToast } from "@/components/ui/use-toast";
 import { ImageUploader } from "@/features/generation/components/ImageUploader";
 import { normalizeSourceImage } from "@/features/generation/lib/normalize-source-image";
 import { GenerationModelControls } from "@/features/generation/components/GenerationModelControls";
 import { GenerationSubmitButton } from "@/features/generation/components/GenerationSubmitButton";
 import {
-  getPercoinCost,
+  creatorLooksCost,
   isFreePlanAllowedModel,
 } from "@/features/generation/lib/model-config";
+import type { CreatorLooksMode } from "@/shared/generation/creator-looks-mode";
 import { SubscriptionUpsellDialog } from "@/features/subscription/components/SubscriptionUpsellDialog";
 import type {
   UploadedImage,
@@ -44,6 +45,12 @@ interface CreatorLooksDetailClientProps {
    * 未指定なら "free" 扱い (= fail-closed、課金モデル選択は upsell へ誘導)。
    */
   subscriptionPlan?: string;
+  /**
+   * 2段階(衣装＋背景)モードをこのユーザーに表示してよいか。
+   * Server 側で公開レベル(admin_only/public)と admin 判定から解決して渡す。
+   * false のときは「衣装のみ / 背景のみ」だけ表示する。
+   */
+  twoStageAvailable?: boolean;
 }
 
 async function fileToBase64(file: File): Promise<string> {
@@ -62,13 +69,15 @@ async function fileToBase64(file: File): Promise<string> {
 export function CreatorLooksDetailClient({
   templateId,
   subscriptionPlan,
+  twoStageAvailable = false,
 }: CreatorLooksDetailClientProps) {
   const t = useTranslations("creatorLooksDetail");
   const { toast } = useToast();
   const router = useRouter();
 
   const [uploadedImage, setUploadedImage] = useState<UploadedImage | null>(null);
-  const [backgroundEnabled, setBackgroundEnabled] = useState(true);
+  const [creatorLooksMode, setCreatorLooksMode] =
+    useState<CreatorLooksMode>("outfit_only");
   const [submitting, setSubmitting] = useState(false);
   const [activeJobId, setActiveJobId] = useState<string | null>(null);
   const [selectedModel, setSelectedModel] = useState<GeminiModel>(
@@ -77,7 +86,35 @@ export function CreatorLooksDetailClient({
   const [isUpsellOpen, setIsUpsellOpen] = useState(false);
 
   const isFreePlan = subscriptionPlan === "free" || !subscriptionPlan;
-  const totalPercoinCost = getPercoinCost(selectedModel) * 1;
+
+  // 表示するモード(2段階は公開許可があるときだけ)。
+  const modeOptions: Array<{
+    mode: CreatorLooksMode;
+    label: string;
+    description: string;
+  }> = [
+    {
+      mode: "outfit_only",
+      label: t("modeOutfitOnlyLabel"),
+      description: t("modeOutfitOnlyDescription"),
+    },
+    ...(twoStageAvailable
+      ? [
+          {
+            mode: "outfit_and_background" as CreatorLooksMode,
+            label: t("modeOutfitAndBackgroundLabel"),
+            description: t("modeOutfitAndBackgroundDescription"),
+          },
+        ]
+      : []),
+    {
+      mode: "background_only",
+      label: t("modeBackgroundOnlyLabel"),
+      description: t("modeBackgroundOnlyDescription"),
+    },
+  ];
+
+  const totalPercoinCost = creatorLooksCost(selectedModel, creatorLooksMode);
   // Style / InspirePageClient と同じ: 「コーデ開始」押下直後 (= fetch 中で jobId 未取得) から
   // ステータスバーを表示するため、submitting または activeJobId のどちらかで InspireGenerationFlow を
   // マウントする。jobId が null の間は内部で「準備中」表示。
@@ -105,14 +142,8 @@ export function CreatorLooksDetailClient({
           styleTemplateId: templateId,
           sourceImageBase64: base64,
           sourceImageMimeType: normalized.type,
-          // Creator Looks: 衣装は必ず移植 / 背景はユーザー選択
-          // アングル / ポーズは現状常に false (= 将来 UI で開放、計画 §A-4)
-          overrides: {
-            outfit: true,
-            angle: false,
-            pose: false,
-            background: backgroundEnabled,
-          },
+          // Creator Looks: 生成モードを送る(override_* は API 側でモードから導出)。
+          creatorLooksMode,
         }),
       });
       if (response.status === 429) {
@@ -159,29 +190,45 @@ export function CreatorLooksDetailClient({
         />
       </div>
 
-      {/* 背景設定 (= モックアップ 03 / 既存 Style 画面 backgroundChange パターンを踏襲) */}
+      {/* 生成モード選択 (= 衣装のみ / 衣装＋背景(2段階) / 背景のみ) */}
       <div className="space-y-2">
-        <Label className="text-base font-medium">{t("backgroundLabel")}</Label>
-        <div className="flex items-start gap-3 rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
-          <Checkbox
-            id="creator-looks-background"
-            checked={backgroundEnabled}
-            onCheckedChange={(v) => setBackgroundEnabled(v === true)}
-            disabled={submitting}
-            className="mt-0.5"
-          />
-          <div className="min-w-0 space-y-1">
-            <Label
-              htmlFor="creator-looks-background"
-              className="cursor-pointer text-sm font-medium"
-            >
-              {t("backgroundCheckboxLabel")}
-            </Label>
-            <p className="text-xs leading-5 text-muted-foreground">
-              {t("backgroundCheckboxDescription")}
-            </p>
-          </div>
-        </div>
+        <Label className="text-base font-medium">{t("modeLabel")}</Label>
+        <RadioGroup
+          value={creatorLooksMode}
+          onValueChange={(v) => setCreatorLooksMode(v as CreatorLooksMode)}
+          disabled={submitting}
+          className="gap-2"
+        >
+          {modeOptions.map((opt) => {
+            const cost = creatorLooksCost(selectedModel, opt.mode);
+            const id = `creator-looks-mode-${opt.mode}`;
+            const selected = creatorLooksMode === opt.mode;
+            return (
+              <Label
+                key={opt.mode}
+                htmlFor={id}
+                className={`flex cursor-pointer items-start gap-3 rounded-lg border px-4 py-3 ${
+                  selected
+                    ? "border-primary bg-primary/5"
+                    : "border-slate-200 bg-slate-50"
+                }`}
+              >
+                <RadioGroupItem id={id} value={opt.mode} className="mt-0.5" />
+                <div className="min-w-0 flex-1 space-y-1">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-sm font-medium">{opt.label}</span>
+                    <span className="shrink-0 text-xs font-medium text-muted-foreground">
+                      {t("modeCost", { cost })}
+                    </span>
+                  </div>
+                  <p className="text-xs leading-5 text-muted-foreground">
+                    {opt.description}
+                  </p>
+                </div>
+              </Label>
+            );
+          })}
+        </RadioGroup>
       </div>
 
       {/* カメラアングル / ポーズ注釈 (= モックアップ 03 の小さい注釈) */}

--- a/features/inspire/components/CreatorLooksDetailSection.tsx
+++ b/features/inspire/components/CreatorLooksDetailSection.tsx
@@ -2,6 +2,13 @@ import Link from "next/link";
 import { getTranslations } from "next-intl/server";
 import { Sparkles } from "lucide-react";
 import { CreatorLooksDetailClient } from "./CreatorLooksDetailClient";
+import { getUser } from "@/lib/auth";
+import { isAdminViewer } from "@/lib/env";
+import { createAdminClient } from "@/lib/supabase/admin";
+import {
+  getCreatorLooksTwoStageVisibility,
+  isTwoStageModeAvailable,
+} from "../lib/creator-looks-two-stage";
 
 /**
  * Creator Looks 投稿の詳細ページ (= /inspire/[templateId] で is_creator_looks=true 時)
@@ -37,6 +44,16 @@ export async function CreatorLooksDetailSection({
 
   const displayTitle = title?.trim() || t("untitled");
   const displayNickname = submitterNickname?.trim() || t("anonymousCreator");
+
+  // 2段階(衣装＋背景)モードをこのユーザーに見せてよいか(公開レベル × admin判定)。
+  const user = await getUser();
+  const twoStageVisibility = await getCreatorLooksTwoStageVisibility(
+    createAdminClient(),
+  );
+  const twoStageAvailable = isTwoStageModeAvailable(
+    twoStageVisibility,
+    user ? isAdminViewer(user.id) : false,
+  );
 
   return (
     <section className="space-y-6">
@@ -82,6 +99,7 @@ export async function CreatorLooksDetailSection({
       <CreatorLooksDetailClient
         templateId={templateId}
         subscriptionPlan={subscriptionPlan}
+        twoStageAvailable={twoStageAvailable}
       />
     </section>
   );

--- a/features/inspire/lib/creator-looks-two-stage.ts
+++ b/features/inspire/lib/creator-looks-two-stage.ts
@@ -1,0 +1,54 @@
+/**
+ * Creator Looks「2段階(衣装＋背景)生成モード」の公開レベル(グローバル設定)。
+ *
+ * - app_settings.key = 'creator_looks_two_stage_visibility'
+ *   - 'admin_only' : admin / プレビュー権限のユーザーにのみ表示・利用可(= 既定・未公開)
+ *   - 'public'     : Creator Looks 利用可ユーザー全員に表示・利用可
+ *
+ * 設計: docs/planning/creator-looks-generation-modes-plan.md (ADR-006)
+ */
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export const TWO_STAGE_VISIBILITY_KEY = "creator_looks_two_stage_visibility";
+
+export const TWO_STAGE_VISIBILITY_VALUES = ["admin_only", "public"] as const;
+export type TwoStageVisibility = (typeof TWO_STAGE_VISIBILITY_VALUES)[number];
+
+export const DEFAULT_TWO_STAGE_VISIBILITY: TwoStageVisibility = "admin_only";
+
+/** 任意値を TwoStageVisibility に解釈する。'public' 以外はすべて admin_only(安全側)。 */
+export function parseTwoStageVisibility(value: unknown): TwoStageVisibility {
+  return value === "public" ? "public" : DEFAULT_TWO_STAGE_VISIBILITY;
+}
+
+/**
+ * 2段階(衣装＋背景)モードが、そのユーザーに表示/利用可能か。
+ * - public      : 全員可
+ * - admin_only  : admin(またはプレビュー権限)のみ可
+ */
+export function isTwoStageModeAvailable(
+  visibility: TwoStageVisibility,
+  isAdmin: boolean,
+): boolean {
+  return visibility === "public" || isAdmin;
+}
+
+/**
+ * app_settings から公開レベルを読む(service_role / admin client 推奨)。
+ * テーブル未作成・行なし・エラー時は admin_only(未公開)へ安全フォールバックする。
+ */
+export async function getCreatorLooksTwoStageVisibility(
+  client: SupabaseClient,
+): Promise<TwoStageVisibility> {
+  try {
+    const { data, error } = await client
+      .from("app_settings")
+      .select("value")
+      .eq("key", TWO_STAGE_VISIBILITY_KEY)
+      .maybeSingle();
+    if (error) return DEFAULT_TWO_STAGE_VISIBILITY;
+    return parseTwoStageVisibility(data?.value);
+  } catch {
+    return DEFAULT_TWO_STAGE_VISIBILITY;
+  }
+}

--- a/lib/admin-audit.ts
+++ b/lib/admin-audit.ts
@@ -27,7 +27,8 @@ export type AdminAuditAction =
   | "prompt_override_reset"
   | "preset_category_create"
   | "preset_category_update"
-  | "preset_category_deactivate";
+  | "preset_category_deactivate"
+  | "creator_looks_two_stage_visibility_update";
 
 export interface AdminAuditLogParams {
   adminUserId: string;

--- a/messages/ar.ts
+++ b/messages/ar.ts
@@ -1792,6 +1792,16 @@ export const arMessages = {
       "Also change background to match the creator's world",
     backgroundCheckboxDescription:
       "When OFF, the original background is preserved as much as possible. When ON, the background from the creator's image is extracted and applied.",
+    modeLabel: "ما الذي تريد إنشاءه",
+    modeCost: "{cost} percoin",
+    modeOutfitOnlyLabel: "الملابس فقط",
+    modeOutfitOnlyDescription: "تغيير الملابس فقط مع إبقاء الخلفية كما هي.",
+    modeOutfitAndBackgroundLabel: "الملابس + الخلفية",
+    modeOutfitAndBackgroundDescription:
+      "تغيير الملابس والخلفية معًا إلى عالم صانع المحتوى. يحافظ الإنشاء على مرحلتين على زاوية الكاميرا مع إظهار المشهد بوضوح.",
+    modeBackgroundOnlyLabel: "الخلفية فقط",
+    modeBackgroundOnlyDescription:
+      "تغيير الخلفية فقط إلى عالم صانع المحتوى مع إبقاء الملابس كما هي.",
     poseAngleNote:
       "* Camera angle and pose are preserved. Future update planned.",
     modelLabel: "نموذج الإنشاء",

--- a/messages/de.ts
+++ b/messages/de.ts
@@ -1795,6 +1795,17 @@ export const deMessages = {
       "Also change background to match the creator's world",
     backgroundCheckboxDescription:
       "When OFF, the original background is preserved as much as possible. When ON, the background from the creator's image is extracted and applied.",
+    modeLabel: "Was generiert werden soll",
+    modeCost: "{cost} Percoin",
+    modeOutfitOnlyLabel: "Nur Outfit",
+    modeOutfitOnlyDescription:
+      "Ändert nur das Outfit. Der Hintergrund bleibt unverändert.",
+    modeOutfitAndBackgroundLabel: "Outfit + Hintergrund",
+    modeOutfitAndBackgroundDescription:
+      "Ändert Outfit und Hintergrund passend zur Welt des Creators. Die zweistufige Generierung behält deinen Kamerawinkel bei und stellt die Szene sauber dar.",
+    modeBackgroundOnlyLabel: "Nur Hintergrund",
+    modeBackgroundOnlyDescription:
+      "Ändert nur den Hintergrund passend zur Welt des Creators. Das Outfit bleibt unverändert.",
     poseAngleNote:
       "* Camera angle and pose are preserved. Future update planned.",
     modelLabel: "Generierungsmodell",

--- a/messages/en.ts
+++ b/messages/en.ts
@@ -1791,6 +1791,17 @@ export const enMessages = {
       "Also change background to match the creator's world",
     backgroundCheckboxDescription:
       "When OFF, the original background is preserved as much as possible. When ON, the background from the creator's image is extracted and applied.",
+    modeLabel: "What to generate",
+    modeCost: "{cost} percoin",
+    modeOutfitOnlyLabel: "Outfit only",
+    modeOutfitOnlyDescription:
+      "Change only the outfit. The background stays as is.",
+    modeOutfitAndBackgroundLabel: "Outfit + background",
+    modeOutfitAndBackgroundDescription:
+      "Change both outfit and background to the creator's world. Two-stage generation keeps your camera angle while rendering the scene cleanly.",
+    modeBackgroundOnlyLabel: "Background only",
+    modeBackgroundOnlyDescription:
+      "Change only the background to the creator's world. The outfit stays as is.",
     poseAngleNote:
       "* Camera angle and pose are preserved. Future update planned.",
     modelLabel: "Generation model",

--- a/messages/es.ts
+++ b/messages/es.ts
@@ -1795,6 +1795,17 @@ export const esMessages = {
       "Also change background to match the creator's world",
     backgroundCheckboxDescription:
       "When OFF, the original background is preserved as much as possible. When ON, the background from the creator's image is extracted and applied.",
+    modeLabel: "Qué generar",
+    modeCost: "{cost} percoin",
+    modeOutfitOnlyLabel: "Solo el outfit",
+    modeOutfitOnlyDescription:
+      "Cambia solo el outfit. El fondo se mantiene igual.",
+    modeOutfitAndBackgroundLabel: "Outfit + fondo",
+    modeOutfitAndBackgroundDescription:
+      "Cambia el outfit y el fondo al mundo del creador. La generación en dos fases conserva tu ángulo de cámara mientras representa la escena con nitidez.",
+    modeBackgroundOnlyLabel: "Solo el fondo",
+    modeBackgroundOnlyDescription:
+      "Cambia solo el fondo al mundo del creador. El outfit se mantiene igual.",
     poseAngleNote:
       "* Camera angle and pose are preserved. Future update planned.",
     modelLabel: "Modelo de generación",

--- a/messages/fr.ts
+++ b/messages/fr.ts
@@ -1795,6 +1795,17 @@ export const frMessages = {
       "Also change background to match the creator's world",
     backgroundCheckboxDescription:
       "When OFF, the original background is preserved as much as possible. When ON, the background from the creator's image is extracted and applied.",
+    modeLabel: "Que générer",
+    modeCost: "{cost} percoin",
+    modeOutfitOnlyLabel: "Tenue uniquement",
+    modeOutfitOnlyDescription:
+      "Change uniquement la tenue. L'arrière-plan reste tel quel.",
+    modeOutfitAndBackgroundLabel: "Tenue + arrière-plan",
+    modeOutfitAndBackgroundDescription:
+      "Change à la fois la tenue et l'arrière-plan pour l'univers du créateur. La génération en deux étapes conserve votre angle de caméra tout en rendant la scène avec netteté.",
+    modeBackgroundOnlyLabel: "Arrière-plan uniquement",
+    modeBackgroundOnlyDescription:
+      "Change uniquement l'arrière-plan pour l'univers du créateur. La tenue reste telle quelle.",
     poseAngleNote:
       "* Camera angle and pose are preserved. Future update planned.",
     modelLabel: "Modèle de génération",

--- a/messages/hi.ts
+++ b/messages/hi.ts
@@ -1793,6 +1793,17 @@ export const hiMessages = {
       "Also change background to match the creator's world",
     backgroundCheckboxDescription:
       "When OFF, the original background is preserved as much as possible. When ON, the background from the creator's image is extracted and applied.",
+    modeLabel: "क्या जेनरेट करना है",
+    modeCost: "{cost} percoin",
+    modeOutfitOnlyLabel: "केवल आउटफिट",
+    modeOutfitOnlyDescription:
+      "केवल आउटफिट बदलें। बैकग्राउंड वैसा ही रहता है।",
+    modeOutfitAndBackgroundLabel: "आउटफिट + बैकग्राउंड",
+    modeOutfitAndBackgroundDescription:
+      "आउटफिट और बैकग्राउंड दोनों को क्रिएटर की दुनिया के अनुसार बदलें। दो-चरण जेनरेशन आपके कैमरा एंगल को बनाए रखते हुए सीन को साफ-सुथरे ढंग से रेंडर करता है।",
+    modeBackgroundOnlyLabel: "केवल बैकग्राउंड",
+    modeBackgroundOnlyDescription:
+      "केवल बैकग्राउंड को क्रिएटर की दुनिया के अनुसार बदलें। आउटफिट वैसा ही रहता है।",
     poseAngleNote:
       "* Camera angle and pose are preserved. Future update planned.",
     modelLabel: "जनरेशन मॉडल",

--- a/messages/id.ts
+++ b/messages/id.ts
@@ -1794,6 +1794,17 @@ export const idMessages = {
       "Also change background to match the creator's world",
     backgroundCheckboxDescription:
       "When OFF, the original background is preserved as much as possible. When ON, the background from the creator's image is extracted and applied.",
+    modeLabel: "Apa yang ingin dibuat",
+    modeCost: "{cost} percoin",
+    modeOutfitOnlyLabel: "Hanya outfit",
+    modeOutfitOnlyDescription:
+      "Ubah hanya outfit. Latar belakang tetap seperti semula.",
+    modeOutfitAndBackgroundLabel: "Outfit + latar belakang",
+    modeOutfitAndBackgroundDescription:
+      "Ubah outfit dan latar belakang sekaligus ke dunia kreator. Pembuatan dua tahap mempertahankan sudut kamera Anda sambil merender adegan dengan bersih.",
+    modeBackgroundOnlyLabel: "Hanya latar belakang",
+    modeBackgroundOnlyDescription:
+      "Ubah hanya latar belakang ke dunia kreator. Outfit tetap seperti semula.",
     poseAngleNote:
       "* Camera angle and pose are preserved. Future update planned.",
     modelLabel: "Model generasi",

--- a/messages/it.ts
+++ b/messages/it.ts
@@ -1795,6 +1795,17 @@ export const itMessages = {
       "Also change background to match the creator's world",
     backgroundCheckboxDescription:
       "When OFF, the original background is preserved as much as possible. When ON, the background from the creator's image is extracted and applied.",
+    modeLabel: "Cosa generare",
+    modeCost: "{cost} percoin",
+    modeOutfitOnlyLabel: "Solo outfit",
+    modeOutfitOnlyDescription:
+      "Cambia solo l'outfit. Lo sfondo resta invariato.",
+    modeOutfitAndBackgroundLabel: "Outfit + sfondo",
+    modeOutfitAndBackgroundDescription:
+      "Cambia sia l'outfit sia lo sfondo nel mondo del creator. La generazione in due fasi mantiene l'angolazione della fotocamera rendendo la scena in modo nitido.",
+    modeBackgroundOnlyLabel: "Solo sfondo",
+    modeBackgroundOnlyDescription:
+      "Cambia solo lo sfondo nel mondo del creator. L'outfit resta invariato.",
     poseAngleNote:
       "* Camera angle and pose are preserved. Future update planned.",
     modelLabel: "Modello di generazione",

--- a/messages/ja.ts
+++ b/messages/ja.ts
@@ -1720,6 +1720,17 @@ export const jaMessages = {
     backgroundCheckboxLabel: "背景もクリエイターの世界に合わせて変更する",
     backgroundCheckboxDescription:
       "OFF のときは元の背景をできるだけ維持し、ON のときはクリエイターの作品から背景を抽出して反映します。",
+    modeLabel: "生成内容",
+    modeCost: "{cost} ペルコイン",
+    modeOutfitOnlyLabel: "衣装だけ",
+    modeOutfitOnlyDescription:
+      "衣装だけを着せ替えます。背景は元のままです。",
+    modeOutfitAndBackgroundLabel: "衣装＋背景",
+    modeOutfitAndBackgroundDescription:
+      "衣装も背景もクリエイターの世界観に変えます。2段階生成でアングルを保ったままキレイに仕上げます。",
+    modeBackgroundOnlyLabel: "背景だけ",
+    modeBackgroundOnlyDescription:
+      "背景だけをクリエイターの世界観に変えます。衣装は元のままです。",
     poseAngleNote:
       "※ カメラアングルとポーズは変わりません。今後のアップデートで対応予定です。",
     modelLabel: "生成モデル",

--- a/messages/ko.ts
+++ b/messages/ko.ts
@@ -1791,6 +1791,16 @@ export const koMessages = {
       "Also change background to match the creator's world",
     backgroundCheckboxDescription:
       "When OFF, the original background is preserved as much as possible. When ON, the background from the creator's image is extracted and applied.",
+    modeLabel: "무엇을 생성할까요",
+    modeCost: "{cost} percoin",
+    modeOutfitOnlyLabel: "의상만",
+    modeOutfitOnlyDescription: "의상만 변경합니다. 배경은 그대로 유지됩니다.",
+    modeOutfitAndBackgroundLabel: "의상 + 배경",
+    modeOutfitAndBackgroundDescription:
+      "의상과 배경을 모두 크리에이터의 세계로 변경합니다. 2단계 생성으로 카메라 앵글을 유지하면서 장면을 깔끔하게 렌더링합니다.",
+    modeBackgroundOnlyLabel: "배경만",
+    modeBackgroundOnlyDescription:
+      "배경만 크리에이터의 세계로 변경합니다. 의상은 그대로 유지됩니다.",
     poseAngleNote:
       "* Camera angle and pose are preserved. Future update planned.",
     modelLabel: "생성 모델",

--- a/messages/pt.ts
+++ b/messages/pt.ts
@@ -1795,6 +1795,17 @@ export const ptMessages = {
       "Also change background to match the creator's world",
     backgroundCheckboxDescription:
       "When OFF, the original background is preserved as much as possible. When ON, the background from the creator's image is extracted and applied.",
+    modeLabel: "O que gerar",
+    modeCost: "{cost} percoin",
+    modeOutfitOnlyLabel: "Apenas o look",
+    modeOutfitOnlyDescription:
+      "Altera apenas o look. O fundo permanece como está.",
+    modeOutfitAndBackgroundLabel: "Look + fundo",
+    modeOutfitAndBackgroundDescription:
+      "Altera o look e o fundo para o mundo do criador. A geração em duas etapas mantém o ângulo da câmera enquanto renderiza a cena com nitidez.",
+    modeBackgroundOnlyLabel: "Apenas o fundo",
+    modeBackgroundOnlyDescription:
+      "Altera apenas o fundo para o mundo do criador. O look permanece como está.",
     poseAngleNote:
       "* Camera angle and pose are preserved. Future update planned.",
     modelLabel: "Modelo de geração",

--- a/messages/th.ts
+++ b/messages/th.ts
@@ -1791,6 +1791,16 @@ export const thMessages = {
       "Also change background to match the creator's world",
     backgroundCheckboxDescription:
       "When OFF, the original background is preserved as much as possible. When ON, the background from the creator's image is extracted and applied.",
+    modeLabel: "ต้องการสร้างอะไร",
+    modeCost: "{cost} percoin",
+    modeOutfitOnlyLabel: "เฉพาะชุด",
+    modeOutfitOnlyDescription: "เปลี่ยนเฉพาะชุด พื้นหลังคงเดิม",
+    modeOutfitAndBackgroundLabel: "ชุด + พื้นหลัง",
+    modeOutfitAndBackgroundDescription:
+      "เปลี่ยนทั้งชุดและพื้นหลังให้เป็นโลกของครีเอเตอร์ การสร้างแบบสองขั้นตอนช่วยรักษามุมกล้องของคุณไว้พร้อมเรนเดอร์ฉากได้อย่างคมชัด",
+    modeBackgroundOnlyLabel: "เฉพาะพื้นหลัง",
+    modeBackgroundOnlyDescription:
+      "เปลี่ยนเฉพาะพื้นหลังให้เป็นโลกของครีเอเตอร์ ชุดคงเดิม",
     poseAngleNote:
       "* Camera angle and pose are preserved. Future update planned.",
     modelLabel: "โมเดลการสร้าง",

--- a/messages/vi.ts
+++ b/messages/vi.ts
@@ -1792,6 +1792,16 @@ export const viMessages = {
       "Also change background to match the creator's world",
     backgroundCheckboxDescription:
       "When OFF, the original background is preserved as much as possible. When ON, the background from the creator's image is extracted and applied.",
+    modeLabel: "Tạo nội dung gì",
+    modeCost: "{cost} percoin",
+    modeOutfitOnlyLabel: "Chỉ trang phục",
+    modeOutfitOnlyDescription: "Chỉ thay đổi trang phục. Phông nền giữ nguyên.",
+    modeOutfitAndBackgroundLabel: "Trang phục + phông nền",
+    modeOutfitAndBackgroundDescription:
+      "Thay đổi cả trang phục và phông nền theo thế giới của nhà sáng tạo. Quá trình tạo hai giai đoạn giữ nguyên góc máy của bạn trong khi dựng cảnh sắc nét.",
+    modeBackgroundOnlyLabel: "Chỉ phông nền",
+    modeBackgroundOnlyDescription:
+      "Chỉ thay đổi phông nền theo thế giới của nhà sáng tạo. Trang phục giữ nguyên.",
     poseAngleNote:
       "* Camera angle and pose are preserved. Future update planned.",
     modelLabel: "Mô hình tạo",

--- a/messages/zh-CN.ts
+++ b/messages/zh-CN.ts
@@ -1789,6 +1789,16 @@ export const zhCnMessages = {
       "Also change background to match the creator's world",
     backgroundCheckboxDescription:
       "When OFF, the original background is preserved as much as possible. When ON, the background from the creator's image is extracted and applied.",
+    modeLabel: "生成内容",
+    modeCost: "{cost} percoin",
+    modeOutfitOnlyLabel: "仅服装",
+    modeOutfitOnlyDescription: "仅更换服装，背景保持不变。",
+    modeOutfitAndBackgroundLabel: "服装 + 背景",
+    modeOutfitAndBackgroundDescription:
+      "将服装和背景一同更换为创作者的世界。两阶段生成可保留你的镜头角度，同时干净利落地渲染场景。",
+    modeBackgroundOnlyLabel: "仅背景",
+    modeBackgroundOnlyDescription:
+      "仅将背景更换为创作者的世界，服装保持不变。",
     poseAngleNote:
       "* Camera angle and pose are preserved. Future update planned.",
     modelLabel: "生成模型",

--- a/messages/zh-TW.ts
+++ b/messages/zh-TW.ts
@@ -1789,6 +1789,16 @@ export const zhTwMessages = {
       "Also change background to match the creator's world",
     backgroundCheckboxDescription:
       "When OFF, the original background is preserved as much as possible. When ON, the background from the creator's image is extracted and applied.",
+    modeLabel: "生成內容",
+    modeCost: "{cost} percoin",
+    modeOutfitOnlyLabel: "僅服裝",
+    modeOutfitOnlyDescription: "僅更換服裝，背景維持不變。",
+    modeOutfitAndBackgroundLabel: "服裝 + 背景",
+    modeOutfitAndBackgroundDescription:
+      "將服裝與背景一併更換為創作者的世界。兩階段生成可保留你的鏡頭角度，同時俐落地算繪場景。",
+    modeBackgroundOnlyLabel: "僅背景",
+    modeBackgroundOnlyDescription:
+      "僅將背景更換為創作者的世界，服裝維持不變。",
     poseAngleNote:
       "* Camera angle and pose are preserved. Future update planned.",
     modelLabel: "生成模型",

--- a/shared/generation/creator-looks-mode.ts
+++ b/shared/generation/creator-looks-mode.ts
@@ -1,0 +1,95 @@
+/**
+ * Creator Looks の生成モード。ユーザーが詳細画面で選択する。
+ *
+ * - "outfit_only"          : 衣装だけ着せる(1回生成)。背景は image_0 のまま。
+ * - "outfit_and_background": 衣装＋背景(2段階生成)。段階1で衣装着せ(背景維持)→
+ *                            段階2で「段階1の出力＋背景テキスト(image_1なし)」で背景を世界観に変える。
+ *                            image_1 の構図が背景にコピーされる問題を回避する。
+ * - "background_only"       : 背景だけ世界観に変える(1回生成)。衣装は image_0 のまま。image_1 は渡さない。
+ *
+ * 本ファイルは pure (ランタイム依存ゼロ) に保ち、client / Next.js handler /
+ * Deno worker のすべてから型・導出を共有する。
+ *
+ * 設計: docs/planning/creator-looks-generation-modes-plan.md
+ */
+
+export const CREATOR_LOOKS_MODES = [
+  "outfit_only",
+  "outfit_and_background",
+  "background_only",
+] as const;
+export type CreatorLooksMode = (typeof CREATOR_LOOKS_MODES)[number];
+
+/** 旧クライアント(モード未指定)互換の既定。背景OFFの衣装着せ=衣装のみ。 */
+export const DEFAULT_CREATOR_LOOKS_MODE: CreatorLooksMode = "outfit_only";
+
+/** 外部入力(JSON/metadata)を CreatorLooksMode に解釈する。未知・非文字列は null。 */
+export function parseCreatorLooksMode(value: unknown): CreatorLooksMode | null {
+  return value === "outfit_only" ||
+    value === "outfit_and_background" ||
+    value === "background_only"
+    ? value
+    : null;
+}
+
+/** 2段階生成(段階1=衣装→段階2=背景)を要するモードか。 */
+export function isTwoStageCreatorLooksMode(mode: CreatorLooksMode): boolean {
+  return mode === "outfit_and_background";
+}
+
+/** モードの生成段階数(2段階なら2、それ以外は1)。 */
+export function maxStagesForCreatorLooksMode(mode: CreatorLooksMode): 1 | 2 {
+  return isTwoStageCreatorLooksMode(mode) ? 2 : 1;
+}
+
+/**
+ * モード → image_jobs の override_outfit / override_background。
+ * Creator Looks は angle / pose は常に false(image_0 維持)。
+ * - outfit_only          : 衣装ON / 背景OFF
+ * - outfit_and_background : 衣装ON / 背景ON (2段階)
+ * - background_only       : 衣装OFF / 背景ON (衣装は image_0 のまま)
+ */
+export function overridesForCreatorLooksMode(mode: CreatorLooksMode): {
+  outfit: boolean;
+  angle: boolean;
+  pose: boolean;
+  background: boolean;
+} {
+  switch (mode) {
+    case "outfit_only":
+      return { outfit: true, angle: false, pose: false, background: false };
+    case "outfit_and_background":
+      return { outfit: true, angle: false, pose: false, background: true };
+    case "background_only":
+      return { outfit: false, angle: false, pose: false, background: true };
+  }
+}
+
+/**
+ * image_jobs.generation_metadata(JSONB) から生成モードを読み取る。
+ * キーなし・不正値は null を返す(呼び出し側で override から導出 or 既定適用)。
+ * worker(Deno) / Next.js の両方から使う。
+ */
+export function getCreatorLooksModeFromGenerationMetadata(
+  metadata: unknown,
+): CreatorLooksMode | null {
+  if (typeof metadata === "object" && metadata !== null) {
+    return parseCreatorLooksMode(
+      (metadata as Record<string, unknown>).creatorLooksMode,
+    );
+  }
+  return null;
+}
+
+/**
+ * override_outfit / override_background からモードを逆引きする(metadata 欠落時のフォールバック)。
+ * 旧 inspire(Creator Looks)ジョブは metadata に mode を持たないため、override から判定する。
+ */
+export function creatorLooksModeFromOverrides(
+  overrideOutfit: boolean,
+  overrideBackground: boolean,
+): CreatorLooksMode {
+  if (!overrideOutfit && overrideBackground) return "background_only";
+  if (overrideOutfit && overrideBackground) return "outfit_and_background";
+  return "outfit_only";
+}

--- a/supabase/functions/image-gen-worker/creator-looks-prompt.ts
+++ b/supabase/functions/image-gen-worker/creator-looks-prompt.ts
@@ -104,3 +104,51 @@ function isSectionHeader(trimmedLine: string): boolean {
   // Background は呼出側で先に判定済みなのでここでは戻ってこない
   return SECTION_HEADER_RE.test(trimmedLine);
 }
+
+/**
+ * hidden_prompt から Background セクションの「説明本文」を取り出す(stripBackgroundSection の逆)。
+ * "Background:" 行から次の空行 or 次の見出しまでを連結して返す。見つからなければ空文字。
+ * 背景のみ生成 / 2段階の段階2(背景変更)で、背景の世界観テキストとして使う。
+ */
+export function extractBackgroundSection(text: string): string {
+  const lines = text.split("\n");
+  const collected: string[] = [];
+  let capturing = false;
+
+  for (const line of lines) {
+    const trimmed = line.trimStart();
+    if (!capturing && trimmed.startsWith(BACKGROUND_HEADER)) {
+      capturing = true;
+      // "Background:" の後ろに同一行で説明が続くケースを拾う
+      const inline = trimmed.slice(BACKGROUND_HEADER.length).trim();
+      if (inline) collected.push(inline);
+      continue;
+    }
+    if (capturing) {
+      if (trimmed === "" || isSectionHeader(trimmed)) break;
+      collected.push(trimmed);
+    }
+  }
+  return collected.join(" ").trim();
+}
+
+/**
+ * 「背景だけ」を変える段階のプロンプトを組み立てる(image_1 は渡さない前提)。
+ *
+ * - 背景のみモード: 元のキャラ(image_0)の衣装・ポーズ・カメラを保ったまま背景だけ世界観に変える。
+ * - 2段階の段階2: 段階1の出力(衣装着せ済み)を image_0 として渡し、背景だけ変える。
+ *
+ * image_1 を渡さないため背景のアングルが image_1 にコピーされない(= 本対策の肝)。
+ * 背景の世界観は hidden_prompt の Background 記述をテキストとして使う。
+ */
+export function composeBackgroundStagePrompt(hiddenPrompt: string): string {
+  const bg = extractBackgroundSection(hiddenPrompt);
+  const background = bg
+    ? `Background: ${bg}`
+    : "Background: a scene that matches the outfit's mood and world.";
+  return [
+    "Change ONLY the background of `image_0.png`. Keep the character, face, hairstyle, body, outfit, accessories, pose, hand positions, camera angle, viewpoint, framing, crop, and art style of `image_0.png` exactly unchanged.",
+    background,
+    "Redraw the background from image_0's own viewpoint so it fits the existing pose and framing. Do not add or remove any subject. Do not change the clothing.",
+  ].join("\n\n");
+}

--- a/supabase/functions/image-gen-worker/index.ts
+++ b/supabase/functions/image-gen-worker/index.ts
@@ -10,10 +10,17 @@ import {
   resolveBackgroundMode,
   resolveInspireTargetSizeBaseIndex,
 } from "../../../shared/generation/prompt-core.ts";
-import { composeCreatorLooksPrompt } from "./creator-looks-prompt.ts";
+import {
+  composeCreatorLooksPrompt,
+  composeBackgroundStagePrompt,
+} from "./creator-looks-prompt.ts";
 import type { GenerationType } from "../../../shared/generation/prompt-core.ts";
 import { buildStyleAttemptReinforcementPrefix } from "../../../shared/generation/style-prompts.ts";
 import { getFramingModeFromGenerationMetadata } from "../../../shared/generation/framing-mode.ts";
+import {
+  getCreatorLooksModeFromGenerationMetadata,
+  creatorLooksModeFromOverrides,
+} from "../../../shared/generation/creator-looks-mode.ts";
 import {
   GEMINI_DISABLED_MESSAGE,
   GEMINI_PROVIDER_ERROR,
@@ -931,6 +938,104 @@ function extractImagesFromGeminiResponse(response: GeminiResponse): Array<{ mime
   }
 
   return images;
+}
+
+/**
+ * Creator Looks 2段階生成(衣装＋背景)の「段階1: 衣装着せ(背景維持)」を1回だけ実行し、
+ * 中間画像(衣装を着せた image_0)を返す(方式A)。
+ *
+ * - image_0(ユーザーキャラ) + image_1(参照画像) + 衣装プロンプトで生成する。
+ * - リトライ・計測・課金はしない(本体の段階2側で計測/課金/返金する)。
+ * - Gemini / OpenAI(gpt-image-2) の両モデルに対応。アスペクト比は image_0 基準。
+ * - 戻り値は段階2の image_0 として使う。
+ */
+async function generateCreatorLooksOutfitStage(params: {
+  dbModel: string;
+  apiModel: string;
+  geminiApiKey: string;
+  image0: InputImageData;
+  image1: InputImageData;
+  prompt: string;
+}): Promise<InputImageData> {
+  const { dbModel, apiModel, geminiApiKey, image0, image1, prompt } = params;
+
+  if (isOpenAIImageModel(dbModel)) {
+    const gptImage2 = parseGptImage2Model(dbModel);
+    if (!gptImage2) {
+      throw new Error(`Invalid GPT Image 2 model: ${dbModel}`);
+    }
+    const [result] = await callOpenAIImageEditMultiInputBatch({
+      prompt,
+      inputImages: [image0, image1],
+      // 衣装着せの出力フレームは image_0(ユーザーキャラ)基準に固定する。
+      targetSizeBaseIndex: 0,
+      timeoutMs: resolveOpenAIRequestTimeoutMs(gptImage2),
+      quality: gptImage2.quality,
+      sizeTier: gptImage2.sizeTier,
+      n: 1,
+    });
+    if (!result) {
+      throw new Error("Creator Looks stage1(outfit) produced no image");
+    }
+    return { base64: result.data, mimeType: result.mimeType };
+  }
+
+  // ===== Gemini 経路 =====
+  const aspectDims = parseImageDimensions(
+    decodeBase64(image0.base64),
+    image0.mimeType,
+  );
+  const aspectRatio = resolveGeminiAspectRatio(aspectDims);
+  const imageSize = extractImageSize(dbModel);
+  const requiresResponseModalities =
+    apiModel === "gemini-3.1-flash-image-preview";
+
+  const requestBody = {
+    contents: [
+      {
+        parts: [
+          { inline_data: { mime_type: image0.mimeType, data: image0.base64 } },
+          { inline_data: { mime_type: image1.mimeType, data: image1.base64 } },
+          { text: prompt },
+        ],
+      },
+    ],
+    safetySettings: [
+      { category: "HARM_CATEGORY_HARASSMENT", threshold: "BLOCK_ONLY_HIGH" },
+      { category: "HARM_CATEGORY_HATE_SPEECH", threshold: "BLOCK_ONLY_HIGH" },
+      { category: "HARM_CATEGORY_SEXUALLY_EXPLICIT", threshold: "BLOCK_NONE" },
+      { category: "HARM_CATEGORY_DANGEROUS_CONTENT", threshold: "BLOCK_ONLY_HIGH" },
+    ],
+    generationConfig: buildGeminiGenerationConfig({
+      imageSize,
+      aspectRatio,
+      requiresResponseModalities,
+    }),
+  };
+
+  const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/${apiModel}:generateContent`;
+  const response = await fetch(apiUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-goog-api-key": geminiApiKey,
+    },
+    body: JSON.stringify(requestBody),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Creator Looks stage1(outfit) Gemini request failed: ${response.status}`,
+    );
+  }
+  const data = (await response.json()) as GeminiResponse;
+  if (isGeminiSafetyBlocked(data)) {
+    throw new Error(SAFETY_POLICY_BLOCKED_ERROR);
+  }
+  const images = extractImagesFromGeminiResponse(data);
+  if (images.length === 0) {
+    throw new Error("Creator Looks stage1(outfit) produced no image");
+  }
+  return { base64: images[0].data, mimeType: images[0].mimeType };
 }
 
 /**
@@ -1883,6 +1988,68 @@ Deno.serve(async () => {
                         job.generation_metadata,
                       ),
                     });
+                  }
+
+                  // === Creator Looks 生成モード処理(方式A) ===
+                  // outfit_and_background: 段階1(衣装着せ・背景維持)を先に生成し、その出力を
+                  //   image_0 に差し替え image_1 を外して、本体生成を段階2(背景変更)にする。
+                  // background_only: image_1 を渡さず、image_0 の衣装を保ったまま背景だけ変える。
+                  // outfit_only: 既存どおり(composeCreatorLooksPrompt で背景維持・衣装着せ)。
+                  if (creatorLooksHiddenPrompt && resolvedInputImageData) {
+                    const clMode =
+                      getCreatorLooksModeFromGenerationMetadata(
+                        job.generation_metadata,
+                      ) ??
+                      creatorLooksModeFromOverrides(
+                        job.override_outfit ?? true,
+                        job.override_background ?? true,
+                      );
+                    if (
+                      clMode === "background_only" &&
+                      resolvedInspireTemplateImage
+                    ) {
+                      const image1Base64 = resolvedInspireTemplateImage.base64;
+                      const idx = parts.findIndex(
+                        (p) => p.inline_data?.data === image1Base64,
+                      );
+                      if (idx >= 0) parts.splice(idx, 1);
+                      resolvedInspireTemplateImage = null;
+                      fullPrompt = composeBackgroundStagePrompt(
+                        creatorLooksHiddenPrompt,
+                      );
+                    } else if (
+                      clMode === "outfit_and_background" &&
+                      resolvedInspireTemplateImage
+                    ) {
+                      // 段階1: 衣装着せ(image_0 + image_1, 背景維持)
+                      const cameraDirective =
+                        promptTemplates["creator_looks.camera_directive"] ?? "";
+                      const stage1 = await generateCreatorLooksOutfitStage({
+                        dbModel,
+                        apiModel,
+                        geminiApiKey: geminiApiKey ?? "",
+                        image0: resolvedInputImageData,
+                        image1: resolvedInspireTemplateImage,
+                        prompt: composeCreatorLooksPrompt(
+                          creatorLooksHiddenPrompt,
+                          false,
+                          cameraDirective,
+                        ),
+                      });
+                      // 段階2用に差し替え: image_0=段階1出力 / image_1なし / 背景プロンプト
+                      resolvedInputImageData = stage1;
+                      resolvedInspireTemplateImage = null;
+                      fullPrompt = composeBackgroundStagePrompt(
+                        creatorLooksHiddenPrompt,
+                      );
+                      parts.length = 0;
+                      parts.push({
+                        inline_data: {
+                          mime_type: stage1.mimeType,
+                          data: stage1.base64,
+                        },
+                      });
+                    }
                   }
 
                   parts.push({

--- a/supabase/migrations/20260618120000_add_app_settings.sql
+++ b/supabase/migrations/20260618120000_add_app_settings.sql
@@ -1,0 +1,45 @@
+-- ===============================================
+-- app_settings: アプリ全体のグローバル設定(key-value)
+-- ===============================================
+-- 専用のグローバル設定テーブルが無かったため新設する。
+-- 初回用途: Creator Looks「2段階(衣装＋背景)生成モード」の公開レベルを
+--   admin が UI から切り替えるための設定 creator_looks_two_stage_visibility。
+--   値は 'admin_only'(admin/プレビューのみ表示) または 'public'(全員に表示)。
+--   既定は 'admin_only'(= 機能フラグも兼ねる。検証後に public へ)。
+--
+-- 書き込みは admin API(service_role クライアント)経由のみを想定し、
+-- 一般ユーザー(anon/authenticated)には INSERT/UPDATE/DELETE ポリシーを作らない(= 拒否)。
+-- 読み取りは認証ユーザーに開放(UI が公開レベルを参照するため)。
+-- ===============================================
+
+CREATE TABLE IF NOT EXISTS public.app_settings (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL,
+  updated_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.app_settings IS 'アプリ全体のグローバル設定(key-value)。書き込みは admin(service_role)のみ';
+
+ALTER TABLE public.app_settings ENABLE ROW LEVEL SECURITY;
+
+-- 読み取り: 認証ユーザーに開放(公開レベルの参照に使う)
+DROP POLICY IF EXISTS app_settings_select_authenticated ON public.app_settings;
+CREATE POLICY app_settings_select_authenticated
+  ON public.app_settings
+  FOR SELECT
+  TO authenticated
+  USING (true);
+
+-- 書き込みポリシーは作らない(= anon/authenticated は拒否)。
+-- admin API は service_role クライアントで RLS をバイパスして更新する。
+
+-- 初期値: Creator Looks 2段階モードは既定で admin_only(未公開)
+INSERT INTO public.app_settings (key, value)
+VALUES ('creator_looks_two_stage_visibility', 'admin_only')
+ON CONFLICT (key) DO NOTHING;
+
+-- ===============================================
+-- DOWN:
+-- DROP TABLE IF EXISTS public.app_settings;
+-- ===============================================

--- a/tests/integration/api/generate-async-route.test.ts
+++ b/tests/integration/api/generate-async-route.test.ts
@@ -33,6 +33,15 @@ jest.mock("@/features/inspire/lib/repository", () => ({
   getStyleTemplateById: jest.fn(),
 }));
 
+// Creator Looks 生成モードのガード判定をテストごとに制御する
+jest.mock("@/lib/auth/creator-looks", () => ({
+  isCreatorLooksEnabledForUser: jest.fn(() => Promise.resolve(true)),
+}));
+jest.mock("@/features/inspire/lib/creator-looks-two-stage", () => ({
+  ...jest.requireActual("@/features/inspire/lib/creator-looks-two-stage"),
+  getCreatorLooksTwoStageVisibility: jest.fn(),
+}));
+
 import type { NextRequest } from "next/server";
 import { POST } from "@/app/api/generate-async/route";
 import {
@@ -48,10 +57,20 @@ import {
 } from "@/features/inspire/lib/repository";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { isAdminViewer } from "@/lib/env";
+import { isCreatorLooksEnabledForUser } from "@/lib/auth/creator-looks";
+import { getCreatorLooksTwoStageVisibility } from "@/features/inspire/lib/creator-looks-two-stage";
 
 const isAdminViewerMock = isAdminViewer as jest.MockedFunction<
   typeof isAdminViewer
 >;
+const isCreatorLooksEnabledForUserMock =
+  isCreatorLooksEnabledForUser as jest.MockedFunction<
+    typeof isCreatorLooksEnabledForUser
+  >;
+const getCreatorLooksTwoStageVisibilityMock =
+  getCreatorLooksTwoStageVisibility as jest.MockedFunction<
+    typeof getCreatorLooksTwoStageVisibility
+  >;
 
 type JsonRecord = Record<string, unknown>;
 const VALID_SOURCE_IMAGE_STOCK_ID = "11111111-1111-4111-8111-111111111111";
@@ -331,6 +350,119 @@ describe("GenerateAsyncRoute integration tests from EARS specs", () => {
         );
       }
     );
+  });
+
+  describe("Creator Looks 生成モード", () => {
+    const CREATOR_LOOKS_TEMPLATE = {
+      ...VISIBLE_STYLE_TEMPLATE,
+      is_creator_looks: true,
+    };
+
+    function callCreatorLooks(creatorLooksMode: string) {
+      return postGenerateAsyncRoute(
+        createRequest({
+          prompt: "creator-looks",
+          sourceImageStockId: VALID_SOURCE_IMAGE_STOCK_ID,
+          generationType: "inspire",
+          styleTemplateId: VALID_STYLE_TEMPLATE_ID,
+          model: "gpt-image-2-low-1k", // 10 percoin
+          creatorLooksMode,
+        }),
+        {
+          getUserFn,
+          jobRepository,
+          invokeImageWorkerFn,
+          supabaseUrl: "https://example.supabase.co",
+        }
+      );
+    }
+
+    beforeEach(() => {
+      getStyleTemplateByIdMock.mockResolvedValue({
+        data: CREATOR_LOOKS_TEMPLATE,
+        error: null,
+      });
+      isCreatorLooksEnabledForUserMock.mockReset();
+      isCreatorLooksEnabledForUserMock.mockResolvedValue(true);
+      getCreatorLooksTwoStageVisibilityMock.mockReset();
+      getCreatorLooksTwoStageVisibilityMock.mockResolvedValue("public");
+
+      // Creator Looks 投稿は cool-down(image_jobs) と hidden_prompt(secrets) を
+      // admin client で参照する。cool-down=0件 / hidden_prompt=準備済み を返す。
+      const imageJobs = {
+        select() {
+          return imageJobs;
+        },
+        eq() {
+          return imageJobs;
+        },
+        gte() {
+          return Promise.resolve({ count: 0, error: null });
+        },
+      };
+      const secrets = {
+        select() {
+          return secrets;
+        },
+        eq() {
+          return secrets;
+        },
+        maybeSingle() {
+          return Promise.resolve({
+            data: { template_id: VALID_STYLE_TEMPLATE_ID },
+            error: null,
+          });
+        },
+      };
+      createAdminClientMock.mockReturnValue({
+        from: (table: string) => (table === "image_jobs" ? imageJobs : secrets),
+      } as unknown as ReturnType<typeof createAdminClient>);
+    });
+
+    test("background_only は override_outfit=false/background=true で1段保存する", async () => {
+      const response = await callCreatorLooks("background_only");
+      expect(response.status).toBe(200);
+      expect(jobRepository.createImageJob).toHaveBeenCalledWith(
+        expect.objectContaining({
+          override_outfit: false,
+          override_background: true,
+          generation_metadata: expect.objectContaining({
+            creatorLooksMode: "background_only",
+            creatorLooksMaxStages: 1,
+          }),
+        })
+      );
+    });
+
+    test("outfit_and_background は公開時 override両true・2段・metadataを保存する", async () => {
+      const response = await callCreatorLooks("outfit_and_background");
+      expect(response.status).toBe(200);
+      expect(jobRepository.createImageJob).toHaveBeenCalledWith(
+        expect.objectContaining({
+          override_outfit: true,
+          override_background: true,
+          generation_metadata: expect.objectContaining({
+            creatorLooksMode: "outfit_and_background",
+            creatorLooksMaxStages: 2,
+          }),
+        })
+      );
+    });
+
+    test("outfit_and_background は admin_only かつ非adminなら403で拒否する", async () => {
+      getCreatorLooksTwoStageVisibilityMock.mockResolvedValue("admin_only");
+      isAdminViewerMock.mockReturnValue(false);
+      const response = await callCreatorLooks("outfit_and_background");
+      expect(response.status).toBe(403);
+      expect(jobRepository.createImageJob).not.toHaveBeenCalled();
+    });
+
+    test("outfit_and_background は admin_only でも admin なら許可する", async () => {
+      getCreatorLooksTwoStageVisibilityMock.mockResolvedValue("admin_only");
+      isAdminViewerMock.mockReturnValue(true);
+      const response = await callCreatorLooks("outfit_and_background");
+      expect(response.status).toBe(200);
+    });
   });
 
   describe("GASYNC-002 postGenerateAsyncRoute", () => {

--- a/tests/unit/features/generation/model-config.test.ts
+++ b/tests/unit/features/generation/model-config.test.ts
@@ -1,5 +1,6 @@
 import {
   getPercoinCost,
+  creatorLooksCost,
   GUEST_ALLOWED_MODELS,
   isCanonicalGuestAllowedModel,
   isModelAvailableForGeneration,
@@ -13,6 +14,24 @@ import {
 import { loadConfigWithGemini } from "@/tests/helpers/load-config-with-gemini";
 
 describe("model-config / model identification helpers", () => {
+  describe("creatorLooksCost", () => {
+    it("衣装のみ/背景のみ=モデルコスト、衣装＋背景=ceil(×2×0.9)", () => {
+      // gemini-3.1-flash-image-preview-512 = 10
+      expect(creatorLooksCost("gemini-3.1-flash-image-preview-512", "outfit_only")).toBe(10);
+      expect(creatorLooksCost("gemini-3.1-flash-image-preview-512", "background_only")).toBe(10);
+      expect(
+        creatorLooksCost("gemini-3.1-flash-image-preview-512", "outfit_and_background"),
+      ).toBe(18); // ceil(10*2*0.9)=18
+    });
+
+    it("1024モデル(20)では 20/36/20 にスケール", () => {
+      expect(creatorLooksCost("gemini-3.1-flash-image-preview-1024", "outfit_only")).toBe(20);
+      expect(
+        creatorLooksCost("gemini-3.1-flash-image-preview-1024", "outfit_and_background"),
+      ).toBe(36); // ceil(20*2*0.9)=36
+    });
+  });
+
   describe("getPercoinCost", () => {
     it("returns the GPT Image 2 percoin matrix", () => {
       expect(getPercoinCost("gpt-image-2-low-1k")).toBe(10);

--- a/tests/unit/features/inspire/creator-looks-two-stage.test.ts
+++ b/tests/unit/features/inspire/creator-looks-two-stage.test.ts
@@ -1,0 +1,74 @@
+import {
+  parseTwoStageVisibility,
+  isTwoStageModeAvailable,
+  getCreatorLooksTwoStageVisibility,
+  DEFAULT_TWO_STAGE_VISIBILITY,
+} from "@/features/inspire/lib/creator-looks-two-stage";
+
+describe("parseTwoStageVisibility", () => {
+  test("'public' のみ public、その他は admin_only(安全側)", () => {
+    expect(parseTwoStageVisibility("public")).toBe("public");
+    expect(parseTwoStageVisibility("admin_only")).toBe("admin_only");
+    expect(parseTwoStageVisibility("foo")).toBe("admin_only");
+    expect(parseTwoStageVisibility(null)).toBe("admin_only");
+    expect(parseTwoStageVisibility(undefined)).toBe("admin_only");
+    expect(DEFAULT_TWO_STAGE_VISIBILITY).toBe("admin_only");
+  });
+});
+
+describe("isTwoStageModeAvailable", () => {
+  test("public は全員可、admin_only は admin のみ可", () => {
+    expect(isTwoStageModeAvailable("public", false)).toBe(true);
+    expect(isTwoStageModeAvailable("public", true)).toBe(true);
+    expect(isTwoStageModeAvailable("admin_only", false)).toBe(false);
+    expect(isTwoStageModeAvailable("admin_only", true)).toBe(true);
+  });
+});
+
+describe("getCreatorLooksTwoStageVisibility", () => {
+  function mockClient(opts: {
+    value?: unknown;
+    error?: unknown;
+    throws?: boolean;
+  }) {
+    return {
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => {
+              if (opts.throws) throw new Error("table missing");
+              return {
+                data: opts.value === undefined ? null : { value: opts.value },
+                error: opts.error ?? null,
+              };
+            },
+          }),
+        }),
+      }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+  }
+
+  test("'public' 行があれば public", async () => {
+    expect(
+      await getCreatorLooksTwoStageVisibility(mockClient({ value: "public" })),
+    ).toBe("public");
+  });
+
+  test("行なし/不正値/エラー/例外はすべて admin_only に安全フォールバック", async () => {
+    expect(await getCreatorLooksTwoStageVisibility(mockClient({}))).toBe(
+      "admin_only",
+    );
+    expect(
+      await getCreatorLooksTwoStageVisibility(mockClient({ value: "weird" })),
+    ).toBe("admin_only");
+    expect(
+      await getCreatorLooksTwoStageVisibility(
+        mockClient({ error: { message: "x" } }),
+      ),
+    ).toBe("admin_only");
+    expect(
+      await getCreatorLooksTwoStageVisibility(mockClient({ throws: true })),
+    ).toBe("admin_only");
+  });
+});

--- a/tests/unit/shared/generation/creator-looks-mode.test.ts
+++ b/tests/unit/shared/generation/creator-looks-mode.test.ts
@@ -1,0 +1,85 @@
+import {
+  CREATOR_LOOKS_MODES,
+  DEFAULT_CREATOR_LOOKS_MODE,
+  parseCreatorLooksMode,
+  isTwoStageCreatorLooksMode,
+  maxStagesForCreatorLooksMode,
+  overridesForCreatorLooksMode,
+  getCreatorLooksModeFromGenerationMetadata,
+  creatorLooksModeFromOverrides,
+} from "@/shared/generation/creator-looks-mode";
+
+describe("parseCreatorLooksMode", () => {
+  test("有効な値はそのまま、不正は null", () => {
+    for (const m of CREATOR_LOOKS_MODES) {
+      expect(parseCreatorLooksMode(m)).toBe(m);
+    }
+    expect(parseCreatorLooksMode("foo")).toBeNull();
+    expect(parseCreatorLooksMode(null)).toBeNull();
+    expect(parseCreatorLooksMode(undefined)).toBeNull();
+    expect(parseCreatorLooksMode(123)).toBeNull();
+  });
+});
+
+describe("段階数と2段階判定", () => {
+  test("衣装＋背景だけ2段階", () => {
+    expect(isTwoStageCreatorLooksMode("outfit_and_background")).toBe(true);
+    expect(isTwoStageCreatorLooksMode("outfit_only")).toBe(false);
+    expect(isTwoStageCreatorLooksMode("background_only")).toBe(false);
+    expect(maxStagesForCreatorLooksMode("outfit_and_background")).toBe(2);
+    expect(maxStagesForCreatorLooksMode("outfit_only")).toBe(1);
+    expect(maxStagesForCreatorLooksMode("background_only")).toBe(1);
+  });
+});
+
+describe("overridesForCreatorLooksMode", () => {
+  test("モード→override(angle/poseは常にfalse)", () => {
+    expect(overridesForCreatorLooksMode("outfit_only")).toEqual({
+      outfit: true,
+      angle: false,
+      pose: false,
+      background: false,
+    });
+    expect(overridesForCreatorLooksMode("outfit_and_background")).toEqual({
+      outfit: true,
+      angle: false,
+      pose: false,
+      background: true,
+    });
+    expect(overridesForCreatorLooksMode("background_only")).toEqual({
+      outfit: false,
+      angle: false,
+      pose: false,
+      background: true,
+    });
+  });
+});
+
+describe("metadata / override 逆引き", () => {
+  test("generation_metadata から mode を読む", () => {
+    expect(
+      getCreatorLooksModeFromGenerationMetadata({
+        creatorLooksMode: "background_only",
+      }),
+    ).toBe("background_only");
+    expect(getCreatorLooksModeFromGenerationMetadata({})).toBeNull();
+    expect(getCreatorLooksModeFromGenerationMetadata(null)).toBeNull();
+    expect(
+      getCreatorLooksModeFromGenerationMetadata({ creatorLooksMode: "x" }),
+    ).toBeNull();
+  });
+
+  test("override から mode を逆引き(metadata 欠落フォールバック)", () => {
+    expect(creatorLooksModeFromOverrides(true, false)).toBe("outfit_only");
+    expect(creatorLooksModeFromOverrides(true, true)).toBe(
+      "outfit_and_background",
+    );
+    expect(creatorLooksModeFromOverrides(false, true)).toBe("background_only");
+    // 衣装OFF・背景OFF は実質「衣装のみ」扱い(既定)
+    expect(creatorLooksModeFromOverrides(false, false)).toBe("outfit_only");
+  });
+
+  test("既定モードは outfit_only", () => {
+    expect(DEFAULT_CREATOR_LOOKS_MODE).toBe("outfit_only");
+  });
+});

--- a/tests/unit/supabase/functions/image-gen-worker/creator-looks-prompt.test.ts
+++ b/tests/unit/supabase/functions/image-gen-worker/creator-looks-prompt.test.ts
@@ -3,6 +3,8 @@
 import {
   composeCreatorLooksPrompt,
   stripBackgroundSection,
+  extractBackgroundSection,
+  composeBackgroundStagePrompt,
 } from "@/supabase/functions/image-gen-worker/creator-looks-prompt";
 
 const SAMPLE_HIDDEN_PROMPT = `CRITICAL INSTRUCTION:
@@ -148,5 +150,42 @@ Constraints:`;
     const input = "A\n\n\n\nB";
     const out = stripBackgroundSection(input);
     expect(out).toBe("A\n\nB");
+  });
+});
+
+describe("extractBackgroundSection", () => {
+  test("Background セクションの本文を取り出す", () => {
+    expect(extractBackgroundSection(SAMPLE_HIDDEN_PROMPT)).toBe(
+      "spring cherry blossom park with soft sunlight",
+    );
+  });
+
+  test("複数行の Background も連結して取り出す", () => {
+    const t = "Styling Direction:\nHead: x\n\nBackground: a sunny\nbeach resort\n\nConstraints:\nNo";
+    expect(extractBackgroundSection(t)).toBe("a sunny beach resort");
+  });
+
+  test("Background が無ければ空文字", () => {
+    expect(extractBackgroundSection("Styling Direction:\nHead: x")).toBe("");
+  });
+});
+
+describe("composeBackgroundStagePrompt", () => {
+  test("背景のみ変更(衣装維持)の指示と Background 記述を含む", () => {
+    const result = composeBackgroundStagePrompt(SAMPLE_HIDDEN_PROMPT);
+    expect(result).toContain("Change ONLY the background");
+    expect(result).toContain(
+      "Background: spring cherry blossom park with soft sunlight",
+    );
+    // 衣装・キャラを維持する指示
+    expect(result).toContain("unchanged");
+    expect(result).toContain("Do not change the clothing");
+  });
+
+  test("Background 記述が無いときはフォールバック文を使う", () => {
+    const result = composeBackgroundStagePrompt("Styling Direction:\nHead: x");
+    expect(result).toContain(
+      "Background: a scene that matches the outfit's mood and world.",
+    );
   });
 });


### PR DESCRIPTION
## 概要

Creator Looks(inspire)の生成に **3つの生成モード** を追加します。背景アングル問題(image_1 を視覚入力で渡すと構図・背景が image_0 と合わない。特にロー×ハイの差が大きいと破綻)への対策として、**衣装＋背景モードを2段階生成**にして根本解決します。

計画書: `docs/planning/creator-looks-generation-modes-plan.md`

## 3つのモードと課金(モデル選択は維持・基準=モデルコスト)

| モード | 生成 | コスト | image_1 |
|---|---|---|---|
| 衣装のみ | 1回(衣装着せ・背景維持) | モデルコスト | 渡す |
| **衣装＋背景** | **2段階**(段1=衣装→段2=背景, image_1なし) | **ceil(×2×0.9)** | 段1のみ |
| 背景のみ | 1回(衣装そのまま・背景変更) | モデルコスト | 渡さない |

→ 512モデルなら **10 / 18 / 10**、1024なら 20/36/20 と自然にスケール。

## 実装(フェーズ別・各コミット)

- **Phase1**: `creator-looks-mode.ts`(mode型/override導出/段階数の pure ヘルパ) ＋ `app_settings` migration(**未適用**)
- **Phase2**: `creatorLooksCost(model, mode)` ＋ 背景ステージプロンプト(`composeBackgroundStagePrompt`/`extractBackgroundSection`)
- **Phase4**: API(`generate-async`)で `creatorLooksMode` 受領→override導出・モード別コスト・**2段階モードの公開ガード**(サーバ側でも 403)
- **Phase5**: 詳細画面を3択モードUIに(モード別コスト表示)。2段階は公開許可時のみ表示。**全15言語 i18n**
- **Phase6**: **Creator Looks 専用 admin 設定ページ**新設(公開レベル admin_only/public をラジオで切替・保存。サイドバー追加)
- **Phase3**: worker 2段階生成(**方式A**: 段階1=衣装着せを専用ヘルパで先に1回生成→出力を image_0 に差し替え image_1 を外し、本体生成を段階2=背景変更に。Gemini/OpenAI 両対応)

## 公開制御(機能フラグ兼用)

- グローバル設定 `app_settings.creator_looks_two_stage_visibility`(`admin_only`/`public`、既定 `admin_only`)
- `admin_only` のときは **admin/プレビュー権限のみ** 2段階モードを表示・利用可(UI非表示＋API 403 の二重ガード)
- admin がページから切替。**検証後に public へ** = 段階公開を兼ねる

## ⚠️ マージ後に必要な手動作業(ユーザー実施)

1. **migration 適用**: `supabase/migrations/20260618120000_add_app_settings.sql`(app_settings 作成＋seed)
2. **worker デプロイ**: `supabase functions deploy image-gen-worker`(2段階生成は worker 変更。deploy しないと反映されません)
3. **実機検証**: 3モードで生成し、特に「衣装＋背景」でロー×ハイのアングル破綻が解消するか確認

## テスト/検証

- 単体: creator-looks-mode / creatorLooksCost / 背景ステージプロンプト / two-stage visibility(計86件パス、既存 generate-async 41件 回帰なし)
- worker: pure helper はテスト済み。2段階オーケストレーションは **deploy 後の実機検証**(Deno のためユニット不可)
- `npm run typecheck`(本番0) / 変更ファイル `eslint` 0 / `npm run build -- --webpack` exit=0 / worker `deno check` は私の追加分エラーなし(残存は既存の Deno 環境由来)

## ロールバック

- `app_settings` は DROP 可(DOWN 用意)。`image_jobs` は新カラムなし(generation_metadata のみ)
- 公開フラグを `admin_only` に戻せば一般ユーザーには出ない(実質オフ)。worker は revert で従来の1回生成に戻る

🤖 Generated with [Claude Code](https://claude.com/claude-code)