### PR TITLE
refactor(coordinate): framing 既定を COORDINATE_DEFAULT_FRAMING_MODE に集約

### DIFF
--- a/app/api/generate-async/handler.ts
+++ b/app/api/generate-async/handler.ts
@@ -4,7 +4,10 @@ import { isCreatorLooksEnabledForUser } from "@/lib/auth/creator-looks";
 import { generationRequestSchema, getSafeExtensionFromMimeType } from "@/features/generation/lib/schema";
 import { convertHeicBase64ToJpeg, isHeicImage } from "@/features/generation/lib/heic-converter";
 import { env, isAdminViewer } from "@/lib/env";
-import type { FramingMode } from "@/shared/generation/framing-mode";
+import {
+  DEFAULT_FRAMING_MODE,
+  type FramingMode,
+} from "@/shared/generation/framing-mode";
 import { ensureSameOrigin } from "@/lib/security/same-origin";
 import type { ImageJobCreateInput } from "@/features/generation/lib/job-types";
 import {
@@ -158,8 +161,10 @@ export async function postGenerateAsyncRoute(
       );
     }
 
-    // framing_mode は全ログインユーザーに公開 (既定=free / 「維持」で locked)。coordinate 限定は schema で検証済み。
-    const effectiveFramingMode: FramingMode = framingMode ?? "locked";
+    // framing_mode は全ログインユーザーに公開 (UI 既定=free / 「維持」で locked)。coordinate 限定は schema で検証済み。
+    // UI は常に framingMode を明示送信するため、ここに来る省略は レガシー/非 UI 経路。
+    // その場合は保守的に DEFAULT_FRAMING_MODE (locked = 現行挙動) へフォールバックする。
+    const effectiveFramingMode: FramingMode = framingMode ?? DEFAULT_FRAMING_MODE;
     const isOpenAIBatchCandidate = isOpenAIImageModel(effectiveModel);
     const isInspireRequest = generationType === "inspire";
 

--- a/features/generation/components/GenerationForm.tsx
+++ b/features/generation/components/GenerationForm.tsx
@@ -47,7 +47,10 @@ import type {
   SourceImageType,
   PickerSourceItem,
 } from "../types";
-import type { FramingMode } from "@/shared/generation/framing-mode";
+import {
+  COORDINATE_DEFAULT_FRAMING_MODE,
+  type FramingMode,
+} from "@/shared/generation/framing-mode";
 import { TUTORIAL_DEMO_IMAGE_PATH } from "@/features/tutorial/lib/constants";
 import { TUTORIAL_STORAGE_KEYS } from "@/features/tutorial/types";
 import { useCurrentUrlForRedirect } from "@/lib/build-current-url";
