### PR TITLE
feat(style): 提供者アイコン未設定時はデフォルトアイコンを表示

### DIFF
--- a/features/style/components/StyleProviderCredit.tsx
+++ b/features/style/components/StyleProviderCredit.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { User } from "lucide-react";
 
 interface StyleProviderCreditProps {
   /** 提供者の表示名(profiles.nickname をライブ取得した値)。 */
@@ -47,10 +48,11 @@ export function StyleProviderCredit({
   const isLarge = size === "lg";
 
   let content;
-  if (iconOnly && avatarUrl) {
-    // アイコンのみ。アクセシブル名は alt が担う。薄いフチで白背景でも輪郭が出る。
+  if (iconOnly) {
+    // アイコンのみ表示。アバター未設定でもニックネームは出さず、デフォルトアイコン
+    // (灰丸 + User、StickyHeader と同流儀)を表示する。薄いフチで白背景でも輪郭が出る。
     const px = isLarge ? 28 : 20;
-    content = (
+    content = avatarUrl ? (
       <Image
         src={avatarUrl}
         // href 経由でリンク化する場合、親 Link の aria-label と二重読み上げになるため alt を空にする。
@@ -59,6 +61,19 @@ export function StyleProviderCredit({
         height={px}
         className="rounded-full object-cover ring-1 ring-black/10"
       />
+    ) : (
+      <span
+        role="img"
+        aria-label={href ? undefined : labelText}
+        className="flex items-center justify-center rounded-full bg-gray-200 ring-1 ring-black/10"
+        style={{ width: px, height: px }}
+      >
+        <User
+          aria-hidden="true"
+          className="text-gray-500"
+          style={{ width: Math.round(px * 0.6), height: Math.round(px * 0.6) }}
+        />
+      </span>
     );
   } else {
     // アバター + 名前のピル(可視表示は名前のみ。「提供/by」はリンクの aria-label が担う)。

--- a/tests/unit/features/style/style-provider-credit.test.tsx
+++ b/tests/unit/features/style/style-provider-credit.test.tsx
@@ -77,11 +77,23 @@ describe("StyleProviderCredit", () => {
     expect(screen.queryByText("提供 mario335599")).toBeNull();
   });
 
-  test("アバター無し: 画像を出さず名前テキストのみ(非リンク)", () => {
+  test("アバター無し(非iconOnly): 画像を出さず名前テキストのみ(非リンク)", () => {
     render(<StyleProviderCredit nickname="mario335599" avatarUrl={null} />);
     expect(screen.getByText("mario335599")).toBeInTheDocument();
     expect(screen.queryByRole("img")).toBeNull();
     expect(screen.queryByRole("link")).toBeNull();
+  });
+
+  test("iconOnly + アバター無し: ニックネームを出さずデフォルトアイコン(role=img)を表示", () => {
+    render(
+      <StyleProviderCredit nickname="mario335599" avatarUrl={null} iconOnly />,
+    );
+    // ニックネームのテキストは出さない
+    expect(screen.queryByText("mario335599")).toBeNull();
+    // デフォルトアイコン(灰丸 + User)を role=img + aria-label で表現
+    expect(
+      screen.getByRole("img", { name: "提供 mario335599" }),
+    ).toBeInTheDocument();
   });
 
   test("locale='en': 接頭辞が by になる", () => {


### PR DESCRIPTION
## 概要
/style・ホームのスタイルカードのクリエイター(提供者)クレジットで、**アバター未設定時にニックネームのテキスト**が出ていたのを、**デフォルトアイコン(灰丸 + lucide User)**を表示するように変更します。

## 変更内容
- `StyleProviderCredit` の `iconOnly` 表示を「アバターあり→アイコン / アバター無し→デフォルトアイコン」に統一(ニックネームのテキストは出さない)。デフォルトアイコンは `StickyHeader` と同流儀(灰丸 + `User`)。
- アクセシビリティ:`role="img"` + `aria-label`(`提供 ◯◯`)で名前を担保。
- 非 `iconOnly`(マイキャラ選択の Style 画像オーバーレイ)の挙動は従来どおり(ニックネーム+アバターがあれば表示)。
- ユニットテスト追加(iconOnly + アバター無し → デフォルトアイコン)。

## テスト
- `npm run lint` / `npm run build -- --webpack` / `npm run test`(2258 pass)すべて緑。