### PR TITLE
feat(collections): travel_to_italy をめくれる旅行日記帳として完走表示(mount/book 切替)

### DIFF
--- a/app/api/admin/preset-categories/[id]/route.ts
+++ b/app/api/admin/preset-categories/[id]/route.ts
@@ -357,6 +357,7 @@ export async function PATCH(
   const collectionResult = parseCollectionSettings(body, {
     isCollectionSeries: existing.isCollectionSeries,
     completionThreshold: existing.completionThreshold,
+    completionViewMode: existing.completionViewMode,
     mountTemplatePath: existing.mountTemplatePath,
     mountLayout: existing.mountLayout,
     mountSlots: existing.mountSlots,

--- a/app/api/admin/preset-categories/collection-settings-payload.ts
+++ b/app/api/admin/preset-categories/collection-settings-payload.ts
@@ -18,6 +18,10 @@ import {
 export interface CollectionSettingsPayload {
   isCollectionSeries?: boolean;
   completionThreshold?: number | null;
+  /** 完走表示モード: 'mount'(単一台紙) / 'book'(めくれる日記帳)。 */
+  completionViewMode?: "mount" | "book";
+  /** book 表示の表紙(0ページ目)画像 storage path。 */
+  bookCoverPath?: string | null;
   /** 完走必須の前提カテゴリ key(完走者限定の解放ゲート)。null=ゲートなし */
   unlockPrerequisiteKey?: string | null;
   /** プリセットを N 体ずつ段階解放する単位(正の整数)。null=最初から全部 */
@@ -67,6 +71,7 @@ export interface CollectionSettingsPayload {
 export interface CollectionSettingsExisting {
   isCollectionSeries: boolean;
   completionThreshold: number | null;
+  completionViewMode?: "mount" | "book";
   mountTemplatePath: string | null;
   mountLayout: MountLayoutKey | null;
   /** 省略時は null(未設定)として扱う */
@@ -112,6 +117,25 @@ export function parseCollectionSettings(
       return { ok: false, error: "completion_threshold must be a positive integer" };
     } else {
       payload.completionThreshold = v;
+    }
+  }
+
+  if (body.completion_view_mode !== undefined) {
+    const v = body.completion_view_mode;
+    if (v !== "mount" && v !== "book") {
+      return { ok: false, error: "completion_view_mode must be 'mount' or 'book'" };
+    }
+    payload.completionViewMode = v;
+  }
+
+  if (body.book_cover_path !== undefined) {
+    const v = body.book_cover_path;
+    if (v === null) {
+      payload.bookCoverPath = null;
+    } else if (typeof v !== "string" || v.trim().length === 0) {
+      return { ok: false, error: "book_cover_path must be a non-empty string or null" };
+    } else {
+      payload.bookCoverPath = v.trim();
     }
   }
 
@@ -651,30 +675,48 @@ export function parseCollectionSettings(
         : (existing.mountSlots ?? null),
   };
 
+  // 完走表示モード(実効値)。book は台紙テンプレ/レイアウトを使わないため R-02 を分岐する。
+  const effectiveViewMode =
+    payload.completionViewMode ?? existing.completionViewMode ?? "mount";
+
   if (effective.isCollectionSeries) {
-    const hasSlots =
-      Array.isArray(effective.mountSlots) && effective.mountSlots.length > 0;
-    if (
-      effective.completionThreshold === null ||
-      effective.completionThreshold <= 0 ||
-      !effective.mountTemplatePath ||
-      (effective.mountLayout === null && !hasSlots)
-    ) {
-      return {
-        ok: false,
-        error:
-          "コレクション有効時は コンプリート必要数(N) / 台紙テンプレ / (レイアウト または カスタム枠) が必要です",
-      };
-    }
-    // mount_slots(カスタム枠)があればそのスロット数、無ければレイアウトのスロット数と一致させる
-    const expectedSlotCount = hasSlots
-      ? effective.mountSlots!.length
-      : slotCountForLayout(effective.mountLayout!);
-    if (effective.completionThreshold !== expectedSlotCount) {
-      return {
-        ok: false,
-        error: "コンプリート必要数(N)は枠(スロット)数と一致させてください",
-      };
+    if (effectiveViewMode === "book") {
+      // book: コンプリート必要数(N=ページ数)のみ必須。台紙テンプレ/レイアウト/枠は不要。
+      if (
+        effective.completionThreshold === null ||
+        effective.completionThreshold <= 0
+      ) {
+        return {
+          ok: false,
+          error: "コレクション有効(book表示)時は コンプリート必要数(N) が必要です",
+        };
+      }
+    } else {
+      // mount(従来台紙): N / 台紙テンプレ / (レイアウト or カスタム枠) が必要。
+      const hasSlots =
+        Array.isArray(effective.mountSlots) && effective.mountSlots.length > 0;
+      if (
+        effective.completionThreshold === null ||
+        effective.completionThreshold <= 0 ||
+        !effective.mountTemplatePath ||
+        (effective.mountLayout === null && !hasSlots)
+      ) {
+        return {
+          ok: false,
+          error:
+            "コレクション有効時は コンプリート必要数(N) / 台紙テンプレ / (レイアウト または カスタム枠) が必要です",
+        };
+      }
+      // mount_slots(カスタム枠)があればそのスロット数、無ければレイアウトのスロット数と一致させる
+      const expectedSlotCount = hasSlots
+        ? effective.mountSlots!.length
+        : slotCountForLayout(effective.mountLayout!);
+      if (effective.completionThreshold !== expectedSlotCount) {
+        return {
+          ok: false,
+          error: "コンプリート必要数(N)は枠(スロット)数と一致させてください",
+        };
+      }
     }
   }
 

--- a/app/api/collections/mount/route.ts
+++ b/app/api/collections/mount/route.ts
@@ -187,7 +187,7 @@ export async function POST(request: NextRequest) {
     const { data: category, error: categoryError } = await admin
       .from("preset_categories")
       .select(
-        "id, mount_template_path, mount_layout, mount_slots, mount_template_width, mount_template_height, completion_threshold, visibility, display_name_ja, ogp_template_path, ogp_mount_placement",
+        "id, mount_template_path, mount_layout, mount_slots, mount_template_width, mount_template_height, completion_threshold, visibility, display_name_ja, ogp_template_path, ogp_mount_placement, completion_view_mode, book_cover_path",
       )
       .eq("key", categoryKey)
       .eq("is_collection_series", true)
@@ -200,6 +200,134 @@ export async function POST(request: NextRequest) {
     if (category.visibility !== "public" && !isAdminViewer(user.id)) {
       throw new Error(`category not public: ${categoryKey}`);
     }
+
+    // ===== book(めくれる日記帳)モード: 台紙合成をスキップし、ページ画像のスナップショット + 表紙OGP =====
+    if ((category as { completion_view_mode?: string }).completion_view_mode === "book") {
+      const bookThreshold =
+        typeof category.completion_threshold === "number"
+          ? category.completion_threshold
+          : null;
+      if (!bookThreshold || bookThreshold <= 0) {
+        throw new Error("collection settings incomplete (book threshold)");
+      }
+      // 採用ページ(selections 優先、無ければ各Day最新・sort_order順)
+      const pageReps = selections
+        ? await resolveSelectedImages({
+            userId: user.id,
+            categoryId: category.id as string,
+            selections,
+            slotCount: bookThreshold,
+          })
+        : await getRepresentativeImagesForCategory({
+            userId: user.id,
+            categoryId: category.id as string,
+            limit: bookThreshold,
+          });
+      if (pageReps.length !== bookThreshold) {
+        throw new Error(
+          `book pages incomplete: ${pageReps.length} of ${bookThreshold}`,
+        );
+      }
+      const bookPagePaths = pageReps.map((r) => r.storagePath);
+
+      // OGP(運営登録のテーマ表紙)を public バケットへコピーし mount_image_path に使う(/m の OGP 用)。
+      const bookOgpPath = `collection-mounts/${user.id}/${categoryKey}/book-ogp-${Date.now()}.png`;
+      const ogpTemplatePath = category.ogp_template_path as string | null;
+      let bookOgpStoredPath: string | null = null;
+      if (ogpTemplatePath) {
+        try {
+          const ogpBuf = await downloadBuffer(
+            admin,
+            TEMPLATE_BUCKET,
+            ogpTemplatePath,
+          );
+          const { error: ogpUploadErr } = await admin.storage
+            .from(GENERATED_IMAGES_BUCKET)
+            .upload(bookOgpPath, ogpBuf, {
+              contentType: "image/png",
+              upsert: false,
+            });
+          if (!ogpUploadErr) bookOgpStoredPath = bookOgpPath;
+        } catch (e) {
+          console.error("book OGP copy failed:", e);
+        }
+      }
+      uploadedPath = bookOgpStoredPath; // 後続失敗時のロールバック対象
+
+      const bookMountPath = bookOgpStoredPath ?? mountStoragePath;
+
+      // 採用ページのスナップショットを保存(初回/更新とも)。
+      const { error: bookUpdateErr } = await admin
+        .from("collection_completions")
+        .update({ book_page_paths: bookPagePaths })
+        .eq("id", completionId)
+        .eq("user_id", user.id);
+      if (bookUpdateErr) {
+        throw new Error(`book pages save failed: ${bookUpdateErr.message}`);
+      }
+
+      const bookSharePath = `/m/${completionId}/book`;
+
+      if (!isUpdate) {
+        const { data: finalized, error: finalizeError } = await admin.rpc(
+          "finalize_collection_completion",
+          {
+            p_completion_id: completionId,
+            p_user_id: user.id,
+            p_mount_image_path: bookMountPath,
+          },
+        );
+        if (finalizeError) {
+          throw new Error(`finalize failed: ${finalizeError.message}`);
+        }
+        if (finalized !== true) {
+          throw new Error("finalize skipped: completion is not generating");
+        }
+        revalidateTag(`collection-completions:${user.id}`, "max");
+        await Promise.allSettled([
+          recordStyleUsageEvent({
+            userId: user.id,
+            authState: "authenticated",
+            eventType: "complete_achieved",
+          }),
+          recordStyleUsageEvent({
+            userId: user.id,
+            authState: "authenticated",
+            eventType: "mount_generated",
+          }),
+        ]);
+      } else {
+        // 作り直し: mount_image_path を差し替え、旧 OGP を削除。
+        await admin
+          .from("collection_completions")
+          .update({ mount_image_path: bookMountPath })
+          .eq("id", completionId)
+          .eq("user_id", user.id);
+        if (previousMountPath && previousMountPath !== bookMountPath) {
+          try {
+            await admin.storage
+              .from(GENERATED_IMAGES_BUCKET)
+              .remove([previousMountPath]);
+          } catch {
+            // best effort
+          }
+        }
+      }
+
+      const bookOgpUrl = bookOgpStoredPath
+        ? admin.storage
+            .from(GENERATED_IMAGES_BUCKET)
+            .getPublicUrl(bookOgpStoredPath).data.publicUrl
+        : mountImageUrl;
+
+      return NextResponse.json({
+        status: "completed",
+        mode: "book",
+        sharePath: bookSharePath,
+        mountImageUrl: bookOgpUrl,
+      });
+    }
+
     const templatePath = category.mount_template_path as string | null;
     const threshold =
       typeof category.completion_threshold === "number"

--- a/app/api/collections/mount/route.ts
+++ b/app/api/collections/mount/route.ts
@@ -202,7 +202,12 @@ export async function POST(request: NextRequest) {
     }
 
     // ===== book(めくれる日記帳)モード: 台紙合成をスキップし、ページ画像のスナップショット + 表紙OGP =====
-    if ((category as { completion_view_mode?: string }).completion_view_mode === "book") {
+    const completionViewMode: "mount" | "book" =
+      (category as { completion_view_mode?: string | null })
+        .completion_view_mode === "book"
+        ? "book"
+        : "mount";
+    if (completionViewMode === "book") {
       const bookThreshold =
         typeof category.completion_threshold === "number"
           ? category.completion_threshold
@@ -230,41 +235,24 @@ export async function POST(request: NextRequest) {
       }
       const bookPagePaths = pageReps.map((r) => r.storagePath);
 
-      // OGP(運営登録のテーマ表紙)を public バケットへコピーし mount_image_path に使う(/m の OGP 用)。
-      const bookOgpPath = `collection-mounts/${user.id}/${categoryKey}/book-ogp-${Date.now()}.png`;
+      // OGP/シェア用の1枚絵は mount-{ts}.png(finalize が許可するパターン)に「必ず実ファイル」をアップロードする。
+      //   優先: 運営登録のテーマ表紙(ogp_template_path)。未設定なら1ページ目を流用してファイルを保証する。
+      // こうして mount_image_path が常に実在オブジェクトを指す(OGP/サムネが404にならない)。
       const ogpTemplatePath = category.ogp_template_path as string | null;
-      let bookOgpStoredPath: string | null = null;
-      if (ogpTemplatePath) {
-        try {
-          const ogpBuf = await downloadBuffer(
-            admin,
-            TEMPLATE_BUCKET,
-            ogpTemplatePath,
-          );
-          const { error: ogpUploadErr } = await admin.storage
-            .from(GENERATED_IMAGES_BUCKET)
-            .upload(bookOgpPath, ogpBuf, {
-              contentType: "image/png",
-              upsert: false,
-            });
-          if (!ogpUploadErr) bookOgpStoredPath = bookOgpPath;
-        } catch (e) {
-          console.error("book OGP copy failed:", e);
-        }
+      const ogpSourceBuf = ogpTemplatePath
+        ? await downloadBuffer(admin, TEMPLATE_BUCKET, ogpTemplatePath)
+        : await downloadBuffer(admin, GENERATED_IMAGES_BUCKET, bookPagePaths[0]);
+      const { error: ogpUploadErr } = await admin.storage
+        .from(GENERATED_IMAGES_BUCKET)
+        .upload(mountStoragePath, ogpSourceBuf, {
+          contentType: "image/png",
+          upsert: false,
+        });
+      if (ogpUploadErr) {
+        throw new Error(`book OGP upload failed: ${ogpUploadErr.message}`);
       }
-      uploadedPath = bookOgpStoredPath; // 後続失敗時のロールバック対象
-
-      const bookMountPath = bookOgpStoredPath ?? mountStoragePath;
-
-      // 採用ページのスナップショットを保存(初回/更新とも)。
-      const { error: bookUpdateErr } = await admin
-        .from("collection_completions")
-        .update({ book_page_paths: bookPagePaths })
-        .eq("id", completionId)
-        .eq("user_id", user.id);
-      if (bookUpdateErr) {
-        throw new Error(`book pages save failed: ${bookUpdateErr.message}`);
-      }
+      uploadedPath = mountStoragePath; // 後続失敗時のロールバック対象
+      const bookMountPath = mountStoragePath;
 
       const bookSharePath = `/m/${completionId}/book`;
 
@@ -283,6 +271,15 @@ export async function POST(request: NextRequest) {
         if (finalized !== true) {
           throw new Error("finalize skipped: completion is not generating");
         }
+        // finalize 成功後に採用ページを保存(failed 行に stale を残さない)。
+        const { error: bookPagesError } = await admin
+          .from("collection_completions")
+          .update({ book_page_paths: bookPagePaths })
+          .eq("id", completionId)
+          .eq("user_id", user.id);
+        if (bookPagesError) {
+          throw new Error(`book pages save failed: ${bookPagesError.message}`);
+        }
         revalidateTag(`collection-completions:${user.id}`, "max");
         await Promise.allSettled([
           recordStyleUsageEvent({
@@ -297,12 +294,20 @@ export async function POST(request: NextRequest) {
           }),
         ]);
       } else {
-        // 作り直し: mount_image_path を差し替え、旧 OGP を削除。
-        await admin
+        // 作り直し: mount_image_path と採用ページを更新。成功確認後にのみ旧ファイルを削除する
+        //   (レガシー isUpdate と同等のエラーハンドリング)。
+        const { error: updateError } = await admin
           .from("collection_completions")
-          .update({ mount_image_path: bookMountPath })
+          .update({
+            mount_image_path: bookMountPath,
+            book_page_paths: bookPagePaths,
+          })
           .eq("id", completionId)
           .eq("user_id", user.id);
+        if (updateError) {
+          throw new Error(`book update failed: ${updateError.message}`);
+        }
+        revalidateTag(`collection-completions:${user.id}`, "max");
         if (previousMountPath && previousMountPath !== bookMountPath) {
           try {
             await admin.storage
@@ -314,11 +319,9 @@ export async function POST(request: NextRequest) {
         }
       }
 
-      const bookOgpUrl = bookOgpStoredPath
-        ? admin.storage
-            .from(GENERATED_IMAGES_BUCKET)
-            .getPublicUrl(bookOgpStoredPath).data.publicUrl
-        : mountImageUrl;
+      const bookOgpUrl = admin.storage
+        .from(GENERATED_IMAGES_BUCKET)
+        .getPublicUrl(bookMountPath).data.publicUrl;
 
       return NextResponse.json({
         status: "completed",

--- a/app/m/[token]/book/page.tsx
+++ b/app/m/[token]/book/page.tsx
@@ -1,0 +1,76 @@
+import type { Metadata } from "next";
+import { connection } from "next/server";
+import { notFound } from "next/navigation";
+import { getUser } from "@/lib/auth";
+import { getCollectionBookByToken } from "@/features/collections/lib/public-mount-server-api";
+import type { CatalogPageData } from "@/features/catalog/components/CatalogPage";
+import { ScrapbookReader } from "@/features/collections/components/ScrapbookReader";
+
+interface BookPageProps {
+  params: Promise<{ token: string }>;
+}
+
+const SHARE_DESCRIPTION =
+  "うちの子の旅行日記(スクラップブック)。あなたのうちの子でも作れます。";
+
+export async function generateMetadata({
+  params,
+}: BookPageProps): Promise<Metadata> {
+  const { token } = await params;
+  const book = await getCollectionBookByToken(token);
+  const title = book
+    ? `${book.displayNameJa} | Persta.AI`
+    : "旅行日記 | Persta.AI";
+
+  const base: Metadata = {
+    title,
+    description: SHARE_DESCRIPTION,
+    robots: { index: false, follow: true },
+  };
+  if (!book || !book.ogpImageUrl) return base;
+
+  return {
+    ...base,
+    openGraph: {
+      title,
+      description: SHARE_DESCRIPTION,
+      type: "article",
+      siteName: "Persta.AI",
+      images: [{ url: book.ogpImageUrl, alt: title, width: 1200, height: 630 }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description: SHARE_DESCRIPTION,
+      images: [book.ogpImageUrl],
+    },
+  };
+}
+
+export default async function CollectionBookPage({ params }: BookPageProps) {
+  await connection();
+  const { token } = await params;
+  const book = await getCollectionBookByToken(token);
+  if (!book) {
+    notFound();
+  }
+
+  const user = await getUser();
+  const isOwner = Boolean(user && user.id === book.ownerId);
+
+  // クレジット項目は渡さない(displayName 無し)= 画像のみのスクラップブックページ。
+  const pages: CatalogPageData[] = book.pageImageUrls.map((url, i) => ({
+    id: String(i),
+    imageUrl: url,
+    alt: null,
+  }));
+
+  return (
+    <ScrapbookReader
+      title={book.displayNameJa}
+      coverImageUrl={book.coverImageUrl}
+      pages={pages}
+      isOwner={isOwner}
+    />
+  );
+}

--- a/app/m/[token]/page.tsx
+++ b/app/m/[token]/page.tsx
@@ -2,9 +2,12 @@ import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
 import { connection } from "next/server";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { getUser } from "@/lib/auth";
-import { getPublicMountByToken } from "@/features/collections/lib/public-mount-server-api";
+import {
+  getCollectionBookByToken,
+  getPublicMountByToken,
+} from "@/features/collections/lib/public-mount-server-api";
 import { mountAspectForCategory } from "@/features/collections/lib/mount-aspects";
 import { MountShareButton } from "@/features/collections/components/MountShareButton";
 import { MountCelebrationBackground } from "@/features/collections/components/MountCelebrationBackground";
@@ -66,6 +69,12 @@ export default async function PublicMountPage({
 }: PublicMountPageProps) {
   await connection();
   const { token } = await params;
+
+  // book(めくれる日記帳)完走は没入の本リーダーへ。/m/<id> への既存導線を全てカバーする。
+  const book = await getCollectionBookByToken(token);
+  if (book) {
+    redirect(`/m/${token}/book`);
+  }
 
   const mount = await getPublicMountByToken(token);
   if (!mount) {

--- a/app/m/[token]/page.tsx
+++ b/app/m/[token]/page.tsx
@@ -24,6 +24,40 @@ export async function generateMetadata({
   params,
 }: PublicMountPageProps): Promise<Metadata> {
   const { token } = await params;
+
+  // book(めくれる日記帳)完走は /m/<id>/book にリダイレクトする。リダイレクトを辿らない
+  // クローラ向けにも、book では台紙ではなく日記帳のタイトル/OGP を返す。
+  const book = await getCollectionBookByToken(token);
+  if (book) {
+    const bookTitle = `${book.displayNameJa} | Persta.AI`;
+    const bookDescription =
+      "うちの子の旅行日記(スクラップブック)。あなたのうちの子でも作れます。";
+    const bookBase: Metadata = {
+      title: bookTitle,
+      description: bookDescription,
+      robots: { index: false, follow: true },
+    };
+    if (!book.ogpImageUrl) return bookBase;
+    return {
+      ...bookBase,
+      openGraph: {
+        title: bookTitle,
+        description: bookDescription,
+        type: "article",
+        siteName: "Persta.AI",
+        images: [
+          { url: book.ogpImageUrl, alt: bookTitle, width: 1200, height: 630 },
+        ],
+      },
+      twitter: {
+        card: "summary_large_image",
+        title: bookTitle,
+        description: bookDescription,
+        images: [book.ogpImageUrl],
+      },
+    };
+  }
+
   const mount = await getPublicMountByToken(token);
   const title = mount
     ? `${mount.displayNameJa} コンプリートカード | Persta.AI`

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -43,8 +43,17 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     if (!pathname) return false;
     return stripLocalePrefix(pathname).pathname === "/creators/submit";
   })();
+  // コレクション完走の「めくれる日記帳」シェアは没入ビュー(/m/<token>/book)。
+  const isCollectionBook = (() => {
+    if (!pathname) return false;
+    return /^\/m\/[^/]+\/book\/?$/.test(stripLocalePrefix(pathname).pathname);
+  })();
   const shouldBypassAppShell =
-    isAdmin || isStandaloneDocs || isCatalogReader || isCreatorPromptSubmit;
+    isAdmin ||
+    isStandaloneDocs ||
+    isCatalogReader ||
+    isCreatorPromptSubmit ||
+    isCollectionBook;
 
   useEffect(() => {
     if (isAdmin) {

--- a/docs/planning/travel-italy-scrapbook-implementation-plan.md
+++ b/docs/planning/travel-italy-scrapbook-implementation-plan.md
@@ -1,0 +1,117 @@
+# travel_to_italy スクラップブック(めくれる旅行日記)実装計画
+
+作成日: 2026-06-27
+対象: コレクション `travel_to_italy`(9:16 縦長・8枚)の完走者向け「めくれる日記帳」シェアページ
+
+## 1. 概要
+
+コラボ企画 `travel_to_italy`(8プリセット=Day1..Day8、9:16縦長のスクラップブック生成)を**コレクションシリーズ化**し、
+完走時に従来の単一コンプリートカード(台紙)ではなく、**8枚を1枚ずつめくれる「旅行日記帳」**として表示・シェアできるようにする。
+めくりUIは絵師カタログ(`/catalog/[slug]`)の `CatalogBookView`(react-pageflip)を流用する。
+
+### 決定事項(ユーザー合意)
+- 完走表示: **本(めくり日記帳)に置き換え**(travel_to_italy のみ。従来台紙は出さない)
+- Xシェア時のOGP: **運営がOGP画像を用意**(別途登録)
+- 各ページの画像: **既定は自動(各Day最新1枚・sort_order順)+ 従来の台紙コンポーザ同様、同一Dayに複数あれば選択UIで差し替え可能**(「作り直し」で更新)
+- **本の0ページ目(表紙)**: travel_to_italy 用に**別途登録した表紙画像**を使う(`BookCover` front = 登録表紙)
+
+### 現状(調査済み)
+- `travel_to_italy`: `is_collection_series=false` / `completion_threshold=null` / `output_aspect_ratio_mode=9:16` / `visibility=admin_only` / published 8枚。
+- 完走の仕組み: `reserve_collection_completion` RPC → `collection_completions`(mount_status, mount_image_path)→ `/api/collections/mount` で単一PNG合成 → 公開ページ `/m/[completionId]`。
+- 各Day代表画像: `getRepresentativeImagesForCategory()`(generation_metadata->oneTapStyle->id でプリセット紐付け、最新1枚・sort_order順)。
+- カタログ本UI: `CatalogReaderModal` + `CatalogBookView`(react-pageflip・縦横自動切替・ジェスチャ)、`BookCover`、AppShell バイパス(`isCatalogReader`)。
+
+## 2. 設計判断(ADR)
+
+### ADR-1: 完走表示モードをカテゴリ設定で分岐
+- **Decision**: `preset_categories` に `completion_view_mode TEXT DEFAULT 'mount'`('mount' | 'book')を追加。travel_to_italy のみ 'book'。
+- **Reason**: 既存カテゴリ(神コレ等)の台紙挙動を一切変えずに、本表示を限定導入できる。
+- **Consequence**: 完走処理・表示が mode で分岐。
+
+### ADR-2: カタログ本UIは「共有コア抽出」で流用
+- **Decision**: `CatalogBookView` のめくり+ジェスチャ中核を汎用 `BookView`(ページは generic + `renderPage` コールバック)として抽出し、カタログ側は薄いラッパで従来どおり利用。スクラップブックは `ScrapbookPage`(9:16画像)を renderPage で描画。
+- **Reason**: 重複を避けつつ、カタログの既存挙動を壊さない。型結合(xAccountUrl 等カタログ固有)を切り離す。
+- **Consequence**: `/catalog` のリグレッション確認が必須。代替案=丸ごと複製(重複増だが影響局所)。リスク次第で複製にフォールバック可。
+
+### ADR-3: 本の画像ページはスナップショット保存 + Dayごとに選択可
+- **Decision**: 完走者が「旅行日記を作る」時、既存 `CollectionMountComposer` 同様の**選択UI**を出す(各Day既定=代表[最新1枚]、複数あれば差し替え可)。確定した「各Dayの採用画像 storage_path 8件」を `collection_completions.book_page_paths JSONB` に保存。
+- **Reason**: 同一Dayに複数生成があるユーザーが望む1枚を選べる(従来台紙のUXを踏襲)。自動選択は再生成で変わるためスナップショットで本を固定。
+- **Consequence**: 選択UI(8枠版)が必要。表示は保存パスから署名URLを発行。「作り直し」で更新可。
+
+### ADR-4: OGPは運営登録画像(既存テンプレ合成基盤を流用)
+- **Decision**: 運営が用意するOGP画像を `travel_to_italy.ogp_template_path` に登録(必要なら `ogp_mount_placement` で代表画像を合成)。既存 `compose-mount-ogp` を流用。
+- **Reason**: OGP生成基盤を再利用でき新規実装が最小。運営がデザインを管理。
+- **Consequence**: 運営がOGP画像を用意(本件はユーザー提供予定)。
+
+### ADR-6: 本の表紙(0ページ目)はカテゴリに登録
+- **Decision**: `preset_categories.book_cover_path`(新列)に travel_to_italy の表紙画像を登録し、`BookCover` の front(0ページ目)に使う。未登録時は簡易表紙にフォールバック。
+- **Reason**: カタログのキャンペーン表紙(cover_storage_path)と同じ考え方。本の世界観を表紙で出す。
+- **Consequence**: 表紙画像(運営アセット)の登録手段が必要(まずはバケット配置+列設定、将来 admin UI 化)。
+
+### ADR-5: 公開シェアは没入の本ビュー専用ルート
+- **Decision**: 本モードの公開シェアは没入ルート(例 `/m/[token]/book` または `/collections/book/[completionId]`)で `CatalogBookView` を全画面表示。OGP メタは表紙画像。AppShell バイパス対象に追加。`/m/[token]`(従来台紙)は mount モードのまま。
+- **Reason**: めくりUIは没入が前提(catalog と同様)。
+
+## 3. EARS(主要要件)
+
+- When ユーザーが travel_to_italy の8種をユニーク生成完了, the system shall 完走を記録し本生成を可能にする。
+- When 完走者が「旅行日記を作る」を押下, the system shall 各Day最新1枚を採用してページパスをスナップショットし、表紙OGPを生成し、シェア用の本を公開する。
+- While completion_view_mode='book', the system shall 単一台紙(mount)合成を行わず本表示にする。
+- When 任意のユーザーがシェアURLを開く, the system shall 没入の本ビュー(8ページめくり)を表示し、所有者にはシェア/作り直し、ゲストには「あなたのうちの子でも作れる」CTAを出す。
+- If 8種に達していない, then the system shall 本生成を拒否(既存 reserve RPC の再検証を流用)。
+
+## 4. 実装フェーズ
+
+```mermaid
+flowchart LR
+  P1[Phase1 DB/設定] --> P2[Phase2 サーバ]
+  P2 --> P3[Phase3 本UI/没入ページ]
+  P3 --> P4[Phase4 導線/整合/テスト]
+```
+
+### Phase 1: DB・カテゴリ設定
+- migration: `preset_categories` に `completion_view_mode`('mount'|'book', default 'mount')と `book_cover_path TEXT`(表紙)追加。`collection_completions.book_page_paths JSONB` 追加。
+- データ設定: travel_to_italy を `is_collection_series=true` / `completion_threshold=8` / `completion_view_mode='book'` に。OGP(`ogp_template_path`=運営提供)と `book_cover_path`(表紙)を設定。
+- ビルド確認: 型/マイグレーション差分が通る。
+
+### Phase 2: サーバー(本生成・取得)
+- `/api/collections/mount`(または新 `/api/collections/book`)を mode 分岐: book モードは台紙合成をスキップし、選択(無ければ代表)8枚を解決→`book_page_paths` 保存→OGP合成→finalize。
+- 公開取得: `getCollectionBook(completionId)` = 表紙 + 8ページ署名URL + 所有者判定。
+- ビルド確認: API 単体で動作。
+
+### Phase 3: 本UI・没入ページ・選択UI
+- `CatalogBookView` を最小変更で流用(ページ型からカタログ固有のクレジット必須項目を任意化)。`ScrapbookPage`(9:16)+ front 表紙=`book_cover_path`。
+- 没入シェアページ(新ルート)で本表示。AppShell バイパスに条件追加。OGP メタ設定。
+- **選択UI**: `CollectionMountComposer` を 8枠・Day選択版として流用し「旅行日記を作る」フローに。
+- ビルド確認: /catalog リグレッション無し + 本ページ表示。
+
+### Phase 4: 導線・整合・テスト
+- 完走者の進捗モーダル/マイページに「旅行日記を見る/作る」CTA(book モード時)。
+- 整合: 図と DB/UI の状態一致、ゲスト/所有者の出し分け、署名URL TTL。
+- 検証: lint/typecheck/test/build、実機(完走→選択→本生成→シェア→ゲスト閲覧→OGP)。
+
+## 5. 主要修正ファイル(見込み)
+
+| ファイル | 操作 | 内容 |
+|---|---|---|
+| supabase/migrations/<new>.sql | 新規 | completion_view_mode / book_page_paths 追加 |
+| features/collections/lib/*(mount/representative) | 修正 | book モード分岐・代表8枚解決・スナップショット |
+| app/api/collections/mount(or book)/route.ts | 修正/新規 | book 生成 |
+| features/collections/lib/public-... | 修正 | 本取得(署名URL) |
+| features/catalog/components/CatalogBookView.tsx | 修正 | 汎用 BookView 抽出(挙動不変) |
+| features/collections/components/ScrapbookBookView/ScrapbookPage | 新規 | 9:16本表示 |
+| app/(没入の本ルート)/page.tsx | 新規 | 公開シェア本ページ |
+| components/AppShell.tsx | 修正 | 本ルートをバイパス対象に |
+| features/my-page/.../CollectionProgressModal | 修正 | 「旅行日記」CTA |
+
+## 6. 前提・運営インプット・リスク
+
+- **運営インプット**: 表紙テーマ画像(OGP用 1200×630 + 本表紙)1枚。プレースメント(うちの子の配置)。
+- **前提**: travel_to_italy を公開(visibility public)するタイミングは運営判断(コラボ公開時)。
+- **リスク**: `CatalogBookView` 汎用化で /catalog を壊さないこと(代替=複製)。react-pageflip の非公開API依存。9:16縦長×モバイルでの見開き挙動(縦は単ページ送りで自然)。
+- **ロールバック**: completion_view_mode 既定 'mount' なので travel_to_italy を 'mount' に戻せば従来挙動。migration は追加列のみ。
+
+## 7. 検証
+- lint / typecheck / test / build --webpack。
+- 実機: 8種生成→完走→「旅行日記を作る」→ 没入本(8ページめくり)→ シェアURL→ ゲスト閲覧→ OGP(表紙)確認。
+- /catalog リグレッション(汎用化の影響)。

--- a/docs/planning/travel-italy-scrapbook-implementation-plan.md
+++ b/docs/planning/travel-italy-scrapbook-implementation-plan.md
@@ -36,7 +36,7 @@
 ### ADR-3: 本の画像ページはスナップショット保存 + Dayごとに選択可
 - **Decision**: 完走者が「旅行日記を作る」時、既存 `CollectionMountComposer` 同様の**選択UI**を出す(各Day既定=代表[最新1枚]、複数あれば差し替え可)。確定した「各Dayの採用画像 storage_path 8件」を `collection_completions.book_page_paths JSONB` に保存。
 - **Reason**: 同一Dayに複数生成があるユーザーが望む1枚を選べる(従来台紙のUXを踏襲)。自動選択は再生成で変わるためスナップショットで本を固定。
-- **Consequence**: 選択UI(8枠版)が必要。表示は保存パスから署名URLを発行。「作り直し」で更新可。
+- **Consequence**: 選択UI(8枠版)が必要。表示は generated-images(public)の公開URLで配信(既存の台紙共有と同方式)。「作り直し」で更新可。
 
 ### ADR-4: OGPは運営登録画像(既存テンプレ合成基盤を流用)
 - **Decision**: 運営が用意するOGP画像を `travel_to_italy.ogp_template_path` に登録(必要なら `ogp_mount_placement` で代表画像を合成)。既存 `compose-mount-ogp` を流用。
@@ -76,7 +76,7 @@ flowchart LR
 
 ### Phase 2: サーバー(本生成・取得)
 - `/api/collections/mount`(または新 `/api/collections/book`)を mode 分岐: book モードは台紙合成をスキップし、選択(無ければ代表)8枚を解決→`book_page_paths` 保存→OGP合成→finalize。
-- 公開取得: `getCollectionBook(completionId)` = 表紙 + 8ページ署名URL + 所有者判定。
+- 公開取得: `getCollectionBookByToken(completionId)` = 表紙 + 8ページ公開URL(generated-images) + 所有者判定。
 - ビルド確認: API 単体で動作。
 
 ### Phase 3: 本UI・没入ページ・選択UI
@@ -87,7 +87,7 @@ flowchart LR
 
 ### Phase 4: 導線・整合・テスト
 - 完走者の進捗モーダル/マイページに「旅行日記を見る/作る」CTA(book モード時)。
-- 整合: 図と DB/UI の状態一致、ゲスト/所有者の出し分け、署名URL TTL。
+- 整合: 図と DB/UI の状態一致、ゲスト/所有者の出し分け、公開URL(generated-images)配信。
 - 検証: lint/typecheck/test/build、実機(完走→選択→本生成→シェア→ゲスト閲覧→OGP)。
 
 ## 5. 主要修正ファイル(見込み)

--- a/features/catalog/components/CatalogPage.tsx
+++ b/features/catalog/components/CatalogPage.tsx
@@ -4,9 +4,13 @@ export interface CatalogPageData {
   id: string;
   imageUrl: string | null;
   alt: string | null;
-  displayName: string;
-  xAccountUrl: string;
-  sourceTweetUrl: string;
+  /**
+   * 絵師クレジット(カタログ用)。スクラップブック(日記帳)流用時は未指定で、
+   * その場合は下部グラデーション+クレジットを描画せず画像のみ全面表示する。
+   */
+  displayName?: string;
+  xAccountUrl?: string;
+  sourceTweetUrl?: string;
 }
 
 interface CatalogPageProps {
@@ -36,7 +40,7 @@ export function CatalogPage({ page, pageNumber, side }: CatalogPageProps) {
       {page.imageUrl ? (
         <Image
           src={page.imageUrl}
-          alt={page.alt ?? page.displayName}
+          alt={page.alt ?? page.displayName ?? ""}
           fill
           unoptimized
           // 本は全ページを DOM に持つ。lazy だと「めくった瞬間」に読み込みが
@@ -55,11 +59,13 @@ export function CatalogPage({ page, pageNumber, side }: CatalogPageProps) {
         </div>
       )}
 
-      {/* 下部グラデーション (クレジットの可読性確保) */}
-      <div
-        aria-hidden
-        className="absolute inset-x-0 bottom-0 h-3/5 bg-gradient-to-t from-black/90 via-black/50 to-transparent"
-      />
+      {/* 下部グラデーション (クレジットの可読性確保)。クレジットが無い(スクラップブック)時は出さない。 */}
+      {page.displayName ? (
+        <div
+          aria-hidden
+          className="absolute inset-x-0 bottom-0 h-3/5 bg-gradient-to-t from-black/90 via-black/50 to-transparent"
+        />
+      ) : null}
 
       {/* 薄い金箔風の枠 — 表紙とトーンを統一 */}
       <div
@@ -75,7 +81,8 @@ export function CatalogPage({ page, pageNumber, side }: CatalogPageProps) {
         />
       ) : null}
 
-      {/* 下部のクレジット */}
+      {/* 下部のクレジット(カタログ用)。スクラップブックでは displayName 未指定で非表示。 */}
+      {page.displayName ? (
       <div className="absolute inset-x-0 bottom-0 z-10 px-7 pb-8 text-center">
         <h2
           className="text-2xl italic leading-snug text-[#f6e8c4] sm:text-3xl"
@@ -132,6 +139,7 @@ export function CatalogPage({ page, pageNumber, side }: CatalogPageProps) {
           — {pageNumber} —
         </p>
       </div>
+      ) : null}
     </div>
   );
 }

--- a/features/collections/components/CollectionMountComposer.tsx
+++ b/features/collections/components/CollectionMountComposer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import {
   Dialog,
@@ -57,6 +58,7 @@ export function CollectionMountComposer({
   onClose,
   onGenerated,
 }: Props) {
+  const router = useRouter();
   const [status, setStatus] = useState<Status>("loading");
   const [outfits, setOutfits] = useState<OutfitOption[]>([]);
   const [selected, setSelected] = useState<Record<string, string>>({});
@@ -74,12 +76,18 @@ export function CollectionMountComposer({
         });
         const data = (await res.json().catch(() => ({}))) as {
           status?: string;
+          mode?: string;
           mountImageUrl?: string;
           sharePath?: string;
           mountTemplateWidth?: number | null;
           mountTemplateHeight?: number | null;
           error?: string;
         };
+        // book(めくれる日記帳)は結果モーダルではなく没入の本リーダーへ直接遷移する。
+        if (res.ok && data.status === "completed" && data.mode === "book" && data.sharePath) {
+          router.push(data.sharePath);
+          return;
+        }
         if (res.ok && data.status === "completed" && data.mountImageUrl) {
           onGenerated({
             categoryKey,
@@ -100,7 +108,7 @@ export function CollectionMountComposer({
         setStatus("error");
       }
     },
-    [categoryKey, onGenerated],
+    [categoryKey, onGenerated, router],
   );
 
   useEffect(() => {

--- a/features/collections/components/ScrapbookReader.tsx
+++ b/features/collections/components/ScrapbookReader.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { X, Share2 } from "lucide-react";
+import { CatalogBookView } from "@/features/catalog/components/CatalogBookView";
+import type { CatalogPageData } from "@/features/catalog/components/CatalogPage";
+
+/**
+ * コレクション完走の「めくれる日記帳(スクラップブック)」没入ビュー。
+ * カタログリーダーの CatalogBookView(react-pageflip)をそのまま流用し、
+ * 0ページ目の表紙(coverImageUrl)+ 各ページ(縦長9:16の生成画像)を表示する。
+ * クレジット(絵師名・Xリンク)は付けない(pages に displayName を渡さない)。
+ */
+export function ScrapbookReader({
+  title,
+  coverImageUrl,
+  pages,
+  isOwner,
+}: {
+  title: string;
+  coverImageUrl: string | null;
+  pages: CatalogPageData[];
+  isOwner: boolean;
+}) {
+  const router = useRouter();
+  const [chromeVisible, setChromeVisible] = useState(true);
+
+  // iOS Safari の rubber band 抑止(CatalogReaderModal と同方針)。
+  useEffect(() => {
+    const html = document.documentElement;
+    const body = document.body;
+    const prevHtmlOverflow = html.style.overflow;
+    const prevBodyOverflow = body.style.overflow;
+    const prevBodyPaddingBottom = body.style.paddingBottom;
+    html.style.overflow = "hidden";
+    body.style.overflow = "hidden";
+    body.style.paddingBottom = "0px";
+    return () => {
+      html.style.overflow = prevHtmlOverflow;
+      body.style.overflow = prevBodyOverflow;
+      body.style.paddingBottom = prevBodyPaddingBottom;
+    };
+  }, []);
+
+  const handleShare = async () => {
+    const url = typeof window !== "undefined" ? window.location.href : "";
+    try {
+      if (navigator.share) {
+        await navigator.share({ title, url });
+      } else if (navigator.clipboard) {
+        await navigator.clipboard.writeText(url);
+      }
+    } catch {
+      // ユーザーキャンセル等は無視
+    }
+  };
+
+  const chromeCls = (base: string) =>
+    `${base} transition-all duration-300 ${
+      chromeVisible
+        ? "translate-y-0 opacity-100"
+        : "pointer-events-none -translate-y-12 opacity-0"
+    }`;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex h-[100dvh] flex-col select-none bg-slate-50"
+      style={{ WebkitTouchCallout: "none" }}
+    >
+      <button
+        type="button"
+        onClick={() => router.back()}
+        aria-label="閉じる"
+        className={chromeCls(
+          "absolute left-4 top-4 z-10 inline-flex h-9 w-9 items-center justify-center rounded-full bg-stone-900/70 text-white shadow-md hover:bg-stone-900",
+        )}
+      >
+        <X className="h-5 w-5" />
+      </button>
+
+      {isOwner ? (
+        <button
+          type="button"
+          onClick={handleShare}
+          className={chromeCls(
+            "absolute right-4 top-4 z-10 inline-flex items-center gap-1.5 rounded-full bg-amber-500 px-4 py-2 text-sm font-bold text-white shadow-md hover:bg-amber-600",
+          )}
+        >
+          <Share2 className="h-4 w-4" />
+          シェア
+        </button>
+      ) : (
+        <Link
+          href="/collections"
+          className={chromeCls(
+            "absolute right-4 top-4 z-10 inline-flex items-center rounded-full bg-amber-500 px-4 py-2 text-xs font-bold text-white shadow-md hover:bg-amber-600",
+          )}
+        >
+          あなたのうちの子でも作れる！
+        </Link>
+      )}
+
+      <main className="relative flex flex-1 items-start justify-center overflow-hidden px-3 py-4 sm:px-6">
+        <CatalogBookView
+          campaignTitle={title}
+          campaignCoverImageUrl={coverImageUrl}
+          pages={pages}
+          onChromeVisibilityChange={(visible) => setChromeVisible(visible)}
+        />
+      </main>
+    </div>
+  );
+}

--- a/features/collections/components/ScrapbookReader.tsx
+++ b/features/collections/components/ScrapbookReader.tsx
@@ -44,6 +44,15 @@ export function ScrapbookReader({
     };
   }, []);
 
+  const handleClose = () => {
+    // 直リンク(履歴なし)で来たゲストは back() が no-op になるため /collections へ。
+    if (typeof window !== "undefined" && window.history.length <= 1) {
+      router.push("/collections");
+    } else {
+      router.back();
+    }
+  };
+
   const handleShare = async () => {
     const url = typeof window !== "undefined" ? window.location.href : "";
     try {
@@ -71,7 +80,7 @@ export function ScrapbookReader({
     >
       <button
         type="button"
-        onClick={() => router.back()}
+        onClick={handleClose}
         aria-label="閉じる"
         className={chromeCls(
           "absolute left-4 top-4 z-10 inline-flex h-9 w-9 items-center justify-center rounded-full bg-stone-900/70 text-white shadow-md hover:bg-stone-900",

--- a/features/collections/lib/public-mount-server-api.ts
+++ b/features/collections/lib/public-mount-server-api.ts
@@ -80,3 +80,78 @@ export async function getPublicMountByToken(
     mountTemplateHeight: catRecord.mount_template_height ?? null,
   };
 }
+
+export interface PublicCollectionBook {
+  completionId: string;
+  ownerId: string;
+  categoryKey: string;
+  displayNameJa: string;
+  /** 0ページ目の表紙画像URL(book_cover_path)。未登録なら null(簡易表紙にフォールバック)。 */
+  coverImageUrl: string | null;
+  /** 各ページ画像URL(順序付き)。 */
+  pageImageUrls: string[];
+  /** OGP/シェア用の1枚絵URL(= mount_image_path のテーマ表紙)。 */
+  ogpImageUrl: string | null;
+  completedAt: string | null;
+}
+
+/**
+ * 公開「めくれる日記帳(book)」用に token(= collection_completions.id)から完了済みの本を解決する。
+ * 完了していない / book_page_paths が無い / 存在しない場合は null。
+ */
+export async function getCollectionBookByToken(
+  token: string,
+): Promise<PublicCollectionBook | null> {
+  if (!UUID_PATTERN.test(token)) {
+    return null;
+  }
+
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("collection_completions")
+    .select(
+      "id, user_id, category_key, mount_image_path, completed_at, book_page_paths, preset_categories(display_name_ja, book_cover_path)",
+    )
+    .eq("id", token)
+    .eq("mount_status", "completed")
+    .maybeSingle();
+
+  if (error || !data) {
+    return null;
+  }
+
+  const rawPaths = (data as { book_page_paths?: unknown }).book_page_paths;
+  const pagePaths = Array.isArray(rawPaths)
+    ? rawPaths.filter((p): p is string => typeof p === "string")
+    : [];
+  if (pagePaths.length === 0) {
+    return null;
+  }
+
+  const pageImageUrls = pagePaths
+    .map((p) => buildPublicGeneratedImageUrl(p))
+    .filter((u): u is string => Boolean(u));
+  if (pageImageUrls.length === 0) {
+    return null;
+  }
+
+  const category = (data as { preset_categories?: unknown }).preset_categories;
+  const cat = Array.isArray(category) ? category[0] : category;
+  const catRecord = (cat ?? {}) as {
+    display_name_ja?: string;
+    book_cover_path?: string | null;
+  };
+
+  return {
+    completionId: data.id as string,
+    ownerId: data.user_id as string,
+    categoryKey: data.category_key as string,
+    displayNameJa: catRecord.display_name_ja ?? "",
+    coverImageUrl: buildPublicGeneratedImageUrl(catRecord.book_cover_path ?? null),
+    pageImageUrls,
+    ogpImageUrl: buildPublicGeneratedImageUrl(
+      (data.mount_image_path as string | null) ?? null,
+    ),
+    completedAt: (data.completed_at as string | null) ?? null,
+  };
+}

--- a/features/collections/lib/public-mount-server-api.ts
+++ b/features/collections/lib/public-mount-server-api.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { cache } from "react";
 import { createAdminClient } from "@/lib/supabase/admin";
 
 const GENERATED_IMAGES_BUCKET = "generated-images";
@@ -99,9 +100,9 @@ export interface PublicCollectionBook {
  * 公開「めくれる日記帳(book)」用に token(= collection_completions.id)から完了済みの本を解決する。
  * 完了していない / book_page_paths が無い / 存在しない場合は null。
  */
-export async function getCollectionBookByToken(
+export const getCollectionBookByToken = cache(async (
   token: string,
-): Promise<PublicCollectionBook | null> {
+): Promise<PublicCollectionBook | null> => {
   if (!UUID_PATTERN.test(token)) {
     return null;
   }
@@ -154,4 +155,4 @@ export async function getCollectionBookByToken(
     ),
     completedAt: (data.completed_at as string | null) ?? null,
   };
-}
+});

--- a/features/collections/lib/representative-images.ts
+++ b/features/collections/lib/representative-images.ts
@@ -75,11 +75,14 @@ export async function getRepresentativeImagesForCategory(params: {
   }
 
   // 4. 集めた衣装を sort_order 昇順に並べ、先頭 limit(=N) 個を採用
+  //    sort_order 同値(重複/未設定)時は presetId で安定化し、
+  //    book のページ順(Day順)が非決定的にならないようにする。
   return Array.from(repByPreset.values())
     .sort(
       (a, b) =>
         (sortOrderByPreset.get(a.presetId) ?? 0) -
-        (sortOrderByPreset.get(b.presetId) ?? 0),
+          (sortOrderByPreset.get(b.presetId) ?? 0) ||
+        a.presetId.localeCompare(b.presetId),
     )
     .slice(0, params.limit);
 }

--- a/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
+++ b/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
@@ -69,6 +69,10 @@ interface FormState {
   visibility: "public" | "admin_only";
   isCollectionSeries: boolean;
   completionThreshold: number | null;
+  /** 完走表示モード: mount(単一台紙) / book(めくれる日記帳) */
+  completionViewMode: "mount" | "book";
+  /** book 表示の表紙(0ページ目)画像 storage path。null=簡易表紙 */
+  bookCoverPath: string | null;
   /** 解放の前提カテゴリ key(完走者限定)。null=ゲートなし */
   unlockPrerequisiteKey: string | null;
   /** 段階解放の単位(正の整数)。null=最初から全部解放 */
@@ -161,6 +165,8 @@ function toFormState(
     visibility: initial?.visibility ?? "admin_only",
     isCollectionSeries: initial?.isCollectionSeries ?? false,
     completionThreshold: initial?.completionThreshold ?? null,
+    completionViewMode: initial?.completionViewMode ?? "mount",
+    bookCoverPath: initial?.bookCoverPath ?? null,
     unlockPrerequisiteKey: initial?.unlockPrerequisiteKey ?? null,
     progressiveBatchSize: initial?.progressiveBatchSize ?? null,
     mountTemplatePath: initial?.mountTemplatePath ?? null,
@@ -628,6 +634,8 @@ export function AdminPresetCategoryFormClient({
               visibility: form.visibility,
               is_collection_series: form.isCollectionSeries,
               completion_threshold: effectiveThreshold,
+              completion_view_mode: form.completionViewMode,
+              book_cover_path: form.bookCoverPath,
               unlock_prerequisite_key: form.unlockPrerequisiteKey,
               progressive_batch_size: form.progressiveBatchSize,
               mount_template_path: form.mountTemplatePath,
@@ -689,6 +697,8 @@ export function AdminPresetCategoryFormClient({
               visibility: form.visibility,
               is_collection_series: form.isCollectionSeries,
               completion_threshold: effectiveThreshold,
+              completion_view_mode: form.completionViewMode,
+              book_cover_path: form.bookCoverPath,
               unlock_prerequisite_key: form.unlockPrerequisiteKey,
               progressive_batch_size: form.progressiveBatchSize,
               mount_template_path: form.mountTemplatePath,
@@ -1219,10 +1229,52 @@ export function AdminPresetCategoryFormClient({
             <span className="font-medium">このカテゴリをコレクションシリーズにする</span>
             <br />
             <span className="text-xs text-slate-500">
-              ON にすると、ユニーク衣装を N 種そろえるとコンプリート判定・台紙生成が走ります。ON 時は下記 N / レイアウト / 台紙テンプレが必須です。
+              ON にすると、ユニーク衣装を N 種そろえるとコンプリート判定・完走表示が走ります。
+              mount(台紙)では下記 N / レイアウト / 台紙テンプレが必須、book(日記帳)では N と表紙のみで動きます。
             </span>
           </span>
         </label>
+
+        {/* 完走表示モード: 単一台紙 or めくれる日記帳(スクラップブック) */}
+        <label className="block">
+          <span className="text-sm font-medium text-slate-700">完走表示モード</span>
+          <select
+            value={form.completionViewMode}
+            onChange={(e) =>
+              update(
+                "completionViewMode",
+                e.target.value === "book" ? "book" : "mount",
+              )
+            }
+            className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm sm:max-w-xs"
+          >
+            <option value="mount">mount（単一コンプリートカード/台紙）</option>
+            <option value="book">book（めくれる日記帳・スクラップブック）</option>
+          </select>
+          <span className="mt-1 block text-xs text-slate-500">
+            book は 9:16 縦長×N枚を1枚ずつめくれる本として表示・シェアします（travel_to_italy 等)。
+          </span>
+        </label>
+
+        {form.completionViewMode === "book" ? (
+          <label className="block">
+            <span className="text-sm font-medium text-slate-700">
+              本の表紙(0ページ目)画像パス
+            </span>
+            <input
+              type="text"
+              value={form.bookCoverPath ?? ""}
+              onChange={(e) =>
+                update("bookCoverPath", e.target.value.trim() || null)
+              }
+              className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm"
+              placeholder="generated-images の storage path（ユーザー生成の表紙を登録）"
+            />
+            <span className="mt-1 block text-xs text-slate-500">
+              未設定なら簡易表紙にフォールバックします。各ページと同じ 9:16 を想定。
+            </span>
+          </label>
+        ) : null}
 
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           <label className="block">
@@ -1240,26 +1292,28 @@ export function AdminPresetCategoryFormClient({
             />
           </label>
 
-          <label className="block">
-            <span className="text-sm font-medium text-slate-700">
-              台紙レイアウト
-            </span>
-            <select
-              value={form.mountLayout}
-              onChange={(e) =>
-                handleLayoutChange(e.target.value as FormState["mountLayout"])
-              }
-              className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm"
-            >
-              <option value="">（未選択）</option>
-              <option value="grid_3">grid_3（3枠）</option>
-              <option value="grid_4">grid_4（4枠・2×2）</option>
-              <option value="grid_6">grid_6（6枠・2×3）</option>
-            </select>
-            <span className="mt-1 block text-xs text-slate-500">
-              レイアウトを変えると枠が作り直されます（調整済みなら確認します）。N を変えると枠数も増減します。
-            </span>
-          </label>
+          {form.completionViewMode !== "book" ? (
+            <label className="block">
+              <span className="text-sm font-medium text-slate-700">
+                台紙レイアウト
+              </span>
+              <select
+                value={form.mountLayout}
+                onChange={(e) =>
+                  handleLayoutChange(e.target.value as FormState["mountLayout"])
+                }
+                className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm"
+              >
+                <option value="">（未選択）</option>
+                <option value="grid_3">grid_3（3枠）</option>
+                <option value="grid_4">grid_4（4枠・2×2）</option>
+                <option value="grid_6">grid_6（6枠・2×3）</option>
+              </select>
+              <span className="mt-1 block text-xs text-slate-500">
+                レイアウトを変えると枠が作り直されます（調整済みなら確認します）。N を変えると枠数も増減します。
+              </span>
+            </label>
+          ) : null}
         </div>
 
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">

--- a/features/style-presets/lib/preset-category-repository.ts
+++ b/features/style-presets/lib/preset-category-repository.ts
@@ -48,6 +48,8 @@ export interface PresetCategoryRow {
   visibility?: StylePresetCategoryVisibility | null;
   is_collection_series?: boolean | null;
   completion_threshold?: number | null;
+  completion_view_mode?: string | null;
+  book_cover_path?: string | null;
   unlock_prerequisite_key?: string | null;
   progressive_batch_size?: number | null;
   unlock_announcement_hero_path?: string | null;
@@ -107,6 +109,10 @@ export interface PresetCategoryAdmin {
   visibility: StylePresetCategoryVisibility;
   isCollectionSeries: boolean;
   completionThreshold: number | null;
+  /** 完走表示モード: 'mount'(単一台紙) / 'book'(めくれる日記帳)。 */
+  completionViewMode: "mount" | "book";
+  /** book 表示の表紙(0ページ目)画像の storage path。 */
+  bookCoverPath: string | null;
   unlockPrerequisiteKey: string | null;
   progressiveBatchSize: number | null;
   unlockAnnouncementHeroPath: string | null;
@@ -165,6 +171,8 @@ export interface PresetCategoryInsert {
   visibility?: StylePresetCategoryVisibility;
   isCollectionSeries?: boolean;
   completionThreshold?: number | null;
+  completionViewMode?: "mount" | "book";
+  bookCoverPath?: string | null;
   unlockPrerequisiteKey?: string | null;
   progressiveBatchSize?: number | null;
   unlockAnnouncementHeroPath?: string | null;
@@ -219,6 +227,8 @@ export interface PresetCategoryUpdate {
   visibility?: StylePresetCategoryVisibility;
   isCollectionSeries?: boolean;
   completionThreshold?: number | null;
+  completionViewMode?: "mount" | "book";
+  bookCoverPath?: string | null;
   unlockPrerequisiteKey?: string | null;
   progressiveBatchSize?: number | null;
   unlockAnnouncementHeroPath?: string | null;
@@ -288,6 +298,8 @@ function mapRow(row: PresetCategoryRow): PresetCategoryAdmin {
     visibility: normalizeVisibility(row.visibility),
     isCollectionSeries: row.is_collection_series ?? false,
     completionThreshold: row.completion_threshold ?? null,
+    completionViewMode: row.completion_view_mode === "book" ? "book" : "mount",
+    bookCoverPath: row.book_cover_path ?? null,
     unlockPrerequisiteKey: row.unlock_prerequisite_key ?? null,
     progressiveBatchSize: row.progressive_batch_size ?? null,
     unlockAnnouncementHeroPath: row.unlock_announcement_hero_path ?? null,
@@ -429,6 +441,8 @@ export async function createPresetCategory(
       visibility: input.visibility ?? "admin_only",
       is_collection_series: input.isCollectionSeries ?? false,
       completion_threshold: input.completionThreshold ?? null,
+      completion_view_mode: input.completionViewMode ?? "mount",
+      book_cover_path: input.bookCoverPath ?? null,
       unlock_prerequisite_key: input.unlockPrerequisiteKey ?? null,
       progressive_batch_size: input.progressiveBatchSize ?? null,
       unlock_announcement_hero_path: input.unlockAnnouncementHeroPath ?? null,
@@ -518,6 +532,10 @@ export async function updatePresetCategory(
     payload.is_collection_series = input.isCollectionSeries;
   if (input.completionThreshold !== undefined)
     payload.completion_threshold = input.completionThreshold;
+  if (input.completionViewMode !== undefined)
+    payload.completion_view_mode = input.completionViewMode;
+  if (input.bookCoverPath !== undefined)
+    payload.book_cover_path = input.bookCoverPath;
   if (input.unlockPrerequisiteKey !== undefined)
     payload.unlock_prerequisite_key = input.unlockPrerequisiteKey;
   if (input.progressiveBatchSize !== undefined)

--- a/supabase/migrations/20260627110000_add_collection_book_view_mode.sql
+++ b/supabase/migrations/20260627110000_add_collection_book_view_mode.sql
@@ -29,11 +29,18 @@ ALTER TABLE public.preset_categories
 ALTER TABLE public.collection_completions
   ADD COLUMN IF NOT EXISTS book_page_paths JSONB;
 
+-- 配列(または NULL)のみ許可(多層防御。アプリ側でも防御的にフィルタする)。
+ALTER TABLE public.collection_completions
+  DROP CONSTRAINT IF EXISTS collection_completions_book_page_paths_check;
+ALTER TABLE public.collection_completions
+  ADD CONSTRAINT collection_completions_book_page_paths_check
+  CHECK (book_page_paths IS NULL OR jsonb_typeof(book_page_paths) = 'array');
+
 COMMENT ON COLUMN public.preset_categories.completion_view_mode IS
   '完走表示モード: mount(単一台紙) / book(めくれる日記帳)。既定 mount。';
 COMMENT ON COLUMN public.preset_categories.book_cover_path IS
-  'book 表示の表紙(0ページ目)画像の storage path(collection-mount-templates 等)。未設定時は簡易表紙。';
+  'book 表示の表紙(0ページ目)画像の storage path。実行時/admin は generated-images(public) を使用。未設定時は簡易表紙。';
 COMMENT ON COLUMN public.collection_completions.book_page_paths IS
-  'book 表示で採用した各ページ画像 storage_path の順序付き配列(スナップショット)。';
+  'book 表示で採用した各ページ画像 storage_path(generated-images)の順序付き配列(スナップショット)。';
 
 COMMIT;

--- a/supabase/migrations/20260627110000_add_collection_book_view_mode.sql
+++ b/supabase/migrations/20260627110000_add_collection_book_view_mode.sql
@@ -1,0 +1,39 @@
+-- コレクション「めくれる日記帳(book)」表示のための列追加。
+-- 対象: travel_to_italy(9:16縦長×8枚のスクラップブック)を、単一台紙ではなく
+--   1枚ずつめくれる本として完走表示・シェアするため。
+--
+-- 本マイグレーションは「列追加のみ」(追加的・後方互換)。
+-- travel_to_italy を実際にコレクション化(is_collection_series=true / completion_threshold=8 /
+--   completion_view_mode='book' / book_cover_path / ogp_template_path 設定)するのは、
+--   本UI・サーバ処理が揃った go-live 時に別途データ更新で行う(半完成状態で完走が動き出さないため)。
+-- 注: 適用は最終確認のうえ一緒に実施する。
+
+BEGIN;
+
+-- 完走表示モード: 'mount'(従来の単一台紙) / 'book'(めくれる日記帳)。既定は mount で既存挙動を維持。
+ALTER TABLE public.preset_categories
+  ADD COLUMN IF NOT EXISTS completion_view_mode TEXT NOT NULL DEFAULT 'mount';
+
+ALTER TABLE public.preset_categories
+  DROP CONSTRAINT IF EXISTS preset_categories_completion_view_mode_check;
+ALTER TABLE public.preset_categories
+  ADD CONSTRAINT preset_categories_completion_view_mode_check
+  CHECK (completion_view_mode IN ('mount', 'book'));
+
+-- book 表示の表紙(0ページ目)画像。カタログのキャンペーン表紙(cover_storage_path)と同じ考え方。
+ALTER TABLE public.preset_categories
+  ADD COLUMN IF NOT EXISTS book_cover_path TEXT;
+
+-- 完走時に採用した各ページ画像 storage_path のスナップショット(book モード用)。
+-- 自動選択(各Day最新1枚)または選択UIで確定した順序付き配列を保存し、シェア後も内容を固定する。
+ALTER TABLE public.collection_completions
+  ADD COLUMN IF NOT EXISTS book_page_paths JSONB;
+
+COMMENT ON COLUMN public.preset_categories.completion_view_mode IS
+  '完走表示モード: mount(単一台紙) / book(めくれる日記帳)。既定 mount。';
+COMMENT ON COLUMN public.preset_categories.book_cover_path IS
+  'book 表示の表紙(0ページ目)画像の storage path(collection-mount-templates 等)。未設定時は簡易表紙。';
+COMMENT ON COLUMN public.collection_completions.book_page_paths IS
+  'book 表示で採用した各ページ画像 storage_path の順序付き配列(スナップショット)。';
+
+COMMIT;

--- a/tests/unit/features/collections/collection-settings-payload.test.ts
+++ b/tests/unit/features/collections/collection-settings-payload.test.ts
@@ -939,4 +939,80 @@ describe("parseCollectionSettings - 解放お知らせ設定(任意・独立)", 
       expect(r.payload.unlockAnnouncementAccentColor).toBeUndefined();
     }
   });
+
+  // ===== 完走表示モード(completion_view_mode) / book =====
+  describe("completion_view_mode (mount / book)", () => {
+    test("book で有効化: N があれば台紙テンプレ/レイアウト無しでも ok(R-02 免除)", () => {
+      const r = parseCollectionSettings(
+        {
+          is_collection_series: true,
+          completion_view_mode: "book",
+          completion_threshold: 8,
+        },
+        OFF,
+      );
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.payload.completionViewMode).toBe("book");
+        expect(r.payload.completionThreshold).toBe(8);
+      }
+    });
+
+    test("book で有効化: N 欠落は拒否", () => {
+      const r = parseCollectionSettings(
+        { is_collection_series: true, completion_view_mode: "book" },
+        OFF,
+      );
+      expect(r.ok).toBe(false);
+    });
+
+    test("既存が book のカテゴリは body に mode 無しでも台紙必須にならない", () => {
+      const existingBook: CollectionSettingsExisting = {
+        isCollectionSeries: true,
+        completionThreshold: 8,
+        completionViewMode: "book",
+        mountTemplatePath: null,
+        mountLayout: null,
+      };
+      // N だけ更新(mode 据え置き)。mount 用 R-02 にひっかからないこと。
+      const r = parseCollectionSettings({ completion_threshold: 8 }, existingBook);
+      expect(r.ok).toBe(true);
+    });
+
+    test("mount(既定)では従来どおり台紙テンプレ/レイアウトが必須", () => {
+      const r = parseCollectionSettings(
+        {
+          is_collection_series: true,
+          completion_view_mode: "mount",
+          completion_threshold: 4,
+        },
+        OFF,
+      );
+      expect(r.ok).toBe(false);
+    });
+
+    test("不正な mode は拒否", () => {
+      const r = parseCollectionSettings(
+        { completion_view_mode: "invalid" },
+        OFF,
+      );
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toMatch(/completion_view_mode/);
+    });
+
+    test("book_cover_path: 空文字は拒否 / null は受理 / 文字列は trim", () => {
+      expect(
+        parseCollectionSettings({ book_cover_path: "  " }, OFF).ok,
+      ).toBe(false);
+      const rNull = parseCollectionSettings({ book_cover_path: null }, OFF);
+      expect(rNull.ok).toBe(true);
+      if (rNull.ok) expect(rNull.payload.bookCoverPath).toBeNull();
+      const rStr = parseCollectionSettings(
+        { book_cover_path: "  travel/cover.png  " },
+        OFF,
+      );
+      expect(rStr.ok).toBe(true);
+      if (rStr.ok) expect(rStr.payload.bookCoverPath).toBe("travel/cover.png");
+    });
+  });
 });


### PR DESCRIPTION
### 概要
コラボ企画 `travel_to_italy`(9:16縦長×8枚のスクラップブック)を**コレクションシリーズ化**し、完走時に従来の単一コンプリートカード(台紙)ではなく、**8枚を1枚ずつめくれる「旅行日記帳」**として表示・シェアできるようにしました。めくりUIは絵師カタログの `CatalogBookView`(react-pageflip)を流用しています。

完走表示は **admin のプリセットカテゴリ画面で mount(従来台紙)/ book(めくれる日記帳)を切替可能**にし、book では台紙テンプレ/レイアウトが不要(N=ページ数のみ)です。これにより、台紙グリッド(最大6枠)では表現できない **N=8** のようなコレクションも扱えます(表紙は別管理で本としては表紙+8=9面)。

### 変更内容
- **DB(`20260627110000`・適用済み)**: `preset_categories.completion_view_mode`('mount'|'book', 既定mount + CHECK)、`preset_categories.book_cover_path`、`collection_completions.book_page_paths`(JSONB + 配列CHECK)を追加。追加列のみ・後方互換。
- **完走表示モード切替(admin)**: preset-category の repository / parser / フォームに `completion_view_mode` と `book_cover_path` を追加。コレクション有効時の台紙必須(R-02)を book モードでは免除し、N(=ページ数)のみ必須に。book 選択時は台紙レイアウト等の mount 専用UIを非表示。
- **サーバ(book 完走処理)**: `/api/collections/mount` に book 分岐。台紙合成をスキップし、選択(無ければ各Day最新・順序安定化)8枚を `book_page_paths` にスナップショット保存。OGP/シェア画像は登録テーマ表紙(`ogp_template_path`)を `mount-{ts}.png`(finalize 許可パターン)に実ファイルとして保存(未設定時は1ページ目流用)。finalize / 作り直し(isUpdate)も対応。
- **公開取得 / 没入リーダー**: `getCollectionBookByToken`(完了のみ・所有者判定、React.cache 化)。`ScrapbookReader`(CatalogBookView 流用の没入めくりビュー。表紙=0ページ目・各ページ9:16・クレジット無し)。没入ルート `app/m/[token]/book`(OGP=テーマ表紙、noindex)。`AppShell` を `/m/<token>/book` でバイパス。
- **完走者導線**: 作成後は book 応答で本リーダーへ直接遷移。既存の `/m/[token]`(台紙ページ)は book 完走なら `/m/<id>/book` へリダイレクトし「見る」導線を集約。`generateMetadata` も book では日記帳タイトル/OGPを返す。
- **カタログUI流用**: `CatalogPage` のクレジット項目(絵師名/Xリンク)を任意化(displayName 未指定で画像のみ表示=スクラップブック流用)。`/catalog` は従来どおり。
- **品質**: multiround-adversarial-review(2ラウンド)を実施し、MUST-FIX 2件 / MUST-ADDRESS 4件 + 安価なOPTIONAL 8件を修正(book finalize のデータ整合性、isUpdate のエラーハンドリング/削除順、メタデータ等)。parser の book テスト追加。
- **実装計画書**: `docs/planning/travel-italy-scrapbook-implementation-plan.md`。

### 実機テスト
- [ ] iOS Safari で主要導線を確認(本めくり・縦スワイプで chrome 開閉・シェア)
- [ ] Android Chrome で主要導線を確認
- [ ] PC(Chrome)で主要導線を確認
- [ ] レスポンシブ表示崩れがないことを確認(9:16縦長ページ)
- [ ] エラーメッセージやバリデーション表示を確認(admin: book/N 設定)
- [ ] 完走→「旅行日記を作る」→ 没入本(8ページめくり)→ シェアURL → ゲスト閲覧 → OGP(テーマ表紙)
- [ ] `/catalog` リグレッション無し(クレジット表示が従来どおり)

### テスト方法
- `npm run lint` / `npm run typecheck` / `npm run build -- --webpack`(緑)
- `npm run test`(全テスト 2267 pass。book parser テスト +6)
- prod へ migration `20260627110000` 適用済み(追加列のみ・既存挙動に影響なし)を確認

> 注: 本機能は go-live 時に travel_to_italy を `is_collection_series=true` / `completion_threshold=8` / `completion_view_mode='book'` に設定し、表紙(`book_cover_path`)を登録して公開します(現状 admin_only・未稼働でユーザー影響なし)。
