### PR TITLE
feat(posts): 投稿詳細のOne-Tap Styleカードに提供者クレジットを表示

### DIFF
--- a/features/posts/components/CachedPostDetail.tsx
+++ b/features/posts/components/CachedPostDetail.tsx
@@ -32,7 +32,7 @@ export async function CachedPostDetail({
   cacheLife("minutes");
 
   const supabase = createAdminClient();
-  const post = await getPost(postId, currentUserId, true, supabase);
+  let post = await getPost(postId, currentUserId, true, supabase);
 
   if (!post) {
     notFound();
@@ -55,18 +55,24 @@ export async function CachedPostDetail({
     const provider = presetSummary
       ? resolveStylePresetProvider(presetSummary)
       : null;
-    if (
-      provider &&
-      post.generation_metadata &&
-      typeof post.generation_metadata === "object"
-    ) {
-      const oneTapStyle = (post.generation_metadata as Record<string, unknown>)
-        .oneTapStyle;
+    const metadata = post.generation_metadata;
+    if (provider && metadata && typeof metadata === "object") {
+      const meta = metadata as Record<string, unknown>;
+      const oneTapStyle = meta.oneTapStyle;
       if (oneTapStyle && typeof oneTapStyle === "object") {
-        const target = oneTapStyle as Record<string, unknown>;
-        target.providerUserId = provider.userId;
-        target.providerNickname = provider.nickname;
-        target.providerAvatarUrl = provider.avatarUrl;
+        // use cache のキャッシュ対象を直接書き換えない。非破壊的に再生成する。
+        post = {
+          ...post,
+          generation_metadata: {
+            ...meta,
+            oneTapStyle: {
+              ...(oneTapStyle as Record<string, unknown>),
+              providerUserId: provider.userId,
+              providerNickname: provider.nickname,
+              providerAvatarUrl: provider.avatarUrl,
+            },
+          },
+        };
       }
     }
   }

--- a/features/posts/components/CachedPostDetail.tsx
+++ b/features/posts/components/CachedPostDetail.tsx
@@ -9,6 +9,9 @@ import {
 } from "../lib/utils";
 import { PostDetailContent } from "./PostDetailContent";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { getOneTapStylePresetMetadata } from "@/shared/generation/one-tap-style-metadata";
+import { getPublishedStylePresetById } from "@/features/style-presets/lib/style-preset-repository";
+import { resolveStylePresetProvider } from "@/features/style-presets/lib/schema";
 
 interface CachedPostDetailProps {
   postId: string;
@@ -37,6 +40,35 @@ export async function CachedPostDetail({
 
   if (post.user_id) {
     cacheTag(`subscription-ui-${post.user_id}`);
+  }
+
+  // One-Tap Style 投稿は、保存時メタデータに提供者情報を持たないため、
+  // preset id から現在の提供者(プリセット単位優先→カテゴリ fallback)をライブ取得し、
+  // メタデータへ注入する。これで詳細ページのカードにもクレジット(/style・ホームと同じ)が出る。
+  const oneTapMeta = getOneTapStylePresetMetadata(post);
+  if (oneTapMeta) {
+    const presetSummary = await getPublishedStylePresetById(
+      oneTapMeta.id,
+      {},
+      supabase,
+    ).catch(() => null);
+    const provider = presetSummary
+      ? resolveStylePresetProvider(presetSummary)
+      : null;
+    if (
+      provider &&
+      post.generation_metadata &&
+      typeof post.generation_metadata === "object"
+    ) {
+      const oneTapStyle = (post.generation_metadata as Record<string, unknown>)
+        .oneTapStyle;
+      if (oneTapStyle && typeof oneTapStyle === "object") {
+        const target = oneTapStyle as Record<string, unknown>;
+        target.providerUserId = provider.userId;
+        target.providerNickname = provider.nickname;
+        target.providerAvatarUrl = provider.avatarUrl;
+      }
+    }
   }
 
   const imageUrl = getPostDisplayUrl(post);

--- a/shared/generation/one-tap-style-metadata.ts
+++ b/shared/generation/one-tap-style-metadata.ts
@@ -15,6 +15,11 @@ export interface OneTapStylePresetMetadata extends Record<string, unknown> {
   billingMode: OneTapStyleBillingMode;
   outputAspectRatioMode: StyleOutputAspectRatioMode;
   reservedAttemptId?: string;
+  // 投稿詳細などのカードで提供者クレジットを出すため、サーバー側で preset id から
+  // ライブ取得した提供者情報を注入する(保存時のスナップショットには含まれない)。
+  providerUserId?: string | null;
+  providerNickname?: string | null;
+  providerAvatarUrl?: string | null;
 }
 
 export interface OneTapStyleGenerationMetadata extends Record<string, unknown> {
@@ -121,6 +126,18 @@ export function getOneTapStylePresetMetadata(
     ...(typeof oneTapStyle.reservedAttemptId === "string"
       ? { reservedAttemptId: oneTapStyle.reservedAttemptId }
       : {}),
+    providerUserId:
+      typeof oneTapStyle.providerUserId === "string"
+        ? oneTapStyle.providerUserId
+        : null,
+    providerNickname:
+      typeof oneTapStyle.providerNickname === "string"
+        ? oneTapStyle.providerNickname
+        : null,
+    providerAvatarUrl:
+      typeof oneTapStyle.providerAvatarUrl === "string"
+        ? oneTapStyle.providerAvatarUrl
+        : null,
   };
 }
 

--- a/tests/unit/shared/generation/one-tap-style-metadata.test.ts
+++ b/tests/unit/shared/generation/one-tap-style-metadata.test.ts
@@ -1,0 +1,75 @@
+/** @jest-environment node */
+
+import { getOneTapStylePresetMetadata } from "@/shared/generation/one-tap-style-metadata";
+
+const baseOneTapStyle = {
+  id: "preset-1",
+  title: "nanoblock",
+  thumbnailImageUrl: "https://example.com/t.webp",
+  thumbnailWidth: 1024,
+  thumbnailHeight: 1024,
+  hasBackgroundPrompt: false,
+  billingMode: "free",
+  outputAspectRatioMode: "1:1",
+};
+
+function record(oneTapStyle: Record<string, unknown>) {
+  return {
+    generation_type: "one_tap_style",
+    generation_metadata: { oneTapStyle },
+  };
+}
+
+describe("getOneTapStylePresetMetadata", () => {
+  test("one_tap_style 以外は null", () => {
+    expect(
+      getOneTapStylePresetMetadata({
+        generation_type: "coordinate",
+        generation_metadata: { oneTapStyle: baseOneTapStyle },
+      }),
+    ).toBeNull();
+  });
+
+  test("基本フィールドを変換し、provider 未設定なら null", () => {
+    const meta = getOneTapStylePresetMetadata(record(baseOneTapStyle));
+    expect(meta).not.toBeNull();
+    expect(meta?.id).toBe("preset-1");
+    expect(meta?.title).toBe("nanoblock");
+    expect(meta?.providerUserId).toBeNull();
+    expect(meta?.providerNickname).toBeNull();
+    expect(meta?.providerAvatarUrl).toBeNull();
+  });
+
+  test("provider 情報があれば surface する", () => {
+    const meta = getOneTapStylePresetMetadata(
+      record({
+        ...baseOneTapStyle,
+        providerUserId: "mario-id",
+        providerNickname: "mario335599",
+        providerAvatarUrl: "https://example.com/m.png",
+      }),
+    );
+    expect(meta?.providerUserId).toBe("mario-id");
+    expect(meta?.providerNickname).toBe("mario335599");
+    expect(meta?.providerAvatarUrl).toBe("https://example.com/m.png");
+  });
+
+  test("provider が文字列以外なら null に正規化する", () => {
+    const meta = getOneTapStylePresetMetadata(
+      record({
+        ...baseOneTapStyle,
+        providerUserId: 123,
+        providerNickname: null,
+      }),
+    );
+    expect(meta?.providerUserId).toBeNull();
+    expect(meta?.providerNickname).toBeNull();
+    expect(meta?.providerAvatarUrl).toBeNull();
+  });
+
+  test("必須フィールド欠落は null", () => {
+    const { id: _omit, ...withoutId } = baseOneTapStyle;
+    void _omit;
+    expect(getOneTapStylePresetMetadata(record(withoutId))).toBeNull();
+  });
+});


### PR DESCRIPTION
### 概要
投稿詳細ページ(`/posts/[id]`)の「ワンタップスタイルで生成」カードにも、ホーム/style と同じ**提供者クレジット(アイコン+ニックネーム)**を表示します。`nanoblock`(提供: mario さん)のように提供者が設定されたプリセットで生成された投稿で、詳細ページにもクレジットが出るようになります。

### 背景
- 投稿の `generation_metadata.oneTapStyle` は**生成時のスナップショット**で、提供者情報を持ちません。
- 既存のクレジット表示(PR #357 / #365)はカード描画(`StylePresetPreviewCard` → `resolveStylePresetProvider`)に集約されているため、カードに渡す preset へ provider 情報があれば自動で表示されます。

### 変更内容
- **`CachedPostDetail`(サーバー境界)**: One-Tap Style 投稿のとき、`oneTapStyle.id`(preset id)から **現在の提供者をライブ取得**(`getPublishedStylePresetById` → `resolveStylePresetProvider`:プリセット単位優先→カテゴリ fallback)し、`generation_metadata.oneTapStyle` に `providerUserId/Nickname/AvatarUrl` を注入。
- **`one-tap-style-metadata.ts`**: `OneTapStylePresetMetadata` に provider 3フィールドを追加し、`getOneTapStylePresetMetadata` が surface するように。
- これにより `PostDetail` / `PostDetailStatic`(どちらも `getOneTapStylePresetMetadata(post)` を使用)経由で `StylePresetPreviewCard` が提供者を表示。**クライアント改修・新規プロップ不要**。

### 影響範囲
- ライブ取得なので**既存投稿にも遡及**して表示。提供者未設定のプリセットは従来どおりクレジットなし。
- 取得は admin client(service role)、`use cache`(minutes)内。client へ渡るのは nickname/avatar/id のみ(過剰露出なし、#357/#365 と同方針)。

### 実機テスト
- [ ] nanoblock 等で生成した投稿の詳細ページに mario さんのアイコン+ニックネームが出る
- [ ] 提供者未設定プリセットの投稿はクレジットが出ない(従来どおり)

### テスト方法
- `npm run lint` / `npm run build -- --webpack` 成功。`npm run test` 全 2250 件 pass(posts / generation / metadata 含む)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
