### PR TITLE
feat(preset-categories): 出力比率に明示9段階(9:16〜16:9)を追加

### DIFF
--- a/app/api/admin/preset-categories/[id]/route.ts
+++ b/app/api/admin/preset-categories/[id]/route.ts
@@ -157,7 +157,12 @@ export async function PATCH(
       | "dual";
   }
   if (body.output_aspect_ratio_mode !== undefined) {
-    if (!isStyleOutputAspectRatioMode(body.output_aspect_ratio_mode)) {
+    // 後方互換: 旧 "square" は "1:1" として受け付ける。
+    const mode =
+      body.output_aspect_ratio_mode === "square"
+        ? "1:1"
+        : body.output_aspect_ratio_mode;
+    if (!isStyleOutputAspectRatioMode(mode)) {
       return NextResponse.json(
         {
           error:
@@ -166,7 +171,7 @@ export async function PATCH(
         { status: 400 },
       );
     }
-    update.outputAspectRatioMode = body.output_aspect_ratio_mode;
+    update.outputAspectRatioMode = mode;
   }
   if (body.user_guidance_ja !== undefined) {
     if (

--- a/app/api/admin/preset-categories/[id]/route.ts
+++ b/app/api/admin/preset-categories/[id]/route.ts
@@ -8,9 +8,9 @@ import {
   getPresetCategoryById,
   PRESET_CATEGORY_IMAGE_INPUT_MODES,
   STYLE_PRESET_CATEGORY_VISIBILITY_VALUES,
-  STYLE_OUTPUT_ASPECT_RATIO_MODES,
   updatePresetCategory,
 } from "@/features/style-presets/lib/preset-category-repository";
+import { isStyleOutputAspectRatioMode } from "@/shared/generation/style-output-aspect-ratio";
 import { parseCollectionSettings } from "../collection-settings-payload";
 import { GENERATION_PROMPT_MAX_LENGTH } from "@/lib/generation/prompt-validation";
 
@@ -157,20 +157,16 @@ export async function PATCH(
       | "dual";
   }
   if (body.output_aspect_ratio_mode !== undefined) {
-    if (
-      typeof body.output_aspect_ratio_mode !== "string" ||
-      !STYLE_OUTPUT_ASPECT_RATIO_MODES.includes(
-        body.output_aspect_ratio_mode as "source" | "square",
-      )
-    ) {
+    if (!isStyleOutputAspectRatioMode(body.output_aspect_ratio_mode)) {
       return NextResponse.json(
-        { error: "output_aspect_ratio_mode must be 'source' or 'square'" },
+        {
+          error:
+            "output_aspect_ratio_mode must be 'source' or one of 9:16,4:5,3:4,2:3,1:1,3:2,4:3,5:4,16:9",
+        },
         { status: 400 },
       );
     }
-    update.outputAspectRatioMode = body.output_aspect_ratio_mode as
-      | "source"
-      | "square";
+    update.outputAspectRatioMode = body.output_aspect_ratio_mode;
   }
   if (body.user_guidance_ja !== undefined) {
     if (

--- a/app/api/admin/preset-categories/route.ts
+++ b/app/api/admin/preset-categories/route.ts
@@ -214,7 +214,12 @@ export async function POST(request: NextRequest) {
       | "dual";
   }
   if (body.output_aspect_ratio_mode !== undefined) {
-    if (!isStyleOutputAspectRatioMode(body.output_aspect_ratio_mode)) {
+    // 後方互換: 旧 "square" は "1:1" として受け付ける。
+    const mode =
+      body.output_aspect_ratio_mode === "square"
+        ? "1:1"
+        : body.output_aspect_ratio_mode;
+    if (!isStyleOutputAspectRatioMode(mode)) {
       return NextResponse.json(
         {
           error:
@@ -223,7 +228,7 @@ export async function POST(request: NextRequest) {
         { status: 400 },
       );
     }
-    payload.outputAspectRatioMode = body.output_aspect_ratio_mode;
+    payload.outputAspectRatioMode = mode;
   }
   if (body.user_guidance_ja !== undefined) {
     if (body.user_guidance_ja !== null && typeof body.user_guidance_ja !== "string") {

--- a/app/api/admin/preset-categories/route.ts
+++ b/app/api/admin/preset-categories/route.ts
@@ -8,8 +8,11 @@ import {
   listPresetCategories,
   PRESET_CATEGORY_IMAGE_INPUT_MODES,
   STYLE_PRESET_CATEGORY_VISIBILITY_VALUES,
-  STYLE_OUTPUT_ASPECT_RATIO_MODES,
 } from "@/features/style-presets/lib/preset-category-repository";
+import {
+  isStyleOutputAspectRatioMode,
+  type StyleOutputAspectRatioMode,
+} from "@/shared/generation/style-output-aspect-ratio";
 import { parseCollectionSettings } from "./collection-settings-payload";
 import type { MountLayoutKey } from "@/features/collections/lib/mount-layouts";
 import { GENERATION_PROMPT_MAX_LENGTH } from "@/lib/generation/prompt-validation";
@@ -67,7 +70,7 @@ interface ParsedCreatePayload {
   badgeTextColor?: string;
   skipBasePrefix?: boolean;
   defaultImageInputMode?: "single" | "dual";
-  outputAspectRatioMode?: "source" | "square";
+  outputAspectRatioMode?: StyleOutputAspectRatioMode;
   userGuidanceJa?: string | null;
   userGuidanceEn?: string | null;
   showSourceImageTypeControl?: boolean;
@@ -211,20 +214,16 @@ export async function POST(request: NextRequest) {
       | "dual";
   }
   if (body.output_aspect_ratio_mode !== undefined) {
-    if (
-      typeof body.output_aspect_ratio_mode !== "string" ||
-      !STYLE_OUTPUT_ASPECT_RATIO_MODES.includes(
-        body.output_aspect_ratio_mode as "source" | "square",
-      )
-    ) {
+    if (!isStyleOutputAspectRatioMode(body.output_aspect_ratio_mode)) {
       return NextResponse.json(
-        { error: "output_aspect_ratio_mode must be 'source' or 'square'" },
+        {
+          error:
+            "output_aspect_ratio_mode must be 'source' or one of 9:16,4:5,3:4,2:3,1:1,3:2,4:3,5:4,16:9",
+        },
         { status: 400 },
       );
     }
-    payload.outputAspectRatioMode = body.output_aspect_ratio_mode as
-      | "source"
-      | "square";
+    payload.outputAspectRatioMode = body.output_aspect_ratio_mode;
   }
   if (body.user_guidance_ja !== undefined) {
     if (body.user_guidance_ja !== null && typeof body.user_guidance_ja !== "string") {

--- a/features/generation/lib/guest-generate.ts
+++ b/features/generation/lib/guest-generate.ts
@@ -6,7 +6,6 @@ import {
   parseImageDimensions,
   type OpenAIImageEditResult,
 } from "@/features/generation/lib/openai-image";
-import { resolveGeminiAspectRatio } from "@/shared/generation/gemini-aspect-ratio";
 import {
   GUEST_ALLOWED_MODELS,
   parseGuestRequestedModel,
@@ -29,6 +28,7 @@ import {
 } from "@/features/i2i-poc/shared/image-constraints";
 import { getGptImage2TargetSize } from "@/shared/generation/openai-image-model";
 import {
+  resolveOutputAspectRatio,
   shouldForceSquareStyleOutput,
   type StyleOutputAspectRatioMode,
 } from "@/shared/generation/style-output-aspect-ratio";
@@ -363,9 +363,11 @@ async function dispatchGemini(
   const imageSize = extractImageSize(input.model as GeminiOnlyModel);
   const { part: imagePart, dimensions: inputDimensions } =
     await fileToInlineDataPartWithDimensions(input.uploadImage);
-  const aspectRatio = shouldForceSquareStyleOutput(input.outputAspectRatioMode)
-    ? "1:1"
-    : resolveGeminiAspectRatio(inputDimensions);
+  // モード="source" は入力比率を自動スナップ、明示比率はその比率で出力する。
+  const aspectRatio = resolveOutputAspectRatio(
+    input.outputAspectRatioMode,
+    inputDimensions,
+  );
   const parts: GeminiContentPart[] = [
     { text: input.promptText },
     imagePart,

--- a/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
+++ b/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
@@ -16,6 +16,10 @@ import {
   setSlotCount,
   splitSlots,
 } from "@/features/collections/lib/slot-edit-geometry";
+import {
+  EXPLICIT_OUTPUT_ASPECT_RATIOS,
+  type StyleOutputAspectRatioMode,
+} from "@/shared/generation/style-output-aspect-ratio";
 import { MountSlotEditor } from "@/features/preset-categories/components/MountSlotEditor";
 import { ProgressModalColorPreview } from "@/features/preset-categories/components/ProgressModalColorPreview";
 
@@ -52,7 +56,7 @@ interface FormState {
   badgeTextColor: string;
   skipBasePrefix: boolean;
   defaultImageInputMode: "single" | "dual";
-  outputAspectRatioMode: "source" | "square";
+  outputAspectRatioMode: StyleOutputAspectRatioMode;
   userGuidanceJa: string;
   userGuidanceEn: string;
   showSourceImageTypeControl: boolean;
@@ -922,16 +926,21 @@ export function AdminPresetCategoryFormClient({
             onChange={(e) =>
               update(
                 "outputAspectRatioMode",
-                e.target.value as "source" | "square",
+                e.target.value as StyleOutputAspectRatioMode,
               )
             }
             className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm"
           >
-            <option value="source">アップロード画像に合わせる</option>
-            <option value="square">正方形固定 (1:1)</option>
+            <option value="source">アップロード画像に合わせる(自動)</option>
+            {EXPLICIT_OUTPUT_ASPECT_RATIOS.map((ratio) => (
+              <option key={ratio} value={ratio}>
+                {ratio}
+                {ratio === "1:1" ? "(正方形)" : ""}
+              </option>
+            ))}
           </select>
           <span className="mt-1 block text-xs text-slate-500">
-            正方形固定にすると、このカテゴリの preset 生成は Gemini / OpenAI ともに 1:1 で出力します。
+            「自動」はアップロード画像の比率に合わせて9段階(9:16〜16:9)の最も近い比率で出力します。比率を明示指定すると、このカテゴリの生成は常にその比率で出力します(Gemini)。OpenAI は 1:1 のみ固定に対応。
           </span>
         </label>
 

--- a/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
+++ b/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
@@ -932,12 +932,16 @@ export function AdminPresetCategoryFormClient({
             className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm"
           >
             <option value="source">アップロード画像に合わせる(自動)</option>
-            {EXPLICIT_OUTPUT_ASPECT_RATIOS.map((ratio) => (
-              <option key={ratio} value={ratio}>
-                {ratio}
-                {ratio === "1:1" ? "(正方形)" : ""}
-              </option>
-            ))}
+            {EXPLICIT_OUTPUT_ASPECT_RATIOS.map((ratio) => {
+              const [w, h] = ratio.split(":").map(Number);
+              const orientation =
+                w === h ? "正方形" : w > h ? "横長" : "縦長";
+              return (
+                <option key={ratio} value={ratio}>
+                  {ratio}（{orientation}）
+                </option>
+              );
+            })}
           </select>
           <span className="mt-1 block text-xs text-slate-500">
             「自動」はアップロード画像の比率に合わせて9段階(9:16〜16:9)の最も近い比率で出力します。比率を明示指定すると、このカテゴリの生成は常にその比率で出力します(Gemini)。OpenAI は 1:1 のみ固定に対応。

--- a/features/preset-categories/components/AdminPresetCategoryListClient.tsx
+++ b/features/preset-categories/components/AdminPresetCategoryListClient.tsx
@@ -61,9 +61,9 @@ export function AdminPresetCategoryListClient({ categories }: Props) {
                       </span>
                       <span className="rounded bg-slate-100 px-1.5 py-0.5 text-xs text-slate-700">
                         出力比率:{" "}
-                        {category.outputAspectRatioMode === "square"
-                          ? "正方形固定"
-                          : "アップロード画像に合わせる"}
+                        {category.outputAspectRatioMode === "source"
+                          ? "アップロードに合わせる"
+                          : category.outputAspectRatioMode}
                       </span>
                       <span
                         className={`rounded px-1.5 py-0.5 text-xs font-medium ${

--- a/features/style-presets/lib/style-preset-repository.ts
+++ b/features/style-presets/lib/style-preset-repository.ts
@@ -1,4 +1,5 @@
 import { createAdminClient } from "@/lib/supabase/admin";
+import { normalizeStyleOutputAspectRatioMode } from "@/shared/generation/style-output-aspect-ratio";
 import {
   buildStylePresetSlug,
   normalizeStylePresetOptionalPrompt,
@@ -186,8 +187,9 @@ function mapCategoryRefStrict(
     badgeColor: embedded.badge_color,
     badgeTextColor: embedded.badge_text_color,
     skipBasePrefix: embedded.skip_base_prefix,
-    outputAspectRatioMode:
-      embedded.output_aspect_ratio_mode === "square" ? "square" : "source",
+    outputAspectRatioMode: normalizeStyleOutputAspectRatioMode(
+      embedded.output_aspect_ratio_mode,
+    ),
     userGuidanceJa: embedded.user_guidance_ja ?? null,
     userGuidanceEn: embedded.user_guidance_en ?? null,
     showSourceImageTypeControl: embedded.show_source_image_type_control ?? true,

--- a/shared/generation/style-output-aspect-ratio.ts
+++ b/shared/generation/style-output-aspect-ratio.ts
@@ -1,22 +1,78 @@
-export const STYLE_OUTPUT_ASPECT_RATIO_MODES = ["source", "square"] as const;
+/**
+ * preset_categories.output_aspect_ratio_mode の正規化と、最終出力アスペクト比の解決。
+ *
+ * モード:
+ * - "source"  … アップロード画像の比率に合わせて自動選択(9段階の最近傍にスナップ)
+ * - 明示比率   … "9:16" 〜 "16:9" の固定比率(コーディネート/style の自動選択と同じ9段階)
+ * - "square"  … 旧仕様の別名。正規化時に "1:1" として扱う(後方互換)
+ *
+ * Edge Function (Deno) / Next.js (Node) 双方から import するため pure TypeScript。
+ */
+import {
+  GEMINI_SUPPORTED_ASPECT_RATIOS,
+  resolveGeminiAspectRatio,
+  type GeminiAspectRatio,
+} from "./gemini-aspect-ratio";
+
+/** 明示指定できる比率(自動選択が使う9段階と一致)。 */
+export const EXPLICIT_OUTPUT_ASPECT_RATIOS: readonly GeminiAspectRatio[] =
+  GEMINI_SUPPORTED_ASPECT_RATIOS.map((entry) => entry.label);
+
+/** admin で選択できる出力比率モード。"source"(自動) + 明示9比率。 */
+export const STYLE_OUTPUT_ASPECT_RATIO_MODES = [
+  "source",
+  "9:16",
+  "4:5",
+  "3:4",
+  "2:3",
+  "1:1",
+  "3:2",
+  "4:3",
+  "5:4",
+  "16:9",
+] as const;
 
 export type StyleOutputAspectRatioMode =
   (typeof STYLE_OUTPUT_ASPECT_RATIO_MODES)[number];
 
+const EXPLICIT_SET: ReadonlySet<string> = new Set(EXPLICIT_OUTPUT_ASPECT_RATIOS);
+
 export function isStyleOutputAspectRatioMode(
   value: unknown,
 ): value is StyleOutputAspectRatioMode {
-  return value === "source" || value === "square";
+  return (
+    value === "source" || (typeof value === "string" && EXPLICIT_SET.has(value))
+  );
 }
 
 export function normalizeStyleOutputAspectRatioMode(
   value: unknown,
 ): StyleOutputAspectRatioMode {
+  // 旧仕様 "square" は 1:1 として扱う(後方互換)。
+  if (value === "square") return "1:1";
   return isStyleOutputAspectRatioMode(value) ? value : "source";
 }
 
-export function shouldForceSquareStyleOutput(
+/**
+ * モード + 入力画像寸法から、最終的な Gemini 出力アスペクト比を解決する。
+ * - "source" … 入力寸法を9段階の最近傍にスナップ(自動選択)
+ * - 明示比率 … その比率をそのまま使う
+ */
+export function resolveOutputAspectRatio(
   mode: unknown,
-): boolean {
-  return normalizeStyleOutputAspectRatioMode(mode) === "square";
+  inputDimensions: { width: number; height: number } | null | undefined,
+): GeminiAspectRatio {
+  const normalized = normalizeStyleOutputAspectRatioMode(mode);
+  if (normalized === "source") {
+    return resolveGeminiAspectRatio(inputDimensions);
+  }
+  return normalized;
+}
+
+/**
+ * 1:1 固定かどうか(OpenAI/GPT Image 2 の正方形 targetSize 判定など、
+ * 比率を直接渡せない経路で使う後方互換ヘルパー)。
+ */
+export function shouldForceSquareStyleOutput(mode: unknown): boolean {
+  return normalizeStyleOutputAspectRatioMode(mode) === "1:1";
 }

--- a/shared/generation/style-output-aspect-ratio.ts
+++ b/shared/generation/style-output-aspect-ratio.ts
@@ -12,7 +12,7 @@ import {
   GEMINI_SUPPORTED_ASPECT_RATIOS,
   resolveGeminiAspectRatio,
   type GeminiAspectRatio,
-} from "./gemini-aspect-ratio";
+} from "./gemini-aspect-ratio.ts";
 
 /** 明示指定できる比率(自動選択が使う9段階と一致)。 */
 export const EXPLICIT_OUTPUT_ASPECT_RATIOS: readonly GeminiAspectRatio[] =

--- a/supabase/migrations/20260621120000_extend_output_aspect_ratio_modes.sql
+++ b/supabase/migrations/20260621120000_extend_output_aspect_ratio_modes.sql
@@ -1,0 +1,49 @@
+-- preset_categories.output_aspect_ratio_mode を「自動(source) + 明示9比率」に拡張する。
+--
+-- 旧仕様: CHECK (output_aspect_ratio_mode IN ('source','square'))
+-- 新仕様: 'source'(アップロード比率に合わせて自動選択) +
+--         コーディネート/style の自動選択と同じ9段階の明示比率
+--         ('9:16','4:5','3:4','2:3','1:1','3:2','4:3','5:4','16:9')
+--
+-- 既存の 'square' は '1:1' に移行する(出力は同じ正方形)。
+-- 旧 CHECK 制約名に依存しないよう、列を参照する CHECK 制約を動的に全て drop してから貼り直す。
+
+DO $$
+DECLARE
+  conname_var text;
+BEGIN
+  -- 1) 先に output_aspect_ratio_mode を参照する CHECK 制約を全て削除する。
+  --    (旧 CHECK('source','square') が有効なままだと次の UPDATE で '1:1' が違反するため)
+  FOR conname_var IN
+    SELECT con.conname
+    FROM pg_constraint con
+    JOIN pg_class rel ON rel.oid = con.conrelid
+    JOIN pg_namespace ns ON ns.oid = rel.relnamespace
+    WHERE ns.nspname = 'public'
+      AND rel.relname = 'preset_categories'
+      AND con.contype = 'c'
+      AND pg_get_constraintdef(con.oid) ILIKE '%output_aspect_ratio_mode%'
+  LOOP
+    EXECUTE format(
+      'ALTER TABLE public.preset_categories DROP CONSTRAINT %I',
+      conname_var
+    );
+  END LOOP;
+
+  -- 2) 既存 'square' → '1:1'(制約が無い状態で実行)
+  UPDATE public.preset_categories
+  SET output_aspect_ratio_mode = '1:1'
+  WHERE output_aspect_ratio_mode = 'square';
+
+  -- 3) 新しい CHECK を貼る
+  ALTER TABLE public.preset_categories
+    ADD CONSTRAINT preset_categories_output_aspect_ratio_mode_check
+    CHECK (
+      output_aspect_ratio_mode IN (
+        'source', '9:16', '4:5', '3:4', '2:3', '1:1', '3:2', '4:3', '5:4', '16:9'
+      )
+    );
+END $$;
+
+COMMENT ON COLUMN public.preset_categories.output_aspect_ratio_mode IS
+  'source = アップロード比率に合わせて自動選択(9段階の最近傍) / 9:16〜16:9 = 明示比率固定(コーディネート/styleの自動選択と同じ9段階)';

--- a/tests/unit/features/generation/guest-generate.test.ts
+++ b/tests/unit/features/generation/guest-generate.test.ts
@@ -333,7 +333,7 @@ describe("guest-generate", () => {
         uploadImage: new File([createPngHeader(1600, 900)], "wide.png", {
           type: "image/png",
         }),
-        outputAspectRatioMode: "square",
+        outputAspectRatioMode: "1:1",
         geminiApiKey: "key",
         fetchFn: fetchFn as unknown as typeof fetch,
       });
@@ -663,7 +663,7 @@ describe("guest-generate", () => {
         uploadImage: new File([createPngHeader(1600, 900)], "wide.png", {
           type: "image/png",
         }),
-        outputAspectRatioMode: "square",
+        outputAspectRatioMode: "1:1",
         geminiApiKey: "(unused)",
         openaiApiKey: "openai-key",
         openaiClient,

--- a/tests/unit/shared/generation/style-output-aspect-ratio.test.ts
+++ b/tests/unit/shared/generation/style-output-aspect-ratio.test.ts
@@ -1,0 +1,93 @@
+/** @jest-environment node */
+
+import {
+  EXPLICIT_OUTPUT_ASPECT_RATIOS,
+  STYLE_OUTPUT_ASPECT_RATIO_MODES,
+  isStyleOutputAspectRatioMode,
+  normalizeStyleOutputAspectRatioMode,
+  resolveOutputAspectRatio,
+  shouldForceSquareStyleOutput,
+} from "@/shared/generation/style-output-aspect-ratio";
+
+describe("style-output-aspect-ratio", () => {
+  test("明示比率は自動選択(Gemini)の9段階と一致する", () => {
+    expect([...EXPLICIT_OUTPUT_ASPECT_RATIOS]).toEqual([
+      "9:16",
+      "4:5",
+      "3:4",
+      "2:3",
+      "1:1",
+      "3:2",
+      "4:3",
+      "5:4",
+      "16:9",
+    ]);
+    // モード一覧 = source + 9比率
+    expect(STYLE_OUTPUT_ASPECT_RATIO_MODES.length).toBe(10);
+    expect(STYLE_OUTPUT_ASPECT_RATIO_MODES[0]).toBe("source");
+  });
+
+  describe("isStyleOutputAspectRatioMode", () => {
+    test("source と 9比率は true", () => {
+      expect(isStyleOutputAspectRatioMode("source")).toBe(true);
+      expect(isStyleOutputAspectRatioMode("3:4")).toBe(true);
+      expect(isStyleOutputAspectRatioMode("16:9")).toBe(true);
+    });
+    test("square や未知値は false(明示モードではない)", () => {
+      expect(isStyleOutputAspectRatioMode("square")).toBe(false);
+      expect(isStyleOutputAspectRatioMode("2:1")).toBe(false);
+      expect(isStyleOutputAspectRatioMode(null)).toBe(false);
+    });
+  });
+
+  describe("normalizeStyleOutputAspectRatioMode", () => {
+    test("旧 square は 1:1 に正規化する(後方互換)", () => {
+      expect(normalizeStyleOutputAspectRatioMode("square")).toBe("1:1");
+    });
+    test("有効値はそのまま、未知値は source", () => {
+      expect(normalizeStyleOutputAspectRatioMode("3:4")).toBe("3:4");
+      expect(normalizeStyleOutputAspectRatioMode("source")).toBe("source");
+      expect(normalizeStyleOutputAspectRatioMode("xxx")).toBe("source");
+      expect(normalizeStyleOutputAspectRatioMode(undefined)).toBe("source");
+    });
+  });
+
+  describe("resolveOutputAspectRatio", () => {
+    test("source は入力寸法を最近傍にスナップ(自動選択)", () => {
+      // 横長入力 → 16:9 付近
+      expect(resolveOutputAspectRatio("source", { width: 1920, height: 1080 })).toBe(
+        "16:9",
+      );
+      // 縦長入力 → 3:4 付近
+      expect(resolveOutputAspectRatio("source", { width: 900, height: 1200 })).toBe(
+        "3:4",
+      );
+      // 寸法不明 → 1:1 フォールバック
+      expect(resolveOutputAspectRatio("source", null)).toBe("1:1");
+    });
+
+    test("明示比率は入力寸法に関係なくその比率を返す", () => {
+      expect(resolveOutputAspectRatio("9:16", { width: 1920, height: 1080 })).toBe(
+        "9:16",
+      );
+      expect(resolveOutputAspectRatio("1:1", { width: 1920, height: 1080 })).toBe(
+        "1:1",
+      );
+    });
+
+    test("旧 square は 1:1 として解決する", () => {
+      expect(resolveOutputAspectRatio("square", { width: 1920, height: 1080 })).toBe(
+        "1:1",
+      );
+    });
+  });
+
+  describe("shouldForceSquareStyleOutput", () => {
+    test("1:1 と旧 square のみ true、他は false", () => {
+      expect(shouldForceSquareStyleOutput("1:1")).toBe(true);
+      expect(shouldForceSquareStyleOutput("square")).toBe(true);
+      expect(shouldForceSquareStyleOutput("source")).toBe(false);
+      expect(shouldForceSquareStyleOutput("3:4")).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
### 概要
admin のプリセットカテゴリの出力比率が「アップロードに合わせる」「1:1」の2択しかなく、縦長・横長などを固定指定できませんでした。コーディネート/style 画面の自動選択が使う**9段階の比率(9:16〜16:9)**を、admin で明示的に固定指定できるように拡張します。

### 変更内容
- `output_aspect_ratio_mode` を **`source`(アップロードに合わせる=自動)+ 明示9比率(9:16 / 4:5 / 3:4 / 2:3 / 1:1 / 3:2 / 4:3 / 5:4 / 16:9)** に拡張。明示比率は自動選択(`resolveGeminiAspectRatio`)と同じ9段階。
- 生成は新ヘルパー `resolveOutputAspectRatio(mode, 入力寸法)` で解決:`source`=入力比率を最近傍へ自動スナップ / 明示=その比率で出力(Gemini)。
- 旧 `square` は `1:1` に正規化・移行(後方互換)。`style-preset-repository` のカテゴリ写像が `square|source` の2値固定だった箇所も `normalize` に修正(明示比率が /style 生成へ伝わるように)。
- DB: `output_aspect_ratio_mode` の CHECK を拡張(既存 `square`→`1:1` 移行込み・制約名に依存しない動的 drop→add)。**本番DBに適用済み**(`3:4` 受理 / `2:1` 拒否を確認)。
- admin フォーム(プルダウンに9比率追加)・一覧表示・API バリデーション(`isStyleOutputAspectRatioMode`)を更新。
- 純ロジックに単体テスト追加。
- OpenAI(GPT Image 2)は従来どおり 1:1 固定のみ対応(明示の非正方形比率は Gemini が対応)。

### 実機テスト
- [ ] admin のプリセットカテゴリ編集で出力比率に 9:16〜16:9 が選べることを確認
- [ ] 明示比率を設定したカテゴリの /style 生成が、その比率で出力されることを確認(Gemini)
- [ ] `source` は従来どおり入力比率に追従することを確認
- [ ] 旧 `square` カテゴリが `1:1` として表示・動作することを確認

### テスト方法
- `npm run lint`(変更ファイル 0 error) / `npm run typecheck`(本変更由来の新規エラーなし。既存 jest-dom 型エラーは除く) / `npm run build -- --webpack`(成功)。
- jest: `style-output-aspect-ratio`(新規9件) / `guest-generate` / `preset-categories` / `lib`(833件 pass)。
- DB マイグレーションは本番適用済み。CHECK が新比率を受理・無効値を拒否することを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
