### PR TITLE
fix(generation): OpenAI(GPT Image 2)でも明示出力比率を反映する

### DIFF
--- a/features/generation/lib/guest-generate.ts
+++ b/features/generation/lib/guest-generate.ts
@@ -28,10 +28,11 @@ import {
 } from "@/features/i2i-poc/shared/image-constraints";
 import { getGptImage2TargetSize } from "@/shared/generation/openai-image-model";
 import {
+  normalizeStyleOutputAspectRatioMode,
   resolveOutputAspectRatio,
-  shouldForceSquareStyleOutput,
   type StyleOutputAspectRatioMode,
 } from "@/shared/generation/style-output-aspect-ratio";
+import { aspectLabelToDimensions } from "@/shared/generation/gemini-aspect-ratio";
 import {
   isOpenAIProviderErrorMessage,
   isSafetyPolicyBlockedErrorMessage,
@@ -286,11 +287,18 @@ async function dispatchOpenAI(
     };
   }
   try {
-    const targetSize = shouldForceSquareStyleOutput(
+    // 明示比率なら、その比率の寸法から OpenAI 出力サイズを決める(GPT Image 2 も非正方形可)。
+    // source は undefined にして入力画像ベース(従来挙動)に委ねる。
+    const aspectMode = normalizeStyleOutputAspectRatioMode(
       input.outputAspectRatioMode,
-    )
-      ? getGptImage2TargetSize(gptImage2.sizeTier, null)
-      : undefined;
+    );
+    const targetSize =
+      aspectMode === "source"
+        ? undefined
+        : getGptImage2TargetSize(
+            gptImage2.sizeTier,
+            aspectLabelToDimensions(aspectMode),
+          );
     let result: OpenAIImageEditResult;
     if (input.referenceImage) {
       const referenceArrayBuffer = await input.referenceImage.arrayBuffer();

--- a/shared/generation/gemini-aspect-ratio.ts
+++ b/shared/generation/gemini-aspect-ratio.ts
@@ -48,15 +48,30 @@ const MAX_RATIO = 16 / 9;
 const FALLBACK_RATIO: GeminiAspectRatio = "1:1";
 
 /**
- * "16:9" などの比率ラベルを {width, height} に変換する。
+ * "16:9" などの比率ラベルを {width, height} に変換する(静的ルックアップ)。
  * OpenAI(GPT Image 2)の出力サイズ決定(getGptImage2TargetSize)に渡す用途。
+ * Record 型なので全 GeminiAspectRatio の網羅が型レベルで保証される。
  */
+const ASPECT_LABEL_DIMENSIONS: Record<
+  GeminiAspectRatio,
+  { width: number; height: number }
+> = {
+  "9:16": { width: 9, height: 16 },
+  "4:5": { width: 4, height: 5 },
+  "3:4": { width: 3, height: 4 },
+  "2:3": { width: 2, height: 3 },
+  "1:1": { width: 1, height: 1 },
+  "3:2": { width: 3, height: 2 },
+  "4:3": { width: 4, height: 3 },
+  "5:4": { width: 5, height: 4 },
+  "16:9": { width: 16, height: 9 },
+};
+
 export function aspectLabelToDimensions(label: GeminiAspectRatio): {
   width: number;
   height: number;
 } {
-  const [w, h] = label.split(":").map(Number);
-  return { width: w, height: h };
+  return ASPECT_LABEL_DIMENSIONS[label];
 }
 
 /**

--- a/shared/generation/gemini-aspect-ratio.ts
+++ b/shared/generation/gemini-aspect-ratio.ts
@@ -48,6 +48,18 @@ const MAX_RATIO = 16 / 9;
 const FALLBACK_RATIO: GeminiAspectRatio = "1:1";
 
 /**
+ * "16:9" などの比率ラベルを {width, height} に変換する。
+ * OpenAI(GPT Image 2)の出力サイズ決定(getGptImage2TargetSize)に渡す用途。
+ */
+export function aspectLabelToDimensions(label: GeminiAspectRatio): {
+  width: number;
+  height: number;
+} {
+  const [w, h] = label.split(":").map(Number);
+  return { width: w, height: h };
+}
+
+/**
  * 入力画像の dimensions から Gemini 用 aspectRatio ラベルを解決する。
  *
  * - dimensions が null / 無効値 (width<=0 / height<=0) → "1:1" にフォールバック

--- a/supabase/functions/image-gen-worker/index.ts
+++ b/supabase/functions/image-gen-worker/index.ts
@@ -47,12 +47,13 @@ import {
 } from "../../../shared/generation/openai-image-model.ts";
 import type { GptImage2CanonicalModel } from "../../../shared/generation/openai-image-model.ts";
 import {
+  aspectLabelToDimensions,
   resolveGeminiAspectRatio,
   type GeminiAspectRatio,
 } from "../../../shared/generation/gemini-aspect-ratio.ts";
 import {
+  normalizeStyleOutputAspectRatioMode,
   resolveOutputAspectRatio,
-  shouldForceSquareStyleOutput,
 } from "../../../shared/generation/style-output-aspect-ratio.ts";
 import {
   callOpenAIImageEditBatch,
@@ -2222,12 +2223,22 @@ Deno.serve(async () => {
                 }
                 const openAIRequestTimeoutMs =
                   resolveOpenAIRequestTimeoutMs(gptImage2);
-                // OpenAI(GPT Image 2)は 1:1 固定のみ対応。明示 "1:1" / 旧 "square" を正方形にする。
-                const targetSize = shouldForceSquareStyleOutput(
-                  oneTapStyleMetadata?.outputAspectRatioMode,
-                )
-                  ? getGptImage2TargetSize(gptImage2.sizeTier, null)
-                  : undefined;
+                // 出力比率: one_tap_style で明示比率なら、その比率の寸法から OpenAI 出力サイズを決める
+                // (GPT Image 2 も 9:16〜16:9 を出力可能)。source / 非one_tap は undefined にして
+                // 呼び出し側の入力画像ベース(従来挙動)に委ねる。
+                const oneTapAspectMode =
+                  job.generation_type === "one_tap_style"
+                    ? normalizeStyleOutputAspectRatioMode(
+                        oneTapStyleMetadata?.outputAspectRatioMode,
+                      )
+                    : "source";
+                const targetSize =
+                  oneTapAspectMode === "source"
+                    ? undefined
+                    : getGptImage2TargetSize(
+                        gptImage2.sizeTier,
+                        aspectLabelToDimensions(oneTapAspectMode),
+                      );
                 const attemptStartedAtMs = Date.now();
                 let attemptHttpStatus: number | null = null;
                 let attemptHttpOk = false;

--- a/tests/unit/features/generation/guest-generate.test.ts
+++ b/tests/unit/features/generation/guest-generate.test.ts
@@ -676,6 +676,30 @@ describe("guest-generate", () => {
       );
     });
 
+    test("outputAspectRatioMode=16:9 は OpenAI でも横長 targetSize になる(入力1:1でも)", async () => {
+      const openaiClient = jest.fn().mockResolvedValue({
+        data: "OPENAI_BASE64",
+        mimeType: "image/png",
+      });
+
+      await dispatchGuestImageGeneration({
+        model: "gpt-image-2-low-1k",
+        promptText: "x",
+        // 入力は正方形だが、明示 16:9 なので出力は横長になるべき
+        uploadImage: new File([createPngHeader(1024, 1024)], "sq.png", {
+          type: "image/png",
+        }),
+        outputAspectRatioMode: "16:9",
+        geminiApiKey: "(unused)",
+        openaiApiKey: "openai-key",
+        openaiClient,
+      });
+
+      const call = openaiClient.mock.calls[0][0] as { targetSize: string };
+      const [w, h] = call.targetSize.split("x").map(Number);
+      expect(w).toBeGreaterThan(h); // 横長
+    });
+
     test("openaiClient が SAFETY エラーを throw すると safety_blocked", async () => {
       const openaiClient = jest.fn().mockRejectedValue(
         new Error("safety_policy_blocked")


### PR DESCRIPTION
### 概要
プリセットカテゴリに 16:9 等の明示出力比率を設定しても、OpenAI(GPT Image 2)で生成されるカテゴリ(例: travel_to_new_zealand)では 1:1 正方形になっていました。原因は one_tap_style の OpenAI 経路が `targetSize` に `null`/`undefined` を渡し、入力画像比率(or 正方形)へフォールバックしていたためです。GPT Image 2 は 9:16〜16:9 の出力に対応している(coordinate 画面が実証)ので、希望比率の寸法を渡すよう是正します。

※ 直前PR #361 の「OpenAI は 1:1 のみ対応」という前提は誤りでした。本PRで全比率に対応します。

### 変更内容
- `gemini-aspect-ratio.ts` に `aspectLabelToDimensions("16:9" → {16,9})` を追加。
- one_tap_style の OpenAI 経路(`image-gen-worker/index.ts` と `guest-generate.ts`)で、**明示比率のとき** `getGptImage2TargetSize(sizeTier, aspectLabelToDimensions(比率))` で希望比率の出力サイズを渡す。
- `source` および非 one_tap_style(coordinate 等)は従来どおり `undefined`(入力画像ベース)を維持 → **既存挙動に影響なし**。
- 単体テスト追加(入力1:1 + 明示16:9 → OpenAI 出力が横長になる)。

### 影響範囲(回帰なし)
- coordinate / style「アップロードに合わせる(source)」: コードパス不変。
- 明示比率カテゴリ(Gemini も OpenAI も): 設定した比率で出力されるよう修正。

### 実機テスト
- [ ] travel_to_new_zealand(16:9・OpenAI)で 1:1 画像を生成 → 横長(16:9相当)で出力されることを確認
- [ ] 明示 9:16 で縦長になることを確認
- [ ] source カテゴリ・coordinate が従来どおりであることを確認

### テスト方法
- `npm run build -- --webpack` 成功。jest: `gemini-aspect-ratio` / `style-output-aspect-ratio` / `guest-generate`(全 pass、明示16:9のOpenAIサイズ検証を追加)。
- ワーカー(Deno)は Supabase Preview のバンドルで検証。
- ⚠️ マージ後に `supabase functions deploy image-gen-worker` で本番反映が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
