### PR TITLE
feat(creators): 申請フォーム冒頭に「申請の流れ」説明を追加

### DIFF
--- a/app/(app)/creators/submit/page.tsx
+++ b/app/(app)/creators/submit/page.tsx
@@ -9,7 +9,6 @@ import {
   type CreatorPromptCategoryBadge,
 } from "@/features/creators/components/CreatorPromptSubmissionForm";
 import { CreatorSubmitTopBar } from "@/features/creators/components/CreatorSubmitTopBar";
-import { CreatorSubmitFlowGuide } from "@/features/creators/components/CreatorSubmitFlowGuide";
 import { CREATOR_PROMPT_CATEGORY_KEYS } from "@/features/style-presets/lib/creator-submission";
 
 export const metadata: Metadata = {
@@ -62,16 +61,12 @@ export default async function CreatorPromptSubmitPage() {
       <CreatorSubmitTopBar />
       <div className="px-4 pb-12 pt-6 md:pt-10">
         {allowed ? (
-          <div className="mx-auto max-w-2xl space-y-6">
-            <CreatorSubmitFlowGuide
-              testImageUrl={env.INSPIRE_TEST_CHARACTER_IMAGE_URL || null}
-            />
-            <CreatorPromptSubmissionForm
-              submitterAvatarUrl={submitterAvatarUrl}
-              submitterNickname={submitterNickname}
-              categoryBadges={categoryBadges}
-            />
-          </div>
+          <CreatorPromptSubmissionForm
+            submitterAvatarUrl={submitterAvatarUrl}
+            submitterNickname={submitterNickname}
+            categoryBadges={categoryBadges}
+            flowGuideTestImageUrl={env.INSPIRE_TEST_CHARACTER_IMAGE_URL || null}
+          />
         ) : (
           <div className="mx-auto max-w-xl rounded-3xl border border-amber-200 bg-amber-50 p-8 text-center">
             <p className="text-2xl">✋</p>

--- a/app/(app)/creators/submit/page.tsx
+++ b/app/(app)/creators/submit/page.tsx
@@ -3,11 +3,13 @@ import type { Metadata } from "next";
 import { requireAuth } from "@/lib/auth";
 import { isCreatorPromptSubmitterAllowed } from "@/lib/auth/creator-looks";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { env } from "@/lib/env";
 import {
   CreatorPromptSubmissionForm,
   type CreatorPromptCategoryBadge,
 } from "@/features/creators/components/CreatorPromptSubmissionForm";
 import { CreatorSubmitTopBar } from "@/features/creators/components/CreatorSubmitTopBar";
+import { CreatorSubmitFlowGuide } from "@/features/creators/components/CreatorSubmitFlowGuide";
 import { CREATOR_PROMPT_CATEGORY_KEYS } from "@/features/style-presets/lib/creator-submission";
 
 export const metadata: Metadata = {
@@ -60,11 +62,16 @@ export default async function CreatorPromptSubmitPage() {
       <CreatorSubmitTopBar />
       <div className="px-4 pb-12 pt-6 md:pt-10">
         {allowed ? (
-          <CreatorPromptSubmissionForm
-            submitterAvatarUrl={submitterAvatarUrl}
-            submitterNickname={submitterNickname}
-            categoryBadges={categoryBadges}
-          />
+          <div className="mx-auto max-w-2xl space-y-6">
+            <CreatorSubmitFlowGuide
+              testImageUrl={env.INSPIRE_TEST_CHARACTER_IMAGE_URL || null}
+            />
+            <CreatorPromptSubmissionForm
+              submitterAvatarUrl={submitterAvatarUrl}
+              submitterNickname={submitterNickname}
+              categoryBadges={categoryBadges}
+            />
+          </div>
         ) : (
           <div className="mx-auto max-w-xl rounded-3xl border border-amber-200 bg-amber-50 p-8 text-center">
             <p className="text-2xl">✋</p>

--- a/features/creators/components/CreatorPromptSubmissionForm.tsx
+++ b/features/creators/components/CreatorPromptSubmissionForm.tsx
@@ -19,6 +19,7 @@ import {
   type CreatorPromptConsentKey,
 } from "@/features/style-presets/lib/creator-submission";
 import { CreatorPromptCardPreview } from "./CreatorPromptCardPreview";
+import { CreatorSubmitFlowGuide } from "./CreatorSubmitFlowGuide";
 
 /** /style での見え方プレビューに渡すカテゴリのバッジ情報(DB の preset_categories 由来)。 */
 export interface CreatorPromptCategoryBadge {
@@ -58,10 +59,13 @@ export function CreatorPromptSubmissionForm({
   submitterAvatarUrl = null,
   submitterNickname = null,
   categoryBadges = {},
+  flowGuideTestImageUrl = null,
 }: {
   submitterAvatarUrl?: string | null;
   submitterNickname?: string | null;
   categoryBadges?: Record<string, CreatorPromptCategoryBadge>;
+  /** 申請の流れ説明に表示する確認用モデル画像(INSPIRE_TEST_CHARACTER_IMAGE_URL)。 */
+  flowGuideTestImageUrl?: string | null;
 } = {}) {
   const router = useRouter();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -194,6 +198,9 @@ export function CreatorPromptSubmissionForm({
           <strong>あなたの名前・アイコン</strong>付きで掲載されます。
         </p>
       </div>
+
+      {/* 申請の流れ(タイトル「プロンプトを提供する 🎨」の直下に配置) */}
+      <CreatorSubmitFlowGuide testImageUrl={flowGuideTestImageUrl} />
 
       {/* スタイルのタイプ: タイトルより上に配置。クリエイターに分かりやすい説明にする */}
       <div className="space-y-2">

--- a/features/creators/components/CreatorSubmitFlowGuide.tsx
+++ b/features/creators/components/CreatorSubmitFlowGuide.tsx
@@ -68,7 +68,7 @@ export function CreatorSubmitFlowGuide({
           <div className="text-sm text-amber-900">
             <p className="font-semibold">承認 → 掲載</p>
             <p className="mt-0.5 text-amber-800">
-              問題なければ承認し、運営がタイミングを見て One-Tap
+              問題なければ承認し、クリエイターと相談した上で One-Tap
               Style(ホーム・Style画面)に掲載します。掲載時はサムネとあなたの名前・アイコン付きで表示されます。
             </p>
           </div>

--- a/features/creators/components/CreatorSubmitFlowGuide.tsx
+++ b/features/creators/components/CreatorSubmitFlowGuide.tsx
@@ -1,0 +1,79 @@
+import Image from "next/image";
+
+/**
+ * /creators/submit 冒頭に出す「申請の流れ」説明。
+ * 申請 → 運営がモデル画像にプロンプトを適用して生成・確認 → 承認 → 掲載、までを説明する。
+ * testImageUrl(運営の確認用モデル画像)があれば実画像を表示する。
+ * ※ 公開時の通知は未実装のため、ここでは通知に言及しない。
+ */
+export function CreatorSubmitFlowGuide({
+  testImageUrl,
+}: {
+  testImageUrl: string | null;
+}) {
+  return (
+    <section className="rounded-2xl border border-amber-200 bg-amber-50/70 p-5">
+      <h2 className="text-base font-bold text-amber-900">申請の流れ</h2>
+      <p className="mt-1 text-sm text-amber-800">
+        提供いただいたプロンプトは、運営が確認したうえで掲載します。
+      </p>
+
+      <ol className="mt-4 space-y-4">
+        <li className="flex gap-3">
+          <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-amber-500 text-xs font-bold text-white">
+            1
+          </span>
+          <div className="text-sm text-amber-900">
+            <p className="font-semibold">入力して申請</p>
+            <p className="mt-0.5 text-amber-800">
+              スタイルのタイプ・タイトル・プロンプト・サムネを入力して申請します。
+            </p>
+          </div>
+        </li>
+
+        <li className="flex gap-3">
+          <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-amber-500 text-xs font-bold text-white">
+            2
+          </span>
+          <div className="text-sm text-amber-900">
+            <p className="font-semibold">運営が生成して確認</p>
+            <p className="mt-0.5 text-amber-800">
+              下のモデル画像にあなたのプロンプトを適用して実際に生成し、仕上がりを運営が確認します。
+              プロンプトは非公開で保護されます。
+            </p>
+            {testImageUrl ? (
+              <figure className="mt-3">
+                <div className="relative h-44 w-32 overflow-hidden rounded-lg border border-amber-200 bg-white">
+                  <Image
+                    src={testImageUrl}
+                    alt="確認に使うモデル画像"
+                    fill
+                    sizes="128px"
+                    className="object-contain"
+                    unoptimized
+                  />
+                </div>
+                <figcaption className="mt-1 text-xs text-amber-700">
+                  確認に使うモデル画像
+                </figcaption>
+              </figure>
+            ) : null}
+          </div>
+        </li>
+
+        <li className="flex gap-3">
+          <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-amber-500 text-xs font-bold text-white">
+            3
+          </span>
+          <div className="text-sm text-amber-900">
+            <p className="font-semibold">承認 → 掲載</p>
+            <p className="mt-0.5 text-amber-800">
+              問題なければ承認し、運営がタイミングを見て One-Tap
+              Style(ホーム・Style画面)に掲載します。掲載時はサムネとあなたの名前・アイコン付きで表示されます。
+            </p>
+          </div>
+        </li>
+      </ol>
+    </section>
+  );
+}


### PR DESCRIPTION
## 概要
`/creators/submit` の冒頭に、申請後にどんな確認が入るかの「申請の流れ」説明を追加します。

## 変更内容
- `CreatorSubmitFlowGuide` を追加し、フォーム上部に3ステップで説明:
  1. 入力して申請(種類・タイトル・プロンプト・サムネ)
  2. **運営がモデル画像にあなたのプロンプトを適用して実際に生成し、仕上がりを確認**(プロンプトは非公開で保護)
  3. 承認 → 運営がタイミングを見て One-Tap Style(ホーム・Style画面)に掲載(サムネ+名前・アイコン付き)
- 確認に使う**モデル画像(`INSPIRE_TEST_CHARACTER_IMAGE_URL`)を実画像で表示**。
- **公開時の通知は現状未実装**のため、文面では通知に言及していません(将来別タスクで実装予定)。

## テスト
- `npm run lint` / `npm run build -- --webpack` / `npm run test` すべて緑。migration なし(DB変更なし)。