### PR TITLE
fix(image-gen-worker): /style の明示出力比率が効かない不具合を修正

### DIFF
--- a/supabase/functions/image-gen-worker/index.ts
+++ b/supabase/functions/image-gen-worker/index.ts
@@ -51,6 +51,10 @@ import {
   type GeminiAspectRatio,
 } from "../../../shared/generation/gemini-aspect-ratio.ts";
 import {
+  resolveOutputAspectRatio,
+  shouldForceSquareStyleOutput,
+} from "../../../shared/generation/style-output-aspect-ratio.ts";
+import {
   callOpenAIImageEditBatch,
   callOpenAIImageEditMultiInputBatch,
   parseImageDimensions,
@@ -2156,12 +2160,15 @@ Deno.serve(async () => {
                         aspectBaseImage.mimeType,
                       )
                     : null;
-                  const forceSquareOneTapStyleOutput =
-                    job.generation_type === "one_tap_style" &&
-                    oneTapStyleMetadata?.outputAspectRatioMode === "square";
+                  // one_tap_style は preset カテゴリの出力比率モードを尊重する
+                  // (source=入力比率に自動スナップ / 明示比率=その比率で出力)。
+                  // それ以外(coordinate / inspire 等)は従来どおり入力比率に自動スナップ。
                   const aspectRatio: GeminiAspectRatio =
-                    forceSquareOneTapStyleOutput
-                      ? "1:1"
+                    job.generation_type === "one_tap_style"
+                      ? resolveOutputAspectRatio(
+                          oneTapStyleMetadata?.outputAspectRatioMode,
+                          aspectDims,
+                        )
                       : resolveGeminiAspectRatio(aspectDims);
 
                   // gemini-3.1-flash-image-preview のみ candidateCount / responseModalities を追加。
@@ -2215,10 +2222,12 @@ Deno.serve(async () => {
                 }
                 const openAIRequestTimeoutMs =
                   resolveOpenAIRequestTimeoutMs(gptImage2);
-                const targetSize =
-                  oneTapStyleMetadata?.outputAspectRatioMode === "square"
-                    ? getGptImage2TargetSize(gptImage2.sizeTier, null)
-                    : undefined;
+                // OpenAI(GPT Image 2)は 1:1 固定のみ対応。明示 "1:1" / 旧 "square" を正方形にする。
+                const targetSize = shouldForceSquareStyleOutput(
+                  oneTapStyleMetadata?.outputAspectRatioMode,
+                )
+                  ? getGptImage2TargetSize(gptImage2.sizeTier, null)
+                  : undefined;
                 const attemptStartedAtMs = Date.now();
                 let attemptHttpStatus: number | null = null;
                 let attemptHttpOk = false;


### PR DESCRIPTION
### 概要
#360 でプリセットカテゴリに明示出力比率(9:16〜16:9)を追加しましたが、修正が同期/ゲスト経路(`guest-generate.ts`)だけで、ログイン時の /style 生成が通る**非同期ワーカー(`image-gen-worker` Edge Function)に未反映**でした。そのため、カテゴリに 9:16 を設定しても 1:1 のアップロード画像で生成すると 1:1 になり、明示比率が効きませんでした。ワーカー側の比率解決を是正します。

### 変更内容
- `image-gen-worker/index.ts` の one_tap_style 経路の比率解決を、旧2値判定(`outputAspectRatioMode === "square" ? "1:1" : 入力寸法の自動スナップ`)から **`resolveOutputAspectRatio(mode, 入力寸法)`** に変更。
  - `source` = 入力比率に自動スナップ(従来どおり)
  - 明示比率(9:16 等)= その比率で出力(修正点)
- OpenAI(GPT Image 2)経路の `targetSize` を `shouldForceSquareStyleOutput()` に統一(明示 `1:1` / 旧 `square` を正方形化)。
- coordinate / inspire 経路は従来どおり入力比率に自動スナップ(コードパス不変)。
- 共有モジュール `style-output-aspect-ratio.ts` を Deno 用に `.ts` 付きで import。

### 影響範囲(回帰なし)
- コーディネート、style の「アップロードに合わせる(source)」は**コードパス完全同一で無影響**。
- 明示比率カテゴリは意図どおりに修正。旧 `square`→`1:1` 移行カテゴリ(神コレ等)も正しく 1:1 固定に復帰。

### 実機テスト
- [ ] style でカテゴリ 9:16 設定 + 1:1 画像 → 9:16 で出力されることを確認
- [ ] style「アップロードに合わせる」が従来どおり入力比率に追従することを確認
- [ ] コーディネート生成が従来どおりであることを確認
- [ ] 旧 square 移行カテゴリ(神コレ等)が 1:1 で出力されることを確認

### テスト方法
- `npm run build -- --webpack` 成功(worker は Next ビルド対象外)。比率解決の純ロジック(`resolveOutputAspectRatio` 等)は #360 で単体テスト済み。
- ワーカー(Deno)は Supabase Preview のバンドルで検証。
- ⚠️ マージ後に `supabase functions deploy image-gen-worker` で本番反映が必要(Vercel では自動デプロイされない)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
