### PR TITLE
fix(style): 生成中の画面離脱→復帰で『ポーリングが停止されました』を解消し結果を自動表示

### DIFF
--- a/features/style/components/StylePageClient.tsx
+++ b/features/style/components/StylePageClient.tsx
@@ -51,6 +51,11 @@ import {
   type AsyncGenerationStatus,
 } from "@/features/generation/lib/async-api";
 import {
+  clearActiveStyleJob,
+  persistActiveStyleJob,
+  readActiveStyleJob,
+} from "@/features/style/lib/active-async-job-storage";
+import {
   buildCoordinatePreparingCopy,
   buildCoordinateStageCopy,
 } from "@/features/generation/lib/coordinate-stage-copy";
@@ -155,6 +160,10 @@ type ResultConfirmationIntent = "change" | "regenerate";
 type GenerationPhase = "idle" | "running" | "completing";
 
 const RESULT_REVEAL_DELAY_MS = 5000;
+// 画面離脱で stop() された際に pollGenerationStatus が reject する内部用メッセージ。
+// 生成失敗ではないため、この値のときはエラー表示せず、復帰時の再ポーリングに委ねる。
+// (ユーザーには出さない内部 sentinel)
+const STYLE_POLLING_STOPPED_SENTINEL = "style:polling-stopped";
 const PREPARING_PROGRESS_PERCENT = 10;
 const PREPARING_PROGRESS_TRANSITION_MS = 3000;
 // Phase 5 で選択モデル単価に基づく動的コストへ移行 (selectedModelPercoinCost)。
@@ -1401,6 +1410,137 @@ export function StylePageClient({
     }
   };
 
