### PR TITLE
feat(creator-looks): 段階2の背景プロンプトをadmin編集可化＋背景の画風一致を強化

### DIFF
--- a/shared/generation/prompt-registry.ts
+++ b/shared/generation/prompt-registry.ts
@@ -230,6 +230,18 @@ No art style change.`;
 const CREATOR_LOOKS_CAMERA_DIRECTIVE_DEFAULT = `TOP PRIORITY RULE — image_1 is an OUTFIT-ONLY reference:
 Copy ONLY the outfit, garments, and accessories from image_1. You MUST completely ignore image_1's background, scenery, camera angle, perspective, pose, framing, and composition — never reproduce any of them. Keep image_0's exact camera angle, viewpoint, framing, crop, and pose unchanged. The background follows the separate background instruction; never copy the background or layout from image_1. Whenever anything other than the outfit conflicts between the two images, image_0 always wins.`;
 
+// Creator Looks: 2段階生成の段階2(背景変更)/背景のみモードで使う背景プロンプト。
+// image_1 を渡さずテキストのみで背景を生成するため、image_0 の画風に合わせる指示を強く持たせる。
+// {background} に hidden_prompt から抽出した背景の世界観テキストが差し込まれる。
+const CREATOR_LOOKS_BACKGROUND_DIRECTIVE_DEFAULT = `Change ONLY the background of image_0.png. Keep the character, face, hairstyle, body, outfit, accessories, pose, hand positions, camera angle, viewpoint, framing, crop, and art style of image_0.png exactly unchanged.
+
+BACKGROUND STYLE — MOST IMPORTANT:
+Draw the new background in the EXACT same illustration style as image_0.png — same linework, shading method, color treatment, texture, brushwork, level of detail, and overall finish. It must look as if the same artist painted the background as part of the original illustration. Do NOT render the background in a photorealistic style or any art style different from image_0.png.
+
+Background: {{background}}
+
+Redraw the background from image_0's own viewpoint so it fits the existing pose and framing. Do not add or remove any subject. Do not change the clothing.`;
+
 // ============================================================================
 // レジストリ本体
 // ============================================================================
@@ -501,6 +513,16 @@ export const PROMPT_REGISTRY = {
       "(image_1 の構図がコピーされる問題への対策)。背景 ON/OFF どちらでも前置される。",
     defaultContent: CREATOR_LOOKS_CAMERA_DIRECTIVE_DEFAULT,
     supportedVariables: [],
+  },
+  "creator_looks.background_directive": {
+    category: "creator_looks",
+    description:
+      "Creator Looks: 2段階生成の段階2(背景変更)/背景のみモードで使う背景プロンプト。" +
+      "image_1 を渡さずテキストのみで背景を生成するため、image_0 の画風に合わせる指示を強く持つ。" +
+      "{{background}} に hidden_prompt から抽出した背景の世界観テキストが差し込まれる。",
+    defaultContent: CREATOR_LOOKS_BACKGROUND_DIRECTIVE_DEFAULT,
+    supportedVariables: ["background"],
+    previewSamples: { background: "spring cherry blossom park with soft sunlight" },
   },
 } as const satisfies Record<string, PromptDefinition>;
 

