### PR TITLE
feat(collections): book表紙をユーザー生成画像(コレクション先頭)にする(N=表紙込み)

### DIFF
--- a/app/m/[token]/book/page.tsx
+++ b/app/m/[token]/book/page.tsx
@@ -58,8 +58,18 @@ export default async function CollectionBookPage({ params }: BookPageProps) {
   const user = await getUser();
   const isOwner = Boolean(user && user.id === book.ownerId);
 
+  // 表紙(0ページ目)の決定:
+  //   - 既定: コレクションの先頭(sort_order 最小)の生成画像=「ユーザー生成の表紙」を front cover にし、
+  //     残りを中身ページにする(完走数 N は表紙を含む。例 travel_to_italy=9)。
+  //   - book_cover_path(共通固定表紙)が設定されている場合のみ、それを front cover にし全ページを中身にする。
+  const hasFixedCover = Boolean(book.coverImageUrl);
+  const coverImageUrl = book.coverImageUrl ?? book.pageImageUrls[0] ?? null;
+  const contentImageUrls = hasFixedCover
+    ? book.pageImageUrls
+    : book.pageImageUrls.slice(1);
+
   // クレジット項目は渡さない(displayName 無し)= 画像のみのスクラップブックページ。
-  const pages: CatalogPageData[] = book.pageImageUrls.map((url, i) => ({
+  const pages: CatalogPageData[] = contentImageUrls.map((url, i) => ({
     id: String(i),
     imageUrl: url,
     alt: null,
@@ -68,7 +78,7 @@ export default async function CollectionBookPage({ params }: BookPageProps) {
   return (
     <ScrapbookReader
       title={book.displayNameJa}
-      coverImageUrl={book.coverImageUrl}
+      coverImageUrl={coverImageUrl}
       pages={pages}
       isOwner={isOwner}
     />

--- a/docs/planning/travel-italy-scrapbook-implementation-plan.md
+++ b/docs/planning/travel-italy-scrapbook-implementation-plan.md
@@ -11,9 +11,9 @@
 
 ### 決定事項(ユーザー合意)
 - 完走表示: **本(めくり日記帳)に置き換え**(travel_to_italy のみ。従来台紙は出さない)
-- Xシェア時のOGP: **運営がOGP画像を用意**(別途登録)
-- 各ページの画像: **既定は自動(各Day最新1枚・sort_order順)+ 従来の台紙コンポーザ同様、同一Dayに複数あれば選択UIで差し替え可能**(「作り直し」で更新)
-- **本の0ページ目(表紙)**: travel_to_italy 用に**別途登録した表紙画像**を使う(`BookCover` front = 登録表紙)
+- Xシェア時のOGP: **運営がOGP画像を用意**(別途登録、`ogp_template_path`)
+- 各ページの画像: **既定は自動(各最新1枚・sort_order順)+ 従来の台紙コンポーザ同様、同一枠に複数あれば選択UIで差し替え可能**(「作り直し」で更新)
+- **本の0ページ目(表紙)**: 【改訂】共通固定表紙ではなく、**表紙も One-Tap Style プリセットとしてユーザーが生成したコンテンツ**を使う。すなわち travel_to_italy に「表紙」プリセットを1枚足し、**完走数 N は表紙を含めて 9**(8 Day + 表紙)。表紙プリセットの sort_order を最小にし、**コレクション先頭(sort_order 最小)の生成画像が `BookCover` front(0ページ目)**になる。`book_cover_path`(カテゴリ列)は「全員共通の固定表紙」にしたい場合のみ使う任意の上書き。
 
 ### 現状(調査済み)
 - `travel_to_italy`: `is_collection_series=false` / `completion_threshold=null` / `output_aspect_ratio_mode=9:16` / `visibility=admin_only` / published 8枚。

--- a/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
+++ b/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
@@ -1259,7 +1259,7 @@ export function AdminPresetCategoryFormClient({
         {form.completionViewMode === "book" ? (
           <label className="block">
             <span className="text-sm font-medium text-slate-700">
-              本の表紙(0ページ目)画像パス
+              本の表紙(0ページ目)画像パス(任意・共通固定表紙)
             </span>
             <input
               type="text"
@@ -1268,10 +1268,10 @@ export function AdminPresetCategoryFormClient({
                 update("bookCoverPath", e.target.value.trim() || null)
               }
               className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm"
-              placeholder="generated-images の storage path（ユーザー生成の表紙を登録）"
+              placeholder="全員共通の固定表紙にする場合のみ generated-images の storage path"
             />
             <span className="mt-1 block text-xs text-slate-500">
-              未設定なら簡易表紙にフォールバックします。各ページと同じ 9:16 を想定。
+              既定は「コレクション先頭(sort_order 最小)プリセットのユーザー生成画像」が表紙になります(完走数 N は表紙プリセットを含めて数える)。ここにパスを入れた場合のみ全員共通の固定表紙に上書き。9:16 を想定。
             </span>
           </label>
         ) : null}


### PR DESCRIPTION
### 概要
本(めくれる日記帳)の**表紙の出どころを変更**しました。当初は「運営が登録する共通の固定表紙(`book_cover_path`)」前提でしたが、方針変更で**表紙も「ユーザーが生成したコンテンツ」**にします。具体的には travel_to_italy に「表紙」プリセットを1枚足し、**完走数 N は表紙を含めて 9**(8 Day + 表紙)とし、**コレクション先頭(sort_order 最小)のユーザー生成画像が本の表紙(0ページ目)**になります。

### 変更内容
- `app/m/[token]/book/page.tsx`: 表紙の決定ロジックを変更。
  - 既定: `coverImageUrl = pageImageUrls[0]`(sort_order 最小=表紙プリセットの生成画像)、`pages = pageImageUrls.slice(1)`(残りが中身)。
  - `book_cover_path`(カテゴリ列)が設定されている場合のみ、それを front cover にして全ページを中身にする(=全員共通の固定表紙の上書き)。
- `AdminPresetCategoryFormClient`: book 表紙パス欄の文言を「任意・共通固定表紙の上書き。既定は先頭プリセットのユーザー生成画像が表紙」に更新。
- 実装計画書を改訂(表紙プリセットを足して N=9、表紙 sort_order 最小)。

### 補足(go-live 手順の変更)
- travel_to_italy は `completion_threshold=9`(表紙込み)で設定。
- 表紙用 One-Tap Style プリセットを1枚追加し、その `sort_order` を最小にする。
- `book_cover_path` は原則未設定(=ユーザー生成の表紙を使う)。

### 実機テスト
- [ ] iOS Safari で主要導線を確認(表紙=自分の生成画像→めくり)
- [ ] Android Chrome で主要導線を確認
- [ ] PC(Chrome)で主要導線を確認
- [ ] レスポンシブ表示崩れがないことを確認
- [ ] 表紙含む9種完走 →「旅行日記を作る」→ 本(表紙=先頭生成画像 + 8中身)→ シェア → ゲスト閲覧 → OGP

### テスト方法
- `npm run lint` / `npm run build -- --webpack`(緑)
- `npm run test`(全テスト 2267 pass)
