### PR TITLE
feat(my-page): コレクションを状態別セクション化し未着手0/Nを排除

### DIFF
--- a/features/collections/hooks/useCollectionProgress.ts
+++ b/features/collections/hooks/useCollectionProgress.ts
@@ -86,9 +86,10 @@ export function useCollectionProgress() {
       // admin 限定プレビュー: 公開前の表示確認用に進捗モーダルを任意状態で再表示する。
       //   ?collection_reset=<categoryKey|1>            … 実データの現在状態を再表示
       //   ?collection_reset=<key>&collection_to=4      … 4個埋まった進捗ビューを強制
-      //   ?collection_reset=<key>&collection_to=4&collection_from=3 … 4個目が埋まる瞬間
-      // collection_to を指定すると、コンプリート済みでも完了ビューに切り替えず進捗ビュー
-      // (枠が埋まる演出)を表示する。一般ユーザーが踏んでも isAdminViewer が false なら無視。
+      //   ?collection_reset=<key>&collection_to=6&collection_from=5 … 6個目が埋まり100%になる瞬間
+      // collection_from を併せて指定すると、コンプリート済みでも完了ビューに切り替えず
+      // 進捗ビュー(枠が埋まる100%演出)を強制表示する。from 未指定で to>=閾値かつ実データ完了の
+      // ときだけ完了(台紙)ビューを出す。一般ユーザーが踏んでも isAdminViewer が false なら無視。
       // ack には触れない(実進捗を汚さない)。
       if (opts?.preview && data.isAdminViewer === true) {
         const { key, to: rawTo, from: rawFrom } = opts.preview;
@@ -102,15 +103,19 @@ export function useCollectionProgress() {
           const toCount = hasTo
             ? Math.max(1, Math.min(rawTo as number, threshold))
             : target.uniqueOutfitCount;
-          const fromCount =
-            typeof rawFrom === "number" && Number.isFinite(rawFrom)
-              ? Math.max(0, Math.min(rawFrom, toCount))
-              : 0;
-          // to を明示したときは進捗ビューを強制(完了ビューに切り替えない)。
-          // 未指定なら実データの完了状態を尊重する。
-          const completed = hasTo
-            ? toCount >= threshold && target.isCompleted
-            : target.isCompleted;
+          const hasFrom =
+            typeof rawFrom === "number" && Number.isFinite(rawFrom);
+          const fromCount = hasFrom
+            ? Math.max(0, Math.min(rawFrom as number, toCount))
+            : 0;
+          // collection_from を併せて指定したときは「枠が埋まる100%アニメ」を見たい意図なので、
+          // コンプリート済みでも完了ビューに切り替えず進捗ビューを強制する。
+          // from 未指定 + to>=閾値 + 実データ完了 のときだけ完了(台紙)ビューを出す。
+          const completed = hasFrom
+            ? false
+            : hasTo
+              ? toCount >= threshold && target.isCompleted
+              : target.isCompleted;
           setCelebration({
             categoryKey: target.categoryKey,
             displayName: target.displayNameJa,

--- a/features/collections/lib/my-page-collection-sections.ts
+++ b/features/collections/lib/my-page-collection-sections.ts
@@ -1,0 +1,103 @@
+/**
+ * マイページ「コレクション」の状態別セクション分け(純ロジック)。
+ *
+ * 設計方針(UX調査の結論):
+ * - マイページに出すのは「着手済み(uniqueOutfitCount>=1)または完了」だけ。
+ *   未着手(0/N かつ未完了)はクラッターになるため一切出さない。
+ *   → これにより神コレ等を常設(表示期間 NULL)にしても全員の 0/N で埋まらない。
+ * - 「あと少し!(残り1〜2着)」を最上段の独立セクションに昇格(ゴール勾配効果)。
+ * - 「進行中」は達成間近順(残り少ない順)で並べる。
+ * - 完了済みは進捗リスト(進行中)からは除外し、完成台紙アルバム側で見せる。
+ *
+ * 看板コンプ率の分母 total は「表示可能な全シリーズ数」(= 未着手も含む raw 件数)。
+ * 未着手は一覧に出さないが「全{total}中{completed}完成」のティーザーとして数だけ使う。
+ */
+import type { CollectionProgress } from "./collection-types";
+
+/**
+ * 残り「この値以下」を「あと少し!」に昇格させる閾値。
+ * 残り0(=全着収集済みだが台紙未作成)も含めて昇格させ、台紙作成へ誘導する。
+ */
+export const ALMOST_DONE_REMAINING_THRESHOLD = 2;
+
+export interface MyPageCollectionSections {
+  /** あと少し!(未完了 & 残り 0〜ALMOST_DONE_REMAINING_THRESHOLD 着)。残り少ない順。 */
+  almostDone: CollectionProgress[];
+  /** 進行中(未完了 & 着手済み & あと少し!以外)。残り少ない順。 */
+  inProgress: CollectionProgress[];
+  /**
+   * 看板コンプ率の分母: 表示可能な全シリーズ ∪ 完了済み(期間終了/ゲート済み台紙も含む)。
+   * 分子 completedCount を必ず含むため「全N中M完成」で N < M の矛盾が起きない。
+   */
+  totalSeries: number;
+  /**
+   * 看板コンプ率の分子: 完了済みシリーズ数(progress の isCompleted ∪ 完成台紙のカテゴリ)。
+   * 完成台紙アルバム(別ソース・無フィルタ)とズレないよう union で数える。
+   */
+  completedCount: number;
+  /**
+   * マイページのコレクションセクションを表示すべきか。
+   * 完成台紙が無く、着手中(あと少し+進行中)も無いなら、非参加ユーザーなので丸ごと隠す。
+   * (completedMounts は別propのため、呼び出し側で OR 条件に加える)
+   */
+  hasEngagement: boolean;
+}
+
+/** そのシリーズの残り必要数(0 未満にはしない)。 */
+export function remainingOutfits(p: CollectionProgress): number {
+  return Math.max(0, p.completionThreshold - p.uniqueOutfitCount);
+}
+
+function isEngagedActive(p: CollectionProgress): boolean {
+  // 未完了かつ1着以上着手済み(= 未着手 0/N を除外)
+  return !p.isCompleted && p.uniqueOutfitCount >= 1;
+}
+
+/** 残り少ない順。同点は着手数の多い順(より投資した順)で安定化。 */
+function byRemainingThenProgress(
+  a: CollectionProgress,
+  b: CollectionProgress,
+): number {
+  const ra = remainingOutfits(a);
+  const rb = remainingOutfits(b);
+  if (ra !== rb) return ra - rb;
+  return b.uniqueOutfitCount - a.uniqueOutfitCount;
+}
+
+export function buildMyPageCollectionSections(
+  progress: readonly CollectionProgress[],
+  /**
+   * 完成台紙アルバム(別ソース・無フィルタ)が持つカテゴリ key。
+   * 看板の completed/total を progress と union して、アルバムとの数字の矛盾を防ぐ。
+   */
+  completedMountCategoryKeys: readonly string[] = [],
+): MyPageCollectionSections {
+  // 完了カテゴリ = progress 上の isCompleted ∪ 完成台紙のカテゴリ(期間終了/ゲートで progress から消えたもの)。
+  const completedKeys = new Set<string>(completedMountCategoryKeys);
+  for (const p of progress) {
+    if (p.isCompleted) completedKeys.add(p.categoryKey);
+  }
+  const completedCount = completedKeys.size;
+
+  // 分母 = 表示可能シリーズ ∪ 完了カテゴリ(必ず completedCount を含む)。
+  const allKeys = new Set<string>(completedKeys);
+  for (const p of progress) allKeys.add(p.categoryKey);
+  const totalSeries = allKeys.size;
+
+  const engaged = progress.filter(isEngagedActive).sort(byRemainingThenProgress);
+
+  // 残り0(全着収集済みだが台紙未作成)も「あと少し!」に含め、台紙作成へ誘導する。
+  const almostDone = engaged.filter(
+    (p) => remainingOutfits(p) <= ALMOST_DONE_REMAINING_THRESHOLD,
+  );
+  const almostDoneKeys = new Set(almostDone.map((p) => p.categoryKey));
+  const inProgress = engaged.filter((p) => !almostDoneKeys.has(p.categoryKey));
+
+  return {
+    almostDone,
+    inProgress,
+    totalSeries,
+    completedCount,
+    hasEngagement: almostDone.length > 0 || inProgress.length > 0,
+  };
+}

--- a/features/collections/lib/my-page-collection-sections.ts
+++ b/features/collections/lib/my-page-collection-sections.ts
@@ -86,12 +86,14 @@ export function buildMyPageCollectionSections(
 
   const engaged = progress.filter(isEngagedActive).sort(byRemainingThenProgress);
 
+  // engaged は isEngagedActive 済みなので、残り着数の閾値だけで2分割できる。
   // 残り0(全着収集済みだが台紙未作成)も「あと少し!」に含め、台紙作成へ誘導する。
   const almostDone = engaged.filter(
     (p) => remainingOutfits(p) <= ALMOST_DONE_REMAINING_THRESHOLD,
   );
-  const almostDoneKeys = new Set(almostDone.map((p) => p.categoryKey));
-  const inProgress = engaged.filter((p) => !almostDoneKeys.has(p.categoryKey));
+  const inProgress = engaged.filter(
+    (p) => remainingOutfits(p) > ALMOST_DONE_REMAINING_THRESHOLD,
+  );
 
   return {
     almostDone,

--- a/features/my-page/components/MyPageCollections.tsx
+++ b/features/my-page/components/MyPageCollections.tsx
@@ -13,6 +13,7 @@ import {
   CollectionMountComposer,
   type MountGeneratedResult,
 } from "@/features/collections/components/CollectionMountComposer";
+import { mountAspectForCategory } from "@/features/collections/lib/mount-aspects";
 import type { CollectionProgress } from "@/features/collections/lib/collection-types";
 import {
   buildMyPageCollectionSections,
@@ -123,6 +124,9 @@ interface ComposerTarget {
   threshold: number;
 }
 
+/** 完成台紙アルバムで「もっと見る」前に表示する枚数。 */
+const MOUNTS_PREVIEW_LIMIT = 6;
+
 export interface CompletedMountView {
   completionId: string;
   categoryKey: string;
@@ -151,6 +155,47 @@ export function MyPageCollections({
   // タップのたびにモーダルを再マウントしてバーを 0 から再アニメさせるための nonce
   const [celebrationNonce, setCelebrationNonce] = useState(0);
   const [composer, setComposer] = useState<ComposerTarget | null>(null);
+  const [showAllMounts, setShowAllMounts] = useState(false);
+  // 「台紙を更新する」の表示可否と threshold のカテゴリ別キャッシュ。
+  // マウント時に先読みし、サムネクリック時は即時反映する。
+  const [recomposeInfo, setRecomposeInfo] = useState<
+    Record<string, { threshold: number; canRecompose: boolean }>
+  >({});
+
+  const loadRecomposeInfo = useCallback(async (categoryKey: string) => {
+    try {
+      const r = await fetch(
+        `/api/collections/options?categoryKey=${encodeURIComponent(categoryKey)}`,
+        { cache: "no-store" },
+      );
+      if (!r.ok) return null;
+      const d = (await r.json()) as {
+        threshold?: number | null;
+        outfits?: { images: unknown[] }[];
+      };
+      const outfits = d.outfits ?? [];
+      const threshold = d.threshold ?? 0;
+      const info = {
+        threshold,
+        canRecompose:
+          threshold > 0 &&
+          outfits.length >= threshold &&
+          outfits.some((o) => o.images.length > 1),
+      };
+      setRecomposeInfo((prev) => ({ ...prev, [categoryKey]: info }));
+      return info;
+    } catch {
+      return null;
+    }
+  }, []);
+
+  // 完了サムネのカテゴリぶんを先読み(数件想定)。失敗してもシェア等には影響しない。
+  useEffect(() => {
+    const keys = [...new Set(completedMounts.map((m) => m.categoryKey))];
+    void (async () => {
+      await Promise.all(keys.map((key) => loadRecomposeInfo(key)));
+    })();
+  }, [completedMounts, loadRecomposeInfo]);
 
   const refreshProgress = useCallback(async () => {
     try {
@@ -207,7 +252,7 @@ export function MyPageCollections({
         collectedImageUrls: [],
       });
       void refreshProgress();
-      // サーバー側 cache(看板の完成数など)を反映するため再描画
+      // サーバー側 cache(完了台紙サムネ)を反映するため再描画
       router.refresh();
     },
     [composer, refreshProgress, router],
@@ -226,6 +271,50 @@ export function MyPageCollections({
     sections.completedCount > 0;
   if (!hasAnything) {
     return null;
+  }
+
+  /**
+   * サムネクリックで「台紙 + シェアボタン」のモーダル(完了モード)を表示。
+   * 拡大表示と兼ねるため CollectionProgressModal の完了ビューを再利用する。
+   * 「台紙を更新する」(canRecompose) と threshold は先読みキャッシュから即時反映し、
+   * 未取得ならフォールバックで取得して反映する
+   * (進捗カードが非表示でも完了サムネから台紙を更新できるようにするため)。
+   */
+  function openMountModal(m: CompletedMountView) {
+    const cached = recomposeInfo[m.categoryKey];
+    setCelebrationNonce((n) => n + 1);
+    setCelebration({
+      categoryKey: m.categoryKey,
+      displayName: m.displayName,
+      fromCount: 0,
+      toCount: 0,
+      threshold: cached?.threshold ?? 0,
+      isCompleted: true,
+      mountImageUrl: m.mountImageUrl,
+      sharePath: `/m/${m.completionId}`,
+      completionId: m.completionId,
+      mountTemplateWidth: m.mountTemplateWidth,
+      mountTemplateHeight: m.mountTemplateHeight,
+      characterImageUrl: null,
+      collectedImageUrls: [],
+      canRecompose: cached?.canRecompose ?? false,
+      // 完了済み台紙の見返しなので、紙吹雪ではなくダイヤのきらめき演出にする。
+      celebrationEffect: "sparkle",
+    });
+    if (!cached) {
+      void loadRecomposeInfo(m.categoryKey).then((info) => {
+        if (!info) return;
+        setCelebration((prev) =>
+          prev && prev.completionId === m.completionId
+            ? {
+                ...prev,
+                threshold: info.threshold,
+                canRecompose: info.canRecompose,
+              }
+            : prev,
+        );
+      });
+    }
   }
 
   function openSeriesModal(series: CollectionProgress) {
@@ -278,6 +367,10 @@ export function MyPageCollections({
     });
   }
 
+  const visibleMounts = showAllMounts
+    ? completedMounts
+    : completedMounts.slice(0, MOUNTS_PREVIEW_LIMIT);
+
   return (
     <Card className="mt-4 mb-6 gap-2 px-5 py-3">
       <div className="flex items-baseline justify-between">
@@ -323,6 +416,50 @@ export function MyPageCollections({
               onOpen={() => openSeriesModal(s)}
             />
           ))}
+        </section>
+      ) : null}
+
+      {/* 完成した台紙(アルバム) */}
+      {completedMounts.length > 0 ? (
+        <section className="mt-3 space-y-2">
+          <h3 className="text-sm font-semibold text-gray-700">完成した台紙</h3>
+          <div className="flex flex-wrap gap-3">
+            {visibleMounts.map((m) => (
+              <button
+                key={m.completionId}
+                type="button"
+                onClick={() => openMountModal(m)}
+                className="relative w-24 overflow-hidden rounded-md border border-gray-200"
+                style={{
+                  aspectRatio: mountAspectForCategory(
+                    m.categoryKey,
+                    m.mountTemplateWidth,
+                    m.mountTemplateHeight,
+                  ),
+                }}
+                aria-label={`${m.displayName} のカードを表示`}
+              >
+                <Image
+                  src={m.mountImageUrl}
+                  alt={`${m.displayName} コンプリートカード`}
+                  fill
+                  sizes="96px"
+                  className="object-cover"
+                />
+              </button>
+            ))}
+          </div>
+          {completedMounts.length > MOUNTS_PREVIEW_LIMIT ? (
+            <button
+              type="button"
+              onClick={() => setShowAllMounts((v) => !v)}
+              className="text-xs font-medium text-gray-500 hover:text-gray-700"
+            >
+              {showAllMounts
+                ? "▴ 閉じる"
+                : `▸ もっと見る（${completedMounts.length}）`}
+            </button>
+          ) : null}
         </section>
       ) : null}
 

--- a/features/my-page/components/MyPageCollections.tsx
+++ b/features/my-page/components/MyPageCollections.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
+import { Check, Sparkles } from "lucide-react";
 import { Card } from "@/components/ui/card";
 import {
   CollectionProgressModal,
@@ -12,13 +13,110 @@ import {
   CollectionMountComposer,
   type MountGeneratedResult,
 } from "@/features/collections/components/CollectionMountComposer";
-import { CollectionProgressRing } from "@/features/collections/components/CollectionProgressRing";
 import { mountAspectForCategory } from "@/features/collections/lib/mount-aspects";
 import type { CollectionProgress } from "@/features/collections/lib/collection-types";
 import {
   buildMyPageCollectionSections,
   remainingOutfits,
 } from "@/features/collections/lib/my-page-collection-sections";
+
+/**
+ * シールアルバム型のコレクションカード(マイページ)。
+ * 集めた衣装サムネ + 未取得スロット(?) + 進捗バーで「集める」体験を表現する。
+ * カード全体タップで進捗モーダルを開く(CTAボタンは持たない)。
+ * highlighted=true(あと少し!)は桃色アクセント + 残り数バッジを付ける。
+ */
+function CollectionAlbumCard({
+  series,
+  highlighted,
+  onOpen,
+}: {
+  series: CollectionProgress;
+  highlighted: boolean;
+  onOpen: () => void;
+}) {
+  const remaining = remainingOutfits(series);
+  const filledImages = series.collectedImageUrls.slice(
+    0,
+    series.uniqueOutfitCount,
+  );
+  // 収集済みだがサムネURLが取れなかった分(画像欠損)はチェック済みスロットで埋める。
+  const filledNoImage = Math.max(
+    0,
+    series.uniqueOutfitCount - filledImages.length,
+  );
+  const ratio =
+    series.completionThreshold > 0
+      ? Math.min(1, series.uniqueOutfitCount / series.completionThreshold)
+      : 0;
+  const badgeLabel = remaining === 0 ? "コンプ！" : `あと${remaining}種`;
+
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className={`w-full rounded-2xl border p-3 text-left transition-colors ${
+        highlighted
+          ? "border-amber-200 bg-amber-50 hover:bg-amber-100"
+          : "border-gray-200 bg-white hover:bg-gray-50"
+      }`}
+      aria-label={`${series.displayNameJa}(${series.uniqueOutfitCount}/${series.completionThreshold}種、${remaining === 0 ? "台紙を作れます" : `あと${remaining}種`})`}
+    >
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <p className="truncate text-sm font-semibold text-gray-800">
+          {series.displayNameJa}
+        </p>
+        {highlighted ? (
+          <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-amber-400 px-2 py-0.5 text-[11px] font-bold text-white">
+            <Sparkles className="h-3 w-3" aria-hidden="true" />
+            {badgeLabel}
+          </span>
+        ) : null}
+      </div>
+
+      <div className="mb-2 flex flex-wrap gap-1.5">
+        {filledImages.map((url, i) => (
+          <span
+            key={`f-${i}`}
+            className="relative h-10 w-10 overflow-hidden rounded-lg border border-amber-200 bg-gray-100"
+          >
+            <Image src={url} alt="" fill sizes="40px" className="object-cover" />
+          </span>
+        ))}
+        {Array.from({ length: filledNoImage }).map((_, i) => (
+          <span
+            key={`fn-${i}`}
+            className="flex h-10 w-10 items-center justify-center rounded-lg border border-amber-200 bg-amber-100 text-amber-500"
+            aria-hidden="true"
+          >
+            <Check className="h-4 w-4" />
+          </span>
+        ))}
+        {Array.from({ length: remaining }).map((_, i) => (
+          <span
+            key={`g-${i}`}
+            className="flex h-10 w-10 items-center justify-center rounded-lg border border-dashed border-gray-300 text-xs font-bold text-gray-300"
+            aria-hidden="true"
+          >
+            ?
+          </span>
+        ))}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-gray-100">
+          <div
+            className="h-full rounded-full bg-amber-400"
+            style={{ width: `${Math.round(ratio * 100)}%` }}
+          />
+        </div>
+        <span className="shrink-0 text-xs font-medium tabular-nums text-gray-500">
+          {series.uniqueOutfitCount}/{series.completionThreshold} 種
+        </span>
+      </div>
+    </button>
+  );
+}
 
 interface ComposerTarget {
   categoryKey: string;
@@ -288,72 +386,21 @@ export function MyPageCollections({
         ) : null}
       </div>
 
-      {/* あと少し!(残り1〜2着を最上段で後押し) */}
+      {/* あと少し!(残り0〜2着を最上段で後押し) */}
       {sections.almostDone.length > 0 ? (
         <section className="mt-2 space-y-2">
-          <h3 className="text-sm font-semibold text-amber-600">
-            ✨ あと少し！
+          <h3 className="flex items-center gap-1 text-sm font-semibold text-amber-600">
+            <Sparkles className="h-4 w-4" aria-hidden="true" />
+            あと少し！
           </h3>
-          {sections.almostDone.map((s) => {
-            const remaining = remainingOutfits(s);
-            // 全着収集済み(残り0)は台紙作成へ、それ以外は生成画面へ誘導。
-            const readyToMount = remaining === 0;
-            const filled = s.collectedImageUrls.slice(0, s.uniqueOutfitCount);
-            const ghostCount = remaining; // 真の残り数(画像URL欠損に影響されない)
-            const ctaLabel = readyToMount
-              ? "コンプ！台紙を作る →"
-              : `あと${remaining}着 着せる →`;
-            const handleClick = readyToMount
-              ? () => openSeriesModal(s)
-              : () => router.push("/style");
-            return (
-              <button
-                key={s.categoryKey}
-                type="button"
-                onClick={handleClick}
-                className="flex w-full items-center gap-3 rounded-lg border border-amber-200 bg-amber-50 p-3 text-left hover:bg-amber-100"
-                aria-label={
-                  readyToMount
-                    ? `${s.displayNameJa} の台紙を作る`
-                    : `${s.displayNameJa} を続ける(あと${remaining}着)`
-                }
-              >
-                <div className="min-w-0 flex-1">
-                  <p className="truncate font-medium text-gray-800">
-                    {s.displayNameJa}
-                  </p>
-                  <div className="mt-1 flex flex-wrap items-center gap-1">
-                    {filled.map((url, i) => (
-                      <span
-                        key={`f-${i}`}
-                        className="relative h-6 w-6 overflow-hidden rounded-full border border-amber-300"
-                      >
-                        <Image
-                          src={url}
-                          alt=""
-                          fill
-                          sizes="24px"
-                          className="object-cover"
-                        />
-                      </span>
-                    ))}
-                    {Array.from({ length: ghostCount }).map((_, i) => (
-                      <span
-                        key={`g-${i}`}
-                        className="flex h-6 w-6 items-center justify-center rounded-full border border-dashed border-amber-300 text-[10px] text-amber-400"
-                        aria-hidden="true"
-                      >
-                        ?
-                      </span>
-                    ))}
-                  </div>
-                </div>
-                <span className="shrink-0 rounded-full bg-amber-500 px-3 py-1 text-xs font-bold text-white">
-                  {ctaLabel}
-                </span>
-              </button>
-            );
-          })}
+          {sections.almostDone.map((s) => (
+            <CollectionAlbumCard
+              key={s.categoryKey}
+              series={s}
+              highlighted
+              onOpen={() => openSeriesModal(s)}
+            />
+          ))}
         </section>
       ) : null}
 
@@ -361,46 +408,14 @@ export function MyPageCollections({
       {sections.inProgress.length > 0 ? (
         <section className="mt-3 space-y-2">
           <h3 className="text-sm font-semibold text-gray-700">進行中</h3>
-          <ul className="space-y-3">
-            {sections.inProgress.map((s) => {
-              const ratio =
-                s.completionThreshold > 0
-                  ? Math.min(1, s.uniqueOutfitCount / s.completionThreshold)
-                  : 0;
-              return (
-                <li key={s.categoryKey}>
-                  <button
-                    type="button"
-                    onClick={() => openSeriesModal(s)}
-                    className="flex w-full items-center gap-4 rounded-lg border border-gray-200 p-3 text-left hover:bg-gray-50"
-                  >
-                    <CollectionProgressRing
-                      ratio={ratio}
-                      complete={false}
-                      imageUrl={s.characterImageUrl}
-                      tintByProgress={false}
-                      color={s.progressModalRingColor}
-                      className="w-16 shrink-0"
-                    >
-                      {!s.characterImageUrl ? (
-                        <span className="text-sm font-bold tabular-nums text-gray-900">
-                          {s.uniqueOutfitCount}/{s.completionThreshold}
-                        </span>
-                      ) : null}
-                    </CollectionProgressRing>
-                    <div className="min-w-0 flex-1">
-                      <p className="truncate font-medium text-gray-800">
-                        {s.displayNameJa}
-                      </p>
-                      <p className="text-sm text-gray-500">
-                        {s.uniqueOutfitCount} / {s.completionThreshold} 種
-                      </p>
-                    </div>
-                  </button>
-                </li>
-              );
-            })}
-          </ul>
+          {sections.inProgress.map((s) => (
+            <CollectionAlbumCard
+              key={s.categoryKey}
+              series={s}
+              highlighted={false}
+              onOpen={() => openSeriesModal(s)}
+            />
+          ))}
         </section>
       ) : null}
 

--- a/features/my-page/components/MyPageCollections.tsx
+++ b/features/my-page/components/MyPageCollections.tsx
@@ -15,12 +15,19 @@ import {
 import { CollectionProgressRing } from "@/features/collections/components/CollectionProgressRing";
 import { mountAspectForCategory } from "@/features/collections/lib/mount-aspects";
 import type { CollectionProgress } from "@/features/collections/lib/collection-types";
+import {
+  buildMyPageCollectionSections,
+  remainingOutfits,
+} from "@/features/collections/lib/my-page-collection-sections";
 
 interface ComposerTarget {
   categoryKey: string;
   displayName: string;
   threshold: number;
 }
+
+/** 完成台紙アルバムで「もっと見る」前に表示する枚数。 */
+const MOUNTS_PREVIEW_LIMIT = 6;
 
 export interface CompletedMountView {
   completionId: string;
@@ -50,6 +57,7 @@ export function MyPageCollections({
   // タップのたびにモーダルを再マウントしてバーを 0 から再アニメさせるための nonce
   const [celebrationNonce, setCelebrationNonce] = useState(0);
   const [composer, setComposer] = useState<ComposerTarget | null>(null);
+  const [showAllMounts, setShowAllMounts] = useState(false);
   // 「台紙を更新する」の表示可否と threshold のカテゴリ別キャッシュ。
   // マウント時に先読みし、サムネクリック時は即時反映する。
   const [recomposeInfo, setRecomposeInfo] = useState<
@@ -152,7 +160,18 @@ export function MyPageCollections({
     [composer, refreshProgress, router],
   );
 
-  if (completedMounts.length === 0 && progress.length === 0) {
+  // 状態別セクション分け(未着手 0/N はここで除外される)。
+  // 看板の数字は完成台紙(別ソース)のカテゴリと union して矛盾を防ぐ。
+  const sections = buildMyPageCollectionSections(
+    progress,
+    completedMounts.map((m) => m.categoryKey),
+  );
+  // 完成台紙(server prop) も着手の一形態。いずれも無ければ非参加ユーザーなので丸ごと隠す。
+  const hasAnything =
+    completedMounts.length > 0 ||
+    sections.hasEngagement ||
+    sections.completedCount > 0;
+  if (!hasAnything) {
     return null;
   }
 
@@ -250,89 +269,183 @@ export function MyPageCollections({
     });
   }
 
+  const visibleMounts = showAllMounts
+    ? completedMounts
+    : completedMounts.slice(0, MOUNTS_PREVIEW_LIMIT);
+
   return (
     <Card className="mt-4 mb-6 gap-2 px-5 py-3">
-      <h2 className="text-base font-semibold text-gray-900">コレクション</h2>
+      <div className="flex items-baseline justify-between">
+        <h2 className="text-base font-semibold text-gray-900">コレクション</h2>
+        {sections.totalSeries > 0 ? (
+          <span className="text-xs text-gray-500">
+            全{sections.totalSeries}中{" "}
+            <span className="font-semibold text-amber-600">
+              {sections.completedCount}
+            </span>
+            完成
+          </span>
+        ) : null}
+      </div>
 
-      {completedMounts.length > 0 ? (
-        <div className="mb-4 flex flex-wrap gap-3">
-          {completedMounts.map((m) => (
-            <button
-              key={m.completionId}
-              type="button"
-              onClick={() => openMountModal(m)}
-              className="relative w-24 overflow-hidden rounded-md border border-gray-200"
-              style={{
-                aspectRatio: mountAspectForCategory(
-                  m.categoryKey,
-                  m.mountTemplateWidth,
-                  m.mountTemplateHeight,
-                ),
-              }}
-              aria-label={`${m.displayName} のカードを表示`}
-            >
-              <Image
-                src={m.mountImageUrl}
-                alt={`${m.displayName} コンプリートカード`}
-                fill
-                sizes="96px"
-                className="object-cover"
-              />
-            </button>
-          ))}
-        </div>
+      {/* あと少し!(残り1〜2着を最上段で後押し) */}
+      {sections.almostDone.length > 0 ? (
+        <section className="mt-2 space-y-2">
+          <h3 className="text-sm font-semibold text-amber-600">
+            ✨ あと少し！
+          </h3>
+          {sections.almostDone.map((s) => {
+            const remaining = remainingOutfits(s);
+            // 全着収集済み(残り0)は台紙作成へ、それ以外は生成画面へ誘導。
+            const readyToMount = remaining === 0;
+            const filled = s.collectedImageUrls.slice(0, s.uniqueOutfitCount);
+            const ghostCount = remaining; // 真の残り数(画像URL欠損に影響されない)
+            const ctaLabel = readyToMount
+              ? "コンプ！台紙を作る →"
+              : `あと${remaining}着 着せる →`;
+            const handleClick = readyToMount
+              ? () => openSeriesModal(s)
+              : () => router.push("/style");
+            return (
+              <button
+                key={s.categoryKey}
+                type="button"
+                onClick={handleClick}
+                className="flex w-full items-center gap-3 rounded-lg border border-amber-200 bg-amber-50 p-3 text-left hover:bg-amber-100"
+                aria-label={
+                  readyToMount
+                    ? `${s.displayNameJa} の台紙を作る`
+                    : `${s.displayNameJa} を続ける(あと${remaining}着)`
+                }
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="truncate font-medium text-gray-800">
+                    {s.displayNameJa}
+                  </p>
+                  <div className="mt-1 flex flex-wrap items-center gap-1">
+                    {filled.map((url, i) => (
+                      <span
+                        key={`f-${i}`}
+                        className="relative h-6 w-6 overflow-hidden rounded-full border border-amber-300"
+                      >
+                        <Image
+                          src={url}
+                          alt=""
+                          fill
+                          sizes="24px"
+                          className="object-cover"
+                        />
+                      </span>
+                    ))}
+                    {Array.from({ length: ghostCount }).map((_, i) => (
+                      <span
+                        key={`g-${i}`}
+                        className="flex h-6 w-6 items-center justify-center rounded-full border border-dashed border-amber-300 text-[10px] text-amber-400"
+                        aria-hidden="true"
+                      >
+                        ?
+                      </span>
+                    ))}
+                  </div>
+                </div>
+                <span className="shrink-0 rounded-full bg-amber-500 px-3 py-1 text-xs font-bold text-white">
+                  {ctaLabel}
+                </span>
+              </button>
+            );
+          })}
+        </section>
       ) : null}
 
-      {progress.length > 0 ? (
-        <ul className="space-y-3">
-          {progress.map((s) => {
-            const ratio =
-              s.completionThreshold > 0
-                ? Math.min(1, s.uniqueOutfitCount / s.completionThreshold)
-                : 0;
-            const completed = s.uniqueOutfitCount >= s.completionThreshold;
-            return (
-              <li key={s.categoryKey}>
-                <button
-                  type="button"
-                  onClick={() => openSeriesModal(s)}
-                  className="flex w-full items-center gap-4 rounded-lg border border-gray-200 p-3 text-left hover:bg-gray-50"
-                >
-                  <CollectionProgressRing
-                    ratio={ratio}
-                    complete={completed}
-                    imageUrl={s.characterImageUrl}
-                    tintByProgress={false}
-                    color={s.progressModalRingColor}
-                    className="w-16 shrink-0"
+      {/* 進行中(達成間近順) */}
+      {sections.inProgress.length > 0 ? (
+        <section className="mt-3 space-y-2">
+          <h3 className="text-sm font-semibold text-gray-700">進行中</h3>
+          <ul className="space-y-3">
+            {sections.inProgress.map((s) => {
+              const ratio =
+                s.completionThreshold > 0
+                  ? Math.min(1, s.uniqueOutfitCount / s.completionThreshold)
+                  : 0;
+              return (
+                <li key={s.categoryKey}>
+                  <button
+                    type="button"
+                    onClick={() => openSeriesModal(s)}
+                    className="flex w-full items-center gap-4 rounded-lg border border-gray-200 p-3 text-left hover:bg-gray-50"
                   >
-                    {!s.characterImageUrl ? (
-                      completed ? (
-                        <span className="text-xs font-bold text-amber-500">
-                          完成
-                        </span>
-                      ) : (
+                    <CollectionProgressRing
+                      ratio={ratio}
+                      complete={false}
+                      imageUrl={s.characterImageUrl}
+                      tintByProgress={false}
+                      color={s.progressModalRingColor}
+                      className="w-16 shrink-0"
+                    >
+                      {!s.characterImageUrl ? (
                         <span className="text-sm font-bold tabular-nums text-gray-900">
                           {s.uniqueOutfitCount}/{s.completionThreshold}
                         </span>
-                      )
-                    ) : null}
-                  </CollectionProgressRing>
-                  <div className="min-w-0 flex-1">
-                    <p className="truncate font-medium text-gray-800">
-                      {s.displayNameJa}
-                    </p>
-                    <p className="text-sm text-gray-500">
-                      {s.uniqueOutfitCount} / {s.completionThreshold} 種
-                      {s.isCompleted ? "（達成）" : ""}
-                    </p>
-                  </div>
-                </button>
-                {/* 台紙作成・更新はモーダル内 CTA に集約(行下のボタンは廃止) */}
-              </li>
-            );
-          })}
-        </ul>
+                      ) : null}
+                    </CollectionProgressRing>
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate font-medium text-gray-800">
+                        {s.displayNameJa}
+                      </p>
+                      <p className="text-sm text-gray-500">
+                        {s.uniqueOutfitCount} / {s.completionThreshold} 種
+                      </p>
+                    </div>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      ) : null}
+
+      {/* 完成した台紙(アルバム) */}
+      {completedMounts.length > 0 ? (
+        <section className="mt-3 space-y-2">
+          <h3 className="text-sm font-semibold text-gray-700">完成した台紙</h3>
+          <div className="flex flex-wrap gap-3">
+            {visibleMounts.map((m) => (
+              <button
+                key={m.completionId}
+                type="button"
+                onClick={() => openMountModal(m)}
+                className="relative w-24 overflow-hidden rounded-md border border-gray-200"
+                style={{
+                  aspectRatio: mountAspectForCategory(
+                    m.categoryKey,
+                    m.mountTemplateWidth,
+                    m.mountTemplateHeight,
+                  ),
+                }}
+                aria-label={`${m.displayName} のカードを表示`}
+              >
+                <Image
+                  src={m.mountImageUrl}
+                  alt={`${m.displayName} コンプリートカード`}
+                  fill
+                  sizes="96px"
+                  className="object-cover"
+                />
+              </button>
+            ))}
+          </div>
+          {completedMounts.length > MOUNTS_PREVIEW_LIMIT ? (
+            <button
+              type="button"
+              onClick={() => setShowAllMounts((v) => !v)}
+              className="text-xs font-medium text-gray-500 hover:text-gray-700"
+            >
+              {showAllMounts
+                ? "▴ 閉じる"
+                : `▸ もっと見る（${completedMounts.length}）`}
+            </button>
+          ) : null}
+        </section>
       ) : null}
 
       <CollectionProgressModal

--- a/features/my-page/components/MyPageCollections.tsx
+++ b/features/my-page/components/MyPageCollections.tsx
@@ -35,7 +35,7 @@ function CollectionAlbumCard({
   onOpen: () => void;
 }) {
   const remaining = remainingOutfits(series);
-  const filledImages = series.collectedImageUrls.slice(
+  const filledImages = (series.collectedImageUrls ?? []).slice(
     0,
     series.uniqueOutfitCount,
   );

--- a/features/my-page/components/MyPageCollections.tsx
+++ b/features/my-page/components/MyPageCollections.tsx
@@ -13,7 +13,6 @@ import {
   CollectionMountComposer,
   type MountGeneratedResult,
 } from "@/features/collections/components/CollectionMountComposer";
-import { mountAspectForCategory } from "@/features/collections/lib/mount-aspects";
 import type { CollectionProgress } from "@/features/collections/lib/collection-types";
 import {
   buildMyPageCollectionSections,
@@ -124,9 +123,6 @@ interface ComposerTarget {
   threshold: number;
 }
 
-/** 完成台紙アルバムで「もっと見る」前に表示する枚数。 */
-const MOUNTS_PREVIEW_LIMIT = 6;
-
 export interface CompletedMountView {
   completionId: string;
   categoryKey: string;
@@ -155,47 +151,6 @@ export function MyPageCollections({
   // タップのたびにモーダルを再マウントしてバーを 0 から再アニメさせるための nonce
   const [celebrationNonce, setCelebrationNonce] = useState(0);
   const [composer, setComposer] = useState<ComposerTarget | null>(null);
-  const [showAllMounts, setShowAllMounts] = useState(false);
-  // 「台紙を更新する」の表示可否と threshold のカテゴリ別キャッシュ。
-  // マウント時に先読みし、サムネクリック時は即時反映する。
-  const [recomposeInfo, setRecomposeInfo] = useState<
-    Record<string, { threshold: number; canRecompose: boolean }>
-  >({});
-
-  const loadRecomposeInfo = useCallback(async (categoryKey: string) => {
-    try {
-      const r = await fetch(
-        `/api/collections/options?categoryKey=${encodeURIComponent(categoryKey)}`,
-        { cache: "no-store" },
-      );
-      if (!r.ok) return null;
-      const d = (await r.json()) as {
-        threshold?: number | null;
-        outfits?: { images: unknown[] }[];
-      };
-      const outfits = d.outfits ?? [];
-      const threshold = d.threshold ?? 0;
-      const info = {
-        threshold,
-        canRecompose:
-          threshold > 0 &&
-          outfits.length >= threshold &&
-          outfits.some((o) => o.images.length > 1),
-      };
-      setRecomposeInfo((prev) => ({ ...prev, [categoryKey]: info }));
-      return info;
-    } catch {
-      return null;
-    }
-  }, []);
-
-  // 完了サムネのカテゴリぶんを先読み(数件想定)。失敗してもシェア等には影響しない。
-  useEffect(() => {
-    const keys = [...new Set(completedMounts.map((m) => m.categoryKey))];
-    void (async () => {
-      await Promise.all(keys.map((key) => loadRecomposeInfo(key)));
-    })();
-  }, [completedMounts, loadRecomposeInfo]);
 
   const refreshProgress = useCallback(async () => {
     try {
@@ -252,7 +207,7 @@ export function MyPageCollections({
         collectedImageUrls: [],
       });
       void refreshProgress();
-      // サーバー側 cache(完了台紙サムネ)を反映するため再描画
+      // サーバー側 cache(看板の完成数など)を反映するため再描画
       router.refresh();
     },
     [composer, refreshProgress, router],
@@ -271,50 +226,6 @@ export function MyPageCollections({
     sections.completedCount > 0;
   if (!hasAnything) {
     return null;
-  }
-
-  /**
-   * サムネクリックで「台紙 + シェアボタン」のモーダル(完了モード)を表示。
-   * 拡大表示と兼ねるため CollectionProgressModal の完了ビューを再利用する。
-   * 「台紙を更新する」(canRecompose) と threshold は先読みキャッシュから即時反映し、
-   * 未取得ならフォールバックで取得して反映する
-   * (進捗カードが非表示でも完了サムネから台紙を更新できるようにするため)。
-   */
-  function openMountModal(m: CompletedMountView) {
-    const cached = recomposeInfo[m.categoryKey];
-    setCelebrationNonce((n) => n + 1);
-    setCelebration({
-      categoryKey: m.categoryKey,
-      displayName: m.displayName,
-      fromCount: 0,
-      toCount: 0,
-      threshold: cached?.threshold ?? 0,
-      isCompleted: true,
-      mountImageUrl: m.mountImageUrl,
-      sharePath: `/m/${m.completionId}`,
-      completionId: m.completionId,
-      mountTemplateWidth: m.mountTemplateWidth,
-      mountTemplateHeight: m.mountTemplateHeight,
-      characterImageUrl: null,
-      collectedImageUrls: [],
-      canRecompose: cached?.canRecompose ?? false,
-      // 完了済み台紙の見返しなので、紙吹雪ではなくダイヤのきらめき演出にする。
-      celebrationEffect: "sparkle",
-    });
-    if (!cached) {
-      void loadRecomposeInfo(m.categoryKey).then((info) => {
-        if (!info) return;
-        setCelebration((prev) =>
-          prev && prev.completionId === m.completionId
-            ? {
-                ...prev,
-                threshold: info.threshold,
-                canRecompose: info.canRecompose,
-              }
-            : prev,
-        );
-      });
-    }
   }
 
   function openSeriesModal(series: CollectionProgress) {
@@ -367,10 +278,6 @@ export function MyPageCollections({
     });
   }
 
-  const visibleMounts = showAllMounts
-    ? completedMounts
-    : completedMounts.slice(0, MOUNTS_PREVIEW_LIMIT);
-
   return (
     <Card className="mt-4 mb-6 gap-2 px-5 py-3">
       <div className="flex items-baseline justify-between">
@@ -416,50 +323,6 @@ export function MyPageCollections({
               onOpen={() => openSeriesModal(s)}
             />
           ))}
-        </section>
-      ) : null}
-
-      {/* 完成した台紙(アルバム) */}
-      {completedMounts.length > 0 ? (
-        <section className="mt-3 space-y-2">
-          <h3 className="text-sm font-semibold text-gray-700">完成した台紙</h3>
-          <div className="flex flex-wrap gap-3">
-            {visibleMounts.map((m) => (
-              <button
-                key={m.completionId}
-                type="button"
-                onClick={() => openMountModal(m)}
-                className="relative w-24 overflow-hidden rounded-md border border-gray-200"
-                style={{
-                  aspectRatio: mountAspectForCategory(
-                    m.categoryKey,
-                    m.mountTemplateWidth,
-                    m.mountTemplateHeight,
-                  ),
-                }}
-                aria-label={`${m.displayName} のカードを表示`}
-              >
-                <Image
-                  src={m.mountImageUrl}
-                  alt={`${m.displayName} コンプリートカード`}
-                  fill
-                  sizes="96px"
-                  className="object-cover"
-                />
-              </button>
-            ))}
-          </div>
-          {completedMounts.length > MOUNTS_PREVIEW_LIMIT ? (
-            <button
-              type="button"
-              onClick={() => setShowAllMounts((v) => !v)}
-              className="text-xs font-medium text-gray-500 hover:text-gray-700"
-            >
-              {showAllMounts
-                ? "▴ 閉じる"
-                : `▸ もっと見る（${completedMounts.length}）`}
-            </button>
-          ) : null}
         </section>
       ) : null}
 

--- a/features/my-page/components/MyPageCollections.tsx
+++ b/features/my-page/components/MyPageCollections.tsx
@@ -422,7 +422,6 @@ export function MyPageCollections({
       {/* 完成した台紙(アルバム) */}
       {completedMounts.length > 0 ? (
         <section className="mt-3 space-y-2">
-          <h3 className="text-sm font-semibold text-gray-700">完成した台紙</h3>
           <div className="flex flex-wrap gap-3">
             {visibleMounts.map((m) => (
               <button

--- a/tests/unit/features/collections/my-page-collection-sections.test.ts
+++ b/tests/unit/features/collections/my-page-collection-sections.test.ts
@@ -1,0 +1,201 @@
+/** @jest-environment node */
+
+import {
+  buildMyPageCollectionSections,
+  remainingOutfits,
+  ALMOST_DONE_REMAINING_THRESHOLD,
+} from "@/features/collections/lib/my-page-collection-sections";
+import type { CollectionProgress } from "@/features/collections/lib/collection-types";
+
+function makeProgress(
+  overrides: Partial<CollectionProgress> & { categoryKey: string },
+): CollectionProgress {
+  const base: CollectionProgress = {
+    categoryId: `id-${overrides.categoryKey}`,
+    categoryKey: overrides.categoryKey,
+    displayNameJa: overrides.categoryKey,
+    displayNameEn: overrides.categoryKey,
+    completionThreshold: 6,
+    uniqueOutfitCount: 0,
+    isCompleted: false,
+    mountStatus: null,
+    mountImagePath: null,
+    completedAt: null,
+    characterImageUrl: null,
+    collectedImageUrls: [],
+    completionId: null,
+    mountTemplateWidth: null,
+    mountTemplateHeight: null,
+    progressModalFrameUrl: null,
+    progressModalFrameWidth: null,
+    progressModalFrameHeight: null,
+    progressModalSlots: null,
+    progressModalButton: null,
+    progressModalCenter: null,
+    progressModalRingColor: null,
+    progressModalBadgeColor: null,
+    progressModalBadgeTextColor: null,
+    progressModalBadgeBgColor: null,
+    progressModalButtonColor: null,
+    progressModalButtonTextColor: null,
+  };
+  return { ...base, ...overrides };
+}
+
+describe("remainingOutfits", () => {
+  test("残り必要数を返す", () => {
+    expect(
+      remainingOutfits(makeProgress({ categoryKey: "a", uniqueOutfitCount: 4 })),
+    ).toBe(2);
+  });
+  test("超過しても負にならない", () => {
+    expect(
+      remainingOutfits(
+        makeProgress({ categoryKey: "a", uniqueOutfitCount: 8 }),
+      ),
+    ).toBe(0);
+  });
+});
+
+describe("buildMyPageCollectionSections", () => {
+  test("未着手(0/N かつ未完了)は almostDone/inProgress から除外される", () => {
+    const r = buildMyPageCollectionSections([
+      makeProgress({ categoryKey: "untouched", uniqueOutfitCount: 0 }),
+    ]);
+    expect(r.almostDone).toHaveLength(0);
+    expect(r.inProgress).toHaveLength(0);
+    expect(r.hasEngagement).toBe(false);
+    // 看板の分母には未着手も含む(ティーザー)
+    expect(r.totalSeries).toBe(1);
+    expect(r.completedCount).toBe(0);
+  });
+
+  test("残り1〜2着は almostDone に昇格し、それ以外の着手中は inProgress", () => {
+    const r = buildMyPageCollectionSections([
+      makeProgress({ categoryKey: "almost1", uniqueOutfitCount: 5 }), // 残り1
+      makeProgress({ categoryKey: "almost2", uniqueOutfitCount: 4 }), // 残り2
+      makeProgress({ categoryKey: "mid", uniqueOutfitCount: 2 }), // 残り4
+    ]);
+    expect(r.almostDone.map((p) => p.categoryKey)).toEqual(["almost1", "almost2"]);
+    expect(r.inProgress.map((p) => p.categoryKey)).toEqual(["mid"]);
+    expect(r.hasEngagement).toBe(true);
+  });
+
+  test("残り少ない順に並ぶ(同点は着手数の多い順)", () => {
+    const r = buildMyPageCollectionSections([
+      makeProgress({ categoryKey: "rem4", uniqueOutfitCount: 2 }), // 残り4
+      makeProgress({ categoryKey: "rem3", uniqueOutfitCount: 3 }), // 残り3
+      makeProgress({
+        categoryKey: "rem4b",
+        completionThreshold: 10,
+        uniqueOutfitCount: 6,
+      }), // 残り4 だが着手多い
+    ]);
+    // 残り3 が先頭、残り4 同点は着手数が多い rem4b が rem4 より先
+    expect(r.inProgress.map((p) => p.categoryKey)).toEqual([
+      "rem3",
+      "rem4b",
+      "rem4",
+    ]);
+  });
+
+  test("完了済みは almostDone/inProgress に出さず、看板の completedCount に数える", () => {
+    const r = buildMyPageCollectionSections([
+      makeProgress({
+        categoryKey: "done",
+        uniqueOutfitCount: 6,
+        isCompleted: true,
+      }),
+      makeProgress({ categoryKey: "wip", uniqueOutfitCount: 5 }),
+    ]);
+    expect(r.almostDone.map((p) => p.categoryKey)).toEqual(["wip"]);
+    expect(r.inProgress).toHaveLength(0);
+    expect(r.completedCount).toBe(1);
+    expect(r.totalSeries).toBe(2);
+  });
+
+  test("達成済みだが uniqueOutfitCount が閾値未満でも completed 扱い(進行中に出さない)", () => {
+    // mount 完成済み(isCompleted)だが台紙更新前などで count が閾値未満のケース
+    const r = buildMyPageCollectionSections([
+      makeProgress({
+        categoryKey: "edge",
+        uniqueOutfitCount: 5,
+        isCompleted: true,
+      }),
+    ]);
+    expect(r.almostDone).toHaveLength(0);
+    expect(r.inProgress).toHaveLength(0);
+    expect(r.completedCount).toBe(1);
+    expect(r.hasEngagement).toBe(false);
+  });
+
+  test("全着収集済みだが台紙未作成(残り0・未完了)は almostDone に入る(台紙作成へ誘導)", () => {
+    const r = buildMyPageCollectionSections([
+      makeProgress({
+        categoryKey: "ready",
+        uniqueOutfitCount: 6,
+        isCompleted: false,
+      }),
+    ]);
+    expect(r.almostDone.map((p) => p.categoryKey)).toEqual(["ready"]);
+    expect(r.inProgress).toHaveLength(0);
+    expect(r.completedCount).toBe(0);
+    expect(r.hasEngagement).toBe(true);
+  });
+
+  test("看板は完成台紙(別ソース)のカテゴリと union し、N≥M を保証する", () => {
+    // 期間終了/ゲートで progress から消えた完成シリーズが完成台紙だけに存在するケース
+    const r = buildMyPageCollectionSections(
+      [makeProgress({ categoryKey: "wip", uniqueOutfitCount: 5 })],
+      ["ended-collab"], // progress に無いが台紙はあるカテゴリ
+    );
+    // completed は union(progress.isCompleted ∪ 台紙) = 1
+    expect(r.completedCount).toBe(1);
+    // total は union(progress ∪ completed) = {wip, ended-collab} = 2(必ず completed 以上)
+    expect(r.totalSeries).toBe(2);
+    expect(r.totalSeries).toBeGreaterThanOrEqual(r.completedCount);
+  });
+
+  test("看板 union: 完成台紙カテゴリが progress の isCompleted と重複しても二重計上しない", () => {
+    const r = buildMyPageCollectionSections(
+      [
+        makeProgress({
+          categoryKey: "done",
+          uniqueOutfitCount: 6,
+          isCompleted: true,
+        }),
+      ],
+      ["done"], // 同じカテゴリが台紙にもある
+    );
+    expect(r.completedCount).toBe(1);
+    expect(r.totalSeries).toBe(1);
+  });
+
+  test("空配列なら全空・hasEngagement=false", () => {
+    const r = buildMyPageCollectionSections([]);
+    expect(r).toEqual({
+      almostDone: [],
+      inProgress: [],
+      totalSeries: 0,
+      completedCount: 0,
+      hasEngagement: false,
+    });
+  });
+
+  test("ALMOST_DONE_REMAINING_THRESHOLD の境界(残り=閾値はalmost、+1はinProgress)", () => {
+    const r = buildMyPageCollectionSections([
+      makeProgress({
+        categoryKey: "boundary",
+        completionThreshold: 10,
+        uniqueOutfitCount: 10 - ALMOST_DONE_REMAINING_THRESHOLD,
+      }), // 残り=閾値
+      makeProgress({
+        categoryKey: "over",
+        completionThreshold: 10,
+        uniqueOutfitCount: 10 - ALMOST_DONE_REMAINING_THRESHOLD - 1,
+      }), // 残り=閾値+1
+    ]);
+    expect(r.almostDone.map((p) => p.categoryKey)).toEqual(["boundary"]);
+    expect(r.inProgress.map((p) => p.categoryKey)).toEqual(["over"]);
+  });
+});

--- a/tests/unit/features/collections/use-collection-progress.test.tsx
+++ b/tests/unit/features/collections/use-collection-progress.test.tsx
@@ -110,6 +110,24 @@ describe("useCollectionProgress の admin プレビュー", () => {
     expect(c.isCompleted).toBe(true);
   });
 
+  it("完了済みでも collection_from 併用なら100%まで埋まる進捗ビューを強制する", async () => {
+    // makeSeries は isCompleted:true(完了済み)。from を指定すると台紙ビューでなく
+    // 進捗ビュー(5→6で100%になるアニメ)を強制する。
+    mockProgressResponse({ items: [makeSeries()], isAdminViewer: true });
+    setUrl(`/ja?collection_reset=${WAFER_KEY}&collection_to=6&collection_from=5`);
+
+    const { result } = renderHook(() => useCollectionProgress());
+
+    await waitFor(() => expect(result.current.celebration).not.toBeNull());
+    const c = result.current.celebration!;
+    expect(c.fromCount).toBe(5);
+    expect(c.toCount).toBe(6);
+    // 完了済み(isCompleted:true)でも from 併用で進捗ビューを強制
+    expect(c.isCompleted).toBe(false);
+    expect(c.mountImageUrl).toBeNull();
+    expect(c.completionId).toBeNull();
+  });
+
   it("非 admin では collection_reset を無視する", async () => {
     mockProgressResponse({
       items: [makeSeries({ uniqueOutfitCount: 6 })],


### PR DESCRIPTION
### 概要
マイページの「コレクション」が全シリーズを進捗順不問で並べ、未着手(0/N)も出てしまう構造でした。コレクションを常設・複数化するとマイページが 0/N で埋まりクラッターになる課題があり、UX調査の結論に沿って「状態別セクション化 + 未着手の排除」に再設計します。これにより神コレ等を常設化(表示期間NULL)しても全員の 0/N で埋まらない土台を作ります。

### 変更内容
- **未着手(0/N かつ未完了)を一覧から排除**(クラッター解消・常設化の前提)。
- **状態別セクション化**:
  - ✨ **あと少し!**(残り0〜2着)を最上段に昇格。ゴーストスロット(`collectedImageUrls` + `?`)+ CTA。残り1〜2着は生成画面へ、残り0(全着収集済み・台紙未作成)は「台紙を作る」へ誘導。
  - **進行中**:着手済みを達成間近順(残り少ない順、同点は着手数の多い順)で表示。
  - **完成した台紙**:アルバム表示 + 「もっと見る」(7枚以上)。
- **看板コンプ率**「全N中M完成」。完成台紙(別ソース・無フィルタ)のカテゴリと `progress` を **union** して数え、期間終了/ゲートで progress から消えた完成シリーズがあっても「N<M」や「0完成なのにサムネあり」の矛盾が起きないようにする。
- 状態分けの純ロジック `buildMyPageCollectionSections` を切り出し、単体テストを追加(未着手排除・あと少し昇格・達成間近順・残り0昇格・union 看板・境界)。

### 実機テスト
- [ ] iOS Safari でマイページのコレクション表示を確認
- [ ] Android Chrome で確認
- [ ] PC（Chrome）で確認
- [ ] 「あと少し!」CTA(着せる/台紙を作る)の遷移を確認
- [ ] 完成した台紙サムネ→モーダル、進行中行→進捗モーダルが従来どおり動作することを確認

### テスト方法
- `npm run lint`(変更ファイル 0 error) / `npm run typecheck`(本変更由来の新規エラーなし) / `npm run build -- --webpack`(成功)。
- jest: `tests/unit/features/collections`・`tests/unit/features/my-page`(283件 pass)。純ロジック12件を新規追加。
- サブエージェントによる回帰レビューを実施し、看板とアルバムのデータソース乖離(高)を修正済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