--- a/supabase/functions/image-gen-worker/creator-looks-prompt.ts
+++ b/supabase/functions/image-gen-worker/creator-looks-prompt.ts
@@ -140,15 +140,31 @@ export function extractBackgroundSection(text: string): string {
  *
  * image_1 を渡さないため背景のアングルが image_1 にコピーされない(= 本対策の肝)。
  * 背景の世界観は hidden_prompt の Background 記述をテキストとして使う。
+ *
+ * @param hiddenPrompt VLM 抽出済みの構造化プロンプト(Background セクションを含む)
+ * @param backgroundDirective admin 編集可の背景プロンプト(creator_looks.background_directive)。
+ *   {background} に hidden_prompt から抽出した背景の世界観テキストが差し込まれる。
+ *   空文字なら従来の固定文にフォールバックする。
  */
-export function composeBackgroundStagePrompt(hiddenPrompt: string): string {
+export function composeBackgroundStagePrompt(
+  hiddenPrompt: string,
+  backgroundDirective = "",
+): string {
   const bg = extractBackgroundSection(hiddenPrompt);
-  const background = bg
-    ? `Background: ${bg}`
-    : "Background: a scene that matches the outfit's mood and world.";
+  const background = bg || "a scene that matches the outfit's mood and world.";
+
+  const directive = backgroundDirective.trim();
+  if (directive) {
+    // {{background}} があれば置換、無ければ末尾に Background 行を補う。
+    return directive.includes("{{background}}")
+      ? directive.split("{{background}}").join(background)
+      : `${directive}\n\nBackground: ${background}`;
+  }
+
+  // フォールバック(従来の固定文)。
   return [
     "Change ONLY the background of `image_0.png`. Keep the character, face, hairstyle, body, outfit, accessories, pose, hand positions, camera angle, viewpoint, framing, crop, and art style of `image_0.png` exactly unchanged.",
-    background,
+    `Background: ${background}`,
     "Redraw the background from image_0's own viewpoint so it fits the existing pose and framing. Do not add or remove any subject. Do not change the clothing.",
   ].join("\n\n");
 }

--- a/supabase/functions/image-gen-worker/index.ts
+++ b/supabase/functions/image-gen-worker/index.ts
@@ -2046,6 +2046,7 @@ Deno.serve(async () => {
                       resolvedInspireTemplateImage = null;
                       fullPrompt = composeBackgroundStagePrompt(
                         creatorLooksHiddenPrompt,
+                        promptTemplates["creator_looks.background_directive"] ?? "",
                       );
                     } else if (
                       clMode === "outfit_and_background" &&
@@ -2071,6 +2072,7 @@ Deno.serve(async () => {
                       resolvedInspireTemplateImage = null;
                       fullPrompt = composeBackgroundStagePrompt(
                         creatorLooksHiddenPrompt,
+                        promptTemplates["creator_looks.background_directive"] ?? "",
                       );
                       parts.length = 0;
                       parts.push({

--- a/tests/unit/supabase/functions/image-gen-worker/creator-looks-prompt.test.ts
+++ b/tests/unit/supabase/functions/image-gen-worker/creator-looks-prompt.test.ts
@@ -188,4 +188,32 @@ describe("composeBackgroundStagePrompt", () => {
       "Background: a scene that matches the outfit's mood and world.",
     );
   });
+
+  test("backgroundDirective(admin編集可)の {{background}} に世界観を差し込む", () => {
+    const directive =
+      "BACKGROUND STYLE: match image_0 art style.\n\nBackground: {{background}}\n\nRedraw.";
+    const result = composeBackgroundStagePrompt(SAMPLE_HIDDEN_PROMPT, directive);
+    expect(result).toContain("BACKGROUND STYLE: match image_0 art style.");
+    expect(result).toContain(
+      "Background: spring cherry blossom park with soft sunlight",
+    );
+    // フォールバックの固定文ではなく directive が使われる
+    expect(result.startsWith("BACKGROUND STYLE")).toBe(true);
+  });
+
+  test("backgroundDirective に {background} が無ければ末尾に Background を補う", () => {
+    const result = composeBackgroundStagePrompt(
+      SAMPLE_HIDDEN_PROMPT,
+      "Keep image_0 art style.",
+    );
+    expect(result).toBe(
+      "Keep image_0 art style.\n\nBackground: spring cherry blossom park with soft sunlight",
+    );
+  });
+
+  test("backgroundDirective が空文字なら従来の固定文(フォールバック)", () => {
+    const result = composeBackgroundStagePrompt(SAMPLE_HIDDEN_PROMPT, "");
+    expect(result).toContain("Change ONLY the background");
+    expect(result).toContain("Do not change the clothing");
+  });
 });


### PR DESCRIPTION
## 概要

衣装＋背景(2段階)の**段階2(背景変更)**および**背景のみ**モードは、背景アングル対策のため `image_1` を渡さず**テキストのみで背景を生成**します。その分「背景を image_0 の画風で描く」指定が弱く、**背景がイラスト本体と馴染まない**（写実寄り・別タッチになる）問題がありました。

そこで、段階2の背景プロンプトを **`creator_looks.background_directive`** として admin の生成プロンプト管理で**編集可能**にし、default に「背景も image_0 の画風で描く」を強く持たせます（`camera_directive` と同じ仕組み）。

## 変更内容
- **prompt-registry**: `creator_looks.background_directive` を追加（admin編集可・category=creator_looks）
  - default は `BACKGROUND STYLE — MOST IMPORTANT`（同じ線画・塗り・テクスチャ・仕上げで描く／写実化しない）＋`{{background}}` 差し込み
  - `supportedVariables=["background"]`、`previewSamples` 付き
- **composeBackgroundStagePrompt**: `backgroundDirective` 引数を追加し、`{{background}}` を hidden_prompt の `Background:` 記述で置換。空文字なら従来の固定文にフォールバック
- **worker(index.ts)**: 段階2／背景のみの2箇所で `promptTemplates["creator_looks.background_directive"]` を渡す
- テスト追加（差し込み／プレースホルダ無し／空文字フォールバック）

## 効果
背景が **image_0 のイラスト画風（線画・塗り・タッチ）に合わせて**描かれるようになり、キャラと馴染みます。今後の微調整は admin の生成プロンプト管理から**デプロイ不要**で可能です。

## デプロイ注意
worker の変更を含むため、**マージ後に `supabase functions deploy image-gen-worker`** が必要です。

## 検証
- `creator-looks-prompt.test` / `prompt-registry.test` / `prompt-override.test` → **36件パス**
- `npm run typecheck` 本番0 / `npm run build -- --webpack` exit=0 / worker `deno check` 私の追加分エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)