### PR TITLE
fix(creator-looks): 衣装＋背景(2段階)のペルコイン消費がモデルコストのままだった課金漏れを修正

### DIFF
--- a/supabase/functions/image-gen-worker/index.ts
+++ b/supabase/functions/image-gen-worker/index.ts
@@ -18,6 +18,7 @@ import type { GenerationType } from "../../../shared/generation/prompt-core.ts";
 import { buildStyleAttemptReinforcementPrefix } from "../../../shared/generation/style-prompts.ts";
 import { getFramingModeFromGenerationMetadata } from "../../../shared/generation/framing-mode.ts";
 import {
+  type CreatorLooksMode,
   getCreatorLooksModeFromGenerationMetadata,
   creatorLooksModeFromOverrides,
 } from "../../../shared/generation/creator-looks-mode.ts";
@@ -724,11 +725,40 @@ function getRequestedImageCount(job: { requested_image_count?: unknown }): numbe
   return Math.min(requested, 4);
 }
 
+// Creator Looks 2段階(衣装＋背景)の割引率。
+// features/generation/lib/model-config.ts の CREATOR_LOOKS_TWO_STAGE_DISCOUNT と必ず一致させること。
+const CREATOR_LOOKS_TWO_STAGE_DISCOUNT = 0.9;
+
+/**
+ * Creator Looks のモード別ペルコイン消費量(API 残高チェックの creatorLooksCost と一致させる)。
+ * - 衣装のみ / 背景のみ(1回): モデルコスト
+ * - 衣装＋背景(2段階): ceil(モデルコスト × 2 × 0.9)
+ */
+function creatorLooksWorkerCost(
+  model: string | null,
+  mode: CreatorLooksMode,
+): number {
+  const base = getPercoinCost(model);
+  if (mode === "outfit_and_background") {
+    return Math.ceil(base * 2 * CREATOR_LOOKS_TWO_STAGE_DISCOUNT);
+  }
+  return base;
+}
+
 function getGenerationPercoinAmount(job: {
   model: string | null;
   requested_image_count?: unknown;
+  generation_metadata?: unknown;
 }): number {
   const normalizedModel = normalizeModelName(job.model);
+  // Creator Looks 生成モード(metadata)があればモード別コスト(2段階=ceil(×2×0.9))を使う。
+  // (= API 層の残高チェックと一致させ、過少/過大課金を防ぐ。Creator Looks は count=1 固定)
+  const clMode = getCreatorLooksModeFromGenerationMetadata(
+    job.generation_metadata,
+  );
+  if (clMode) {
+    return creatorLooksWorkerCost(normalizedModel, clMode);
+  }
   const count = isOpenAIImageModel(normalizedModel)
     ? getRequestedImageCount(job)
     : 1;


### PR DESCRIPTION
## 概要

実機検証で、**衣装＋背景(2段階)生成のペルコイン消費がモデルコスト(例: 10)のまま**で、想定の `ceil(モデルコスト×2×0.9)`(例: 18)になっていない課金漏れを発見・修正します。

実消費(`credit_transactions`)の確認:
| モード | 期待 | 実際(修正前) |
|---|---|---|
| 衣装のみ | 10 | 10 ✅ |
| 背景のみ | 10 | 10 ✅ |
| **衣装＋背景** | **18** | **10** ❌ |

## 原因

worker の `getGenerationPercoinAmount` が `getPercoinCost(model)*count` のままで、`creatorLooksMode` を考慮していませんでした。API 層の残高チェック(`handler` の `creatorLooksCost`)は 18 を使うため、**残高チェックと実消費が不整合(過少課金)** でした(計画書 ADR-003「両者で同じコストを使う」の worker 側実装漏れ)。

## 修正

- worker に `creatorLooksWorkerCost(model, mode)` を追加(`ceil(モデルコスト×2×0.9)`)。`features/generation/lib/model-config.ts` の `creatorLooksCost` とロジック・割引率(0.9)を一致
- `getGenerationPercoinAmount`: `generation_metadata.creatorLooksMode` があればモード別コストを使用(Creator Looks は count=1 固定)。それ以外(コーディネート/style/衣装のみ/背景のみ)は従来どおり

## 影響範囲

- 衣装＋背景の実消費が **18 に是正**され、API 残高チェックと一致
- `metadata.creatorLooksMode` を持たない既存生成(コーディネート/style/通常 inspire/衣装のみ/背景のみ)は**従来どおり**で影響なし

## デプロイ注意

worker(`image-gen-worker`)の変更です。**マージ後に `supabase functions deploy image-gen-worker` が必要**です。

## 検証

- worker `deno check`: 私の追加分(`creatorLooksWorkerCost`/`getGenerationPercoinAmount`)に型エラーなし(残存29は既存のDeno環境由来)
- 既存の課金ロジック(`creatorLooksCost`)は単体テスト済み。worker 内コピーは同一ロジック・実機で再確認予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)