### PR TITLE
feat(style-presets): スタイルに提供者(クリエイター)クレジットを追加

### DIFF
--- a/features/style-presets/lib/schema.ts
+++ b/features/style-presets/lib/schema.ts
@@ -58,6 +58,15 @@ export interface StylePresetCategoryRef {
   visibility: StylePresetCategoryVisibility;
   isActive: boolean;
   /**
+   * 提供者(クリエイター)の profiles.id。コラボ/提供スタイルのクレジット表示に使う。
+   * 未設定(従来カテゴリ)なら null/undefined。リポジトリ層では常に値を埋める optional 属性。
+   */
+  providerUserId?: string | null;
+  /** 提供者の表示名(profiles.nickname をライブ取得)。provider 未設定なら null。 */
+  providerNickname?: string | null;
+  /** 提供者のアバター URL(profiles.avatar_url をライブ取得)。未設定なら null。 */
+  providerAvatarUrl?: string | null;
+  /**
    * 解放の前提条件となる別カテゴリの key。設定時、当該カテゴリを完走したユーザーにのみ
    * このカテゴリを解放する。null なら前提条件なし(従来どおり無条件公開)。
    */

--- a/features/style-presets/lib/style-preset-repository.ts
+++ b/features/style-presets/lib/style-preset-repository.ts
@@ -21,6 +21,12 @@ interface PublishedStylePresetAccessOptions {
   includeAdminOnly?: boolean;
 }
 
+interface ProviderProfileRow {
+  id: string;
+  nickname: string | null;
+  avatar_url: string | null;
+}
+
 interface StylePresetCategoryRow {
   id: string;
   key: string;
@@ -29,6 +35,9 @@ interface StylePresetCategoryRow {
   badge_color: string;
   badge_text_color: string;
   skip_base_prefix: boolean;
+  provider_user_id?: string | null;
+  // PostgREST embedded select で profiles を JOIN した結果(provider クレジット用)
+  provider?: ProviderProfileRow | ProviderProfileRow[] | null;
   output_aspect_ratio_mode?: string | null;
   user_guidance_ja?: string | null;
   user_guidance_en?: string | null;
@@ -80,7 +89,7 @@ interface StylePresetRow {
 }
 
 const STYLE_PRESET_WITH_CATEGORY_SELECT =
-  "*, category:preset_categories!style_presets_category_id_fkey(id, key, display_name_ja, display_name_en, badge_color, badge_text_color, skip_base_prefix, output_aspect_ratio_mode, user_guidance_ja, user_guidance_en, show_source_image_type_control, show_background_change_control, show_generation_model_control, show_user_prompt_input, user_prompt_label, user_prompt_placeholder, user_prompt_max_length, visibility, is_active, unlock_prerequisite_key, progressive_batch_size, unlock_announcement_hero_path, unlock_announcement_initial_body, unlock_announcement_drip_body, unlock_announcement_accent_color, unlock_announcement_accent_hover_color, unlock_announcement_title_color, unlock_announcement_soft_color)";
+  "*, category:preset_categories!style_presets_category_id_fkey(id, key, display_name_ja, display_name_en, badge_color, badge_text_color, skip_base_prefix, output_aspect_ratio_mode, user_guidance_ja, user_guidance_en, show_source_image_type_control, show_background_change_control, show_generation_model_control, show_user_prompt_input, user_prompt_label, user_prompt_placeholder, user_prompt_max_length, visibility, is_active, provider_user_id, provider:profiles!preset_categories_provider_user_id_fkey(id, nickname, avatar_url), unlock_prerequisite_key, progressive_batch_size, unlock_announcement_hero_path, unlock_announcement_initial_body, unlock_announcement_drip_body, unlock_announcement_accent_color, unlock_announcement_accent_hover_color, unlock_announcement_title_color, unlock_announcement_soft_color)";
 
 function getSupabase(client?: SupabaseClient): SupabaseClient {
   return client ?? createAdminClient();
@@ -119,6 +128,14 @@ function extractCategory(
   return embedded;
 }
 
+function extractProvider(
+  embedded: StylePresetCategoryRow["provider"],
+): ProviderProfileRow | null {
+  if (!embedded) return null;
+  if (Array.isArray(embedded)) return embedded[0] ?? null;
+  return embedded;
+}
+
 function mapCategoryRefStrict(
   row: StylePresetRow,
   embedded: StylePresetCategoryRow | null,
@@ -146,6 +163,9 @@ function mapCategoryRefStrict(
       userPromptMaxLength: null,
       visibility: "public",
       isActive: true,
+      providerUserId: null,
+      providerNickname: null,
+      providerAvatarUrl: null,
       unlockPrerequisiteKey: null,
       progressiveBatchSize: null,
       unlockAnnouncementHeroPath: null,
@@ -157,6 +177,7 @@ function mapCategoryRefStrict(
       unlockAnnouncementSoftColor: null,
     };
   }
+  const provider = extractProvider(embedded.provider);
   return {
     id: embedded.id,
     key: embedded.key,
@@ -178,6 +199,9 @@ function mapCategoryRefStrict(
     userPromptMaxLength: embedded.user_prompt_max_length ?? null,
     visibility: normalizeCategoryVisibility(embedded.visibility),
     isActive: embedded.is_active,
+    providerUserId: embedded.provider_user_id ?? null,
+    providerNickname: provider?.nickname ?? null,
+    providerAvatarUrl: provider?.avatar_url ?? null,
     unlockPrerequisiteKey: embedded.unlock_prerequisite_key ?? null,
     progressiveBatchSize: embedded.progressive_batch_size ?? null,
     unlockAnnouncementHeroPath: embedded.unlock_announcement_hero_path ?? null,

--- a/features/style/components/StylePageClient.tsx
+++ b/features/style/components/StylePageClient.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import { useRouter } from "next/navigation";
+import { StyleProviderCredit } from "@/features/style/components/StyleProviderCredit";
 import {
   useCallback,
   useEffect,
@@ -220,6 +221,7 @@ function StyleReferencePanel({
   collapsed = false,
   aspectRatio,
   tooltip,
+  providerOverlay,
 }: {
   label: string;
   imageSrc: string;
@@ -232,6 +234,11 @@ function StyleReferencePanel({
    * preset カテゴリの user_guidance を画像内に表示するために使う。
    */
   tooltip?: React.ReactNode;
+  /**
+   * 画像コンテナの左下に絶対配置で重ねる任意の要素 (提供者クレジットを想定)。
+   * タップで提供者プロフィールへ遷移できる。
+   */
+  providerOverlay?: React.ReactNode;
 }) {
   return (
     <div className={className ?? "space-y-3"}>
@@ -262,6 +269,13 @@ function StyleReferencePanel({
               className={`absolute z-10 ${collapsed ? "right-1 top-1" : "right-2 top-2"}`}
             >
               {tooltip}
+            </div>
+          ) : null}
+          {providerOverlay ? (
+            <div
+              className={`absolute z-10 ${collapsed ? "bottom-1 left-1" : "bottom-2 left-2"}`}
+            >
+              {providerOverlay}
             </div>
           ) : null}
         </div>
@@ -1790,6 +1804,17 @@ export function StylePageClient({
                       />
                     );
                   })()}
+                  providerOverlay={
+                    selectedPreset.category.providerUserId &&
+                    selectedPreset.category.providerNickname ? (
+                      <StyleProviderCredit
+                        nickname={selectedPreset.category.providerNickname}
+                        avatarUrl={selectedPreset.category.providerAvatarUrl ?? null}
+                        href={`/users/${selectedPreset.category.providerUserId}`}
+                        locale={styleCardLocale}
+                      />
+                    ) : null
+                  }
                 />
               ) : null}
             </div>

--- a/features/style/components/StylePageClient.tsx
+++ b/features/style/components/StylePageClient.tsx
@@ -1812,6 +1812,7 @@ export function StylePageClient({
                         avatarUrl={selectedPreset.category.providerAvatarUrl ?? null}
                         href={`/users/${selectedPreset.category.providerUserId}`}
                         locale={styleCardLocale}
+                        size="lg"
                       />
                     ) : null
                   }

--- a/features/style/components/StylePresetPreviewCard.tsx
+++ b/features/style/components/StylePresetPreviewCard.tsx
@@ -159,7 +159,8 @@ export function StylePresetPreviewCard({
                 nickname={preset.category.providerNickname}
                 avatarUrl={preset.category.providerAvatarUrl ?? null}
                 locale={locale}
-                className="absolute bottom-7 left-1.5 z-10 max-w-[80%]"
+                iconOnly
+                className="absolute bottom-7 left-1.5 z-10"
               />
             )}
           {!dripLocked && isLocked && (

--- a/features/style/components/StylePresetPreviewCard.tsx
+++ b/features/style/components/StylePresetPreviewCard.tsx
@@ -153,16 +153,6 @@ export function StylePresetPreviewCard({
               {badgeText}
             </span>
           )}
-          {!dripLocked &&
-            preset.category?.providerNickname && (
-              <StyleProviderCredit
-                nickname={preset.category.providerNickname}
-                avatarUrl={preset.category.providerAvatarUrl ?? null}
-                locale={locale}
-                iconOnly
-                className="absolute bottom-7 left-1.5 z-10"
-              />
-            )}
           {!dripLocked && isLocked && (
             <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/65 px-2 backdrop-blur-[1px]">
               <span className="inline-flex items-center rounded-full bg-gradient-to-r from-pink-500 to-orange-400 px-3 py-1 text-center text-[11px] font-bold leading-tight text-white shadow-md">
@@ -172,9 +162,18 @@ export function StylePresetPreviewCard({
           )}
         </div>
         <div
-          className="flex items-center border-t bg-white px-3"
+          className="flex items-center gap-1.5 border-t bg-white px-3"
           style={{ height: STYLE_PRESET_CARD_TITLE_HEIGHT_PX }}
         >
+          {preset.category?.providerNickname && (
+            <StyleProviderCredit
+              nickname={preset.category.providerNickname}
+              avatarUrl={preset.category.providerAvatarUrl ?? null}
+              locale={locale}
+              iconOnly
+              className="flex shrink-0 items-center"
+            />
+          )}
           <p
             className="truncate text-sm font-medium text-slate-900"
             title={preset.title}

--- a/features/style/components/StylePresetPreviewCard.tsx
+++ b/features/style/components/StylePresetPreviewCard.tsx
@@ -4,6 +4,7 @@ import type { Ref } from "react";
 import Image from "next/image";
 import { Lock } from "lucide-react";
 import { Card } from "@/components/ui/card";
+import { StyleProviderCredit } from "@/features/style/components/StyleProviderCredit";
 
 const PRESET_NAME_MAX_CHARACTERS = 16;
 const STYLE_PRESET_CARD_WIDTH_PX = 180;
@@ -18,6 +19,9 @@ interface StylePresetPreviewCardCategory {
   displayNameEn: string;
   badgeColor: string;
   badgeTextColor: string;
+  /** 提供者クレジット(設定時のみカテゴリラベルの上に「提供 <nickname>」を表示)。 */
+  providerNickname?: string | null;
+  providerAvatarUrl?: string | null;
 }
 
 interface StylePresetPreviewCardData {
@@ -149,6 +153,15 @@ export function StylePresetPreviewCard({
               {badgeText}
             </span>
           )}
+          {!dripLocked &&
+            preset.category?.providerNickname && (
+              <StyleProviderCredit
+                nickname={preset.category.providerNickname}
+                avatarUrl={preset.category.providerAvatarUrl ?? null}
+                locale={locale}
+                className="absolute bottom-7 left-1.5 z-10 max-w-[80%]"
+              />
+            )}
           {!dripLocked && isLocked && (
             <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/65 px-2 backdrop-blur-[1px]">
               <span className="inline-flex items-center rounded-full bg-gradient-to-r from-pink-500 to-orange-400 px-3 py-1 text-center text-[11px] font-bold leading-tight text-white shadow-md">

--- a/features/style/components/StyleProviderCredit.tsx
+++ b/features/style/components/StyleProviderCredit.tsx
@@ -59,12 +59,12 @@ export function StyleProviderCredit({
       />
     );
   } else {
-    // アバター + 名前のピル。リンク時のアクセシブル名は可視テキストが担う。
+    // アバター + 名前のピル(可視表示は名前のみ。「提供/by」はリンクの aria-label が担う)。
     const px = isLarge ? 20 : 14;
     content = (
       <span
         className={`inline-flex items-center rounded-full bg-black/55 font-semibold leading-tight text-white shadow-sm backdrop-blur-[1px] ${
-          isLarge ? "gap-1.5 px-2.5 py-1 text-sm" : "gap-1 px-1.5 py-0.5 text-[10px]"
+          isLarge ? "gap-1.5 px-2.5 py-1 text-xs" : "gap-1 px-1.5 py-0.5 text-[10px]"
         }`}
       >
         {avatarUrl ? (
@@ -77,7 +77,7 @@ export function StyleProviderCredit({
           />
         ) : null}
         <span className={isLarge ? "max-w-[180px] truncate" : "max-w-[88px] truncate"}>
-          {labelText}
+          {nickname}
         </span>
       </span>
     );
@@ -91,6 +91,7 @@ export function StyleProviderCredit({
         rel="noopener noreferrer"
         // 親(画像カード等)のクリック・選択ハンドラと競合させない。
         onClick={(event) => event.stopPropagation()}
+        aria-label={labelText}
         className={className}
       >
         {content}

--- a/features/style/components/StyleProviderCredit.tsx
+++ b/features/style/components/StyleProviderCredit.tsx
@@ -47,15 +47,15 @@ export function StyleProviderCredit({
 
   let content;
   if (iconOnly && avatarUrl) {
-    // アイコンのみ(白フチで画像上でも視認できるように)。アクセシブル名は alt が担う。
-    const px = isLarge ? 28 : 24;
+    // アイコンのみ。アクセシブル名は alt が担う。薄いフチで白背景でも輪郭が出る。
+    const px = isLarge ? 28 : 20;
     content = (
       <Image
         src={avatarUrl}
         alt={labelText}
         width={px}
         height={px}
-        className="rounded-full object-cover shadow ring-2 ring-white/80"
+        className="rounded-full object-cover ring-1 ring-black/10"
       />
     );
   } else {

--- a/features/style/components/StyleProviderCredit.tsx
+++ b/features/style/components/StyleProviderCredit.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+
+interface StyleProviderCreditProps {
+  /** 提供者の表示名(profiles.nickname をライブ取得した値)。 */
+  nickname: string;
+  /** 提供者のアバター URL(profiles.avatar_url)。null なら名前のみ表示。 */
+  avatarUrl: string | null;
+  /**
+   * 設定するとチップ全体が提供者プロフィール (/users/[id]) へのリンクになる。
+   * 省略/null のときは非リンクの静的ラベルとして表示する
+   * (例: ホーム/一覧カードは内側がボタンのため非リンク)。
+   */
+  href?: string | null;
+  /** "提供" / "by" の接頭辞を選ぶための locale。省略時は 'ja'。 */
+  locale?: "ja" | "en";
+  /** リンク/ラベルのラッパに付与する追加 class(主に絶対配置の位置指定用)。 */
+  className?: string;
+}
+
+/**
+ * /style とホームのスタイルカードに出す「提供 <nickname>」クレジット。
+ * 提供者は preset_categories.provider_user_id (= profiles) からライブ取得した
+ * nickname / avatar_url を表示する。href 指定時はプロフィールへの別タブリンクになる。
+ */
+export function StyleProviderCredit({
+  nickname,
+  avatarUrl,
+  href,
+  locale = "ja",
+  className,
+}: StyleProviderCreditProps) {
+  const prefix = locale === "en" ? "by" : "提供";
+  const labelText = `${prefix} ${nickname}`;
+
+  const chip = (
+    <span className="inline-flex items-center gap-1 rounded-full bg-black/55 px-1.5 py-0.5 text-[10px] font-semibold leading-tight text-white shadow-sm backdrop-blur-[1px]">
+      {avatarUrl ? (
+        <Image
+          src={avatarUrl}
+          alt=""
+          width={14}
+          height={14}
+          className="h-3.5 w-3.5 rounded-full object-cover"
+        />
+      ) : null}
+      <span className="max-w-[88px] truncate">{labelText}</span>
+    </span>
+  );
+
+  if (href) {
+    return (
+      <Link
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        // 親(画像カード等)のクリック・選択ハンドラと競合させない。
+        onClick={(event) => event.stopPropagation()}
+        aria-label={labelText}
+        className={className}
+      >
+        {chip}
+      </Link>
+    );
+  }
+
+  return (
+    <span aria-label={labelText} className={className}>
+      {chip}
+    </span>
+  );
+}

--- a/features/style/components/StyleProviderCredit.tsx
+++ b/features/style/components/StyleProviderCredit.tsx
@@ -16,12 +16,19 @@ interface StyleProviderCreditProps {
   href?: string | null;
   /** "提供" / "by" の接頭辞を選ぶための locale。省略時は 'ja'。 */
   locale?: "ja" | "en";
-  /** リンク/ラベルのラッパに付与する追加 class(主に絶対配置の位置指定用)。 */
+  /** ラッパに付与する追加 class(主に絶対配置の位置指定用)。 */
   className?: string;
+  /**
+   * true のときアバターアイコンのみ表示する(名前テキストを出さない)。
+   * 小さな一覧カード向け。avatarUrl が無い場合は名前ピルにフォールバックする。
+   */
+  iconOnly?: boolean;
+  /** 表示サイズ。'sm'(既定, カード)/ 'lg'(/style の選択画像オーバーレイ用)。 */
+  size?: "sm" | "lg";
 }
 
 /**
- * /style とホームのスタイルカードに出す「提供 <nickname>」クレジット。
+ * /style とホームのスタイルカードに出す提供者クレジット。
  * 提供者は preset_categories.provider_user_id (= profiles) からライブ取得した
  * nickname / avatar_url を表示する。href 指定時はプロフィールへの別タブリンクになる。
  */
@@ -31,24 +38,50 @@ export function StyleProviderCredit({
   href,
   locale = "ja",
   className,
+  iconOnly = false,
+  size = "sm",
 }: StyleProviderCreditProps) {
   const prefix = locale === "en" ? "by" : "提供";
   const labelText = `${prefix} ${nickname}`;
+  const isLarge = size === "lg";
 
-  const chip = (
-    <span className="inline-flex items-center gap-1 rounded-full bg-black/55 px-1.5 py-0.5 text-[10px] font-semibold leading-tight text-white shadow-sm backdrop-blur-[1px]">
-      {avatarUrl ? (
-        <Image
-          src={avatarUrl}
-          alt=""
-          width={14}
-          height={14}
-          className="h-3.5 w-3.5 rounded-full object-cover"
-        />
-      ) : null}
-      <span className="max-w-[88px] truncate">{labelText}</span>
-    </span>
-  );
+  let content;
+  if (iconOnly && avatarUrl) {
+    // アイコンのみ(白フチで画像上でも視認できるように)。アクセシブル名は alt が担う。
+    const px = isLarge ? 28 : 24;
+    content = (
+      <Image
+        src={avatarUrl}
+        alt={labelText}
+        width={px}
+        height={px}
+        className="rounded-full object-cover shadow ring-2 ring-white/80"
+      />
+    );
+  } else {
+    // アバター + 名前のピル。リンク時のアクセシブル名は可視テキストが担う。
+    const px = isLarge ? 20 : 14;
+    content = (
+      <span
+        className={`inline-flex items-center rounded-full bg-black/55 font-semibold leading-tight text-white shadow-sm backdrop-blur-[1px] ${
+          isLarge ? "gap-1.5 px-2.5 py-1 text-sm" : "gap-1 px-1.5 py-0.5 text-[10px]"
+        }`}
+      >
+        {avatarUrl ? (
+          <Image
+            src={avatarUrl}
+            alt=""
+            width={px}
+            height={px}
+            className="rounded-full object-cover"
+          />
+        ) : null}
+        <span className={isLarge ? "max-w-[180px] truncate" : "max-w-[88px] truncate"}>
+          {labelText}
+        </span>
+      </span>
+    );
+  }
 
   if (href) {
     return (
@@ -58,17 +91,12 @@ export function StyleProviderCredit({
         rel="noopener noreferrer"
         // 親(画像カード等)のクリック・選択ハンドラと競合させない。
         onClick={(event) => event.stopPropagation()}
-        aria-label={labelText}
         className={className}
       >
-        {chip}
+        {content}
       </Link>
     );
   }
 
-  return (
-    <span aria-label={labelText} className={className}>
-      {chip}
-    </span>
-  );
+  return <span className={className}>{content}</span>;
 }

--- a/features/style/components/StyleProviderCredit.tsx
+++ b/features/style/components/StyleProviderCredit.tsx
@@ -52,7 +52,8 @@ export function StyleProviderCredit({
     content = (
       <Image
         src={avatarUrl}
-        alt={labelText}
+        // href 経由でリンク化する場合、親 Link の aria-label と二重読み上げになるため alt を空にする。
+        alt={href ? "" : labelText}
         width={px}
         height={px}
         className="rounded-full object-cover ring-1 ring-black/10"

--- a/supabase/migrations/20260620090000_add_provider_user_id_to_preset_categories.sql
+++ b/supabase/migrations/20260620090000_add_provider_user_id_to_preset_categories.sql
@@ -1,0 +1,33 @@
+-- preset_categories に「提供者(クリエイター)クレジット」用のカラムを追加する。
+--
+-- 目的:
+--   コラボ/提供スタイル(例: 神コレ衣装)を、提供者本人のクレジット付きで公開できるようにする。
+--   設定時、/style とホームのスタイルカードに「提供 <nickname>」を表示し、
+--   選択画像のオーバーレイから /users/[provider_user_id] の本人プロフィールへ遷移できる。
+--
+-- 設計:
+--   - provider_user_id は profiles(id) を参照する。これにより PostgREST の embedded select で
+--     提供者の nickname / avatar_url をライブ取得でき、本人がプロフィールを更新すれば自動追従する。
+--   - NULL のときは従来どおりクレジット非表示(既存カテゴリの挙動は一切変わらない)。
+--   - プロフィール削除時はクレジットを外すだけにしたいので ON DELETE SET NULL。
+
+ALTER TABLE public.preset_categories
+  ADD COLUMN IF NOT EXISTS provider_user_id UUID NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'preset_categories_provider_user_id_fkey'
+  ) THEN
+    ALTER TABLE public.preset_categories
+      ADD CONSTRAINT preset_categories_provider_user_id_fkey
+      FOREIGN KEY (provider_user_id)
+      REFERENCES public.profiles(id)
+      ON DELETE SET NULL;
+  END IF;
+END $$;
+
+COMMENT ON COLUMN public.preset_categories.provider_user_id IS
+  '提供者(クリエイター)の profiles.id。設定時 /style とホームのスタイルカードにクレジット表示し /users/[id] へリンクする。NULL なら従来どおりクレジットなし。';

--- a/tests/unit/features/style/style-preset-preview-card.test.tsx
+++ b/tests/unit/features/style/style-preset-preview-card.test.tsx
@@ -97,6 +97,49 @@ describe("StylePresetPreviewCard - バッジ表示", () => {
   });
 });
 
+const PROVIDER_CATEGORY = {
+  key: "godly_dress",
+  displayNameJa: "神話の女神ドレス",
+  displayNameEn: "Mythic Goddess Dress",
+  badgeColor: "#7c3aed",
+  badgeTextColor: "#ffffff",
+  providerNickname: "mario335599",
+  providerAvatarUrl: "https://example.com/avatar.webp",
+} as const;
+
+describe("StylePresetPreviewCard - 提供者クレジット", () => {
+  test("providerNickname があると『提供 <nickname>』を表示する", () => {
+    render(
+      <StylePresetPreviewCard
+        preset={makePreset({ category: PROVIDER_CATEGORY })}
+        alt="alt"
+      />,
+    );
+    expect(screen.getByText("提供 mario335599")).toBeInTheDocument();
+  });
+
+  test("locale='en' では『by <nickname>』を表示する", () => {
+    render(
+      <StylePresetPreviewCard
+        preset={makePreset({ category: PROVIDER_CATEGORY })}
+        alt="alt"
+        locale="en"
+      />,
+    );
+    expect(screen.getByText("by mario335599")).toBeInTheDocument();
+  });
+
+  test("providerNickname が無いカテゴリではクレジットを表示しない", () => {
+    render(
+      <StylePresetPreviewCard
+        preset={makePreset({ category: CHIBI_CATEGORY })}
+        alt="alt"
+      />,
+    );
+    expect(screen.queryByText(/提供/)).toBeNull();
+  });
+});
+
 describe("StylePresetPreviewCard - ロック表示", () => {
   test("lockedLabel を渡すとロックラベルを表示する", () => {
     render(

--- a/tests/unit/features/style/style-preset-preview-card.test.tsx
+++ b/tests/unit/features/style/style-preset-preview-card.test.tsx
@@ -108,17 +108,19 @@ const PROVIDER_CATEGORY = {
 } as const;
 
 describe("StylePresetPreviewCard - 提供者クレジット", () => {
-  test("providerNickname があると『提供 <nickname>』を表示する", () => {
+  test("providerNickname があると提供者アイコン(アイコンのみ)を表示する", () => {
     render(
       <StylePresetPreviewCard
         preset={makePreset({ category: PROVIDER_CATEGORY })}
         alt="alt"
       />,
     );
-    expect(screen.getByText("提供 mario335599")).toBeInTheDocument();
+    // カードはアイコンのみ: アバター img の代替テキストでクレジットを表現し、名前テキストは出さない
+    expect(screen.getByAltText("提供 mario335599")).toBeInTheDocument();
+    expect(screen.queryByText("提供 mario335599")).toBeNull();
   });
 
-  test("locale='en' では『by <nickname>』を表示する", () => {
+  test("locale='en' ではアイコンの代替テキストが『by <nickname>』になる", () => {
     render(
       <StylePresetPreviewCard
         preset={makePreset({ category: PROVIDER_CATEGORY })}
@@ -126,7 +128,7 @@ describe("StylePresetPreviewCard - 提供者クレジット", () => {
         locale="en"
       />,
     );
-    expect(screen.getByText("by mario335599")).toBeInTheDocument();
+    expect(screen.getByAltText("by mario335599")).toBeInTheDocument();
   });
 
   test("providerNickname が無いカテゴリではクレジットを表示しない", () => {
@@ -136,7 +138,7 @@ describe("StylePresetPreviewCard - 提供者クレジット", () => {
         alt="alt"
       />,
     );
-    expect(screen.queryByText(/提供/)).toBeNull();
+    expect(screen.queryByAltText(/提供|by/)).toBeNull();
   });
 });
 

--- a/tests/unit/features/style/style-provider-credit.test.tsx
+++ b/tests/unit/features/style/style-provider-credit.test.tsx
@@ -1,0 +1,98 @@
+/** @jest-environment jsdom */
+
+import type { MouseEventHandler, ReactNode } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { StyleProviderCredit } from "@/features/style/components/StyleProviderCredit";
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({ alt }: { alt: string }) => <img alt={alt} />,
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+    onClick,
+    "aria-label": ariaLabel,
+  }: {
+    children: ReactNode;
+    href: string;
+    onClick?: MouseEventHandler;
+    "aria-label"?: string;
+  }) => (
+    <a href={href} aria-label={ariaLabel} onClick={onClick}>
+      {children}
+    </a>
+  ),
+}));
+
+const AVATAR = "https://example.com/avatar.webp";
+
+describe("StyleProviderCredit", () => {
+  test("iconOnly: アバターのみ表示。非リンク時は alt にクレジットを入れる", () => {
+    render(
+      <StyleProviderCredit nickname="mario335599" avatarUrl={AVATAR} iconOnly />,
+    );
+    expect(screen.getByAltText("提供 mario335599")).toBeInTheDocument();
+    // アイコンのみ=可視テキストは出さない
+    expect(screen.queryByText("提供 mario335599")).toBeNull();
+    // href なし=非リンク
+    expect(screen.queryByRole("link")).toBeNull();
+  });
+
+  test("iconOnly + href: リンク化し、二重読み上げ防止で img alt は空になる", () => {
+    render(
+      <StyleProviderCredit
+        nickname="mario335599"
+        avatarUrl={AVATAR}
+        iconOnly
+        href="/users/u1"
+      />,
+    );
+    const link = screen.getByRole("link", { name: "提供 mario335599" });
+    expect(link).toHaveAttribute("href", "/users/u1");
+    // alt は空(aria-label が名前を担う)
+    expect(screen.queryByAltText("提供 mario335599")).toBeNull();
+    // onClick(stopPropagation)が配線されていること(クリックで例外が出ない)
+    fireEvent.click(link);
+    expect(link).toBeInTheDocument();
+  });
+
+  test("ピル + href: 可視は名前のみ、リンクのアクセシブル名は『提供 名前』", () => {
+    render(
+      <StyleProviderCredit
+        nickname="mario335599"
+        avatarUrl={AVATAR}
+        href="/users/u1"
+        size="lg"
+      />,
+    );
+    expect(
+      screen.getByRole("link", { name: "提供 mario335599" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("mario335599")).toBeInTheDocument();
+    // 可視テキストに接頭辞「提供」は出さない
+    expect(screen.queryByText("提供 mario335599")).toBeNull();
+  });
+
+  test("アバター無し: 画像を出さず名前テキストのみ(非リンク)", () => {
+    render(<StyleProviderCredit nickname="mario335599" avatarUrl={null} />);
+    expect(screen.getByText("mario335599")).toBeInTheDocument();
+    expect(screen.queryByRole("img")).toBeNull();
+    expect(screen.queryByRole("link")).toBeNull();
+  });
+
+  test("locale='en': 接頭辞が by になる", () => {
+    render(
+      <StyleProviderCredit
+        nickname="mario335599"
+        avatarUrl={AVATAR}
+        iconOnly
+        locale="en"
+      />,
+    );
+    expect(screen.getByAltText("by mario335599")).toBeInTheDocument();
+  });
+});

--- a/tests/unit/lib/style-preset-repository.test.ts
+++ b/tests/unit/lib/style-preset-repository.test.ts
@@ -278,6 +278,70 @@ describe("style-preset repository", () => {
     );
   });
 
+  test("listPublishedStylePresets_provider埋め込みが配列で返っても先頭を採用する", async () => {
+    const query = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnValueOnce({
+        order: jest.fn().mockResolvedValue({
+          data: [
+            {
+              id: "preset-provider-arr",
+              slug: "godly-dress-odin",
+              title: "神話ドレス_オーディン",
+              styling_prompt: "prompt",
+              background_prompt: null,
+              thumbnail_image_url: "https://example.com/style.webp",
+              thumbnail_storage_path: null,
+              thumbnail_width: 912,
+              thumbnail_height: 1173,
+              sort_order: 0,
+              status: "published",
+              category_id: "category-godly",
+              image_input_mode: "single",
+              reference_image_url: null,
+              reference_image_storage_path: null,
+              reference_image_width: null,
+              reference_image_height: null,
+              category: {
+                ...TEST_CATEGORY_ROW,
+                id: "category-godly",
+                key: "godly_dress",
+                provider_user_id: "user-mario",
+                // PostgREST が to-one を配列で返すケース
+                provider: [
+                  {
+                    id: "user-mario",
+                    nickname: "mario335599",
+                    avatar_url: "https://example.com/avatar.webp",
+                  },
+                ],
+              },
+              created_by: null,
+              updated_by: null,
+              created_at: "2026-06-20T00:00:00.000Z",
+              updated_at: "2026-06-20T00:00:00.000Z",
+            },
+          ],
+          error: null,
+        }),
+      }),
+    };
+
+    mockCreateAdminClient.mockReturnValue({
+      from: jest.fn(() => query),
+    } as never);
+
+    const presets = await listPublishedStylePresets();
+
+    expect(presets[0]?.category).toEqual(
+      expect.objectContaining({
+        providerNickname: "mario335599",
+        providerAvatarUrl: "https://example.com/avatar.webp",
+      }),
+    );
+  });
+
   test("listPublishedStylePresets_運営限定カテゴリは既定で除外し管理者指定では含める", async () => {
     const publicRow = {
       id: "preset-public",

--- a/tests/unit/lib/style-preset-repository.test.ts
+++ b/tests/unit/lib/style-preset-repository.test.ts
@@ -196,6 +196,9 @@ describe("style-preset repository", () => {
           userPromptMaxLength: null,
           visibility: "public",
           isActive: true,
+          providerUserId: null,
+          providerNickname: null,
+          providerAvatarUrl: null,
           unlockPrerequisiteKey: null,
           progressiveBatchSize: null,
           unlockAnnouncementHeroPath: null,
@@ -210,6 +213,69 @@ describe("style-preset repository", () => {
         dualReferenceSource: "admin",
       },
     ]);
+  });
+
+  test("listPublishedStylePresets_提供者(provider)埋め込みをクレジット情報へ変換する", async () => {
+    const query = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnValueOnce({
+        order: jest.fn().mockResolvedValue({
+          data: [
+            {
+              id: "preset-provider",
+              slug: "godly-dress-zeus",
+              title: "神話ドレス_ゼウス",
+              styling_prompt: "prompt",
+              background_prompt: null,
+              thumbnail_image_url: "https://example.com/style.webp",
+              thumbnail_storage_path: null,
+              thumbnail_width: 912,
+              thumbnail_height: 1173,
+              sort_order: 0,
+              status: "published",
+              category_id: "category-godly",
+              image_input_mode: "single",
+              reference_image_url: null,
+              reference_image_storage_path: null,
+              reference_image_width: null,
+              reference_image_height: null,
+              category: {
+                ...TEST_CATEGORY_ROW,
+                id: "category-godly",
+                key: "godly_dress",
+                provider_user_id: "user-mario",
+                provider: {
+                  id: "user-mario",
+                  nickname: "mario335599",
+                  avatar_url: "https://example.com/avatar.webp",
+                },
+              },
+              created_by: null,
+              updated_by: null,
+              created_at: "2026-06-20T00:00:00.000Z",
+              updated_at: "2026-06-20T00:00:00.000Z",
+            },
+          ],
+          error: null,
+        }),
+      }),
+    };
+
+    mockCreateAdminClient.mockReturnValue({
+      from: jest.fn(() => query),
+    } as never);
+
+    const presets = await listPublishedStylePresets();
+
+    expect(presets).toHaveLength(1);
+    expect(presets[0]?.category).toEqual(
+      expect.objectContaining({
+        providerUserId: "user-mario",
+        providerNickname: "mario335599",
+        providerAvatarUrl: "https://example.com/avatar.webp",
+      })
+    );
   });
 
   test("listPublishedStylePresets_運営限定カテゴリは既定で除外し管理者指定では含める", async () => {


### PR DESCRIPTION
### 概要
神コレ/ぷち神のような「コラボ・提供スタイル」を、**提供者本人のクレジット付き**で公開できるようにします。現状はスタイルが誰の提供か分からず、提供クリエイターへの還元(露出)もできませんでした。スタイルに提供者のアイコン/名前を表示し、提供者のプロフィールへ誘導できるようにします。提供者はカテゴリに紐づけ、表示名・アバターは本人のプロフィールからライブ取得します(本人がプロフィールを更新すれば自動で追従)。

### 変更内容
- `preset_categories.provider_user_id`(`profiles` 参照 / `ON DELETE SET NULL`)を追加するマイグレーションを追加。これにより PostgREST の埋め込み select で提供者の `nickname` / `avatar_url` を取得できる。
- 公開プリセット取得の埋め込み select に `provider` を追加し、`StylePresetCategoryRef` に `providerUserId` / `providerNickname` / `providerAvatarUrl` を追加(optional 属性。provider 未設定の既存カテゴリは挙動不変)。
- ホーム / `/style` 一覧カード: タイトルの左に**提供者アバター(アイコンのみ)** を表示。
- `/style` の選択画像オーバーレイ: 名前付きの大きめチップを表示し、**タップで提供者プロフィール(`/users/[id]`)へ別タブ遷移**(可視は名前のみ、`aria-label` に「提供 〜」を保持)。
- 新規コンポーネント `StyleProviderCredit`(iconOnly / size の表示バリエーション)。
- 単体テスト追加(provider のマッピング / カードのアイコン表示)。

### 実機テスト
- [ ] iOS Safari で主要導線を確認
- [ ] Android Chrome で主要導線を確認
- [ ] PC（Chrome）で主要導線を確認
- [ ] レスポンシブ表示崩れがないことを確認
- [ ] 提供者チップのタップで `/users/[id]` に別タブ遷移することを確認

### テスト方法
- `npm run lint`(変更ファイル 0 error) / `npm run typecheck`(本変更由来の新規エラーなし) / `npm run build -- --webpack`(成功) を確認。
- 関連 jest スイート pass: `style-preset-repository` / `get-public-style-presets` / `style-page-client` / `style-preset-preview-card`(provider マッピング・アイコン表示のテストを追加)。
- マイグレーションは本番DBに適用済み。`provider_user_id` を神コレ / ぷち神 / godly_dress 系へ設定済みのため、本PRデプロイ後に画面表示を確認予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
