### PR TITLE
feat(style-presets): プリセットのクリエイター選択 + 招待クリエイター管理画面

### DIFF
--- a/app/(app)/admin/admin-nav-items.ts
+++ b/app/(app)/admin/admin-nav-items.ts
@@ -116,6 +116,12 @@ export const adminNavItems: AdminNavItem[] = [
     iconKey: "image",
   },
   {
+    path: "/admin/creator-allowlist",
+    label: "クリエイター招待",
+    description: "申請可・クレジット選択肢になる招待クリエイターを管理",
+    iconKey: "shield-check",
+  },
+  {
     path: "/admin/creator-looks-two-stage",
     label: "Creator Looks設定",
     description: "衣装＋背景の2段階生成モードの公開レベルを管理",

--- a/app/(app)/admin/creator-allowlist/CreatorAllowlistClient.tsx
+++ b/app/(app)/admin/creator-allowlist/CreatorAllowlistClient.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { useToast } from "@/components/ui/use-toast";
+import type { CreatorAllowlistMember } from "@/features/creators/lib/creator-allowlist-repository";
+
+interface SearchUser {
+  user_id: string;
+  nickname: string | null;
+  avatar_url: string | null;
+}
+
+export function CreatorAllowlistClient({
+  initialMembers,
+}: {
+  initialMembers: CreatorAllowlistMember[];
+}) {
+  const { toast } = useToast();
+  const [members, setMembers] = useState<CreatorAllowlistMember[]>(initialMembers);
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<SearchUser[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [busyUserId, setBusyUserId] = useState<string | null>(null);
+
+  const memberUserIds = new Set(members.map((m) => m.userId));
+
+  const reload = async () => {
+    const res = await fetch("/api/admin/creator-allowlist");
+    if (res.ok) {
+      setMembers((await res.json()) as CreatorAllowlistMember[]);
+    }
+  };
+
+  const handleSearch = async () => {
+    const q = query.trim();
+    if (q.length < 2) {
+      toast({
+        title: "検索",
+        description: "2文字以上で検索してください",
+        variant: "destructive",
+      });
+      return;
+    }
+    setSearching(true);
+    try {
+      const res = await fetch(
+        `/api/admin/users/search?q=${encodeURIComponent(q)}`
+      );
+      const body = (await res.json().catch(() => null)) as
+        | { users?: SearchUser[]; error?: string }
+        | null;
+      if (!res.ok) {
+        throw new Error(body?.error || "検索に失敗しました");
+      }
+      setResults(body?.users ?? []);
+    } catch (error) {
+      toast({
+        title: "エラー",
+        description: error instanceof Error ? error.message : "検索に失敗しました",
+        variant: "destructive",
+      });
+    } finally {
+      setSearching(false);
+    }
+  };
+
+  const handleAdd = async (userId: string) => {
+    setBusyUserId(userId);
+    try {
+      const res = await fetch("/api/admin/creator-allowlist", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ userId }),
+      });
+      const body = (await res.json().catch(() => null)) as
+        | { error?: string }
+        | null;
+      if (!res.ok) {
+        throw new Error(body?.error || "追加に失敗しました");
+      }
+      toast({ title: "追加しました", description: "招待クリエイターに追加しました" });
+      await reload();
+    } catch (error) {
+      toast({
+        title: "エラー",
+        description: error instanceof Error ? error.message : "追加に失敗しました",
+        variant: "destructive",
+      });
+    } finally {
+      setBusyUserId(null);
+    }
+  };
+
+  const handleToggle = async (userId: string, nextActive: boolean) => {
+    setBusyUserId(userId);
+    try {
+      const res = await fetch(`/api/admin/creator-allowlist/${userId}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ isActive: nextActive }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as
+          | { error?: string }
+          | null;
+        throw new Error(body?.error || "更新に失敗しました");
+      }
+      await reload();
+    } catch (error) {
+      toast({
+        title: "エラー",
+        description: error instanceof Error ? error.message : "更新に失敗しました",
+        variant: "destructive",
+      });
+    } finally {
+      setBusyUserId(null);
+    }
+  };
+
+  const handleRemove = async (userId: string) => {
+    if (!window.confirm("この招待を削除しますか?(履歴は残りません)")) return;
+    setBusyUserId(userId);
+    try {
+      const res = await fetch(`/api/admin/creator-allowlist/${userId}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as
+          | { error?: string }
+          | null;
+        throw new Error(body?.error || "削除に失敗しました");
+      }
+      toast({ title: "削除しました" });
+      await reload();
+    } catch (error) {
+      toast({
+        title: "エラー",
+        description: error instanceof Error ? error.message : "削除に失敗しました",
+        variant: "destructive",
+      });
+    } finally {
+      setBusyUserId(null);
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      {/* 追加: ユーザー検索 */}
+      <section className="space-y-3">
+        <h2 className="text-base font-semibold text-slate-900">クリエイターを追加</h2>
+        <div className="flex gap-2">
+          <Input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleSearch();
+              }
+            }}
+            placeholder="ニックネーム または ユーザーID で検索"
+          />
+          <Button type="button" onClick={handleSearch} disabled={searching}>
+            {searching ? "検索中..." : "検索"}
+          </Button>
+        </div>
+
+        {results.length > 0 ? (
+          <ul className="divide-y rounded-lg border border-slate-200">
+            {results.map((u) => {
+              const already = memberUserIds.has(u.user_id);
+              return (
+                <li
+                  key={u.user_id}
+                  className="flex items-center gap-3 p-3"
+                >
+                  <Avatar url={u.avatar_url} alt={u.nickname ?? ""} />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium text-slate-900">
+                      {u.nickname ?? "(名前未設定)"}
+                    </p>
+                    <p className="truncate text-xs text-slate-400">{u.user_id}</p>
+                  </div>
+                  {already ? (
+                    <Badge variant="secondary">登録済み</Badge>
+                  ) : (
+                    <Button
+                      type="button"
+                      size="sm"
+                      onClick={() => handleAdd(u.user_id)}
+                      disabled={busyUserId === u.user_id}
+                    >
+                      招待
+                    </Button>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        ) : null}
+      </section>
+
+      {/* 一覧 */}
+      <section className="space-y-3">
+        <h2 className="text-base font-semibold text-slate-900">
+          招待クリエイター({members.length}人)
+        </h2>
+        {members.length === 0 ? (
+          <p className="text-sm text-slate-500">まだ登録がありません。</p>
+        ) : (
+          <ul className="divide-y rounded-lg border border-slate-200">
+            {members.map((m) => (
+              <li key={m.userId} className="flex items-center gap-3 p-3">
+                <Avatar url={m.avatarUrl} alt={m.nickname ?? ""} />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <p className="truncate text-sm font-medium text-slate-900">
+                      {m.nickname ?? "(名前未設定)"}
+                    </p>
+                    <Badge variant={m.isActive ? "default" : "secondary"}>
+                      {m.isActive ? "有効" : "無効"}
+                    </Badge>
+                  </div>
+                  <p className="truncate text-xs text-slate-400">{m.userId}</p>
+                  {m.note ? (
+                    <p className="truncate text-xs text-slate-500">{m.note}</p>
+                  ) : null}
+                </div>
+                <div className="flex shrink-0 gap-2">
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={() => handleToggle(m.userId, !m.isActive)}
+                    disabled={busyUserId === m.userId}
+                  >
+                    {m.isActive ? "無効化" : "有効化"}
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="destructive"
+                    onClick={() => handleRemove(m.userId)}
+                    disabled={busyUserId === m.userId}
+                  >
+                    削除
+                  </Button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function Avatar({ url, alt }: { url: string | null; alt: string }) {
+  if (!url) {
+    return <span className="h-9 w-9 shrink-0 rounded-full bg-slate-200" />;
+  }
+  return (
+    <span className="relative h-9 w-9 shrink-0 overflow-hidden rounded-full bg-slate-200">
+      <Image src={url} alt={alt} fill sizes="36px" className="object-cover" />
+    </span>
+  );
+}

--- a/app/(app)/admin/creator-allowlist/page.tsx
+++ b/app/(app)/admin/creator-allowlist/page.tsx
@@ -1,0 +1,45 @@
+import { connection } from "next/server";
+import { redirect } from "next/navigation";
+import { Card, CardContent } from "@/components/ui/card";
+import { getUser } from "@/lib/auth";
+import { getAdminUserIds } from "@/lib/env";
+import { listCreatorAllowlist } from "@/features/creators/lib/creator-allowlist-repository";
+import { CreatorAllowlistClient } from "./CreatorAllowlistClient";
+
+export default async function AdminCreatorAllowlistPage() {
+  await connection();
+
+  const user = await getUser();
+  const adminUserIds = getAdminUserIds();
+  if (!user || adminUserIds.length === 0 || !adminUserIds.includes(user.id)) {
+    redirect("/");
+  }
+
+  const members = await listCreatorAllowlist();
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1
+          className="text-2xl font-bold tracking-tight text-slate-900 sm:text-3xl"
+          style={{
+            fontFamily: "var(--font-admin-heading), ui-monospace, monospace",
+          }}
+        >
+          クリエイター招待
+        </h1>
+        <p className="mt-1 text-slate-600">
+          招待クリエイター(allowlist)を管理します。ここに登録された人は
+          プロンプト申請(/creators/submit)ができ、One-Tap Style の
+          クリエイター(提供者クレジット)選択肢にも表示されます。
+        </p>
+      </header>
+
+      <Card className="overflow-hidden border-violet-200/60 bg-white/95 shadow-sm">
+        <CardContent className="p-6 sm:p-8">
+          <CreatorAllowlistClient initialMembers={members} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/(app)/admin/style-presets/StylePresetForm.tsx
+++ b/app/(app)/admin/style-presets/StylePresetForm.tsx
@@ -21,10 +21,15 @@ import type {
   StylePresetStatus,
 } from "@/features/style-presets/lib/schema";
 import type { PresetCategoryAdmin } from "@/features/style-presets/lib/preset-category-repository";
+import type { AllowlistedCreator } from "@/features/style-presets/lib/style-preset-repository";
+
+/** クリエイター(提供者クレジット)未選択を表す Select 用センチネル値。 */
+const NO_PROVIDER_VALUE = "__none__";
 
 interface StylePresetFormProps {
   preset?: StylePresetAdmin;
   categories: PresetCategoryAdmin[];
+  creators: AllowlistedCreator[];
   onSuccess: () => void | Promise<void>;
   onCancel: () => void;
 }
@@ -32,6 +37,7 @@ interface StylePresetFormProps {
 export function StylePresetForm({
   preset,
   categories,
+  creators,
   onSuccess,
   onCancel,
 }: StylePresetFormProps) {
@@ -105,6 +111,10 @@ export function StylePresetForm({
   );
   const [dualReferenceSource, setDualReferenceSource] =
     useState<DualReferenceSource>(preset?.dualReferenceSource ?? "admin");
+  // クリエイター(提供者クレジット)。空文字=クレジット無し。
+  const [providerUserId, setProviderUserId] = useState<string>(
+    preset?.providerUserId ?? ""
+  );
   const [referenceFile, setReferenceFile] = useState<File | null>(null);
   const [referencePreviewUrl, setReferencePreviewUrl] = useState<string | null>(
     preset?.referenceImageUrl ?? null,
@@ -226,6 +236,8 @@ export function StylePresetForm({
       formData.append("category_id", categoryId);
       formData.append("image_input_mode", imageInputMode);
       formData.append("dual_reference_source", dualReferenceSource);
+      // クリエイター(提供者クレジット)。空文字でクレジット無しに更新できる。
+      formData.append("provider_user_id", providerUserId);
       if (file) {
         formData.append("file", file);
       }
@@ -384,6 +396,30 @@ export function StylePresetForm({
             </Select>
             <p className="mt-1 text-xs text-slate-500">
               raw カテゴリは共通プロンプトを付与しません。新規 admin/preset-categories で追加可能。
+            </p>
+          </div>
+          <div>
+            <Label htmlFor="provider_user_id">クリエイター(提供者クレジット)</Label>
+            <Select
+              value={providerUserId === "" ? NO_PROVIDER_VALUE : providerUserId}
+              onValueChange={(v) =>
+                setProviderUserId(v === NO_PROVIDER_VALUE ? "" : v)
+              }
+            >
+              <SelectTrigger id="provider_user_id" className="mt-1 min-h-[44px]">
+                <SelectValue placeholder="クリエイターを選択" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={NO_PROVIDER_VALUE}>クレジット無し</SelectItem>
+                {creators.map((c) => (
+                  <SelectItem key={c.id} value={c.id}>
+                    {c.nickname ?? c.id}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="mt-1 text-xs text-slate-500">
+              設定すると /style・ホームのカードに「提供 ◯◯」が表示されます。選択肢は招待クリエイター(allowlist)のみ。
             </p>
           </div>
           <div>

--- a/app/(app)/admin/style-presets/StylePresetForm.tsx
+++ b/app/(app)/admin/style-presets/StylePresetForm.tsx
@@ -115,6 +115,30 @@ export function StylePresetForm({
   const [providerUserId, setProviderUserId] = useState<string>(
     preset?.providerUserId ?? ""
   );
+  // 選択肢: 招待クリエイター(allowlist)に加え、既に設定済みのクリエイターが allowlist 外でも
+  // 表示・維持できるよう「現在のクレジット」を選択肢に含める(既存クレジットを壊さない)。
+  const allowlistedCreatorIds = useMemo(
+    () => new Set(creators.map((c) => c.id)),
+    [creators]
+  );
+  const creatorOptions = useMemo(() => {
+    const list = [...creators];
+    const current = preset?.providerUserId;
+    if (current && !allowlistedCreatorIds.has(current)) {
+      list.unshift({
+        id: current,
+        nickname: preset?.providerNickname ?? null,
+        avatarUrl: preset?.providerAvatarUrl ?? null,
+      });
+    }
+    return list;
+  }, [
+    creators,
+    allowlistedCreatorIds,
+    preset?.providerUserId,
+    preset?.providerNickname,
+    preset?.providerAvatarUrl,
+  ]);
   const [referenceFile, setReferenceFile] = useState<File | null>(null);
   const [referencePreviewUrl, setReferencePreviewUrl] = useState<string | null>(
     preset?.referenceImageUrl ?? null,
@@ -411,9 +435,10 @@ export function StylePresetForm({
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value={NO_PROVIDER_VALUE}>クレジット無し</SelectItem>
-                {creators.map((c) => (
+                {creatorOptions.map((c) => (
                   <SelectItem key={c.id} value={c.id}>
                     {c.nickname ?? c.id}
+                    {!allowlistedCreatorIds.has(c.id) ? "(現在のクレジット・招待外)" : ""}
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/app/(app)/admin/style-presets/StylePresetListClient.tsx
+++ b/app/(app)/admin/style-presets/StylePresetListClient.tsx
@@ -54,6 +54,7 @@ import { useToast } from "@/components/ui/use-toast";
 import { StylePresetForm } from "./StylePresetForm";
 import type { StylePresetAdmin } from "@/features/style-presets/lib/schema";
 import type { PresetCategoryAdmin } from "@/features/style-presets/lib/preset-category-repository";
+import type { AllowlistedCreator } from "@/features/style-presets/lib/style-preset-repository";
 
 interface SortableStylePresetCardProps {
   preset: StylePresetAdmin;
@@ -222,11 +223,13 @@ const pointerSensorOptions = {
 interface StylePresetListClientProps {
   initialPresets: StylePresetAdmin[];
   categories: PresetCategoryAdmin[];
+  creators: AllowlistedCreator[];
 }
 
 export function StylePresetListClient({
   initialPresets,
   categories,
+  creators,
 }: StylePresetListClientProps) {
   const [presets, setPresets] = useState<StylePresetAdmin[]>(initialPresets);
   const [editingPreset, setEditingPreset] = useState<StylePresetAdmin | null>(
@@ -416,6 +419,7 @@ export function StylePresetListClient({
           </DialogHeader>
           <StylePresetForm
             categories={categories}
+            creators={creators}
             onSuccess={async () => {
               setIsCreateOpen(false);
               await reload();
@@ -441,6 +445,7 @@ export function StylePresetListClient({
             <StylePresetForm
               preset={editingPreset}
               categories={categories}
+              creators={creators}
               onSuccess={async () => {
                 setEditingPreset(null);
                 await reload();

--- a/app/(app)/admin/style-presets/page.tsx
+++ b/app/(app)/admin/style-presets/page.tsx
@@ -3,7 +3,10 @@ import { redirect } from "next/navigation";
 import { Card, CardContent } from "@/components/ui/card";
 import { getUser } from "@/lib/auth";
 import { getAdminUserIds } from "@/lib/env";
-import { listStylePresetsForAdmin } from "@/features/style-presets/lib/style-preset-repository";
+import {
+  listAllowlistedCreators,
+  listStylePresetsForAdmin,
+} from "@/features/style-presets/lib/style-preset-repository";
 import { listPresetCategories } from "@/features/style-presets/lib/preset-category-repository";
 import { StylePresetListClient } from "./StylePresetListClient";
 import { CreatorPromptReviewPanel } from "./CreatorPromptReviewPanel";
@@ -18,10 +21,12 @@ export default async function AdminStylePresetsPage() {
     redirect("/");
   }
 
-  const [presets, categories] = await Promise.all([
+  const [presets, categories, creators] = await Promise.all([
     listStylePresetsForAdmin(),
     // 編集時に既存の inactive category を維持できるよう includeInactive=true
     listPresetCategories({ includeInactive: true }),
+    // クリエイター(提供者クレジット)選択肢 = 招待クリエイター(allowlist)。
+    listAllowlistedCreators(),
   ]);
 
   // クリエイター提供プロンプトの申請(pending かつ申請者あり)を審査パネルに出す。
@@ -61,6 +66,7 @@ export default async function AdminStylePresetsPage() {
           <StylePresetListClient
             initialPresets={presets}
             categories={categories}
+            creators={creators}
           />
         </CardContent>
       </Card>

--- a/app/api/admin/creator-allowlist/[userId]/route.ts
+++ b/app/api/admin/creator-allowlist/[userId]/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/auth";
+import { ensureSameOrigin } from "@/lib/security/same-origin";
+import { logAdminAction } from "@/lib/admin-audit";
+import {
+  removeCreatorAllowlistMember,
+  setCreatorAllowlistActive,
+} from "@/features/creators/lib/creator-allowlist-repository";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** PATCH: 有効/無効の切替({ isActive: boolean })。 */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ userId: string }> }
+) {
+  const originGuard = ensureSameOrigin(request);
+  if (originGuard) return originGuard;
+
+  let adminUser;
+  try {
+    adminUser = await requireAdmin();
+  } catch (error) {
+    if (error instanceof NextResponse) return error;
+    throw error;
+  }
+
+  const { userId } = await params;
+  if (!UUID_PATTERN.test(userId)) {
+    return NextResponse.json({ error: "ユーザーIDが不正です" }, { status: 400 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "入力が不正です" }, { status: 400 });
+  }
+  const isActive = (body as { isActive?: unknown })?.isActive;
+  if (typeof isActive !== "boolean") {
+    return NextResponse.json(
+      { error: "isActive は真偽値で指定してください" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    await setCreatorAllowlistActive(userId, isActive);
+    await logAdminAction({
+      adminUserId: adminUser.id,
+      actionType: "creator_allowlist_update",
+      targetType: "creator_looks_allowlist",
+      targetId: userId,
+      metadata: { isActive },
+    });
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error("[admin creator-allowlist] PATCH error:", error);
+    return NextResponse.json(
+      { error: "招待クリエイターの更新に失敗しました" },
+      { status: 500 }
+    );
+  }
+}
+
+/** DELETE: 物理削除。 */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ userId: string }> }
+) {
+  const originGuard = ensureSameOrigin(request);
+  if (originGuard) return originGuard;
+
+  let adminUser;
+  try {
+    adminUser = await requireAdmin();
+  } catch (error) {
+    if (error instanceof NextResponse) return error;
+    throw error;
+  }
+
+  const { userId } = await params;
+  if (!UUID_PATTERN.test(userId)) {
+    return NextResponse.json({ error: "ユーザーIDが不正です" }, { status: 400 });
+  }
+
+  try {
+    await removeCreatorAllowlistMember(userId);
+    await logAdminAction({
+      adminUserId: adminUser.id,
+      actionType: "creator_allowlist_remove",
+      targetType: "creator_looks_allowlist",
+      targetId: userId,
+    });
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error("[admin creator-allowlist] DELETE error:", error);
+    return NextResponse.json(
+      { error: "招待クリエイターの削除に失敗しました" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/admin/creator-allowlist/[userId]/route.ts
+++ b/app/api/admin/creator-allowlist/[userId]/route.ts
@@ -6,9 +6,7 @@ import {
   removeCreatorAllowlistMember,
   setCreatorAllowlistActive,
 } from "@/features/creators/lib/creator-allowlist-repository";
-
-const UUID_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+import { isUuid } from "@/lib/is-uuid";
 
 /** PATCH: 有効/無効の切替({ isActive: boolean })。 */
 export async function PATCH(
@@ -27,7 +25,7 @@ export async function PATCH(
   }
 
   const { userId } = await params;
-  if (!UUID_PATTERN.test(userId)) {
+  if (!isUuid(userId)) {
     return NextResponse.json({ error: "ユーザーIDが不正です" }, { status: 400 });
   }
 
@@ -81,7 +79,7 @@ export async function DELETE(
   }
 
   const { userId } = await params;
-  if (!UUID_PATTERN.test(userId)) {
+  if (!isUuid(userId)) {
     return NextResponse.json({ error: "ユーザーIDが不正です" }, { status: 400 });
   }
 

--- a/app/api/admin/creator-allowlist/route.ts
+++ b/app/api/admin/creator-allowlist/route.ts
@@ -7,9 +7,7 @@ import {
   listCreatorAllowlist,
   profileExistsForUserId,
 } from "@/features/creators/lib/creator-allowlist-repository";
-
-const UUID_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+import { isUuid } from "@/lib/is-uuid";
 
 export async function GET() {
   await connection();
@@ -58,7 +56,7 @@ export async function POST(request: NextRequest) {
   const noteRaw = (body as { note?: unknown })?.note;
   const note = typeof noteRaw === "string" && noteRaw.length > 0 ? noteRaw : null;
 
-  if (!UUID_PATTERN.test(userId)) {
+  if (!isUuid(userId)) {
     return NextResponse.json(
       { error: "ユーザーIDが不正です" },
       { status: 400 }

--- a/app/api/admin/creator-allowlist/route.ts
+++ b/app/api/admin/creator-allowlist/route.ts
@@ -1,0 +1,92 @@
+import { connection, NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/auth";
+import { ensureSameOrigin } from "@/lib/security/same-origin";
+import { logAdminAction } from "@/lib/admin-audit";
+import {
+  addCreatorAllowlistMember,
+  listCreatorAllowlist,
+  profileExistsForUserId,
+} from "@/features/creators/lib/creator-allowlist-repository";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function GET() {
+  await connection();
+  try {
+    await requireAdmin();
+  } catch (error) {
+    if (error instanceof NextResponse) return error;
+    throw error;
+  }
+
+  try {
+    const members = await listCreatorAllowlist();
+    return NextResponse.json(members);
+  } catch (error) {
+    console.error("[admin creator-allowlist] GET error:", error);
+    return NextResponse.json(
+      { error: "招待クリエイター一覧の取得に失敗しました" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const originGuard = ensureSameOrigin(request);
+  if (originGuard) return originGuard;
+
+  let adminUser;
+  try {
+    adminUser = await requireAdmin();
+  } catch (error) {
+    if (error instanceof NextResponse) return error;
+    throw error;
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "入力が不正です" }, { status: 400 });
+  }
+
+  const userId =
+    typeof (body as { userId?: unknown })?.userId === "string"
+      ? (body as { userId: string }).userId
+      : "";
+  const noteRaw = (body as { note?: unknown })?.note;
+  const note = typeof noteRaw === "string" && noteRaw.length > 0 ? noteRaw : null;
+
+  if (!UUID_PATTERN.test(userId)) {
+    return NextResponse.json(
+      { error: "ユーザーIDが不正です" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    // 実在ユーザー(profiles)のみ許可。
+    if (!(await profileExistsForUserId(userId))) {
+      return NextResponse.json(
+        { error: "該当するユーザーが見つかりません" },
+        { status: 400 }
+      );
+    }
+
+    await addCreatorAllowlistMember({ userId, note, addedBy: adminUser.id });
+    await logAdminAction({
+      adminUserId: adminUser.id,
+      actionType: "creator_allowlist_add",
+      targetType: "creator_looks_allowlist",
+      targetId: userId,
+    });
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error("[admin creator-allowlist] POST error:", error);
+    return NextResponse.json(
+      { error: "招待クリエイターの追加に失敗しました" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/admin/style-presets/[id]/route.ts
+++ b/app/api/admin/style-presets/[id]/route.ts
@@ -175,12 +175,15 @@ export async function PATCH(
     // クリエイター(提供者クレジット)の解決:
     //   - フィールド未送信 → 現状維持(undefined)
     //   - 空文字 → null(クレジット解除)
-    //   - 値あり → allowlist 所属を必須に
+    //   - 既存と同値 → そのまま維持(allowlist 外の既存クレジットも壊さない)
+    //   - 新規/変更 → allowlist 所属を必須に
     let providerUserId: string | null | undefined;
     if (typeof providerUserIdEntry !== "string") {
       providerUserId = undefined;
     } else if (providerUserIdEntry.length === 0) {
       providerUserId = null;
+    } else if (providerUserIdEntry === (existing.providerUserId ?? null)) {
+      providerUserId = providerUserIdEntry;
     } else {
       const creators = await listAllowlistedCreators();
       if (!creators.some((c) => c.id === providerUserIdEntry)) {

--- a/app/api/admin/style-presets/[id]/route.ts
+++ b/app/api/admin/style-presets/[id]/route.ts
@@ -11,6 +11,7 @@ import {
 import {
   deleteStylePreset,
   getStylePresetForAdminById,
+  listAllowlistedCreators,
   updateStylePreset,
 } from "@/features/style-presets/lib/style-preset-repository";
 import { getPresetCategoryById } from "@/features/style-presets/lib/preset-category-repository";
@@ -60,6 +61,7 @@ export async function PATCH(
     const categoryIdEntry = formData.get("category_id");
     const imageInputModeEntry = formData.get("image_input_mode");
     const dualReferenceSourceEntry = formData.get("dual_reference_source");
+    const providerUserIdEntry = formData.get("provider_user_id");
     const file = formData.get("file");
     const referenceFile = formData.get("reference_file");
     const hasNewReferenceFile =
@@ -170,6 +172,26 @@ export async function PATCH(
       }
     }
 
+    // クリエイター(提供者クレジット)の解決:
+    //   - フィールド未送信 → 現状維持(undefined)
+    //   - 空文字 → null(クレジット解除)
+    //   - 値あり → allowlist 所属を必須に
+    let providerUserId: string | null | undefined;
+    if (typeof providerUserIdEntry !== "string") {
+      providerUserId = undefined;
+    } else if (providerUserIdEntry.length === 0) {
+      providerUserId = null;
+    } else {
+      const creators = await listAllowlistedCreators();
+      if (!creators.some((c) => c.id === providerUserIdEntry)) {
+        return NextResponse.json(
+          { error: "クリエイターは招待リストから選んでください" },
+          { status: 400 }
+        );
+      }
+      providerUserId = providerUserIdEntry;
+    }
+
     // 共通の更新ペイロード
     const updatePayload = {
       title,
@@ -189,6 +211,8 @@ export async function PATCH(
       referenceImageStoragePath: existing.referenceImageStoragePath,
       referenceImageWidth: existing.referenceImageWidth,
       referenceImageHeight: existing.referenceImageHeight,
+      // provider は undefined(未送信)なら repository 側で現状維持。
+      providerUserId,
     };
 
     // 新しい reference file (= admin dual の場合のみ意味あり) を新規 object に保存し、DB 更新成功後に旧 object を削除する。

--- a/app/api/admin/style-presets/[id]/route.ts
+++ b/app/api/admin/style-presets/[id]/route.ts
@@ -182,7 +182,11 @@ export async function PATCH(
       providerUserId = undefined;
     } else if (providerUserIdEntry.length === 0) {
       providerUserId = null;
-    } else if (providerUserIdEntry === (existing.providerUserId ?? null)) {
+    } else if (
+      existing.providerUserId !== null &&
+      providerUserIdEntry === existing.providerUserId
+    ) {
+      // 既存と同値(変更なし)= グランドファーザー。allowlist 外の既存クレジットも壊さない。
       providerUserId = providerUserIdEntry;
     } else {
       const creators = await listAllowlistedCreators();

--- a/app/api/admin/style-presets/route.ts
+++ b/app/api/admin/style-presets/route.ts
@@ -10,6 +10,7 @@ import {
 } from "@/features/style-presets/lib/schema";
 import {
   createStylePreset,
+  listAllowlistedCreators,
   listStylePresetsForAdmin,
 } from "@/features/style-presets/lib/style-preset-repository";
 import { getPresetCategoryById } from "@/features/style-presets/lib/preset-category-repository";
@@ -65,6 +66,7 @@ export async function POST(request: NextRequest) {
     const categoryIdEntry = formData.get("category_id");
     const imageInputModeEntry = formData.get("image_input_mode");
     const dualReferenceSourceEntry = formData.get("dual_reference_source");
+    const providerUserIdEntry = formData.get("provider_user_id");
     const file = formData.get("file");
     const referenceFile = formData.get("reference_file");
 
@@ -178,6 +180,21 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    // クリエイター(提供者クレジット): 空なら null。指定時は allowlist 所属を必須にする。
+    const providerUserId =
+      typeof providerUserIdEntry === "string" && providerUserIdEntry.length > 0
+        ? providerUserIdEntry
+        : null;
+    if (providerUserId) {
+      const creators = await listAllowlistedCreators();
+      if (!creators.some((c) => c.id === providerUserId)) {
+        return NextResponse.json(
+          { error: "クリエイターは招待リストから選んでください" },
+          { status: 400 }
+        );
+      }
+    }
+
     const presetId = crypto.randomUUID();
     const uploaded = await uploadStylePresetImage(
       file,
@@ -225,6 +242,7 @@ export async function POST(request: NextRequest) {
       referenceImageStoragePath,
       referenceImageWidth,
       referenceImageHeight,
+      providerUserId,
     });
 
     revalidateStylePresets();

--- a/features/creators/lib/creator-allowlist-repository.ts
+++ b/features/creators/lib/creator-allowlist-repository.ts
@@ -83,27 +83,53 @@ export async function listCreatorAllowlist(
 }
 
 /**
- * メンバー追加(冪等 upsert)。既存行があれば is_active=true に戻す。
- * 戻り値は追加/更新後の行が active かどうか。
+ * メンバー追加(冪等)。
+ * - 既存行があれば is_active=true に戻すのみ(既存の note / added_by / invited_at は保全。
+ *   note は今回明示された場合のみ上書き)。
+ * - 行が無ければ新規 insert する。
+ * upsert(onConflict) は conflict 時に payload 全カラムを UPDATE して note/added_by を破壊するため使わない。
  */
 export async function addCreatorAllowlistMember(
   params: { userId: string; note?: string | null; addedBy?: string | null },
   client?: SupabaseClient
 ): Promise<void> {
   const supabase = getSupabase(client);
-  const { error } = await supabase
+
+  const { data: existing, error: selectError } = await supabase
     .from("creator_looks_allowlist")
-    .upsert(
-      {
-        user_id: params.userId,
-        is_active: true,
-        note: params.note ?? null,
-        added_by: params.addedBy ?? null,
-      },
-      { onConflict: "user_id" }
-    );
+    .select("user_id")
+    .eq("user_id", params.userId)
+    .maybeSingle();
+  if (selectError) {
+    console.error("[creator-allowlist] add(select) error:", selectError);
+    throw new Error("招待クリエイターの追加に失敗しました");
+  }
+
+  if (existing) {
+    // 再有効化: is_active のみ確実に戻す。note は今回指定された時だけ上書き(既存を壊さない)。
+    const patch: { is_active: boolean; note?: string | null } = { is_active: true };
+    if (params.note != null) {
+      patch.note = params.note;
+    }
+    const { error } = await supabase
+      .from("creator_looks_allowlist")
+      .update(patch)
+      .eq("user_id", params.userId);
+    if (error) {
+      console.error("[creator-allowlist] add(reactivate) error:", error);
+      throw new Error("招待クリエイターの追加に失敗しました");
+    }
+    return;
+  }
+
+  const { error } = await supabase.from("creator_looks_allowlist").insert({
+    user_id: params.userId,
+    is_active: true,
+    note: params.note ?? null,
+    added_by: params.addedBy ?? null,
+  });
   if (error) {
-    console.error("[creator-allowlist] add error:", error);
+    console.error("[creator-allowlist] add(insert) error:", error);
     throw new Error("招待クリエイターの追加に失敗しました");
   }
 }

--- a/features/creators/lib/creator-allowlist-repository.ts
+++ b/features/creators/lib/creator-allowlist-repository.ts
@@ -1,0 +1,160 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+/**
+ * 招待クリエイター(creator_looks_allowlist)管理のためのリポジトリ。
+ * - allowlist は「プロンプトを申請できる人」かつ「プリセットのクリエイター(提供者クレジット)選択肢」の母集団。
+ * - allowlist.user_id は auth.users(id)。表示名/アイコンは profiles.user_id で突き合わせる。
+ * - admin 専用操作のため service role(createAdminClient)で実行する。
+ */
+
+export interface CreatorAllowlistMember {
+  /** auth.users.id(= allowlist.user_id)。プリセットのクレジットは profiles.id を使うので別途 profileId も返す。 */
+  userId: string;
+  /** profiles.id(= style_presets.provider_user_id に入る値)。profile 未作成なら null。 */
+  profileId: string | null;
+  nickname: string | null;
+  avatarUrl: string | null;
+  isActive: boolean;
+  note: string | null;
+  invitedAt: string | null;
+}
+
+function getSupabase(client?: SupabaseClient): SupabaseClient {
+  return client ?? createAdminClient();
+}
+
+/** allowlist 全件(active + inactive)を profiles と突き合わせて返す(invited_at 降順)。 */
+export async function listCreatorAllowlist(
+  client?: SupabaseClient
+): Promise<CreatorAllowlistMember[]> {
+  const supabase = getSupabase(client);
+  const { data: rows, error } = await supabase
+    .from("creator_looks_allowlist")
+    .select("user_id, is_active, note, invited_at")
+    .order("invited_at", { ascending: false });
+  if (error) {
+    console.error("[creator-allowlist] list error:", error);
+    throw new Error("招待クリエイター一覧の取得に失敗しました");
+  }
+
+  const list = (rows ?? []) as Array<{
+    user_id: string;
+    is_active: boolean;
+    note: string | null;
+    invited_at: string | null;
+  }>;
+  if (list.length === 0) return [];
+
+  const userIds = list.map((r) => r.user_id);
+  const { data: profiles, error: profileError } = await supabase
+    .from("profiles")
+    .select("id, nickname, avatar_url, user_id")
+    .in("user_id", userIds);
+  if (profileError) {
+    console.error("[creator-allowlist] profiles error:", profileError);
+    throw new Error("招待クリエイター一覧の取得に失敗しました");
+  }
+
+  const byUserId = new Map(
+    (profiles ?? []).map((p) => {
+      const row = p as {
+        id: string;
+        nickname: string | null;
+        avatar_url: string | null;
+        user_id: string;
+      };
+      return [row.user_id, row] as const;
+    })
+  );
+
+  return list.map((r) => {
+    const profile = byUserId.get(r.user_id);
+    return {
+      userId: r.user_id,
+      profileId: profile?.id ?? null,
+      nickname: profile?.nickname ?? null,
+      avatarUrl: profile?.avatar_url ?? null,
+      isActive: r.is_active,
+      note: r.note,
+      invitedAt: r.invited_at,
+    };
+  });
+}
+
+/**
+ * メンバー追加(冪等 upsert)。既存行があれば is_active=true に戻す。
+ * 戻り値は追加/更新後の行が active かどうか。
+ */
+export async function addCreatorAllowlistMember(
+  params: { userId: string; note?: string | null; addedBy?: string | null },
+  client?: SupabaseClient
+): Promise<void> {
+  const supabase = getSupabase(client);
+  const { error } = await supabase
+    .from("creator_looks_allowlist")
+    .upsert(
+      {
+        user_id: params.userId,
+        is_active: true,
+        note: params.note ?? null,
+        added_by: params.addedBy ?? null,
+      },
+      { onConflict: "user_id" }
+    );
+  if (error) {
+    console.error("[creator-allowlist] add error:", error);
+    throw new Error("招待クリエイターの追加に失敗しました");
+  }
+}
+
+/** 有効/無効の切替。 */
+export async function setCreatorAllowlistActive(
+  userId: string,
+  isActive: boolean,
+  client?: SupabaseClient
+): Promise<void> {
+  const supabase = getSupabase(client);
+  const { error } = await supabase
+    .from("creator_looks_allowlist")
+    .update({ is_active: isActive })
+    .eq("user_id", userId);
+  if (error) {
+    console.error("[creator-allowlist] set active error:", error);
+    throw new Error("招待クリエイターの更新に失敗しました");
+  }
+}
+
+/** 物理削除。 */
+export async function removeCreatorAllowlistMember(
+  userId: string,
+  client?: SupabaseClient
+): Promise<void> {
+  const supabase = getSupabase(client);
+  const { error } = await supabase
+    .from("creator_looks_allowlist")
+    .delete()
+    .eq("user_id", userId);
+  if (error) {
+    console.error("[creator-allowlist] remove error:", error);
+    throw new Error("招待クリエイターの削除に失敗しました");
+  }
+}
+
+/** 指定 user_id に profiles が存在するか(追加時の検証用)。 */
+export async function profileExistsForUserId(
+  userId: string,
+  client?: SupabaseClient
+): Promise<boolean> {
+  const supabase = getSupabase(client);
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("user_id")
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (error) {
+    console.error("[creator-allowlist] profile exists error:", error);
+    return false;
+  }
+  return Boolean(data);
+}

--- a/features/style-presets/lib/schema.ts
+++ b/features/style-presets/lib/schema.ts
@@ -114,6 +114,10 @@ export interface StylePresetAdmin {
   referenceImageStoragePath: string | null;
   referenceImageWidth: number | null;
   referenceImageHeight: number | null;
+  /** プリセット単位のクリエイター(提供者クレジット)= profiles.id。null ならクレジット無し。 */
+  providerUserId?: string | null;
+  providerNickname?: string | null;
+  providerAvatarUrl?: string | null;
   createdBy: string | null;
   updatedBy: string | null;
   createdAt: string;
@@ -184,6 +188,8 @@ export interface StylePresetInsert {
   referenceImageStoragePath?: string | null;
   referenceImageWidth?: number | null;
   referenceImageHeight?: number | null;
+  /** プリセット単位のクリエイター(提供者クレジット)= profiles.id。null でクレジット無し。 */
+  providerUserId?: string | null;
 }
 
 export interface StylePresetUpdate {
@@ -205,6 +211,8 @@ export interface StylePresetUpdate {
   referenceImageStoragePath?: string | null;
   referenceImageWidth?: number | null;
   referenceImageHeight?: number | null;
+  /** プリセット単位のクリエイター(提供者クレジット)= profiles.id。null でクレジット解除。 */
+  providerUserId?: string | null;
 }
 
 export const stylePresetReorderSchema = z.object({

--- a/features/style-presets/lib/style-preset-repository.ts
+++ b/features/style-presets/lib/style-preset-repository.ts
@@ -239,6 +239,7 @@ function normalizeDualReferenceSource(
 }
 
 function mapRowToAdmin(row: StylePresetRow): StylePresetAdmin {
+  const provider = extractProvider(row.provider);
   return {
     id: row.id,
     slug: row.slug,
@@ -258,6 +259,10 @@ function mapRowToAdmin(row: StylePresetRow): StylePresetAdmin {
     referenceImageStoragePath: row.reference_image_storage_path,
     referenceImageWidth: row.reference_image_width,
     referenceImageHeight: row.reference_image_height,
+    // プリセット単位のクリエイター(提供者クレジット)。編集フォームの既定 + update 時の現状維持に使う。
+    providerUserId: row.provider_user_id ?? null,
+    providerNickname: provider?.nickname ?? null,
+    providerAvatarUrl: provider?.avatar_url ?? null,
     createdBy: row.created_by,
     updatedBy: row.updated_by,
     createdAt: row.created_at,
@@ -367,6 +372,63 @@ export async function getStylePresetForAdminById(
   return data ? mapRowToAdmin(data as StylePresetRow) : null;
 }
 
+/** 提供者クレジット選択肢。id = profiles.id(= style_presets.provider_user_id に入る値)。 */
+export interface AllowlistedCreator {
+  id: string;
+  nickname: string | null;
+  avatarUrl: string | null;
+}
+
+/**
+ * 提供者クレジット選択用: creator_looks_allowlist (is_active) のクリエイターを
+ * profiles と突き合わせて返す。allowlist.user_id は auth.users(id) なので profiles.user_id で join。
+ * 値(id)は profiles.id = style_presets.provider_user_id。
+ */
+export async function listAllowlistedCreators(
+  client?: SupabaseClient
+): Promise<AllowlistedCreator[]> {
+  const supabase = getSupabase(client);
+  const { data: rows, error } = await supabase
+    .from("creator_looks_allowlist")
+    .select("user_id")
+    .eq("is_active", true);
+  if (error) {
+    console.error("[style-preset-repository] allowlist load error:", error);
+    throw new Error("クリエイター一覧の取得に失敗しました");
+  }
+  const userIds = (rows ?? [])
+    .map((r) => String((r as { user_id: string }).user_id))
+    .filter(Boolean);
+  if (userIds.length === 0) return [];
+
+  const { data: profiles, error: profileError } = await supabase
+    .from("profiles")
+    .select("id, nickname, avatar_url, user_id")
+    .in("user_id", userIds);
+  if (profileError) {
+    console.error(
+      "[style-preset-repository] allowlist profiles error:",
+      profileError
+    );
+    throw new Error("クリエイター一覧の取得に失敗しました");
+  }
+
+  return (profiles ?? [])
+    .map((p) => {
+      const row = p as {
+        id: string;
+        nickname: string | null;
+        avatar_url: string | null;
+      };
+      return {
+        id: String(row.id),
+        nickname: row.nickname ?? null,
+        avatarUrl: row.avatar_url ?? null,
+      };
+    })
+    .sort((a, b) => (a.nickname ?? "").localeCompare(b.nickname ?? "", "ja"));
+}
+
 export async function listPublishedStylePresets(
   options: PublishedStylePresetAccessOptions = {},
   client?: SupabaseClient
@@ -472,6 +534,7 @@ export async function createStylePreset(
     p_reference_image_width: input.referenceImageWidth ?? null,
     p_reference_image_height: input.referenceImageHeight ?? null,
     p_dual_reference_source: input.dualReferenceSource ?? "admin",
+    p_provider_user_id: input.providerUserId ?? null,
   });
 
   const row = mapRpcRow(data);
@@ -656,6 +719,11 @@ export async function updateStylePreset(
       input.dualReferenceSource !== undefined
         ? input.dualReferenceSource
         : existing.dualReferenceSource,
+    // RPC は直接代入のため、未指定なら現状値を維持して意図しない解除を防ぐ。
+    p_provider_user_id:
+      input.providerUserId !== undefined
+        ? input.providerUserId
+        : existing.providerUserId ?? null,
   });
 
   const row = mapRpcRow(data);

--- a/lib/admin-audit.ts
+++ b/lib/admin-audit.ts
@@ -30,7 +30,10 @@ export type AdminAuditAction =
   | "preset_category_deactivate"
   | "creator_looks_two_stage_visibility_update"
   | "creator_style_preset_approve"
-  | "creator_style_preset_reject";
+  | "creator_style_preset_reject"
+  | "creator_allowlist_add"
+  | "creator_allowlist_update"
+  | "creator_allowlist_remove";
 
 export interface AdminAuditLogParams {
   adminUserId: string;

--- a/lib/is-uuid.ts
+++ b/lib/is-uuid.ts
@@ -1,0 +1,7 @@
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** RFC 4122 形式の UUID 文字列か判定する。 */
+export function isUuid(value: string): boolean {
+  return UUID_PATTERN.test(value);
+}

--- a/supabase/migrations/20260626100000_add_provider_user_id_to_style_preset_rpcs.sql
+++ b/supabase/migrations/20260626100000_add_provider_user_id_to_style_preset_rpcs.sql
@@ -1,0 +1,237 @@
+-- admin が各プリセットの「クリエイター(提供者クレジット = provider_user_id)」を
+-- 選択・変更できるようにするため、create_style_preset / update_style_preset RPC に
+-- p_provider_user_id 引数を追加する。
+--
+-- 方針:
+--   - 引数追加はアリティ変更のため CREATE OR REPLACE 不可(別オーバーロードになり曖昧化)。
+--     よって DROP + CREATE で作り直し、権限を元どおり再付与する。
+--   - 末尾に p_provider_user_id UUID DEFAULT NULL を追加(既存の名前付き呼び出しは非破壊)。
+--   - update は直接代入(= フォームが現在値/選択値を常に送る前提。NULL でクレジット解除可)。
+--   - 「選択できるのは allowlist のクリエイターのみ」という業務制約は API 層で検証する
+--     (provider_user_id は profiles.id 参照で、列の FK のみが DB 側の保証)。
+-- 注: 本作業では適用しない方針(適用は最終確認のうえ一緒に実施する)。
+
+DROP FUNCTION IF EXISTS public.create_style_preset(
+  UUID, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, INTEGER, INTEGER, INTEGER, TEXT, UUID,
+  UUID, TEXT, TEXT, TEXT, INTEGER, INTEGER, TEXT
+);
+DROP FUNCTION IF EXISTS public.update_style_preset(
+  UUID, TEXT, TEXT, TEXT, TEXT, TEXT, INTEGER, INTEGER, INTEGER, TEXT, UUID,
+  UUID, TEXT, TEXT, TEXT, INTEGER, INTEGER, TEXT
+);
+
+CREATE FUNCTION public.create_style_preset(
+  p_id UUID,
+  p_slug TEXT,
+  p_title TEXT,
+  p_styling_prompt TEXT,
+  p_background_prompt TEXT DEFAULT NULL,
+  p_thumbnail_image_url TEXT DEFAULT NULL,
+  p_thumbnail_storage_path TEXT DEFAULT NULL,
+  p_thumbnail_width INTEGER DEFAULT 0,
+  p_thumbnail_height INTEGER DEFAULT 0,
+  p_sort_order INTEGER DEFAULT 0,
+  p_status TEXT DEFAULT 'draft',
+  p_created_by UUID DEFAULT NULL,
+  p_category_id UUID DEFAULT NULL,
+  p_image_input_mode TEXT DEFAULT 'single',
+  p_reference_image_url TEXT DEFAULT NULL,
+  p_reference_image_storage_path TEXT DEFAULT NULL,
+  p_reference_image_width INTEGER DEFAULT NULL,
+  p_reference_image_height INTEGER DEFAULT NULL,
+  p_dual_reference_source TEXT DEFAULT 'admin',
+  p_provider_user_id UUID DEFAULT NULL
+)
+RETURNS public.style_presets
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_created public.style_presets;
+  v_category_id UUID;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtextextended('style_presets_order', 0));
+
+  IF p_category_id IS NULL THEN
+    SELECT id INTO v_category_id FROM public.preset_categories WHERE key = 'coordinate';
+    IF v_category_id IS NULL THEN
+      RAISE EXCEPTION 'default preset_categories row "coordinate" is missing';
+    END IF;
+  ELSE
+    v_category_id := p_category_id;
+  END IF;
+
+  INSERT INTO public.style_presets (
+    id,
+    slug,
+    title,
+    styling_prompt,
+    background_prompt,
+    thumbnail_image_url,
+    thumbnail_storage_path,
+    thumbnail_width,
+    thumbnail_height,
+    sort_order,
+    status,
+    created_by,
+    updated_by,
+    category_id,
+    image_input_mode,
+    reference_image_url,
+    reference_image_storage_path,
+    reference_image_width,
+    reference_image_height,
+    dual_reference_source,
+    provider_user_id
+  )
+  VALUES (
+    p_id,
+    p_slug,
+    p_title,
+    p_styling_prompt,
+    NULLIF(p_background_prompt, ''),
+    p_thumbnail_image_url,
+    p_thumbnail_storage_path,
+    p_thumbnail_width,
+    p_thumbnail_height,
+    GREATEST(0, COALESCE(p_sort_order, 0)),
+    p_status,
+    p_created_by,
+    p_created_by,
+    v_category_id,
+    COALESCE(p_image_input_mode, 'single'),
+    p_reference_image_url,
+    p_reference_image_storage_path,
+    p_reference_image_width,
+    p_reference_image_height,
+    COALESCE(p_dual_reference_source, 'admin'),
+    p_provider_user_id
+  )
+  RETURNING * INTO v_created;
+
+  PERFORM public.place_style_preset_at_order(
+    v_created.id,
+    GREATEST(0, COALESCE(p_sort_order, 0)),
+    p_created_by
+  );
+
+  SELECT *
+  INTO v_created
+  FROM public.style_presets
+  WHERE id = v_created.id;
+
+  RETURN v_created;
+END;
+$$;
+
+CREATE FUNCTION public.update_style_preset(
+  p_id UUID,
+  p_title TEXT,
+  p_styling_prompt TEXT,
+  p_background_prompt TEXT DEFAULT NULL,
+  p_thumbnail_image_url TEXT DEFAULT NULL,
+  p_thumbnail_storage_path TEXT DEFAULT NULL,
+  p_thumbnail_width INTEGER DEFAULT 0,
+  p_thumbnail_height INTEGER DEFAULT 0,
+  p_sort_order INTEGER DEFAULT 0,
+  p_status TEXT DEFAULT 'draft',
+  p_updated_by UUID DEFAULT NULL,
+  p_category_id UUID DEFAULT NULL,
+  p_image_input_mode TEXT DEFAULT 'single',
+  p_reference_image_url TEXT DEFAULT NULL,
+  p_reference_image_storage_path TEXT DEFAULT NULL,
+  p_reference_image_width INTEGER DEFAULT NULL,
+  p_reference_image_height INTEGER DEFAULT NULL,
+  p_dual_reference_source TEXT DEFAULT 'admin',
+  p_provider_user_id UUID DEFAULT NULL
+)
+RETURNS public.style_presets
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_updated public.style_presets;
+  v_category_id UUID;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtextextended('style_presets_order', 0));
+
+  IF p_category_id IS NULL THEN
+    SELECT category_id INTO v_category_id FROM public.style_presets WHERE id = p_id;
+    IF v_category_id IS NULL THEN
+      RAISE EXCEPTION 'style preset not found';
+    END IF;
+  ELSE
+    v_category_id := p_category_id;
+  END IF;
+
+  UPDATE public.style_presets
+  SET
+    title = p_title,
+    styling_prompt = p_styling_prompt,
+    background_prompt = NULLIF(p_background_prompt, ''),
+    thumbnail_image_url = p_thumbnail_image_url,
+    thumbnail_storage_path = p_thumbnail_storage_path,
+    thumbnail_width = p_thumbnail_width,
+    thumbnail_height = p_thumbnail_height,
+    sort_order = GREATEST(0, COALESCE(p_sort_order, 0)),
+    status = p_status,
+    updated_by = p_updated_by,
+    category_id = v_category_id,
+    image_input_mode = COALESCE(p_image_input_mode, 'single'),
+    reference_image_url = p_reference_image_url,
+    reference_image_storage_path = p_reference_image_storage_path,
+    reference_image_width = p_reference_image_width,
+    reference_image_height = p_reference_image_height,
+    dual_reference_source = COALESCE(p_dual_reference_source, 'admin'),
+    provider_user_id = p_provider_user_id
+  WHERE id = p_id
+  RETURNING * INTO v_updated;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'style preset not found';
+  END IF;
+
+  PERFORM public.place_style_preset_at_order(
+    p_id,
+    GREATEST(0, COALESCE(p_sort_order, 0)),
+    p_updated_by
+  );
+
+  SELECT *
+  INTO v_updated
+  FROM public.style_presets
+  WHERE id = p_id;
+
+  RETURN v_updated;
+END;
+$$;
+
+-- 権限を元どおり再付与(SECURITY DEFINER の admin 用 RPC。anon/authenticated からは実行不可)。
+REVOKE EXECUTE ON FUNCTION public.create_style_preset(
+  UUID, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, INTEGER, INTEGER, INTEGER, TEXT, UUID,
+  UUID, TEXT, TEXT, TEXT, INTEGER, INTEGER, TEXT, UUID
+) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.update_style_preset(
+  UUID, TEXT, TEXT, TEXT, TEXT, TEXT, INTEGER, INTEGER, INTEGER, TEXT, UUID,
+  UUID, TEXT, TEXT, TEXT, INTEGER, INTEGER, TEXT, UUID
+) FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.create_style_preset(
+  UUID, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, INTEGER, INTEGER, INTEGER, TEXT, UUID,
+  UUID, TEXT, TEXT, TEXT, INTEGER, INTEGER, TEXT, UUID
+) TO service_role;
+GRANT EXECUTE ON FUNCTION public.update_style_preset(
+  UUID, TEXT, TEXT, TEXT, TEXT, TEXT, INTEGER, INTEGER, INTEGER, TEXT, UUID,
+  UUID, TEXT, TEXT, TEXT, INTEGER, INTEGER, TEXT, UUID
+) TO service_role;
+
+COMMENT ON FUNCTION public.create_style_preset(
+  UUID, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, INTEGER, INTEGER, INTEGER, TEXT, UUID,
+  UUID, TEXT, TEXT, TEXT, INTEGER, INTEGER, TEXT, UUID
+) IS 'スタイル新規作成(p_provider_user_id でクリエイター=提供者クレジットを設定可)';
+COMMENT ON FUNCTION public.update_style_preset(
+  UUID, TEXT, TEXT, TEXT, TEXT, TEXT, INTEGER, INTEGER, INTEGER, TEXT, UUID,
+  UUID, TEXT, TEXT, TEXT, INTEGER, INTEGER, TEXT, UUID
+) IS 'スタイル更新(p_provider_user_id でクリエイター=提供者クレジットを設定/解除可)';

--- a/supabase/migrations/20260626100000_add_provider_user_id_to_style_preset_rpcs.sql
+++ b/supabase/migrations/20260626100000_add_provider_user_id_to_style_preset_rpcs.sql
@@ -9,7 +9,12 @@
 --   - update は直接代入(= フォームが現在値/選択値を常に送る前提。NULL でクレジット解除可)。
 --   - 「選択できるのは allowlist のクリエイターのみ」という業務制約は API 層で検証する
 --     (provider_user_id は profiles.id 参照で、列の FK のみが DB 側の保証)。
--- 注: 本作業では適用しない方針(適用は最終確認のうえ一緒に実施する)。
+--
+-- 適用順序(重要): 本マイグレーション(RPC 差し替え)を先に適用してからコードをデプロイすること。
+--   アプリは create/update で p_provider_user_id を常時送るため、未適用のままコードを出すと
+--   PostgREST のオーバーロード解決に失敗し、全プリセットの作成・更新が PGRST202 で壊れる。
+
+BEGIN;
 
 DROP FUNCTION IF EXISTS public.create_style_preset(
   UUID, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, INTEGER, INTEGER, INTEGER, TEXT, UUID,
@@ -235,3 +240,5 @@ COMMENT ON FUNCTION public.update_style_preset(
   UUID, TEXT, TEXT, TEXT, TEXT, TEXT, INTEGER, INTEGER, INTEGER, TEXT, UUID,
   UUID, TEXT, TEXT, TEXT, INTEGER, INTEGER, TEXT, UUID
 ) IS 'スタイル更新(p_provider_user_id でクリエイター=提供者クレジットを設定/解除可)';
+
+COMMIT;

--- a/tests/unit/lib/style-preset-repository.test.ts
+++ b/tests/unit/lib/style-preset-repository.test.ts
@@ -516,9 +516,70 @@ describe("style-preset repository", () => {
       p_reference_image_width: null,
       p_reference_image_height: null,
       p_dual_reference_source: "admin",
+      p_provider_user_id: null,
     });
     expect(updated.sortOrder).toBe(2);
     expect(updated.updatedBy).toBe("admin-2");
+  });
+
+  test("updateStylePreset_providerUserId は 設定/解除/未指定維持 が RPC に正しく渡る", async () => {
+    const baseRow = {
+      id: "preset-1",
+      slug: "preset-1",
+      title: "T",
+      styling_prompt: "P",
+      background_prompt: null,
+      thumbnail_image_url: "https://example.com/old.webp",
+      thumbnail_storage_path: "style-presets/preset-1/old.webp",
+      thumbnail_width: 720,
+      thumbnail_height: 960,
+      sort_order: 1,
+      status: "draft" as const,
+      category_id: TEST_CATEGORY_ID,
+      image_input_mode: "single" as const,
+      reference_image_url: null,
+      reference_image_storage_path: null,
+      reference_image_width: null,
+      reference_image_height: null,
+      category: TEST_CATEGORY_ROW,
+      created_by: "admin-1",
+      updated_by: "admin-1",
+      created_at: "2026-03-22T00:00:00.000Z",
+      updated_at: "2026-03-22T00:00:00.000Z",
+    };
+
+    const runUpdate = async (
+      existingProvider: string | null,
+      input: { providerUserId?: string | null }
+    ) => {
+      const existingRow = { ...baseRow, provider_user_id: existingProvider };
+      const maybeSingle = jest
+        .fn()
+        .mockResolvedValueOnce({ data: existingRow, error: null })
+        .mockResolvedValueOnce({ data: existingRow, error: null });
+      const from = jest.fn().mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        maybeSingle,
+      });
+      const rpc = jest.fn().mockResolvedValue({ data: existingRow, error: null });
+      mockCreateAdminClient.mockReturnValue({ from, rpc } as never);
+      await updateStylePreset("preset-1", {
+        title: "T",
+        updatedBy: "admin-2",
+        ...input,
+      });
+      return rpc.mock.calls[0][1] as Record<string, unknown>;
+    };
+
+    // 設定: 明示した値が渡る
+    expect((await runUpdate(null, { providerUserId: "creator-x" })).p_provider_user_id).toBe(
+      "creator-x"
+    );
+    // 解除: null が渡る
+    expect((await runUpdate("creator-x", { providerUserId: null })).p_provider_user_id).toBeNull();
+    // 未指定: 既存値を維持する(意図せぬ解除をしない)
+    expect((await runUpdate("creator-x", {})).p_provider_user_id).toBe("creator-x");
   });
 
   test("createStylePreset_dualReferenceSource=user_upload を指定すると RPC に user_upload が渡る", async () => {


### PR DESCRIPTION
## 概要
admin が各 One-Tap Style プリセットに「クリエイター(提供者クレジット = provider_user_id)」を設定できるようにし、あわせて招待クリエイター(creator_looks_allowlist)を管理する admin 画面を追加します。クレジット表示(/style・ホームの「提供 ◯◯」+ /users/[id] リンク)は既存実装を流用します。

## 変更内容
### 1. プリセットのクリエイター選択
- `create_style_preset` / `update_style_preset` RPC に `p_provider_user_id` を追加(DROP+CREATE・権限再付与、`20260626100000`)。update は直接代入で、フォームが現在値を常時送る方式。
- repository: create/update に providerUserId を受け渡し、`mapRowToAdmin` で provider を実マッピング(編集既定 + 更新時の現状維持に必要)。`listAllowlistedCreators` 追加。
- API(POST/PATCH): `provider_user_id` を受け取り、**新規/変更時は allowlist 所属を必須検証**。既存と同値はグランドファーザー(allowlist 外の既存クレジットを壊さない)。
- UI: `StylePresetForm` に「クリエイター(提供者クレジット)」選択(クレジット無し + 招待クリエイター)。

### 2. 招待クリエイター管理画面
- `/admin/creator-allowlist` を新設(一覧 / ユーザー検索で追加 / 有効・無効 / 削除)。追加は既存 `/api/admin/users/search` を流用。
- API は requireAdmin + Same-Origin + 監査ログ(`creator_allowlist_add/update/remove`)。
- 登録者は `/creators/submit` で申請可 + クリエイター選択肢に表示。

### 3. 敵対的レビュー(MRAR)対応
- テスト破綻修正(updateStylePreset)+ provider の設定/解除/維持テスト追加、upsert の note/added_by 保全、migration の適用順序明記 + BEGIN/COMMIT、UUID 判定の集約(`lib/is-uuid.ts`)ほか。

## ⚠️ 適用手順(重要)
**RPC マイグレーション `20260626100000` を先に適用 → その後コードをデプロイ**してください。アプリは create/update で `p_provider_user_id` を常時送るため、未適用のままコードが出ると PostgREST のオーバーロード解決に失敗し、全プリセットの作成・更新が PGRST202 で壊れます。

## テスト
- `npm run lint` / `npm run typecheck`(既存のテスト型エラーを除き緑) / `npm run test`(2257 pass) / `npm run build -- --webpack` すべて確認済み。