### PR TITLE
feat(collections): コレクション図鑑ページ /collections を追加(発見特化)

### DIFF
--- a/app/collections/page.tsx
+++ b/app/collections/page.tsx
@@ -39,10 +39,8 @@ export default async function CollectionsIndexPage() {
   let userId: string | null = null;
   try {
     const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    userId = user?.id ?? null;
+    const { data } = await supabase.auth.getUser();
+    userId = data?.user?.id ?? null;
   } catch {
     // 取得失敗はゲスト扱い(図鑑は匿名でも閲覧可能)
   }

--- a/app/collections/page.tsx
+++ b/app/collections/page.tsx
@@ -1,0 +1,77 @@
+import type { Metadata } from "next";
+import { connection } from "next/server";
+import { getLocale } from "next-intl/server";
+import { createClient } from "@/lib/supabase/server";
+import { isAdminViewer } from "@/lib/env";
+import { getPublicCollectionSeriesCatalog } from "@/features/collections/lib/collection-catalog-repository";
+import { getCollectionProgressForUser } from "@/features/collections/lib/collection-progress-repository";
+import { buildCollectionCatalogView } from "@/features/collections/lib/collection-catalog-view";
+import { CollectionCatalogGrid } from "@/features/collections/components/CollectionCatalogGrid";
+
+const OGP_IMAGE = "/og/wafer-god.jpg";
+const PAGE_TITLE = "コレクション図鑑｜うちの子で集めよう | Persta.AI";
+const PAGE_DESCRIPTION =
+  "うちの子で楽しめるコレクション一覧。集めてコンプリートカードを完成させ、SNS でシェアしよう。";
+
+export const metadata: Metadata = {
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
+  openGraph: {
+    title: "コレクション図鑑｜うちの子で集めよう",
+    description: "うちの子で楽しめるコレクション一覧。集めてコンプリートしよう。",
+    type: "website",
+    siteName: "Persta.AI",
+    images: [
+      { url: OGP_IMAGE, width: 1200, height: 630, alt: "コレクション | Persta.AI" },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "コレクション図鑑｜うちの子で集めよう",
+    description: "うちの子で楽しめるコレクション一覧。集めてコンプリートしよう。",
+    images: [OGP_IMAGE],
+  },
+};
+
+export default async function CollectionsIndexPage() {
+  await connection();
+
+  let userId: string | null = null;
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    userId = user?.id ?? null;
+  } catch {
+    // 取得失敗はゲスト扱い(図鑑は匿名でも閲覧可能)
+  }
+
+  const localeValue = await getLocale();
+  const locale = localeValue === "en" ? "en" : "ja";
+
+  const [catalog, progress] = await Promise.all([
+    getPublicCollectionSeriesCatalog(),
+    userId
+      ? getCollectionProgressForUser(userId, isAdminViewer(userId))
+      : Promise.resolve([]),
+  ]);
+
+  const entries = buildCollectionCatalogView(catalog, progress);
+
+  return (
+    <main className="mx-auto w-full max-w-3xl px-4 py-6">
+      <header className="mb-4">
+        <h1 className="text-xl font-bold text-gray-900">
+          {locale === "en" ? "Collections" : "コレクション図鑑"}
+        </h1>
+        <p className="mt-1 text-sm text-gray-500">
+          {locale === "en"
+            ? "Collect outfits for your character and complete each card."
+            : "うちの子で集めて、コンプリートカードを完成させよう。"}
+        </p>
+      </header>
+      <CollectionCatalogGrid entries={entries} locale={locale} />
+    </main>
+  );
+}

--- a/features/collections/components/CollectionCatalogGrid.tsx
+++ b/features/collections/components/CollectionCatalogGrid.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { Sparkles } from "lucide-react";
 import type {
+  CollectionCatalogAvailability,
   CollectionCatalogEntry,
   CollectionCatalogState,
 } from "@/features/collections/lib/collection-catalog-view";
@@ -19,20 +20,38 @@ function hrefForEntry(entry: CollectionCatalogEntry): string {
 
 function StateBadge({
   state,
+  availability,
   remaining,
   threshold,
   locale,
 }: {
   state: CollectionCatalogState;
+  availability: CollectionCatalogAvailability;
   remaining: number;
   threshold: number;
   locale: "ja" | "en";
 }) {
+  // 完成は実績としていつでも優先表示。
   if (state === "completed") {
     return (
       <span className="inline-flex items-center gap-1 rounded-full bg-amber-400 px-2 py-0.5 text-[11px] font-bold text-white">
         <Sparkles className="h-3 w-3" aria-hidden="true" />
         {locale === "en" ? "Complete" : "コンプ済み"}
+      </span>
+    );
+  }
+  // 期間外: 集めようと誘わず、終了/近日を正直に出す。
+  if (availability === "ended") {
+    return (
+      <span className="inline-flex items-center rounded-full bg-gray-200 px-2 py-0.5 text-[11px] font-bold text-gray-600">
+        {locale === "en" ? "Ended" : "終了・また登場"}
+      </span>
+    );
+  }
+  if (availability === "upcoming") {
+    return (
+      <span className="inline-flex items-center rounded-full bg-sky-100 px-2 py-0.5 text-[11px] font-bold text-sky-700">
+        {locale === "en" ? "Coming soon" : "近日"}
       </span>
     );
   }
@@ -75,6 +94,26 @@ export function CollectionCatalogGrid({
           entry.completionThreshold > 0
             ? Math.min(1, entry.uniqueOutfitCount / entry.completionThreshold)
             : 0;
+        const dimmed =
+          entry.availability === "ended" || entry.availability === "upcoming";
+        const showProgressBar =
+          entry.state === "in_progress" && entry.availability === "available";
+        const subLabel =
+          entry.state === "completed"
+            ? locale === "en"
+              ? "Completed"
+              : "コンプリート済み"
+            : entry.availability === "ended"
+              ? locale === "en"
+                ? "Coming back soon"
+                : "また登場します"
+              : entry.availability === "upcoming"
+                ? locale === "en"
+                  ? "Coming soon"
+                  : "近日公開"
+                : locale === "en"
+                  ? `Collect all ${entry.completionThreshold}`
+                  : `${entry.completionThreshold}種あつめよう`;
         return (
           <li key={entry.key}>
             <Link
@@ -88,11 +127,7 @@ export function CollectionCatalogGrid({
                     alt={name}
                     fill
                     sizes="(max-width: 640px) 50vw, 200px"
-                    className={`object-cover ${
-                      entry.state === "not_started"
-                        ? "opacity-90"
-                        : "opacity-100"
-                    }`}
+                    className={`object-cover ${dimmed ? "opacity-60 grayscale" : "opacity-100"}`}
                   />
                 ) : (
                   <div
@@ -105,6 +140,7 @@ export function CollectionCatalogGrid({
                 <div className="absolute left-1.5 top-1.5">
                   <StateBadge
                     state={entry.state}
+                    availability={entry.availability}
                     remaining={entry.remaining}
                     threshold={entry.completionThreshold}
                     locale={locale}
@@ -118,7 +154,7 @@ export function CollectionCatalogGrid({
                 >
                   {name}
                 </p>
-                {entry.state === "in_progress" ? (
+                {showProgressBar ? (
                   <div className="mt-1.5 flex items-center gap-1.5">
                     <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-gray-100">
                       <div
@@ -131,11 +167,7 @@ export function CollectionCatalogGrid({
                     </span>
                   </div>
                 ) : (
-                  <p className="mt-1 text-xs text-gray-400">
-                    {locale === "en"
-                      ? `Collect all ${entry.completionThreshold}`
-                      : `${entry.completionThreshold}種あつめよう`}
-                  </p>
+                  <p className="mt-1 text-xs text-gray-400">{subLabel}</p>
                 )}
               </div>
             </Link>

--- a/features/collections/components/CollectionCatalogGrid.tsx
+++ b/features/collections/components/CollectionCatalogGrid.tsx
@@ -44,7 +44,7 @@ function StateBadge({
   if (availability === "ended") {
     return (
       <span className="inline-flex items-center rounded-full bg-gray-200 px-2 py-0.5 text-[11px] font-bold text-gray-600">
-        {locale === "en" ? "Ended" : "終了・また登場"}
+        {locale === "en" ? "Ended" : "終了"}
       </span>
     );
   }
@@ -104,9 +104,7 @@ export function CollectionCatalogGrid({
               ? "Completed"
               : "コンプリート済み"
             : entry.availability === "ended"
-              ? locale === "en"
-                ? "Coming back soon"
-                : "また登場します"
+              ? ""
               : entry.availability === "upcoming"
                 ? locale === "en"
                   ? "Coming soon"
@@ -166,9 +164,9 @@ export function CollectionCatalogGrid({
                       {entry.uniqueOutfitCount}/{entry.completionThreshold}
                     </span>
                   </div>
-                ) : (
+                ) : subLabel ? (
                   <p className="mt-1 text-xs text-gray-400">{subLabel}</p>
-                )}
+                ) : null}
               </div>
             </Link>
           </li>

--- a/features/collections/components/CollectionCatalogGrid.tsx
+++ b/features/collections/components/CollectionCatalogGrid.tsx
@@ -1,21 +1,24 @@
+"use client";
+
+import { useState } from "react";
 import Image from "next/image";
-import Link from "next/link";
 import { Sparkles } from "lucide-react";
+import {
+  CollectionProgressModal,
+  type CollectionCelebration,
+} from "@/features/collections/components/CollectionProgressModal";
 import type {
   CollectionCatalogAvailability,
   CollectionCatalogEntry,
   CollectionCatalogState,
 } from "@/features/collections/lib/collection-catalog-view";
 
-/**
- * 図鑑カードのタップ先。専用ガイドがあるシリーズはそこへ、無ければ集める導線(/style)へ。
- */
-const GUIDE_HREF_BY_KEY: Record<string, string> = {
-  collectible_wafer_sticker_god_6p: "/collections/wafer",
-};
-
-function hrefForEntry(entry: CollectionCatalogEntry): string {
-  return GUIDE_HREF_BY_KEY[entry.key] ?? "/style";
+/** generated-images(public バケット)の保存パスから公開URLを組み立てる(クライアント可)。 */
+function buildMountUrl(path: string | null): string | null {
+  if (!path) return null;
+  const base = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  if (!base) return null;
+  return `${base}/storage/v1/object/public/generated-images/${path}`;
 }
 
 function StateBadge({
@@ -31,7 +34,6 @@ function StateBadge({
   threshold: number;
   locale: "ja" | "en";
 }) {
-  // 完成は実績としていつでも優先表示。
   if (state === "completed") {
     return (
       <span className="inline-flex items-center gap-1 rounded-full bg-amber-400 px-2 py-0.5 text-[11px] font-bold text-white">
@@ -40,7 +42,6 @@ function StateBadge({
       </span>
     );
   }
-  // 期間外: 集めようと誘わず、終了/近日を正直に出す。
   if (availability === "ended") {
     return (
       <span className="inline-flex items-center rounded-full bg-gray-200 px-2 py-0.5 text-[11px] font-bold text-gray-600">
@@ -76,6 +77,11 @@ export function CollectionCatalogGrid({
   entries: CollectionCatalogEntry[];
   locale: "ja" | "en";
 }) {
+  const [celebration, setCelebration] = useState<CollectionCelebration | null>(
+    null,
+  );
+  const [nonce, setNonce] = useState(0);
+
   if (entries.length === 0) {
     return (
       <p className="py-16 text-center text-sm text-gray-500">
@@ -86,34 +92,59 @@ export function CollectionCatalogGrid({
     );
   }
 
+  // コンプリート済みのカードをタップ → 完成台紙(コンプリート)モーダルを開く。
+  function openCompleted(entry: CollectionCatalogEntry, name: string) {
+    setNonce((n) => n + 1);
+    setCelebration({
+      categoryKey: entry.key,
+      displayName: name,
+      fromCount: entry.completionThreshold,
+      toCount: entry.completionThreshold,
+      threshold: entry.completionThreshold,
+      isCompleted: true,
+      mountImageUrl: buildMountUrl(entry.mountImagePath),
+      mountTemplateWidth: entry.mountTemplateWidth,
+      mountTemplateHeight: entry.mountTemplateHeight,
+      sharePath: entry.completionId ? `/m/${entry.completionId}` : null,
+      completionId: entry.completionId,
+      characterImageUrl: null,
+      collectedImageUrls: [],
+      celebrationEffect: "sparkle",
+    });
+  }
+
   return (
-    <ul className="grid grid-cols-2 gap-3 sm:grid-cols-3">
-      {entries.map((entry) => {
-        const name = locale === "en" ? entry.displayNameEn : entry.displayNameJa;
-        const ratio =
-          entry.completionThreshold > 0
-            ? Math.min(1, entry.uniqueOutfitCount / entry.completionThreshold)
-            : 0;
-        // 終了したコレクションはどこにも遷移させない(リンク無効)。
-        const clickable = entry.availability !== "ended";
-        const showProgressBar =
-          entry.state === "in_progress" && entry.availability === "available";
-        const subLabel =
-          entry.state === "completed"
-            ? locale === "en"
-              ? "Completed"
-              : "コンプリート済み"
-            : entry.availability === "ended"
-              ? ""
-              : entry.availability === "upcoming"
-                ? locale === "en"
-                  ? "Coming soon"
-                  : "近日公開"
-                : locale === "en"
-                  ? `Collect all ${entry.completionThreshold}`
-                  : `${entry.completionThreshold}種あつめよう`;
-        const cardInner = (
-          <>
+    <>
+      <ul className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+        {entries.map((entry) => {
+          const name =
+            locale === "en" ? entry.displayNameEn : entry.displayNameJa;
+          const ratio =
+            entry.completionThreshold > 0
+              ? Math.min(1, entry.uniqueOutfitCount / entry.completionThreshold)
+              : 0;
+          // コンプリート者だけタップ可能(=モーダル)。それ以外はどこにも遷移しない。
+          const isClickable = entry.state === "completed";
+          const showProgressBar =
+            entry.state === "in_progress" &&
+            entry.availability === "available";
+          const subLabel =
+            entry.state === "completed"
+              ? locale === "en"
+                ? "Completed"
+                : "コンプリート済み"
+              : entry.availability === "ended"
+                ? ""
+                : entry.availability === "upcoming"
+                  ? locale === "en"
+                    ? "Coming soon"
+                    : "近日公開"
+                  : locale === "en"
+                    ? `Collect all ${entry.completionThreshold}`
+                    : `${entry.completionThreshold}種あつめよう`;
+
+          const cardInner = (
+            <>
               <div className="relative aspect-square bg-gray-100">
                 {entry.imageUrl ? (
                   <Image
@@ -164,25 +195,36 @@ export function CollectionCatalogGrid({
                   <p className="mt-1 text-xs text-gray-400">{subLabel}</p>
                 ) : null}
               </div>
-          </>
-        );
-        return (
-          <li key={entry.key}>
-            {clickable ? (
-              <Link
-                href={hrefForEntry(entry)}
-                className="block overflow-hidden rounded-2xl border border-gray-200 bg-white transition-colors hover:bg-gray-50"
-              >
-                {cardInner}
-              </Link>
-            ) : (
-              <div className="block cursor-default overflow-hidden rounded-2xl border border-gray-200 bg-white">
-                {cardInner}
-              </div>
-            )}
-          </li>
-        );
-      })}
-    </ul>
+            </>
+          );
+
+          return (
+            <li key={entry.key}>
+              {isClickable ? (
+                <button
+                  type="button"
+                  onClick={() => openCompleted(entry, name)}
+                  className="block w-full overflow-hidden rounded-2xl border border-gray-200 bg-white text-left transition-colors hover:bg-gray-50"
+                  aria-label={`${name} のコンプリートカードを表示`}
+                >
+                  {cardInner}
+                </button>
+              ) : (
+                <div className="block overflow-hidden rounded-2xl border border-gray-200 bg-white">
+                  {cardInner}
+                </div>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+
+      <CollectionProgressModal
+        key={celebration ? `${celebration.categoryKey}-${nonce}` : "none"}
+        open={!!celebration}
+        celebration={celebration}
+        onClose={() => setCelebration(null)}
+      />
+    </>
   );
 }

--- a/features/collections/components/CollectionCatalogGrid.tsx
+++ b/features/collections/components/CollectionCatalogGrid.tsx
@@ -1,0 +1,147 @@
+import Image from "next/image";
+import Link from "next/link";
+import { Sparkles } from "lucide-react";
+import type {
+  CollectionCatalogEntry,
+  CollectionCatalogState,
+} from "@/features/collections/lib/collection-catalog-view";
+
+/**
+ * 図鑑カードのタップ先。専用ガイドがあるシリーズはそこへ、無ければ集める導線(/style)へ。
+ */
+const GUIDE_HREF_BY_KEY: Record<string, string> = {
+  collectible_wafer_sticker_god_6p: "/collections/wafer",
+};
+
+function hrefForEntry(entry: CollectionCatalogEntry): string {
+  return GUIDE_HREF_BY_KEY[entry.key] ?? "/style";
+}
+
+function StateBadge({
+  state,
+  remaining,
+  threshold,
+  locale,
+}: {
+  state: CollectionCatalogState;
+  remaining: number;
+  threshold: number;
+  locale: "ja" | "en";
+}) {
+  if (state === "completed") {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-amber-400 px-2 py-0.5 text-[11px] font-bold text-white">
+        <Sparkles className="h-3 w-3" aria-hidden="true" />
+        {locale === "en" ? "Complete" : "コンプ済み"}
+      </span>
+    );
+  }
+  if (state === "in_progress") {
+    return (
+      <span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-bold text-amber-700">
+        {locale === "en" ? `${remaining} left` : `あと${remaining}種`}
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-bold text-gray-500">
+      {locale === "en" ? `${threshold} to collect` : `全${threshold}種`}
+    </span>
+  );
+}
+
+export function CollectionCatalogGrid({
+  entries,
+  locale,
+}: {
+  entries: CollectionCatalogEntry[];
+  locale: "ja" | "en";
+}) {
+  if (entries.length === 0) {
+    return (
+      <p className="py-16 text-center text-sm text-gray-500">
+        {locale === "en"
+          ? "No collections available yet. Check back soon!"
+          : "いまは公開中のコレクションがありません。お楽しみに！"}
+      </p>
+    );
+  }
+
+  return (
+    <ul className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+      {entries.map((entry) => {
+        const name = locale === "en" ? entry.displayNameEn : entry.displayNameJa;
+        const ratio =
+          entry.completionThreshold > 0
+            ? Math.min(1, entry.uniqueOutfitCount / entry.completionThreshold)
+            : 0;
+        return (
+          <li key={entry.key}>
+            <Link
+              href={hrefForEntry(entry)}
+              className="block overflow-hidden rounded-2xl border border-gray-200 bg-white transition-colors hover:bg-gray-50"
+            >
+              <div className="relative aspect-square bg-gray-100">
+                {entry.imageUrl ? (
+                  <Image
+                    src={entry.imageUrl}
+                    alt={name}
+                    fill
+                    sizes="(max-width: 640px) 50vw, 200px"
+                    className={`object-cover ${
+                      entry.state === "not_started"
+                        ? "opacity-90"
+                        : "opacity-100"
+                    }`}
+                  />
+                ) : (
+                  <div
+                    className="flex h-full w-full items-center justify-center text-3xl font-bold text-gray-300"
+                    aria-hidden="true"
+                  >
+                    ?
+                  </div>
+                )}
+                <div className="absolute left-1.5 top-1.5">
+                  <StateBadge
+                    state={entry.state}
+                    remaining={entry.remaining}
+                    threshold={entry.completionThreshold}
+                    locale={locale}
+                  />
+                </div>
+              </div>
+              <div className="p-2.5">
+                <p
+                  className="truncate text-sm font-semibold text-gray-800"
+                  title={name}
+                >
+                  {name}
+                </p>
+                {entry.state === "in_progress" ? (
+                  <div className="mt-1.5 flex items-center gap-1.5">
+                    <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-gray-100">
+                      <div
+                        className="h-full rounded-full bg-amber-400"
+                        style={{ width: `${Math.round(ratio * 100)}%` }}
+                      />
+                    </div>
+                    <span className="shrink-0 text-[11px] font-medium tabular-nums text-gray-500">
+                      {entry.uniqueOutfitCount}/{entry.completionThreshold}
+                    </span>
+                  </div>
+                ) : (
+                  <p className="mt-1 text-xs text-gray-400">
+                    {locale === "en"
+                      ? `Collect all ${entry.completionThreshold}`
+                      : `${entry.completionThreshold}種あつめよう`}
+                  </p>
+                )}
+              </div>
+            </Link>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/features/collections/components/CollectionCatalogGrid.tsx
+++ b/features/collections/components/CollectionCatalogGrid.tsx
@@ -149,7 +149,7 @@ export function CollectionCatalogGrid({
                 {entry.imageUrl ? (
                   <Image
                     src={entry.imageUrl}
-                    alt={name}
+                    alt=""
                     fill
                     sizes="(max-width: 640px) 50vw, 200px"
                     className="object-cover"

--- a/features/collections/components/CollectionCatalogGrid.tsx
+++ b/features/collections/components/CollectionCatalogGrid.tsx
@@ -94,8 +94,8 @@ export function CollectionCatalogGrid({
           entry.completionThreshold > 0
             ? Math.min(1, entry.uniqueOutfitCount / entry.completionThreshold)
             : 0;
-        const dimmed =
-          entry.availability === "ended" || entry.availability === "upcoming";
+        // 終了したコレクションはどこにも遷移させない(リンク無効)。
+        const clickable = entry.availability !== "ended";
         const showProgressBar =
           entry.state === "in_progress" && entry.availability === "available";
         const subLabel =
@@ -112,12 +112,8 @@ export function CollectionCatalogGrid({
                 : locale === "en"
                   ? `Collect all ${entry.completionThreshold}`
                   : `${entry.completionThreshold}種あつめよう`;
-        return (
-          <li key={entry.key}>
-            <Link
-              href={hrefForEntry(entry)}
-              className="block overflow-hidden rounded-2xl border border-gray-200 bg-white transition-colors hover:bg-gray-50"
-            >
+        const cardInner = (
+          <>
               <div className="relative aspect-square bg-gray-100">
                 {entry.imageUrl ? (
                   <Image
@@ -125,7 +121,7 @@ export function CollectionCatalogGrid({
                     alt={name}
                     fill
                     sizes="(max-width: 640px) 50vw, 200px"
-                    className={`object-cover ${dimmed ? "opacity-60 grayscale" : "opacity-100"}`}
+                    className="object-cover"
                   />
                 ) : (
                   <div
@@ -168,7 +164,22 @@ export function CollectionCatalogGrid({
                   <p className="mt-1 text-xs text-gray-400">{subLabel}</p>
                 ) : null}
               </div>
-            </Link>
+          </>
+        );
+        return (
+          <li key={entry.key}>
+            {clickable ? (
+              <Link
+                href={hrefForEntry(entry)}
+                className="block overflow-hidden rounded-2xl border border-gray-200 bg-white transition-colors hover:bg-gray-50"
+              >
+                {cardInner}
+              </Link>
+            ) : (
+              <div className="block cursor-default overflow-hidden rounded-2xl border border-gray-200 bg-white">
+                {cardInner}
+              </div>
+            )}
           </li>
         );
       })}

--- a/features/collections/lib/collection-catalog-repository.ts
+++ b/features/collections/lib/collection-catalog-repository.ts
@@ -20,6 +20,9 @@ export interface CollectionCatalogItem {
   displayOrder: number;
   /** 解放ゲート(設定時は前提カテゴリ完走まで図鑑に出さない)。 */
   unlockPrerequisiteKey: string | null;
+  /** 開催期間(図鑑では「集めよう/終了・また登場/近日」の出し分けに使う)。null は制限なし。 */
+  collectionDisplayStartsAt: string | null;
+  collectionDisplayEndsAt: string | null;
 }
 
 /**
@@ -35,7 +38,7 @@ export async function getPublicCollectionSeriesCatalog(): Promise<
   const { data, error } = await supabase
     .from("preset_categories")
     .select(
-      "id, key, display_name_ja, display_name_en, completion_threshold, collection_character_path, mount_template_path, display_order, unlock_prerequisite_key",
+      "id, key, display_name_ja, display_name_en, completion_threshold, collection_character_path, mount_template_path, display_order, unlock_prerequisite_key, collection_display_starts_at, collection_display_ends_at",
     )
     .eq("is_collection_series", true)
     .eq("is_active", true)
@@ -64,5 +67,9 @@ export async function getPublicCollectionSeriesCatalog(): Promise<
     displayOrder: (row.display_order as number | null) ?? 0,
     unlockPrerequisiteKey:
       (row.unlock_prerequisite_key as string | null) ?? null,
+    collectionDisplayStartsAt:
+      (row.collection_display_starts_at as string | null) ?? null,
+    collectionDisplayEndsAt:
+      (row.collection_display_ends_at as string | null) ?? null,
   }));
 }

--- a/features/collections/lib/collection-catalog-repository.ts
+++ b/features/collections/lib/collection-catalog-repository.ts
@@ -1,0 +1,68 @@
+import "server-only";
+
+import { createAdminClient } from "@/lib/supabase/admin";
+import { buildPublicGeneratedImageUrl } from "./public-mount-server-api";
+
+/**
+ * コレクション図鑑(/collections)の公開カタログ1件。
+ * ログイン不要で「どんなコレクションがあるか」を見せるためのメタ情報。
+ * 進捗(集めた数など)は持たず、ログイン時に CollectionProgress を categoryKey でマージする。
+ */
+export interface CollectionCatalogItem {
+  id: string;
+  key: string;
+  displayNameJa: string;
+  displayNameEn: string;
+  completionThreshold: number;
+  /** 図鑑カードの代表画像(リング中央キャラ)。無ければ台紙テンプレにフォールバック。 */
+  characterImageUrl: string | null;
+  mountTemplateUrl: string | null;
+  displayOrder: number;
+  /** 解放ゲート(設定時は前提カテゴリ完走まで図鑑に出さない)。 */
+  unlockPrerequisiteKey: string | null;
+}
+
+/**
+ * 公開コレクション系列のカタログを取得する(匿名OK)。
+ * is_collection_series=true / is_active=true / visibility=public のみ。
+ * 表示期間(collection_display_*)は進捗UI用なので図鑑カタログでは無視し、
+ * 「どんなコレクションがあるか」を一覧で見せる。失敗時は空配列(致命にしない)。
+ */
+export async function getPublicCollectionSeriesCatalog(): Promise<
+  CollectionCatalogItem[]
+> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("preset_categories")
+    .select(
+      "id, key, display_name_ja, display_name_en, completion_threshold, collection_character_path, mount_template_path, display_order, unlock_prerequisite_key",
+    )
+    .eq("is_collection_series", true)
+    .eq("is_active", true)
+    .eq("visibility", "public")
+    .order("display_order", { ascending: true })
+    .order("key", { ascending: true });
+
+  if (error) {
+    console.error("[collection-catalog-repository] list error:", error);
+    return [];
+  }
+
+  return (data ?? []).map((row) => ({
+    id: row.id as string,
+    key: row.key as string,
+    displayNameJa: row.display_name_ja as string,
+    displayNameEn:
+      (row.display_name_en as string | null) ?? (row.display_name_ja as string),
+    completionThreshold: (row.completion_threshold as number | null) ?? 0,
+    characterImageUrl: buildPublicGeneratedImageUrl(
+      (row.collection_character_path as string | null) ?? null,
+    ),
+    mountTemplateUrl: buildPublicGeneratedImageUrl(
+      (row.mount_template_path as string | null) ?? null,
+    ),
+    displayOrder: (row.display_order as number | null) ?? 0,
+    unlockPrerequisiteKey:
+      (row.unlock_prerequisite_key as string | null) ?? null,
+  }));
+}

--- a/features/collections/lib/collection-catalog-view.ts
+++ b/features/collections/lib/collection-catalog-view.ts
@@ -27,6 +27,11 @@ export interface CollectionCatalogEntry {
   remaining: number;
   state: CollectionCatalogState;
   availability: CollectionCatalogAvailability;
+  /** 完成台紙(コンプリートモーダル表示用)。未完成は null。 */
+  completionId: string | null;
+  mountImagePath: string | null;
+  mountTemplateWidth: number | null;
+  mountTemplateHeight: number | null;
 }
 
 /** 表示期間 [starts, ends) に対する now の開催状況を返す。null は制限なし=available。 */
@@ -102,6 +107,10 @@ export function buildCollectionCatalogView(
         remaining,
         state,
         availability,
+        completionId: p?.completionId ?? null,
+        mountImagePath: p?.mountImagePath ?? null,
+        mountTemplateWidth: p?.mountTemplateWidth ?? null,
+        mountTemplateHeight: p?.mountTemplateHeight ?? null,
       };
     })
     .sort((a, b) => entryRank(a) - entryRank(b));

--- a/features/collections/lib/collection-catalog-view.ts
+++ b/features/collections/lib/collection-catalog-view.ts
@@ -1,0 +1,72 @@
+/**
+ * コレクション図鑑(/collections)の表示用ビューを純ロジックで組み立てる。
+ * カタログ(匿名メタ)とユーザー進捗をマージし、状態(未着手/進行中/完成)を付けて並べ替える。
+ *
+ * - 解放ゲート(unlock_prerequisite_key)が未達のシリーズは図鑑から除外する
+ *   (/style・マイページと同じポリシー。匿名は前提未完走として除外)。
+ * - 並び順は「進行中 → 未着手 → 完成」(集めたくなる順)。同状態はカタログ順(displayOrder)を維持。
+ */
+import type { CollectionCatalogItem } from "./collection-catalog-repository";
+import type { CollectionProgress } from "./collection-types";
+
+export type CollectionCatalogState =
+  | "completed"
+  | "in_progress"
+  | "not_started";
+
+export interface CollectionCatalogEntry {
+  key: string;
+  displayNameJa: string;
+  displayNameEn: string;
+  imageUrl: string | null;
+  completionThreshold: number;
+  uniqueOutfitCount: number;
+  remaining: number;
+  state: CollectionCatalogState;
+}
+
+function stateRank(s: CollectionCatalogState): number {
+  return s === "in_progress" ? 0 : s === "not_started" ? 1 : 2;
+}
+
+export function buildCollectionCatalogView(
+  catalog: readonly CollectionCatalogItem[],
+  progress: readonly CollectionProgress[],
+): CollectionCatalogEntry[] {
+  const progressByKey = new Map(progress.map((p) => [p.categoryKey, p]));
+  const completedKeys = new Set(
+    progress.filter((p) => p.isCompleted).map((p) => p.categoryKey),
+  );
+
+  return catalog
+    .filter((item) => {
+      // 解放ゲート: 前提カテゴリ未完走なら図鑑に出さない。
+      if (!item.unlockPrerequisiteKey) return true;
+      return completedKeys.has(item.unlockPrerequisiteKey);
+    })
+    .map((item) => {
+      const p = progressByKey.get(item.key);
+      const uniqueOutfitCount = p?.uniqueOutfitCount ?? 0;
+      const isCompleted = p?.isCompleted ?? false;
+      const remaining = Math.max(
+        0,
+        item.completionThreshold - uniqueOutfitCount,
+      );
+      const state: CollectionCatalogState = isCompleted
+        ? "completed"
+        : uniqueOutfitCount > 0
+          ? "in_progress"
+          : "not_started";
+      return {
+        key: item.key,
+        displayNameJa: item.displayNameJa,
+        displayNameEn: item.displayNameEn,
+        imageUrl: item.characterImageUrl ?? item.mountTemplateUrl,
+        completionThreshold: item.completionThreshold,
+        uniqueOutfitCount,
+        remaining,
+        state,
+      };
+    })
+    .sort((a, b) => stateRank(a.state) - stateRank(b.state));
+}

--- a/features/collections/lib/collection-catalog-view.ts
+++ b/features/collections/lib/collection-catalog-view.ts
@@ -14,6 +14,9 @@ export type CollectionCatalogState =
   | "in_progress"
   | "not_started";
 
+/** 開催状況: 集められる / 終了(復刻待ち) / 近日(開始前)。 */
+export type CollectionCatalogAvailability = "available" | "ended" | "upcoming";
+
 export interface CollectionCatalogEntry {
   key: string;
   displayNameJa: string;
@@ -23,15 +26,42 @@ export interface CollectionCatalogEntry {
   uniqueOutfitCount: number;
   remaining: number;
   state: CollectionCatalogState;
+  availability: CollectionCatalogAvailability;
 }
 
-function stateRank(s: CollectionCatalogState): number {
-  return s === "in_progress" ? 0 : s === "not_started" ? 1 : 2;
+/** 表示期間 [starts, ends) に対する now の開催状況を返す。null は制限なし=available。 */
+function computeAvailability(
+  startsAt: string | null,
+  endsAt: string | null,
+  now: Date,
+): CollectionCatalogAvailability {
+  if (startsAt) {
+    const s = new Date(startsAt);
+    if (!Number.isNaN(s.getTime()) && now < s) return "upcoming";
+  }
+  if (endsAt) {
+    const e = new Date(endsAt);
+    if (!Number.isNaN(e.getTime()) && now >= e) return "ended";
+  }
+  return "available";
+}
+
+/**
+ * 並び順: 集める導線が活きるものを上に。
+ * 進行中 → 未着手(開催中) → 近日 → 終了 → 完成。
+ */
+function entryRank(entry: CollectionCatalogEntry): number {
+  if (entry.state === "completed") return 4;
+  if (entry.availability === "ended") return 3;
+  if (entry.availability === "upcoming") return 2;
+  if (entry.state === "in_progress") return 0;
+  return 1; // 開催中の未着手
 }
 
 export function buildCollectionCatalogView(
   catalog: readonly CollectionCatalogItem[],
   progress: readonly CollectionProgress[],
+  now: Date = new Date(),
 ): CollectionCatalogEntry[] {
   const progressByKey = new Map(progress.map((p) => [p.categoryKey, p]));
   const completedKeys = new Set(
@@ -57,6 +87,11 @@ export function buildCollectionCatalogView(
         : uniqueOutfitCount > 0
           ? "in_progress"
           : "not_started";
+      const availability = computeAvailability(
+        item.collectionDisplayStartsAt,
+        item.collectionDisplayEndsAt,
+        now,
+      );
       return {
         key: item.key,
         displayNameJa: item.displayNameJa,
@@ -66,7 +101,8 @@ export function buildCollectionCatalogView(
         uniqueOutfitCount,
         remaining,
         state,
+        availability,
       };
     })
-    .sort((a, b) => stateRank(a.state) - stateRank(b.state));
+    .sort((a, b) => entryRank(a) - entryRank(b));
 }

--- a/features/collections/lib/collection-catalog-view.ts
+++ b/features/collections/lib/collection-catalog-view.ts
@@ -87,11 +87,12 @@ export function buildCollectionCatalogView(
         0,
         item.completionThreshold - uniqueOutfitCount,
       );
-      const state: CollectionCatalogState = isCompleted
-        ? "completed"
-        : uniqueOutfitCount > 0
-          ? "in_progress"
-          : "not_started";
+      let state: CollectionCatalogState = "not_started";
+      if (isCompleted) {
+        state = "completed";
+      } else if (uniqueOutfitCount > 0) {
+        state = "in_progress";
+      }
       const availability = computeAvailability(
         item.collectionDisplayStartsAt,
         item.collectionDisplayEndsAt,

--- a/features/my-page/components/MyPageCollections.tsx
+++ b/features/my-page/components/MyPageCollections.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { Check, Sparkles } from "lucide-react";
@@ -269,8 +270,24 @@ export function MyPageCollections({
     completedMounts.length > 0 ||
     sections.hasEngagement ||
     sections.completedCount > 0;
+  // 未参加ユーザーにも図鑑への入口だけは出す(0/N の羅列は出さず、発見導線のみ)。
   if (!hasAnything) {
-    return null;
+    return (
+      <Card className="mt-4 mb-6 gap-2 px-5 py-3">
+        <div className="flex items-center justify-between">
+          <h2 className="text-base font-semibold text-gray-900">コレクション</h2>
+          <Link
+            href="/collections"
+            className="text-xs font-semibold text-amber-600 hover:text-amber-700"
+          >
+            図鑑をみる →
+          </Link>
+        </div>
+        <p className="text-sm text-gray-500">
+          集めて図鑑を完成させよう✨
+        </p>
+      </Card>
+    );
   }
 
   /**
@@ -373,17 +390,25 @@ export function MyPageCollections({
 
   return (
     <Card className="mt-4 mb-6 gap-2 px-5 py-3">
-      <div className="flex items-baseline justify-between">
+      <div className="flex items-baseline justify-between gap-2">
         <h2 className="text-base font-semibold text-gray-900">コレクション</h2>
-        {sections.totalSeries > 0 ? (
-          <span className="text-xs text-gray-500">
-            全{sections.totalSeries}中{" "}
-            <span className="font-semibold text-amber-600">
-              {sections.completedCount}
+        <div className="flex items-baseline gap-3">
+          {sections.totalSeries > 0 ? (
+            <span className="text-xs text-gray-500">
+              全{sections.totalSeries}中{" "}
+              <span className="font-semibold text-amber-600">
+                {sections.completedCount}
+              </span>
+              完成
             </span>
-            完成
-          </span>
-        ) : null}
+          ) : null}
+          <Link
+            href="/collections"
+            className="shrink-0 text-xs font-semibold text-amber-600 hover:text-amber-700"
+          >
+            図鑑をみる →
+          </Link>
+        </div>
       </div>
 
       {/* あと少し!(残り0〜2着を最上段で後押し) */}

--- a/tests/unit/features/collections/collection-catalog-view.test.ts
+++ b/tests/unit/features/collections/collection-catalog-view.test.ts
@@ -17,6 +17,8 @@ function makeCatalogItem(
     mountTemplateUrl: null,
     displayOrder: 0,
     unlockPrerequisiteKey: null,
+    collectionDisplayStartsAt: null,
+    collectionDisplayEndsAt: null,
   };
   return { ...base, ...overrides };
 }
@@ -118,6 +120,81 @@ describe("buildCollectionCatalogView", () => {
       [makeProgress("base", 6, true)],
     );
     expect(view.map((e) => e.key).sort()).toEqual(["base", "gated"]);
+  });
+
+  test("表示期間が過ぎたコレクションは availability='ended'(集めようと誘わない)", () => {
+    const now = new Date("2026-06-22T00:00:00Z");
+    const view = buildCollectionCatalogView(
+      [
+        makeCatalogItem({
+          key: "ended",
+          collectionDisplayStartsAt: "2026-06-13T11:00:00Z",
+          collectionDisplayEndsAt: "2026-06-21T13:00:00Z",
+        }),
+      ],
+      [],
+      now,
+    );
+    expect(view[0]?.availability).toBe("ended");
+  });
+
+  test("開始前のコレクションは availability='upcoming'", () => {
+    const now = new Date("2026-06-10T00:00:00Z");
+    const view = buildCollectionCatalogView(
+      [
+        makeCatalogItem({
+          key: "future",
+          collectionDisplayStartsAt: "2026-06-13T11:00:00Z",
+          collectionDisplayEndsAt: "2026-06-21T13:00:00Z",
+        }),
+      ],
+      [],
+      now,
+    );
+    expect(view[0]?.availability).toBe("upcoming");
+  });
+
+  test("期間内・期間なしは availability='available'", () => {
+    const now = new Date("2026-06-15T00:00:00Z");
+    const view = buildCollectionCatalogView(
+      [
+        makeCatalogItem({ key: "noperiod" }),
+        makeCatalogItem({
+          key: "inperiod",
+          collectionDisplayStartsAt: "2026-06-13T11:00:00Z",
+          collectionDisplayEndsAt: "2026-06-21T13:00:00Z",
+        }),
+      ],
+      [],
+      now,
+    );
+    expect(view.every((e) => e.availability === "available")).toBe(true);
+  });
+
+  test("並び順: 開催中 → 近日 → 終了 → 完成", () => {
+    const now = new Date("2026-06-15T00:00:00Z");
+    const view = buildCollectionCatalogView(
+      [
+        makeCatalogItem({
+          key: "ended",
+          collectionDisplayEndsAt: "2026-06-14T00:00:00Z",
+        }),
+        makeCatalogItem({
+          key: "upcoming",
+          collectionDisplayStartsAt: "2026-06-20T00:00:00Z",
+        }),
+        makeCatalogItem({ key: "available" }),
+        makeCatalogItem({ key: "done" }),
+      ],
+      [makeProgress("done", 6, true)],
+      now,
+    );
+    expect(view.map((e) => e.key)).toEqual([
+      "available",
+      "upcoming",
+      "ended",
+      "done",
+    ]);
   });
 
   test("characterImageUrl が無ければ mountTemplateUrl にフォールバック", () => {

--- a/tests/unit/features/collections/collection-catalog-view.test.ts
+++ b/tests/unit/features/collections/collection-catalog-view.test.ts
@@ -1,0 +1,136 @@
+/** @jest-environment node */
+
+import { buildCollectionCatalogView } from "@/features/collections/lib/collection-catalog-view";
+import type { CollectionCatalogItem } from "@/features/collections/lib/collection-catalog-repository";
+import type { CollectionProgress } from "@/features/collections/lib/collection-types";
+
+function makeCatalogItem(
+  overrides: Partial<CollectionCatalogItem> & { key: string },
+): CollectionCatalogItem {
+  const base: CollectionCatalogItem = {
+    id: `id-${overrides.key}`,
+    key: overrides.key,
+    displayNameJa: overrides.key,
+    displayNameEn: overrides.key,
+    completionThreshold: 6,
+    characterImageUrl: `https://example.com/${overrides.key}.webp`,
+    mountTemplateUrl: null,
+    displayOrder: 0,
+    unlockPrerequisiteKey: null,
+  };
+  return { ...base, ...overrides };
+}
+
+function makeProgress(
+  key: string,
+  uniqueOutfitCount: number,
+  isCompleted = false,
+): CollectionProgress {
+  return {
+    categoryId: `id-${key}`,
+    categoryKey: key,
+    displayNameJa: key,
+    displayNameEn: key,
+    completionThreshold: 6,
+    uniqueOutfitCount,
+    isCompleted,
+    mountStatus: isCompleted ? "completed" : null,
+    mountImagePath: null,
+    completedAt: null,
+    characterImageUrl: null,
+    collectedImageUrls: [],
+    completionId: null,
+    mountTemplateWidth: null,
+    mountTemplateHeight: null,
+    progressModalFrameUrl: null,
+    progressModalFrameWidth: null,
+    progressModalFrameHeight: null,
+    progressModalSlots: null,
+    progressModalButton: null,
+    progressModalCenter: null,
+    progressModalRingColor: null,
+    progressModalBadgeColor: null,
+    progressModalBadgeTextColor: null,
+    progressModalBadgeBgColor: null,
+    progressModalButtonColor: null,
+    progressModalButtonTextColor: null,
+  };
+}
+
+describe("buildCollectionCatalogView", () => {
+  test("匿名(進捗なし)は全カタログを未着手で返す", () => {
+    const view = buildCollectionCatalogView(
+      [makeCatalogItem({ key: "a" }), makeCatalogItem({ key: "b" })],
+      [],
+    );
+    expect(view).toHaveLength(2);
+    expect(view.every((e) => e.state === "not_started")).toBe(true);
+    expect(view[0]?.uniqueOutfitCount).toBe(0);
+    expect(view[0]?.remaining).toBe(6);
+    expect(view[0]?.imageUrl).toBe("https://example.com/a.webp");
+  });
+
+  test("進捗をマージして状態を付ける(完成/進行中/未着手)", () => {
+    const view = buildCollectionCatalogView(
+      [
+        makeCatalogItem({ key: "done" }),
+        makeCatalogItem({ key: "wip" }),
+        makeCatalogItem({ key: "new" }),
+      ],
+      [makeProgress("done", 6, true), makeProgress("wip", 3)],
+    );
+    const byKey = Object.fromEntries(view.map((e) => [e.key, e]));
+    expect(byKey.done.state).toBe("completed");
+    expect(byKey.wip.state).toBe("in_progress");
+    expect(byKey.wip.remaining).toBe(3);
+    expect(byKey.new.state).toBe("not_started");
+  });
+
+  test("並び順は 進行中 → 未着手 → 完成", () => {
+    const view = buildCollectionCatalogView(
+      [
+        makeCatalogItem({ key: "done" }),
+        makeCatalogItem({ key: "new" }),
+        makeCatalogItem({ key: "wip" }),
+      ],
+      [makeProgress("done", 6, true), makeProgress("wip", 2)],
+    );
+    expect(view.map((e) => e.key)).toEqual(["wip", "new", "done"]);
+  });
+
+  test("解放ゲート: 前提カテゴリ未完走のシリーズは除外する", () => {
+    const view = buildCollectionCatalogView(
+      [
+        makeCatalogItem({ key: "base" }),
+        makeCatalogItem({ key: "gated", unlockPrerequisiteKey: "base" }),
+      ],
+      [], // base 未完走
+    );
+    expect(view.map((e) => e.key)).toEqual(["base"]);
+  });
+
+  test("解放ゲート: 前提カテゴリ完走済みなら表示する", () => {
+    const view = buildCollectionCatalogView(
+      [
+        makeCatalogItem({ key: "base" }),
+        makeCatalogItem({ key: "gated", unlockPrerequisiteKey: "base" }),
+      ],
+      [makeProgress("base", 6, true)],
+    );
+    expect(view.map((e) => e.key).sort()).toEqual(["base", "gated"]);
+  });
+
+  test("characterImageUrl が無ければ mountTemplateUrl にフォールバック", () => {
+    const view = buildCollectionCatalogView(
+      [
+        makeCatalogItem({
+          key: "a",
+          characterImageUrl: null,
+          mountTemplateUrl: "https://example.com/mount.png",
+        }),
+      ],
+      [],
+    );
+    expect(view[0]?.imageUrl).toBe("https://example.com/mount.png");
+  });
+});


### PR DESCRIPTION
### 概要
これまでは「神コレ等のカテゴリを生成して初めて」コレクション機能の存在に気づく状態で、他カテゴリしか使わないユーザーには発見の手段がありませんでした。発見に特化した公開ページ **`/collections`(コレクション図鑑)** を新設し、どんなコレクションがあるかを一覧で見せて「集める」導線につなげます。完成台紙はマイページに残し、図鑑は発見に専念します。

### 変更内容
- **新規ページ `app/collections/page.tsx`**(`/collections/wafer` と同じ public・**匿名OK**・metadata/OGP付き)。
- **公開カタログ取得** `getPublicCollectionSeriesCatalog()`(匿名でも `preset_categories` の is_collection_series/active/public を一覧。キャラ画像を公開URL化)。
- **ログイン時は進捗をマージ**(`getCollectionProgressForUser`)し、状態(進行中/未着手/完成)+ 達成間近順で表示。**解放ゲート未達シリーズ(例: 神コレ未完走時のぷち神)は図鑑から除外**。
- 純ロジック `buildCollectionCatalogView`(マージ/状態判定/ゲート/並び替え)を切り出し、単体テスト6件を追加。
- **カード `CollectionCatalogGrid`**: 画像 + 名前 + 状態バッジ(コンプ済み/あと◯種/全N種)+ 進捗バー。タップで集める導線(神コレ→`/collections/wafer`、他→`/style`)。
- **マイページのコレクション欄に「図鑑をみる →」入口を追加**。未参加ユーザーにも発見できるよう、コレクション未着手でも 0/N の羅列は出さずに「集めて図鑑を完成させよう✨ / 図鑑をみる →」の入口だけを表示。

### 実機テスト
- [ ] iOS Safari で `/collections` 表示・カードのリンク遷移を確認
- [ ] Android Chrome で確認
- [ ] PC（Chrome）で確認
- [ ] ログイン時は進捗(状態バッジ/進捗バー)が反映されることを確認
- [ ] 未ログイン(匿名)でも一覧が表示されることを確認
- [ ] マイページの「図鑑をみる →」から遷移できることを確認

### テスト方法
- `npm run lint`(変更ファイル 0 error) / `npm run typecheck`(本変更由来の新規エラーなし) / `npm run build -- --webpack`(成功・`/collections` ルート生成を確認)。
- jest: `tests/unit/features/collections`・`tests/unit/features/my-page`(290件 pass)。`buildCollectionCatalogView` の単体テスト6件を新規追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