+  // 非同期ジョブ成功時の確定処理(結果表示 + 一覧再取得 + 各種通知)。
+  // 通常生成と復帰時の両方から呼ぶため切り出す。styleId は復帰時に
+  // selectedPreset と一致しないことがあるので明示的に受け取る。
+  const finalizeStyleAsyncSuccess = (
+    finalStatus: AsyncGenerationStatus,
+    styleId: string,
+  ) => {
+    if (!finalStatus.resultImageUrl) {
+      return;
+    }
+    setResultImageUrl(finalStatus.resultImageUrl);
+    setQueuedResultImageUrl(finalStatus.resultImageUrl);
+    setResultGeneratedImageId(finalStatus.generatedImageId ?? null);
+    setGenerationPhase("completing");
+    refreshRateLimitStatus();
+    void refreshPercoinBalance();
+    // 生成結果一覧（use cache）を最新化。/coordinate と同じく
+    // revalidate API → router.refresh() の順で叩いて、現在マウント中の
+    // ページの RSC ペイロードを再フェッチさせる（router.refresh が無いと
+    // 生成完了後にスケルトンが出っぱなしになる）。
+    void (async () => {
+      try {
+        await fetch("/api/revalidate/style", { method: "POST" });
+      } catch {
+        // 無効化失敗時も refresh は継続する
+      }
+      router.refresh();
+    })();
+    if (styleId) {
+      void recordStyleUsageClientEvent({
+        eventType: "generate",
+        styleId,
+      }).catch(() => {
+        // Tracking failures should not affect the page UX.
+      });
+    }
+    // コレクション進捗を即時再チェック(全画面チェッカーへ通知)。
+    // 非同期生成で他画面にいてもポーリングが拾うが、style画面では即時に出す。
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new Event(COLLECTION_PROGRESS_REFRESH_EVENT));
+    }
+  };
+
+  // jobId のポーリングを開始し、結果を確定する。通常生成・復帰の両方で使う。
+  // 画面離脱で stop() された場合(pollingStopped sentinel)は、エラーにせず
+  // sessionStorage を保持したまま静かに抜ける(復帰時に再開して表示する)。
+  const pollAndFinalizeStyleJob = async (jobId: string, styleId: string) => {
+    const { promise, stop } = pollGenerationStatus(jobId, {
+      interval: getStyleAsyncPollingIntervalMs,
+      messages: { pollingStopped: STYLE_POLLING_STOPPED_SENTINEL },
+      onStatusUpdate: (status) => {
+        setActiveAsyncJobStatus(status);
+      },
+    });
+    activePollStopRef.current = stop;
+
+    try {
+      const finalStatus = await promise;
+      stopActivePolling();
+      setActiveAsyncJobStatus(finalStatus);
+
+      if (finalStatus.status !== "succeeded" || !finalStatus.resultImageUrl) {
+        clearActiveStyleJob();
+        handleGenerationError(finalStatus.errorMessage || t("generationFailed"));
+        refreshRateLimitStatus();
+        void refreshPercoinBalance();
+        return;
+      }
+
+      clearActiveStyleJob();
+      finalizeStyleAsyncSuccess(finalStatus, styleId);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : t("unknownError");
+      if (message === STYLE_POLLING_STOPPED_SENTINEL) {
+        // 画面離脱でポーリングを中断しただけ。ジョブはサーバーで継続するため
+        // エラー表示せず、永続化を残して復帰時の再ポーリングに委ねる。
+        return;
+      }
+      clearActiveStyleJob();
+      handleGenerationError(message);
+      void refreshPercoinBalance();
+    }
+  };
+
+  // 画面復帰(remount)時に、離脱中も継続していた非同期ジョブを復元する。
+  // sessionStorage に jobId が残っていれば現在の状態を取得し、
+  //  - 完了済み → 結果を表示(通常完了と同じ流れ)
+  //  - 進行中   → 再ポーリングを開始
+  // を行う。取得失敗・失敗ジョブは静かに片付ける(古いエラーを蒸し返さない)。
+  useEffect(() => {
+    const persisted = readActiveStyleJob();
+    if (!persisted) {
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      const status = await getGenerationStatus(persisted.jobId).catch(
+        () => null,
+      );
+      if (cancelled) {
+        return;
+      }
+      if (!status) {
+        clearActiveStyleJob();
+        return;
+      }
+      if (status.status === "succeeded") {
+        clearActiveStyleJob();
+        if (status.resultImageUrl) {
+          setActiveAsyncJobStatus(status);
+          finalizeStyleAsyncSuccess(status, persisted.styleId);
+        }
+        return;
+      }
+      if (status.status === "failed") {
+        clearActiveStyleJob();
+        return;
+      }
+      // 進行中: UI を生成中に戻して再ポーリングを開始する
+      setGenerationPhase("running");
+      setActiveAsyncJobStatus(status);
+      await pollAndFinalizeStyleJob(persisted.jobId, persisted.styleId);
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // マウント時に一度だけ実行する(復帰=remount を契機にする)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const generateImageWithAsyncJob = async () => {
     if (
       !selectedPreset ||
@@ -1533,56 +1673,12 @@ export function StylePageClient({
       }));
       setActiveAsyncJobStatus(latestKnownStatus);
 
-      const { promise, stop } = pollGenerationStatus(payload.jobId, {
-        interval: getStyleAsyncPollingIntervalMs,
-        onStatusUpdate: (status) => {
-          setActiveAsyncJobStatus(status);
-        },
-      });
-      activePollStopRef.current = stop;
-
-      const finalStatus = await promise;
-      stopActivePolling();
-      setActiveAsyncJobStatus(finalStatus);
-
-      if (finalStatus.status !== "succeeded" || !finalStatus.resultImageUrl) {
-        handleGenerationError(
-          finalStatus.errorMessage || t("generationFailed")
-        );
-        refreshRateLimitStatus();
-        void refreshPercoinBalance();
-        return;
-      }
-
-      setResultImageUrl(finalStatus.resultImageUrl);
-      setQueuedResultImageUrl(finalStatus.resultImageUrl);
-      setResultGeneratedImageId(finalStatus.generatedImageId ?? null);
-      setGenerationPhase("completing");
-      refreshRateLimitStatus();
-      void refreshPercoinBalance();
-      // 生成結果一覧（use cache）を最新化。/coordinate と同じく
-      // revalidate API → router.refresh() の順で叩いて、現在マウント中の
-      // ページの RSC ペイロードを再フェッチさせる（router.refresh が無いと
-      // 生成完了後にスケルトンが出っぱなしになる）。
-      void (async () => {
-        try {
-          await fetch("/api/revalidate/style", { method: "POST" });
-        } catch {
-          // 無効化失敗時も refresh は継続する
-        }
-        router.refresh();
-      })();
-      void recordStyleUsageClientEvent({
-        eventType: "generate",
+      // 進行中ジョブを保持: 画面離脱→復帰しても復元・再ポーリングできるようにする。
+      persistActiveStyleJob({
+        jobId: payload.jobId,
         styleId: selectedPreset.id,
-      }).catch(() => {
-        // Tracking failures should not affect the page UX.
       });
-      // コレクション進捗を即時再チェック(全画面チェッカーへ通知)。
-      // 非同期生成で他画面にいてもポーリングが拾うが、style画面では即時に出す。
-      if (typeof window !== "undefined") {
-        window.dispatchEvent(new Event(COLLECTION_PROGRESS_REFRESH_EVENT));
-      }
+      await pollAndFinalizeStyleJob(payload.jobId, selectedPreset.id);
     } catch (error) {
       handleGenerationError(
         error instanceof Error ? error.message : t("unknownError")

--- a/features/style/lib/active-async-job-storage.ts
+++ b/features/style/lib/active-async-job-storage.ts
@@ -1,0 +1,88 @@
+/**
+ * /style の非同期生成ジョブを「画面離脱→復帰」で復元するための一時保存。
+ *
+ * 背景: /style で生成中に他画面へ移動すると StylePageClient が unmount し、
+ * ポーリングが停止する(= pollingStopped)。ジョブ自体はサーバーで継続するため、
+ * 進行中の jobId を sessionStorage に保持しておき、復帰時に再ポーリングして
+ * 通常完了と同じ流れで結果を表示する。
+ *
+ * sessionStorage を使う理由:
+ * - タブ単位で生存し、ナビゲーション(unmount/remount)を跨いで残る
+ * - タブを閉じれば消えるので、別セッションに古いジョブを持ち越さない
+ *
+ * 完了(成功表示 or 失敗)時・新規生成開始時に必ず clear する。
+ */
+
+const STORAGE_KEY = "persta:style:active-async-job";
+
+export interface PersistedActiveStyleJob {
+  jobId: string;
+  /** 復帰時の利用イベント記録(recordStyleUsageClientEvent)に使う */
+  styleId: string;
+}
+
+function getSessionStorage(): Storage | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  try {
+    return window.sessionStorage;
+  } catch {
+    // プライベートモード等でアクセスが拒否される場合がある
+    return null;
+  }
+}
+
+export function persistActiveStyleJob(job: PersistedActiveStyleJob): void {
+  const storage = getSessionStorage();
+  if (!storage) {
+    return;
+  }
+  if (!job.jobId) {
+    return;
+  }
+  try {
+    storage.setItem(STORAGE_KEY, JSON.stringify(job));
+  } catch {
+    // 保存失敗は致命的ではない(復帰表示ができないだけ)
+  }
+}
+
+export function readActiveStyleJob(): PersistedActiveStyleJob | null {
+  const storage = getSessionStorage();
+  if (!storage) {
+    return null;
+  }
+  try {
+    const raw = storage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw) as Partial<PersistedActiveStyleJob> | null;
+    if (
+      !parsed ||
+      typeof parsed.jobId !== "string" ||
+      parsed.jobId.length === 0
+    ) {
+      return null;
+    }
+    return {
+      jobId: parsed.jobId,
+      styleId: typeof parsed.styleId === "string" ? parsed.styleId : "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function clearActiveStyleJob(): void {
+  const storage = getSessionStorage();
+  if (!storage) {
+    return;
+  }
+  try {
+    storage.removeItem(STORAGE_KEY);
+  } catch {
+    // 削除失敗は無視
+  }
+}

--- a/tests/unit/features/style/active-async-job-storage.test.ts
+++ b/tests/unit/features/style/active-async-job-storage.test.ts
@@ -1,0 +1,46 @@
+/** @jest-environment jsdom */
+
+import {
+  clearActiveStyleJob,
+  persistActiveStyleJob,
+  readActiveStyleJob,
+} from "@/features/style/lib/active-async-job-storage";
+
+describe("active-async-job-storage", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  test("persist → read で往復できる", () => {
+    persistActiveStyleJob({ jobId: "job-1", styleId: "style-1" });
+    expect(readActiveStyleJob()).toEqual({ jobId: "job-1", styleId: "style-1" });
+  });
+
+  test("未保存なら null", () => {
+    expect(readActiveStyleJob()).toBeNull();
+  });
+
+  test("clear で消える", () => {
+    persistActiveStyleJob({ jobId: "job-1", styleId: "style-1" });
+    clearActiveStyleJob();
+    expect(readActiveStyleJob()).toBeNull();
+  });
+
+  test("jobId 空文字は保存しない", () => {
+    persistActiveStyleJob({ jobId: "", styleId: "style-1" });
+    expect(readActiveStyleJob()).toBeNull();
+  });
+
+  test("壊れた JSON は null(例外を投げない)", () => {
+    window.sessionStorage.setItem("persta:style:active-async-job", "{not json");
+    expect(readActiveStyleJob()).toBeNull();
+  });
+
+  test("styleId 欠落でも jobId があれば復元(styleId は空文字)", () => {
+    window.sessionStorage.setItem(
+      "persta:style:active-async-job",
+      JSON.stringify({ jobId: "job-9" }),
+    );
+    expect(readActiveStyleJob()).toEqual({ jobId: "job-9", styleId: "" });
+  });
+});

--- a/tests/unit/features/style/active-async-job-storage.test.ts
+++ b/tests/unit/features/style/active-async-job-storage.test.ts
@@ -43,4 +43,35 @@ describe("active-async-job-storage", () => {
     );
     expect(readActiveStyleJob()).toEqual({ jobId: "job-9", styleId: "" });
   });
+
+  test("storage の各操作が throw しても安全に処理する(quota/アクセス拒否等)", () => {
+    const original = window.sessionStorage;
+    Object.defineProperty(window, "sessionStorage", {
+      configurable: true,
+      value: {
+        getItem: () => {
+          throw new Error("access denied");
+        },
+        setItem: () => {
+          throw new Error("quota exceeded");
+        },
+        removeItem: () => {
+          throw new Error("blocked");
+        },
+        clear: () => {},
+      },
+    });
+    try {
+      expect(() =>
+        persistActiveStyleJob({ jobId: "job-1", styleId: "style-1" }),
+      ).not.toThrow();
+      expect(readActiveStyleJob()).toBeNull();
+      expect(() => clearActiveStyleJob()).not.toThrow();
+    } finally {
+      Object.defineProperty(window, "sessionStorage", {
+        configurable: true,
+        value: original,
+      });
+    }
+  });
 });

--- a/tests/unit/features/style/style-page-client.test.tsx
+++ b/tests/unit/features/style/style-page-client.test.tsx
@@ -690,6 +690,7 @@ describe("StylePageClient", () => {
   afterEach(() => {
     jest.useRealTimers();
     window.localStorage.clear();
+    window.sessionStorage.clear();
     global.fetch = originalFetch;
     mockToast.mockReset();
     mockDismissToast.mockReset();
@@ -1098,6 +1099,43 @@ describe("StylePageClient", () => {
 
     // ゲストは1枚生成後、結果消失と上限エラーを防ぐため再生成ボタンは無効のまま。
     expect(screen.getByRole("button", { name: /Start Styling/ })).toBeDisabled();
+  });
+
+  test("復帰時_sessionStorageの完了済みジョブを再開し結果を確定する_エラーにしない", async () => {
+    // 生成中に離脱して走り続けていたジョブを保持している状態を再現する。
+    window.sessionStorage.setItem(
+      "persta:style:active-async-job",
+      JSON.stringify({ jobId: "style-job-001", styleId: "resumed-style-id" }),
+    );
+    // 復帰時の状態取得は「完了済み」を返す。
+    generationStatusResponseQueue = [
+      createJsonResponse({
+        id: "style-job-001",
+        status: "succeeded",
+        processingStage: "completed",
+        resultImageUrl: "https://cdn.example.com/generated-style-result.png",
+        previewImageUrl: null,
+        errorMessage: null,
+        generatedImageId: "generated-image-001",
+      }),
+    ];
+
+    render(<StylePageClient presets={presets} />);
+
+    // 復帰 → getGenerationStatus(succeeded) → 確定処理(利用イベント記録)が走る。
+    await waitFor(() =>
+      expect(mockRecordStyleUsageClientEvent).toHaveBeenCalledWith({
+        eventType: "generate",
+        styleId: "resumed-style-id",
+      }),
+    );
+
+    // 完了確定したので保持はクリアされ、誤エラーも出ない。
+    await waitFor(() =>
+      expect(
+        window.sessionStorage.getItem("persta:style:active-async-job"),
+      ).toBeNull(),
+    );
   });
 
   test("reduced motion が有効な場合は生成ステータスへのスクロールを即時にする", async () => {


### PR DESCRIPTION
### 概要
/style で生成中に他画面へ移動して戻ると「**ポーリングが停止されました**」という赤いエラーが表示されることがありました。実際にはジョブはサーバー側で完走しており、画面を更新すると生成結果が表示される状態でした。

原因:
- /style 生成は `pollGenerationStatus` でジョブ状態を監視します。
- 画面を離れると `StylePageClient` が unmount され、後片付けで `stop()` が呼ばれ、監視中の `await` が **pollingStopped** で reject。
- `StylePageClient` はこれを**生成失敗として扱い**エラー表示していました(/coordinate は同じ pollingStopped を握りつぶす実装で、/style だけ対応漏れ)。
- かつ復帰時にジョブを再開しないため、手動更新するまで結果が出ませんでした。

### 変更内容
- **(A) 誤エラー抑止**: pollingStopped を内部 sentinel(`STYLE_POLLING_STOPPED_SENTINEL`)として識別し、生成失敗として扱わない(エラー banner を出さない)。
- **(B) 復帰時に自動表示**: 進行中の `jobId`(と `styleId`)を `sessionStorage` に保持し、/style に戻った(remount)時に状態を取得して
  - 完了済み → 結果を表示(通常完了と同じ確定処理: メイン結果 + 一覧再取得 + コレクション進捗通知)
  - 進行中 → 再ポーリングを開始
  - 取得失敗 / 失敗ジョブ → 静かに片付ける(古いエラーを蒸し返さない)
- 成功確定処理(`finalizeStyleAsyncSuccess`)とポーリング処理(`pollAndFinalizeStyleJob`)を切り出し、通常生成と復帰で共用。
- 保持ロジックはテスト可能な純モジュール `features/style/lib/active-async-job-storage.ts` に分離し単体テスト追加。

### 影響範囲(回帰なし)
- 通常の /style 生成フローは挙動不変(確定処理を関数に切り出しただけ)。
- 復帰しないケース(離脱しない通常完了)は従来どおり。
- coordinate / ゲスト経路は対象外(変更なし)。
- 再開は再 POST しないため**ペルコインの二重消費なし**。

### 実機テスト
- [ ] /style 生成中に他画面へ移動→戻る → 赤いエラーが出ない
- [ ] 戻った時点で完了済みなら、更新せず結果が表示される
- [ ] 戻った時点で進行中なら、生成中表示のまま完了時に結果が出る
- [ ] 通常(離脱しない)生成が従来どおり完了表示される

### テスト方法
- `npm run lint` / `npm run typecheck`(本変更由来エラーなし) / `npm run build -- --webpack`(成功)。
- jest: `tests/unit/features/style` `tests/unit/features/generation`(447 passed、style-page-client 含む回帰なし) + 保持ヘルパの新規単体テスト。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
