### PR TITLE
feat(analytics): S3計測修復 — 流入元(外部チャネル)と課金起点の記録

### DIFF
--- a/app/api/credits/checkout/route.ts
+++ b/app/api/credits/checkout/route.ts
@@ -14,6 +14,13 @@ import { getCreditsRouteCopy } from "@/features/credits/lib/route-copy";
 
 const checkoutBodySchema = z.object({
   packageId: z.string().min(1, "packageId is required"),
+  // 課金起点(計測用・任意): どの画面/導線から購入したか。例: purchase_page, balance_empty_modal, collection_complete。
+  origin: z
+    .string()
+    .trim()
+    .toLowerCase()
+    .regex(/^[a-z0-9_-]{1,40}$/)
+    .optional(),
 });
 
 function handleStripeError(
@@ -97,7 +104,7 @@ export async function POST(request: NextRequest) {
       return jsonError(copy.packageIdRequired, "CREDITS_PACKAGE_ID_REQUIRED", 400);
     }
 
-    const { packageId } = parsed.data;
+    const { packageId, origin } = parsed.data;
     const percoinPackage = findPercoinPackage(packageId);
     if (!percoinPackage) {
       return jsonError(copy.invalidPackage, "CREDITS_PACKAGE_NOT_FOUND", 404);
@@ -163,6 +170,8 @@ export async function POST(request: NextRequest) {
       metadata: {
         packageId: percoinPackage.id,
         percoinAmount: String(percoinPackage.credits),
+        // 課金起点(計測用)。webhook で credit_transactions.metadata.origin に転記する。
+        ...(origin ? { origin } : {}),
       },
     });
 

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -481,6 +481,8 @@ async function handlePercoinCheckoutCompleted(
       mode: isStripeTestMode() ? "test" : "live",
       revenueYen: normalizeRevenueYen(session.amount_total),
       revenueSource: "stripe_checkout",
+      // 課金起点(計測用)。checkout の metadata.origin を転記(どの画面/導線から購入したか)。
+      ...(session.metadata?.origin ? { origin: session.metadata.origin } : {}),
     },
     supabaseClient: supabase,
   });

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -11,6 +11,7 @@ import { CollectionProgressChecker } from "@/components/CollectionProgressChecke
 import { CollectionUnlockDripListener } from "@/features/collections/components/CollectionUnlockDripListener";
 import { BonusNotificationToastListener } from "@/features/notifications/components/BonusNotificationToastListener";
 import { TutorialTourProvider } from "@/features/tutorial/components/TutorialTourProvider";
