### PR TITLE
fix(posts): admin_onlyカテゴリのプリセットでも投稿詳細にクレジット表示

### DIFF
--- a/features/posts/components/CachedPostDetail.tsx
+++ b/features/posts/components/CachedPostDetail.tsx
@@ -47,9 +47,12 @@ export async function CachedPostDetail({
   // メタデータへ注入する。これで詳細ページのカードにもクレジット(/style・ホームと同じ)が出る。
   const oneTapMeta = getOneTapStylePresetMetadata(post);
   if (oneTapMeta) {
+    // 提供者クレジット表示用の lookup。投稿自体は公開済みで、取り出すのは提供者の
+    // 公開情報(ニックネーム/アイコン)のみのため、カテゴリが admin_only でも取得する
+    // (character_remix のような admin_only カテゴリのプリセットでもクレジットを出す)。
     const presetSummary = await getPublishedStylePresetById(
       oneTapMeta.id,
-      {},
+      { includeAdminOnly: true },
       supabase,
     ).catch(() => null);
     const provider = presetSummary


### PR DESCRIPTION
### 概要
PR #366 で投稿詳細ページのカードに提供者クレジットを出すようにしましたが、**`nanoblock`(カテゴリ `character_remix` = `admin_only`)では表示されない**不具合がありました。

### 原因
`CachedPostDetail` の提供者 lookup `getPublishedStylePresetById(id, {})` が、`canAccessCategory` の既定動作で **admin_only カテゴリを弾いて null** を返すため、provider が取得できずクレジットが注入されませんでした。

### 修正
provider 取得時に `{ includeAdminOnly: true }` を指定。投稿自体は公開済みで、取り出すのは**提供者の公開情報(ニックネーム/アイコン)のみ**のため、カテゴリの公開可否とは独立してクレジットを出してよい。

### 影響範囲
- `character_remix`(admin_only)の nanoblock 等で生成した**既存投稿にも遡及**してクレジットが出る。
- public カテゴリの挙動は不変。プロンプト等の非公開情報は引き続き露出しない。

### テスト方法
- `npm run lint` / `npm run build -- --webpack` 成功。

🤖 Generated with [Claude Code](https://claude.com/claude-code)