@@ -154,7 +157,9 @@ export function GenerationForm({
   // framing_mode: 既定は free(image_0 の同一性だけ維持し、衣装/ポーズ/カメラ/背景は
   // ユーザー指示に委ねる)。「ポーズ・カメラをできるだけ維持」チェックON で locked に切替。
   // 全ログインユーザー対象。ゲスト同期経路は framingMode 非対応のため認証済みのみ表示。
-  const [poseMode, setPoseMode] = useState<FramingMode>("free_pose");
+  const [poseMode, setPoseMode] = useState<FramingMode>(
+    COORDINATE_DEFAULT_FRAMING_MODE
+  );
   const shouldShowPoseModeControl = authState === "authenticated";
   const [selectedCount, setSelectedCount] = useState(1);
   const [selectedModel, setSelectedModel] = useState<GeminiModel>(
@@ -286,10 +291,10 @@ export function GenerationForm({
       backgroundMode,
       count: Math.min(selectedCount, maxGenerationCount),
       model: effectiveSelectedModel,
-      // framing_mode: locked 以外(=free_pose, 既定)を選んだときのみ渡す
-      ...(shouldShowPoseModeControl && poseMode !== "locked"
-        ? { framingMode: poseMode }
-        : {}),
+      // framing_mode は UI の選択を常に明示送信する (locked も含む)。
+      // 省略に頼らないことで「サーバが省略=locked にフォールバックする」前提と
+      // UI 既定 (free) の乖離を構造的に防ぐ (COORDINATE_DEFAULT_FRAMING_MODE 参照)。
+      ...(shouldShowPoseModeControl ? { framingMode: poseMode } : {}),
     });
   };
 

--- a/features/generation/lib/async-api.ts
+++ b/features/generation/lib/async-api.ts
@@ -119,8 +119,9 @@ export async function generateImageAsync(
       count: request.count ?? 1,
       generationType: request.generationType || "coordinate",
       model: request.model || DEFAULT_GENERATION_MODEL,
-      // framing_mode: free_pose(既定)のときのみ送る (省略 = locked = 「維持」チェックON)。
-      ...(request.framingMode === "free_pose"
+      // framing_mode は UI の選択 (free_pose / locked) を常に明示送信する。
+      // 省略に頼らず値を必ず載せることで、サーバの省略時フォールバックと UI 既定の乖離を防ぐ。
+      ...(request.framingMode
         ? { framingMode: request.framingMode }
         : {}),
     }),

--- a/shared/generation/framing-mode.ts
+++ b/shared/generation/framing-mode.ts
@@ -14,7 +14,24 @@
 export const FRAMING_MODES = ["locked", "free_pose"] as const;
 export type FramingMode = (typeof FRAMING_MODES)[number];
 
+/**
+ * framingMode が未指定 (省略) のときのフォールバック。
+ * 用途は 2 つで、いずれも「保守的に現行挙動へ倒す」ためのもの:
+ *  1. 既存ジョブの generation_metadata に framingMode が無い場合 (getFramingModeFromGenerationMetadata)
+ *  2. リクエストが framingMode を送ってこない場合 (レガシー / 非 UI 経路)
+ * UI の既定値ではない点に注意 (UI 既定は COORDINATE_DEFAULT_FRAMING_MODE)。
+ */
 export const DEFAULT_FRAMING_MODE: FramingMode = "locked";
+
+/**
+ * コーディネート生成 UI の既定値。コーデ画面はこの値で初期化し、ユーザーが
+ * 「ポーズ・カメラをできるだけ維持」をチェックしない限り、この値を明示的に送る。
+ * DEFAULT_FRAMING_MODE (= 省略時の保守的フォールバック) とは別概念で、値も異なる:
+ *  - COORDINATE_DEFAULT_FRAMING_MODE = "free_pose" … UI が能動的に選ぶ既定
+ *  - DEFAULT_FRAMING_MODE            = "locked"    … 省略/レガシー時の保守的既定
+ * UI は常に framingMode を明示送信するため、サーバのフォールバックに依存しない。
+ */
+export const COORDINATE_DEFAULT_FRAMING_MODE: FramingMode = "free_pose";
 
 /**
  * 外部入力 (formData / JSON / metadata) を FramingMode に解釈する。


### PR DESCRIPTION
### 概要
コードレビューで記録した指摘 **#6(client free / server locked の二重定義)** を解消します。コーデ生成の framing 既定値を **名前付き定数に集約**し、「UI が free を既定にしているのにサーバの省略時フォールバックは locked」という静かな乖離を**構造的に防止**します。

### 背景
- `#368` で coアーデ生成の既定を free 化したが、UI 既定(free)は `GenerationForm` の useState リテラル、サーバ省略時フォールバックは `handler` のリテラル `"locked"` に分散していた。
- 将来、コーデの別投入経路が framingMode を付けずに叩くと、UI が free を謳っていてもサーバは locked で生成し、体験が静かに割れるリスクがあった。

### 変更内容
- **`shared/generation/framing-mode.ts`**: `COORDINATE_DEFAULT_FRAMING_MODE`(= `free_pose`, コーデ UI 既定)を新設。`DEFAULT_FRAMING_MODE`(= `locked`, 省略/レガシー/メタデータ解析時の保守的フォールバック)との**役割と値の違いをドキュメント化**。
- **`GenerationForm.tsx`**: `poseMode` 初期値のリテラルを `COORDINATE_DEFAULT_FRAMING_MODE` に置換。さらに **framingMode を常に明示送信**(`locked` も省略せず送る)。省略に依存しないことで乖離を構造的に防ぐ。
- **`async-api.ts`**: framingMode を値があれば常に送信。
- **`handler.ts`**: 省略時フォールバックを `"locked"` リテラル → `DEFAULT_FRAMING_MODE` に置換し、意図(UI は明示送信／省略=レガシー=保守的に locked)をコメント化。

### 挙動への影響
**挙動は不変**:
- `locked` 明示 → metadata に framingMode を入れない(従来どおり)
- `free_pose` → metadata に framingMode を入れる
- 省略(レガシー/非 UI) → `DEFAULT_FRAMING_MODE`(locked)へ保守的にフォールバック

### 検証
- `npm run lint` / `typecheck` / `test`(2252 pass) / `build -- --webpack` を確認。
- `framing-mode.ts` の変更は定数追加のみで worker が使う関数は不変 → **worker 再デプロイ不要**。