+import { SignupSourceCapture } from "@/features/auth/components/SignupSourceCapture";
 import { stripLocalePrefix } from "@/i18n/config";
 
 /**
@@ -60,6 +61,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
 
   return (
     <>
+      <SignupSourceCapture />
       <Suspense fallback={<div className="h-16" />}>
         <StickyHeader />
       </Suspense>

--- a/features/auth/components/AuthForm.tsx
+++ b/features/auth/components/AuthForm.tsx
@@ -20,9 +20,21 @@ import {
 } from "@/components/ui/dialog";
 import { signIn, signUp, signInWithOAuth, type OAuthProvider } from "../lib/auth-client";
 import { parseSignupSource, type SignupSource } from "../lib/signup-source";
+import { SIGNUP_SOURCE_COOKIE } from "./SignupSourceCapture";
 import { useToast } from "@/components/ui/use-toast";
 import { PasswordRequirements, isPasswordValid } from "./PasswordRequirements";
 import { useWebViewDetection, buildIntentUrl } from "./WebViewBanner";
+
+/** first-touch で保存された流入元 cookie を読む(SSR では null)。 */
+function readSignupSourceCookie(): string | null {
+  if (typeof document === "undefined") return null;
+  const match = document.cookie
+    .split("; ")
+    .find((c) => c.startsWith(`${SIGNUP_SOURCE_COOKIE}=`));
+  return match
+    ? decodeURIComponent(match.slice(SIGNUP_SOURCE_COOKIE.length + 1))
+    : null;
+}
 
 interface AuthFormProps {
   mode: "signin" | "signup";
@@ -84,9 +96,12 @@ export function AuthForm({
 
   // URLクエリパラメータから紹介コードを取得
   const referralCode = searchParams.get("ref");
-  // prop 指定(モーダル内導線)を優先し、無ければ URL クエリから解決する。
+  // prop 指定(モーダル内導線)を優先 → URL クエリ → first-touch cookie の順で解決する。
+  // (X 等の外部リンクがホーム等に着地し、その後に登録しても流入元を拾えるようにする)
   const signupSource =
-    signupSourceProp ?? parseSignupSource(searchParams.get("signup_source"));
+    signupSourceProp ??
+    parseSignupSource(searchParams.get("signup_source")) ??
+    parseSignupSource(readSignupSourceCookie());
 
   const resolveRedirectTarget = () =>
     redirectTo ??

--- a/features/auth/components/SignupSourceCapture.tsx
+++ b/features/auth/components/SignupSourceCapture.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { parseSignupSource } from "@/features/auth/lib/signup-source";
+
+/** first-touch の流入元を保持する cookie 名。AuthForm の読み取りと一致させること。 */
+export const SIGNUP_SOURCE_COOKIE = "persta_signup_source";
+
+/**
+ * 着地時に URL の ?signup_source=(無ければ ?utm_source=)を first-touch で cookie 保存する。
+ * X 等の外部リンクがホームや /style に着地し、その後に登録しても流入元を失わないようにするための計測補助。
+ * 既に cookie があれば上書きしない(初回流入を尊重)。表示は何もしない。
+ */
+export function SignupSourceCapture() {
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const params = new URLSearchParams(window.location.search);
+    const source = parseSignupSource(
+      params.get("signup_source") ?? params.get("utm_source")
+    );
+    if (!source) return;
+    const exists = document.cookie
+      .split("; ")
+      .some((c) => c.startsWith(`${SIGNUP_SOURCE_COOKIE}=`));
+    if (exists) return;
+    const maxAge = 60 * 60 * 24 * 30; // 30日(first-touch)
+    document.cookie = `${SIGNUP_SOURCE_COOKIE}=${encodeURIComponent(
+      source
+    )}; path=/; max-age=${maxAge}; SameSite=Lax`;
+  }, []);
+
+  return null;
+}

--- a/features/auth/lib/signup-source.ts
+++ b/features/auth/lib/signup-source.ts
@@ -1,19 +1,27 @@
 export const STYLE_SIGNUP_SOURCE = "style" as const;
 export const WARDROBE_SIGNUP_SOURCE = "wardrobe" as const;
 
-export type SignupSource =
-  | typeof STYLE_SIGNUP_SOURCE
-  | typeof WARDROBE_SIGNUP_SOURCE;
+/**
+ * 流入元タグ。代表値は STYLE_SIGNUP_SOURCE / WARDROBE_SIGNUP_SOURCE だが、
+ * X 等の外部チャネル(例: x_profile, x_post_20260627)も自由形式で受け付ける。
+ * 値は parseSignupSource でサニタイズ済み(小文字英数 + _ -、1..40文字)。
+ * DB 側の CHECK 制約(profiles_signup_source_check)も同じ書式。
+ */
+export type SignupSource = string;
 
-const SIGNUP_SOURCES: readonly SignupSource[] = [
-  STYLE_SIGNUP_SOURCE,
-  WARDROBE_SIGNUP_SOURCE,
-];
+/** signup_source として許可する書式(DB の CHECK と一致させること)。 */
+const SIGNUP_SOURCE_PATTERN = /^[a-z0-9_-]{1,40}$/;
 
+/**
+ * 流入元タグをサニタイズして返す。トリム→小文字化し、許可文字・長さを満たせばその値、
+ * 満たさなければ null。これにより外部チャネルの任意タグも安全に保存できる。
+ */
 export function parseSignupSource(
   value: string | null | undefined
 ): SignupSource | null {
-  return SIGNUP_SOURCES.find((source) => source === value) ?? null;
+  if (!value) return null;
+  const normalized = value.trim().toLowerCase();
+  return SIGNUP_SOURCE_PATTERN.test(normalized) ? normalized : null;
 }
 
 export function buildStyleSignupPath(nextPath = "/style"): string {

--- a/features/credits/components/PercoinPurchaseGrid.tsx
+++ b/features/credits/components/PercoinPurchaseGrid.tsx
@@ -12,7 +12,12 @@ import { PercoinPurchaseCard } from "./PercoinPurchaseCard";
  * ペルコイン購入グリッド（自前UI + Checkout Session API）
  * Stripe Pricing Tableの4商品制限を回避し、5つすべてのパッケージを表示
  */
-export function PercoinPurchaseGrid() {
+export function PercoinPurchaseGrid({
+  origin = "purchase_page",
+}: {
+  /** 課金起点(計測用)。表示元の画面/導線を渡す。例: purchase_page, balance_empty_modal。 */
+  origin?: string;
+} = {}) {
   const t = useTranslations("credits");
   const locale = useLocale();
   const router = useRouter();
@@ -31,7 +36,7 @@ export function PercoinPurchaseGrid() {
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ packageId }),
+        body: JSON.stringify({ packageId, origin }),
       });
 
       const data = await response.json().catch(() => null);

--- a/supabase/migrations/20260627100000_relax_signup_source_for_external_channels.sql
+++ b/supabase/migrations/20260627100000_relax_signup_source_for_external_channels.sql
@@ -1,0 +1,22 @@
+-- S3 計測修復: signup_source(流入元タグ)を外部チャネル(X 等)でも記録できるようにする。
+--
+-- 背景: これまで CHECK 制約が値リスト('style','wardrobe')に限定され、外部チャネルの
+--   タグ(x_profile 等)が弾かれて NULL になり、流入元の 95% が欠損していた。
+-- 変更: 固定値リストの CHECK を「書式チェック(小文字英数 + _ -, 1..40文字)」に緩和する。
+--   既存の 'style' / 'wardrobe' は引き続き有効。アプリ側(parseSignupSource)でも同じ書式で
+--   サニタイズしてから保存する。
+-- 注: 追加的・後方互換(既存値は全て新 CHECK を満たす)。本作業では適用しない方針(最終確認のうえ一緒に適用)。
+
+BEGIN;
+
+ALTER TABLE public.profiles
+  DROP CONSTRAINT IF EXISTS profiles_signup_source_check;
+
+ALTER TABLE public.profiles
+  ADD CONSTRAINT profiles_signup_source_check
+  CHECK (signup_source IS NULL OR signup_source ~ '^[a-z0-9_-]{1,40}$');
+
+COMMENT ON COLUMN public.profiles.signup_source IS
+  '流入元タグ(小文字英数 + _ -、1..40文字)。代表値: style / wardrobe。外部チャネル例: x_profile, x_post_20260627, instagram。';
+
+COMMIT;

--- a/tests/unit/features/auth/signup-source.test.ts
+++ b/tests/unit/features/auth/signup-source.test.ts
@@ -5,15 +5,32 @@ import {
 } from "@/features/auth/lib/signup-source";
 
 describe("parseSignupSource", () => {
-  test("既知の値(style / wardrobe)はそのまま返す", () => {
+  test("代表値(style / wardrobe)はそのまま返す", () => {
     expect(parseSignupSource("style")).toBe(STYLE_SIGNUP_SOURCE);
     expect(parseSignupSource("wardrobe")).toBe(WARDROBE_SIGNUP_SOURCE);
   });
 
-  test("未知の値 / null / undefined / 空文字は null", () => {
-    expect(parseSignupSource("coordinate")).toBeNull();
+  test("外部チャネル等の自由形式タグも受理する(書式を満たす場合)", () => {
+    expect(parseSignupSource("x_profile")).toBe("x_profile");
+    expect(parseSignupSource("x_post_20260627")).toBe("x_post_20260627");
+    expect(parseSignupSource("instagram")).toBe("instagram");
+  });
+
+  test("トリム・小文字化してサニタイズする", () => {
+    expect(parseSignupSource("  X_Profile  ")).toBe("x_profile");
+    expect(parseSignupSource("INSTAGRAM")).toBe("instagram");
+  });
+
+  test("null / undefined / 空文字は null", () => {
     expect(parseSignupSource("")).toBeNull();
     expect(parseSignupSource(null)).toBeNull();
     expect(parseSignupSource(undefined)).toBeNull();
+  });
+
+  test("書式違反(許可外文字 / 40字超)は null", () => {
+    expect(parseSignupSource("has space")).toBeNull();
+    expect(parseSignupSource("bad!char")).toBeNull();
+    expect(parseSignupSource("日本語タグ")).toBeNull();
+    expect(parseSignupSource("a".repeat(41))).toBeNull();
   });
 });


### PR DESCRIPTION
## 概要
売上向上リサーチの最優先 S3(計測修復)。「どの導線が効いたか・どの画面から課金したか」を追えるようにする。現状 signup_source は95%欠損(値が style/wardrobe のみ許可で外部チャネルが弾かれていた)。

## 変更内容
### 集客元 signup_source(外部チャネル対応)
- `profiles_signup_source_check` を固定値リスト → **書式チェック(小文字英数 + `_ -`、1..40)** に緩和(migration `20260627100000`・後方互換)。`x_profile` 等の外部タグを受理。
- `parseSignupSource` を自由形式サニタイズに変更(代表値 style/wardrobe は維持)。
- **first-touch cookie 保存**(`SignupSourceCapture` を AppShell に常設):着地時の `?signup_source`(無ければ `?utm_source`)を保存し、ホーム等に着地→後から登録しても流入元を拾う。`AuthForm` は prop→URL→cookie の順で解決(email/OAuth 両対応)。

### 課金起点 origin
- `/api/credits/checkout` に `origin`(任意・サニタイズ)→ Stripe `metadata` → webhook で `credit_transactions.metadata.origin` に転記。
- `PercoinPurchaseGrid` に `origin` prop(既定 `purchase_page`)を追加。

## ⚠️ 適用順序
migration `20260627100000` は後方互換(既存値は新CHECKを満たす)。**適用 → デプロイ**の順で実施。

## テスト
- lint / typecheck(既存テスト型エラー除き) / build / test(2257 pass)すべて緑。

## 使い方(運用)
- X の固定ポスト/プロフィール等のリンクに `?signup_source=x_profile`(任意タグ)を付与 → 登録時に記録。
- 購入導線を増やす際は `<PercoinPurchaseGrid origin="balance_empty_modal" />` のように起点を渡す。