### PR TITLE
feat(collections): 順番固定の1つずつ解放(sequential unlock)を追加

### DIFF
--- a/app/(app)/style/generate-async/handler.ts
+++ b/app/(app)/style/generate-async/handler.ts
@@ -5,6 +5,7 @@ import {
 } from "@/features/i2i-poc/shared/image-constraints";
 import { getPublishedStylePresetForGeneration } from "@/features/style-presets/lib/style-preset-repository";
 import { authorizeStylePresetUnlock } from "@/features/collections/lib/collection-unlock-server";
+import { categoryNeedsUnlockContext } from "@/features/collections/lib/collection-unlock";
 import { createClient } from "@/lib/supabase/server";
 import { recordStyleUsageEvent } from "@/features/style/lib/style-usage-events";
 import { getAllMessages } from "@/i18n/messages";
@@ -173,12 +174,14 @@ export async function postStyleGenerateAsyncRoute(
     }
 
     // 解放ゲート(unlock gating)のサーバー側認可。
-    // unlock_prerequisite_key が設定されたカテゴリのみ:
-    //  - 前提条件カテゴリを完走していなければ 403
-    //  - 段階解放(drip)で未解放のプリセットなら 403
-    // 既存カテゴリ(両列 null)は no-op で従来どおり許可される。
-    // UI でのカード非表示はセキュリティではないため、ここで必ず弾く。
-    if (preset.category.unlockPrerequisiteKey) {
+    // 対象カテゴリ(categoryNeedsUnlockContext):
+    //  - unlock_prerequisite_key 付き → 前提カテゴリ未完走なら 403
+    //  - sequential_unlock → sort_order 昇順(先頭=表紙)で未解放のプリセットなら 403
+    //  - いずれも段階解放(drip)で未解放のプリセットなら 403
+    // 対象でないカテゴリ(両方 false)は authorizeStylePresetUnlock が即 {allowed:true} を返す。
+    // 「どのカテゴリがゲート対象か」は共有述語に一元化し、新しい解放モード追加時の
+    // ガード漏れ(認可バイパス)を防ぐ。UI 非表示はセキュリティではないため、ここで必ず弾く。
+    if (categoryNeedsUnlockContext(preset.category)) {
       const authedClient = await createClient();
       const unlockAuth = await authorizeStylePresetUnlock(
         preset.category,

--- a/app/api/admin/preset-categories/collection-settings-payload.ts
+++ b/app/api/admin/preset-categories/collection-settings-payload.ts
@@ -26,6 +26,8 @@ export interface CollectionSettingsPayload {
   unlockPrerequisiteKey?: string | null;
   /** プリセットを N 体ずつ段階解放する単位(正の整数)。null=最初から全部 */
   progressiveBatchSize?: number | null;
+  /** 順番固定の1つずつ解放(sequential unlock)。true で先頭=表紙から昇順に順次解放。 */
+  sequentialUnlock?: boolean;
   /** 解放お知らせ初回モーダルのヒーロー画像パス(public バケット)。null=固定画像にフォールバック */
   unlockAnnouncementHeroPath?: string | null;
   /** 解放お知らせ初回モーダルの本文。null=現行ハードコード文 */
@@ -168,6 +170,14 @@ export function parseCollectionSettings(
     } else {
       payload.progressiveBatchSize = v;
     }
+  }
+
+  // 順番固定の1つずつ解放(sequential unlock)。
+  if (body.sequential_unlock !== undefined) {
+    if (typeof body.sequential_unlock !== "boolean") {
+      return { ok: false, error: "sequential_unlock must be boolean" };
+    }
+    payload.sequentialUnlock = body.sequential_unlock;
   }
 
   if (body.mount_template_path !== undefined) {

--- a/features/collections/lib/collection-unlock-announcement.ts
+++ b/features/collections/lib/collection-unlock-announcement.ts
@@ -58,6 +58,9 @@ export function buildCollectionUnlockAnnouncements(
   context: CollectionUnlockContext,
 ): CollectionUnlockAnnouncement[] {
   // 解放ゲート付き かつ 前提完走済み のカテゴリだけを、出現順(sort_order 昇順)に集約する。
+  // 注: sequential_unlock(前提なし・昇順)カテゴリは「解放お知らせ」未対応。意図的にここで
+  //   スキップする(prerequisite が無いため下の continue で除外)。対応する場合は下の .reverse()
+  //   と progressiveBatchSize 前提(降順)を sequential 用に見直すこと。
   const itemsByCategoryKey = new Map<string, StylePresetPublicSummary[]>();
   for (const preset of presets) {
     const prerequisite = preset.category.unlockPrerequisiteKey;

--- a/features/collections/lib/collection-unlock-gating.ts
+++ b/features/collections/lib/collection-unlock-gating.ts
@@ -1,5 +1,9 @@
 import type { StylePresetPublicSummary } from "@/features/style-presets/lib/schema";
-import { isPresetUnlocked } from "./collection-unlock";
+import {
+  isPresetUnlocked,
+  sequentialBatchSize,
+  unlockJudgmentIndex,
+} from "./collection-unlock";
 
 /**
  * ユーザーごとの解放判定に必要なコンテキスト。
@@ -59,30 +63,35 @@ export function applyCollectionUnlockGating(
     const ascendingIndex = seenCountByCategoryKey.get(category.key) ?? 0;
     seenCountByCategoryKey.set(category.key, ascendingIndex + 1);
 
-    // 前提条件なし(従来カテゴリ) → そのまま通す。
-    if (!category.unlockPrerequisiteKey) {
+    const hasPrereq = Boolean(category.unlockPrerequisiteKey);
+    const sequential = category.sequentialUnlock === true;
+
+    // 前提条件カテゴリ未完走 → 一覧から除去(ティザーなし)。
+    if (
+      hasPrereq &&
+      !context.prerequisiteCompletedKeys.has(category.unlockPrerequisiteKey!)
+    ) {
+      continue;
+    }
+
+    // drip 適用条件: sequential(前提なしでも単独で順次解放) または 前提カテゴリ付き。
+    // どちらでもない従来カテゴリは無条件公開(従来挙動)。
+    if (!sequential && !hasPrereq) {
       result.push(preset);
       continue;
     }
 
-    // 前提条件カテゴリ未完走 → 一覧から除去(ティザーなし)。
-    if (!context.prerequisiteCompletedKeys.has(category.unlockPrerequisiteKey)) {
-      continue;
-    }
-
-    // 完走済み → 段階解放。解放数を超えるものは locked にして残す。
-    // 解放ゲート付きカテゴリは sort_order の多い方(末尾)から解放するため、解放判定の
-    // index を反転する(表示順は昇順のまま並べ替えない)。
+    // 段階解放。解放数を超えるものは locked にして残す。
+    //  - sequential: 先頭(sort_order 最小=表紙)から昇順で解放。batch 未設定は 1。
+    //  - 既存(前提付き): sort_order の末尾から降順で解放(index 反転)。
     const distinctGenerated =
       context.distinctGeneratedByCategoryKey.get(category.key) ?? 0;
     const total = totalByCategoryKey.get(category.key) ?? 0;
-    const unlockIndex = total - 1 - ascendingIndex;
-    const unlocked = isPresetUnlocked(
-      unlockIndex,
-      distinctGenerated,
-      category.progressiveBatchSize,
-      total,
-    );
+    const batch = sequential
+      ? sequentialBatchSize(category.progressiveBatchSize)
+      : category.progressiveBatchSize;
+    const unlockIndex = unlockJudgmentIndex(ascendingIndex, total, sequential);
+    const unlocked = isPresetUnlocked(unlockIndex, distinctGenerated, batch, total);
 
     result.push(unlocked ? preset : { ...preset, locked: true });
   }

--- a/features/collections/lib/collection-unlock-gating.ts
+++ b/features/collections/lib/collection-unlock-gating.ts
@@ -27,7 +27,8 @@ export interface CollectionUnlockContext {
  * /style の配信用に、解放ゲート(前提条件カテゴリの完走 + 段階解放)を
  * ユーザーごとに適用する純粋関数。
  *
- * - `unlockPrerequisiteKey` が null のカテゴリ → 一切変更しない(従来挙動)。
+ * - `unlockPrerequisiteKey` が null かつ `sequentialUnlock` でないカテゴリ → 一切変更しない(従来挙動)。
+ * - `sequentialUnlock=true` のカテゴリ → 前提なしでも sort_order 昇順(先頭=表紙)から段階解放。
  * - 前提条件カテゴリが未完走のユーザー → そのカテゴリのプリセットを「一覧から完全に除去」
  *   (ティザーを出さない方針)。
  * - 完走済みユーザー → プリセットは残すが、解放数を超えるものに `locked: true` を立て、

--- a/features/collections/lib/collection-unlock-server.ts
+++ b/features/collections/lib/collection-unlock-server.ts
@@ -165,10 +165,12 @@ export type StylePresetUnlockAuthorization =
 /**
  * generate route のサーバー側認可: 解放ゲート付きカテゴリのプリセット生成を許可するか。
  *
- * `unlockPrerequisiteKey` が null のカテゴリ(= 既存カテゴリすべて)は常に許可(no-op)。
- * ゲート付きの場合のみ:
- *   1. 前提条件カテゴリを完走しているか(get_collection_progress RPC)
- *   2. 当該プリセットが sort_order 上で解放数の範囲内か(段階解放)
+ * ゲート対象は「unlock_prerequisite_key 付き」または「sequential_unlock=true」のカテゴリ。
+ * どちらでもないカテゴリ(両方 null/false)は常に許可(no-op)。
+ * ゲート対象の場合のみ:
+ *   1. (前提付きのとき)前提条件カテゴリを完走しているか(get_collection_progress RPC)
+ *   2. 当該プリセットが sort_order 上で解放数の範囲内か(段階解放。
+ *      sequential=昇順[先頭=表紙から] / 既存=降順[末尾から]、unlockJudgmentIndex で共有)
  * を検証する。UI 非表示はセキュリティではないため、ここで必ず弾く。
  *
  * @param category 生成対象プリセットのカテゴリ参照(unlock 列を含む)

--- a/features/collections/lib/collection-unlock-server.ts
+++ b/features/collections/lib/collection-unlock-server.ts
@@ -5,7 +5,11 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import type { StylePresetPublicSummary } from "@/features/style-presets/lib/schema";
 import { listPublishedStylePresets } from "@/features/style-presets/lib/style-preset-repository";
 import { getCollectionProgress } from "./collection-progress-repository";
-import { computeUnlockedCount } from "./collection-unlock";
+import {
+  computeUnlockedCount,
+  sequentialBatchSize,
+  unlockJudgmentIndex,
+} from "./collection-unlock";
 import type { CollectionUnlockContext } from "./collection-unlock-gating";
 
 /**
@@ -34,7 +38,8 @@ export async function resolveCollectionUnlockContext(
   userId: string,
   authedClient: SupabaseClient,
 ): Promise<CollectionUnlockContext> {
-  // 解放ゲートを持つカテゴリだけを対象にする(前提条件なしカテゴリは判定不要)。
+  // 解放ゲートを持つカテゴリ(前提付き)＋ sequential(前提なしで単独順次解放)を対象にする。
+  // sequential も distinct 集計が必要なため gatedCategoryKeys に含める。
   const gatedCategoryKeys = new Set<string>();
   const prerequisiteKeys = new Set<string>();
   for (const preset of presets) {
@@ -42,6 +47,8 @@ export async function resolveCollectionUnlockContext(
     if (prerequisite) {
       gatedCategoryKeys.add(preset.category.key);
       prerequisiteKeys.add(prerequisite);
+    } else if (preset.category.sequentialUnlock === true) {
+      gatedCategoryKeys.add(preset.category.key);
     }
   }
 
@@ -173,32 +180,36 @@ export type StylePresetUnlockAuthorization =
 export async function authorizeStylePresetUnlock(
   category: Pick<
     StylePresetPublicSummary["category"],
-    "key" | "unlockPrerequisiteKey" | "progressiveBatchSize"
+    "key" | "unlockPrerequisiteKey" | "progressiveBatchSize" | "sequentialUnlock"
   >,
   presetId: string,
   userId: string,
   authedClient: SupabaseClient,
   options: { includeAdminOnly?: boolean } = {},
 ): Promise<StylePresetUnlockAuthorization> {
-  // ゲートなし(従来カテゴリ) → 常に許可。
-  if (!category.unlockPrerequisiteKey) {
+  const hasPrereq = Boolean(category.unlockPrerequisiteKey);
+  const sequential = category.sequentialUnlock === true;
+
+  // ゲートなし(前提なし かつ sequential でもない従来カテゴリ) → 常に許可。
+  if (!hasPrereq && !sequential) {
     return { allowed: true };
   }
 
-  // 1) 前提条件カテゴリの完走チェック。
-  const { completedKeys } = await resolveCompletedPrerequisiteKeys(
-    new Set([category.unlockPrerequisiteKey]),
-    authedClient,
-  );
-  if (!completedKeys.has(category.unlockPrerequisiteKey)) {
-    return { allowed: false, reason: "prerequisite_incomplete" };
+  // 1) 前提条件カテゴリの完走チェック(前提付きのときのみ)。
+  if (hasPrereq) {
+    const { completedKeys } = await resolveCompletedPrerequisiteKeys(
+      new Set([category.unlockPrerequisiteKey!]),
+      authedClient,
+    );
+    if (!completedKeys.has(category.unlockPrerequisiteKey!)) {
+      return { allowed: false, reason: "prerequisite_incomplete" };
+    }
   }
 
   // 2) 段階解放の範囲内チェック。
   //    sort_order 上の index と総数を、公開一覧(sort_order 昇順)から導出する。
-  //    解放ゲート付きカテゴリは解放順を sort_order の降順にするため index を反転し、
-  //    applyCollectionUnlockGating(配信側)の降順表示・降順解放と一致させる。
-  //    この関数は冒頭で unlockPrerequisiteKey 無しを return 済みなので、ここは常にゲート付き。
+  //    方向は配信側 applyCollectionUnlockGating と共有ヘルパー(unlockJudgmentIndex)で一致させる:
+  //    sequential は昇順(先頭=表紙から)、既存ゲートは降順(末尾から)。
   const published = await listPublishedStylePresets({
     includeAdminOnly: options.includeAdminOnly === true,
   });
@@ -211,19 +222,17 @@ export async function authorizeStylePresetUnlock(
     return { allowed: false, reason: "preset_locked" };
   }
 
-  // 降順 index(末尾=sort_order 最大 を index 0 とする)。
-  const indexInCategory = total - 1 - ascendingIndex;
+  const indexInCategory = unlockJudgmentIndex(ascendingIndex, total, sequential);
 
   const distinctCounts = await resolveDistinctGeneratedCounts(
     new Set([category.key]),
     userId,
   );
   const distinctGenerated = distinctCounts.get(category.key) ?? 0;
-  const unlockedCount = computeUnlockedCount(
-    distinctGenerated,
-    category.progressiveBatchSize,
-    total,
-  );
+  const batch = sequential
+    ? sequentialBatchSize(category.progressiveBatchSize)
+    : category.progressiveBatchSize;
+  const unlockedCount = computeUnlockedCount(distinctGenerated, batch, total);
 
   if (indexInCategory >= unlockedCount) {
     return { allowed: false, reason: "preset_locked" };

--- a/features/collections/lib/collection-unlock.ts
+++ b/features/collections/lib/collection-unlock.ts
@@ -68,6 +68,24 @@ export function sequentialBatchSize(batchSize: number | null): number {
 }
 
 /**
+ * そのカテゴリが「解放ゲート(unlock gating)」の対象か。true のとき、配信側は
+ * 解放コンテキスト(distinct 集計等)を解決し、生成側は認可チェックを必ず行う。
+ *
+ * 対象条件(単一の真実源):
+ *  - unlock_prerequisite_key 付き(前提カテゴリ完走ゲート + 既存 drip)
+ *  - sequential_unlock(前提なしでも順次解放)
+ *
+ * 配信(StylePageBody / Home カルーセル)・生成認可(generate-async)・(将来の解放モード)で
+ * この述語を共有し、片側だけ条件が漏れる不整合(UIはロックなのに生成は素通り等)を防ぐ。
+ */
+export function categoryNeedsUnlockContext(category: {
+  unlockPrerequisiteKey: string | null;
+  sequentialUnlock: boolean;
+}): boolean {
+  return category.unlockPrerequisiteKey != null || category.sequentialUnlock === true;
+}
+
+/**
  * sort_order 昇順 index(0 始まり) を、解放判定で使う index に変換する。
  *  - sequential=true: 昇順そのまま(先頭=sort_order 最小=表紙 から前へ解放)
  *  - sequential=false(既存): total-1-ascendingIndex(末尾=sort_order 最大 から解放)

--- a/features/collections/lib/collection-unlock.ts
+++ b/features/collections/lib/collection-unlock.ts
@@ -58,3 +58,27 @@ export function isPresetUnlocked(
   const unlockedCount = computeUnlockedCount(distinctGenerated, batchSize, total);
   return presetIndexInSortOrder < unlockedCount;
 }
+
+/**
+ * 順番固定(sequential)解放での「実効 batch」。未設定/非正なら 1(=1つずつ解放)。
+ * sequential_unlock=true のカテゴリで batch を省略しても「前を生成したら次」が成立するようにする。
+ */
+export function sequentialBatchSize(batchSize: number | null): number {
+  return batchSize && batchSize > 0 ? batchSize : 1;
+}
+
+/**
+ * sort_order 昇順 index(0 始まり) を、解放判定で使う index に変換する。
+ *  - sequential=true: 昇順そのまま(先頭=sort_order 最小=表紙 から前へ解放)
+ *  - sequential=false(既存): total-1-ascendingIndex(末尾=sort_order 最大 から解放)
+ *
+ * 表示ゲート(collection-unlock-gating)とサーバー認可(collection-unlock-server)で
+ * 同一の方向ロジックを共有し、片側だけ向きがずれる不整合(UI解放なのに403等)を防ぐ。
+ */
+export function unlockJudgmentIndex(
+  ascendingIndex: number,
+  total: number,
+  sequential: boolean,
+): number {
+  return sequential ? ascendingIndex : total - 1 - ascendingIndex;
+}

--- a/features/home/components/CachedHomeStylePresetSection.tsx
+++ b/features/home/components/CachedHomeStylePresetSection.tsx
@@ -5,6 +5,7 @@ import {
 } from "@/features/collections/lib/collection-unlock-gating";
 import { buildCollectionUnlockAnnouncements } from "@/features/collections/lib/collection-unlock-announcement";
 import { resolveCollectionUnlockContext } from "@/features/collections/lib/collection-unlock-server";
+import { categoryNeedsUnlockContext } from "@/features/collections/lib/collection-unlock";
 import { PetitUnlockAnnouncer } from "@/features/collections/components/PetitUnlockAnnouncer";
 import { createClient } from "@/lib/supabase/server";
 import { HomeStylePresetCarousel } from "./HomeStylePresetCarousel";
@@ -36,9 +37,9 @@ export async function CachedHomeStylePresetSection({
     includeAdminOnly: isAdminViewer,
   });
 
-  // 解放ルール付きカテゴリが無ければ完全 no-op(authed client も作らない)。
-  const hasGatedCategory = cachedPresets.some(
-    (preset) => preset.category.unlockPrerequisiteKey != null,
+  // 解放ゲート対象カテゴリ(前提カテゴリ付き or sequential)が無ければ完全 no-op(authed client も作らない)。
+  const hasGatedCategory = cachedPresets.some((preset) =>
+    categoryNeedsUnlockContext(preset.category),
   );
   let unlockContext: CollectionUnlockContext = EMPTY_UNLOCK_CONTEXT;
   if (userId && hasGatedCategory) {

--- a/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
+++ b/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
@@ -1424,10 +1424,10 @@ export function AdminPresetCategoryFormClient({
               className="mt-1 h-4 w-4 rounded border-slate-300"
             />
             <span className="text-sm text-slate-700">
-              <span className="font-medium">順番固定で1つずつ解放する（sequential unlock）</span>
+              <span className="font-medium">順番固定で順次解放する（sequential unlock）</span>
               <br />
               <span className="text-xs text-slate-500">
-                ON にすると、前提カテゴリが無くても <strong>sort_order 先頭（最小）＝表紙</strong> から昇順に1つずつ解放します（前を生成すると次が解放）。段階解放の単位が空のときは1体ずつ。旅行日記など「表紙→Day1→…」の順序固定に使います。OFF の既存挙動（前提カテゴリ付きは末尾から）には影響しません。
+                ON にすると、前提カテゴリが無くても <strong>sort_order 先頭（最小）＝表紙</strong> から昇順に解放します（前を生成すると次が解放）。解放単位は上の「段階解放の単位」に従い、<strong>空のときは1つずつ</strong>。旅行日記など「表紙→Day1→…」の順序固定に使います。OFF の既存挙動（前提カテゴリ付きは末尾から）には影響しません。
               </span>
             </span>
           </label>

--- a/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
+++ b/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
@@ -77,6 +77,8 @@ interface FormState {
   unlockPrerequisiteKey: string | null;
   /** 段階解放の単位(正の整数)。null=最初から全部解放 */
   progressiveBatchSize: number | null;
+  /** 順番固定の1つずつ解放(sequential unlock)。true で先頭=表紙から昇順に順次解放 */
+  sequentialUnlock: boolean;
   mountTemplatePath: string | null;
   mountLayout: "" | "grid_3" | "grid_4" | "grid_6";
   /** カスタム枠(正規化矩形配列)。null なら mountLayout プリセットを使用 */
@@ -169,6 +171,7 @@ function toFormState(
     bookCoverPath: initial?.bookCoverPath ?? null,
     unlockPrerequisiteKey: initial?.unlockPrerequisiteKey ?? null,
     progressiveBatchSize: initial?.progressiveBatchSize ?? null,
+    sequentialUnlock: initial?.sequentialUnlock ?? false,
     mountTemplatePath: initial?.mountTemplatePath ?? null,
     mountLayout: initial?.mountLayout ?? "",
     mountSlots: initial?.mountSlots ?? null,
@@ -638,6 +641,7 @@ export function AdminPresetCategoryFormClient({
               book_cover_path: form.bookCoverPath,
               unlock_prerequisite_key: form.unlockPrerequisiteKey,
               progressive_batch_size: form.progressiveBatchSize,
+              sequential_unlock: form.sequentialUnlock,
               mount_template_path: form.mountTemplatePath,
               mount_layout: form.mountLayout === "" ? null : form.mountLayout,
               mount_slots: form.mountSlots,
@@ -701,6 +705,7 @@ export function AdminPresetCategoryFormClient({
               book_cover_path: form.bookCoverPath,
               unlock_prerequisite_key: form.unlockPrerequisiteKey,
               progressive_batch_size: form.progressiveBatchSize,
+              sequential_unlock: form.sequentialUnlock,
               mount_template_path: form.mountTemplatePath,
               mount_layout: form.mountLayout === "" ? null : form.mountLayout,
               mount_slots: form.mountSlots,
@@ -1410,6 +1415,22 @@ export function AdminPresetCategoryFormClient({
               </span>
             </label>
           </div>
+
+          <label className="flex items-start gap-3">
+            <input
+              type="checkbox"
+              checked={form.sequentialUnlock}
+              onChange={(e) => update("sequentialUnlock", e.target.checked)}
+              className="mt-1 h-4 w-4 rounded border-slate-300"
+            />
+            <span className="text-sm text-slate-700">
+              <span className="font-medium">順番固定で1つずつ解放する（sequential unlock）</span>
+              <br />
+              <span className="text-xs text-slate-500">
+                ON にすると、前提カテゴリが無くても <strong>sort_order 先頭（最小）＝表紙</strong> から昇順に1つずつ解放します（前を生成すると次が解放）。段階解放の単位が空のときは1体ずつ。旅行日記など「表紙→Day1→…」の順序固定に使います。OFF の既存挙動（前提カテゴリ付きは末尾から）には影響しません。
+              </span>
+            </span>
+          </label>
         </div>
 
         {/* 解放お知らせモーダル(PetitUnlockAnnouncer)のカスタム設定。

--- a/features/style-presets/lib/preset-category-repository.ts
+++ b/features/style-presets/lib/preset-category-repository.ts
@@ -52,6 +52,7 @@ export interface PresetCategoryRow {
   book_cover_path?: string | null;
   unlock_prerequisite_key?: string | null;
   progressive_batch_size?: number | null;
+  sequential_unlock?: boolean | null;
   unlock_announcement_hero_path?: string | null;
   unlock_announcement_initial_body?: string | null;
   unlock_announcement_drip_body?: string | null;
@@ -115,6 +116,8 @@ export interface PresetCategoryAdmin {
   bookCoverPath: string | null;
   unlockPrerequisiteKey: string | null;
   progressiveBatchSize: number | null;
+  /** 順番固定の1つずつ解放(sequential unlock)。詳細は schema.ts の同名フィールド参照。 */
+  sequentialUnlock: boolean;
   unlockAnnouncementHeroPath: string | null;
   unlockAnnouncementInitialBody: string | null;
   unlockAnnouncementDripBody: string | null;
@@ -175,6 +178,7 @@ export interface PresetCategoryInsert {
   bookCoverPath?: string | null;
   unlockPrerequisiteKey?: string | null;
   progressiveBatchSize?: number | null;
+  sequentialUnlock?: boolean;
   unlockAnnouncementHeroPath?: string | null;
   unlockAnnouncementInitialBody?: string | null;
   unlockAnnouncementDripBody?: string | null;
@@ -231,6 +235,7 @@ export interface PresetCategoryUpdate {
   bookCoverPath?: string | null;
   unlockPrerequisiteKey?: string | null;
   progressiveBatchSize?: number | null;
+  sequentialUnlock?: boolean;
   unlockAnnouncementHeroPath?: string | null;
   unlockAnnouncementInitialBody?: string | null;
   unlockAnnouncementDripBody?: string | null;
@@ -302,6 +307,7 @@ function mapRow(row: PresetCategoryRow): PresetCategoryAdmin {
     bookCoverPath: row.book_cover_path ?? null,
     unlockPrerequisiteKey: row.unlock_prerequisite_key ?? null,
     progressiveBatchSize: row.progressive_batch_size ?? null,
+    sequentialUnlock: row.sequential_unlock ?? false,
     unlockAnnouncementHeroPath: row.unlock_announcement_hero_path ?? null,
     unlockAnnouncementInitialBody: row.unlock_announcement_initial_body ?? null,
     unlockAnnouncementDripBody: row.unlock_announcement_drip_body ?? null,
@@ -445,6 +451,7 @@ export async function createPresetCategory(
       book_cover_path: input.bookCoverPath ?? null,
       unlock_prerequisite_key: input.unlockPrerequisiteKey ?? null,
       progressive_batch_size: input.progressiveBatchSize ?? null,
+      sequential_unlock: input.sequentialUnlock ?? false,
       unlock_announcement_hero_path: input.unlockAnnouncementHeroPath ?? null,
       unlock_announcement_initial_body:
         input.unlockAnnouncementInitialBody ?? null,
@@ -540,6 +547,8 @@ export async function updatePresetCategory(
     payload.unlock_prerequisite_key = input.unlockPrerequisiteKey;
   if (input.progressiveBatchSize !== undefined)
     payload.progressive_batch_size = input.progressiveBatchSize;
+  if (input.sequentialUnlock !== undefined)
+    payload.sequential_unlock = input.sequentialUnlock;
   if (input.unlockAnnouncementHeroPath !== undefined)
     payload.unlock_announcement_hero_path = input.unlockAnnouncementHeroPath;
   if (input.unlockAnnouncementInitialBody !== undefined)

--- a/features/style-presets/lib/schema.ts
+++ b/features/style-presets/lib/schema.ts
@@ -82,6 +82,14 @@ export interface StylePresetCategoryRef {
    */
   progressiveBatchSize: number | null;
   /**
+   * 順番固定の「1つずつ解放(sequential unlock)」。true のとき:
+   *  - 前提カテゴリ(unlock_prerequisite_key)が無くても段階解放を適用する(単独で順次解放可)。
+   *  - 解放方向を sort_order 昇順(先頭=表紙から前へ)にする(既存 drip は降順)。
+   *  - batch 未設定時は 1(=1つずつ)として扱う。
+   * 既存カテゴリは false で従来挙動を維持。
+   */
+  sequentialUnlock: boolean;
+  /**
    * 解放お知らせモーダル(PetitUnlockAnnouncer)のカスタム設定。
    * いずれも null なら現行のハードコード(画像 /collections/petit-unlock-hero.png ・
    * 紫基調の文言/配色)にフォールバックする。features/collections/components/UnlockModals.tsx 参照。

--- a/features/style-presets/lib/style-preset-repository.ts
+++ b/features/style-presets/lib/style-preset-repository.ts
@@ -53,6 +53,7 @@ interface StylePresetCategoryRow {
   is_active: boolean;
   unlock_prerequisite_key?: string | null;
   progressive_batch_size?: number | null;
+  sequential_unlock?: boolean | null;
   unlock_announcement_hero_path?: string | null;
   unlock_announcement_initial_body?: string | null;
   unlock_announcement_drip_body?: string | null;
@@ -101,7 +102,7 @@ interface StylePresetRow {
 }
 
 const STYLE_PRESET_WITH_CATEGORY_SELECT =
-  "*, provider:profiles!style_presets_provider_user_id_fkey(id, nickname, avatar_url), category:preset_categories!style_presets_category_id_fkey(id, key, display_name_ja, display_name_en, badge_color, badge_text_color, skip_base_prefix, output_aspect_ratio_mode, user_guidance_ja, user_guidance_en, show_source_image_type_control, show_background_change_control, show_generation_model_control, show_user_prompt_input, user_prompt_label, user_prompt_placeholder, user_prompt_max_length, visibility, is_active, provider_user_id, provider:profiles!preset_categories_provider_user_id_fkey(id, nickname, avatar_url), unlock_prerequisite_key, progressive_batch_size, unlock_announcement_hero_path, unlock_announcement_initial_body, unlock_announcement_drip_body, unlock_announcement_accent_color, unlock_announcement_accent_hover_color, unlock_announcement_title_color, unlock_announcement_soft_color)";
+  "*, provider:profiles!style_presets_provider_user_id_fkey(id, nickname, avatar_url), category:preset_categories!style_presets_category_id_fkey(id, key, display_name_ja, display_name_en, badge_color, badge_text_color, skip_base_prefix, output_aspect_ratio_mode, user_guidance_ja, user_guidance_en, show_source_image_type_control, show_background_change_control, show_generation_model_control, show_user_prompt_input, user_prompt_label, user_prompt_placeholder, user_prompt_max_length, visibility, is_active, provider_user_id, provider:profiles!preset_categories_provider_user_id_fkey(id, nickname, avatar_url), unlock_prerequisite_key, progressive_batch_size, sequential_unlock, unlock_announcement_hero_path, unlock_announcement_initial_body, unlock_announcement_drip_body, unlock_announcement_accent_color, unlock_announcement_accent_hover_color, unlock_announcement_title_color, unlock_announcement_soft_color)";
 
 function getSupabase(client?: SupabaseClient): SupabaseClient {
   return client ?? createAdminClient();
@@ -180,6 +181,7 @@ function mapCategoryRefStrict(
       providerAvatarUrl: null,
       unlockPrerequisiteKey: null,
       progressiveBatchSize: null,
+      sequentialUnlock: false,
       unlockAnnouncementHeroPath: null,
       unlockAnnouncementInitialBody: null,
       unlockAnnouncementDripBody: null,
@@ -217,6 +219,7 @@ function mapCategoryRefStrict(
     providerAvatarUrl: provider?.avatar_url ?? null,
     unlockPrerequisiteKey: embedded.unlock_prerequisite_key ?? null,
     progressiveBatchSize: embedded.progressive_batch_size ?? null,
+    sequentialUnlock: embedded.sequential_unlock ?? false,
     unlockAnnouncementHeroPath: embedded.unlock_announcement_hero_path ?? null,
     unlockAnnouncementInitialBody:
       embedded.unlock_announcement_initial_body ?? null,

--- a/features/style/components/StylePageBody.tsx
+++ b/features/style/components/StylePageBody.tsx
@@ -15,6 +15,7 @@ import { isAdminViewer } from "@/lib/env";
 import { getUserProfileServer } from "@/features/my-page/lib/server-api";
 import { createClient } from "@/lib/supabase/server";
 import { resolveCollectionUnlockContext } from "@/features/collections/lib/collection-unlock-server";
+import { categoryNeedsUnlockContext } from "@/features/collections/lib/collection-unlock";
 import {
   applyCollectionUnlockGating,
   type CollectionUnlockContext,
@@ -54,10 +55,10 @@ export async function StylePageBody({ searchParams }: StylePageBodyProps) {
   // 解放ゲート(unlock gating)はユーザー依存のため、グローバルキャッシュの外で適用する。
   //  - 前提条件カテゴリ未完走 → 解放対象カテゴリのプリセットを一覧から除去
   //  - 完走済み → 段階解放(drip)で未解放ぶんに locked フラグを立てる
-  // 解放ルール付きカテゴリ(unlockPrerequisiteKey != null)が一覧に無ければ完全 no-op。
+  // 解放ゲート対象カテゴリ(前提カテゴリ付き or sequential)が一覧に無ければ完全 no-op。
   // その場合は authed client の生成すらスキップする(従来カテゴリのみのときの無駄を避ける)。
-  const hasGatedCategory = cachedPresets.some(
-    (preset) => preset.category.unlockPrerequisiteKey != null,
+  const hasGatedCategory = cachedPresets.some((preset) =>
+    categoryNeedsUnlockContext(preset.category),
   );
   const presets =
     user && hasGatedCategory

--- a/supabase/migrations/20260628100000_add_sequential_unlock.sql
+++ b/supabase/migrations/20260628100000_add_sequential_unlock.sql
@@ -1,0 +1,15 @@
+-- カテゴリ内プリセットの「順番固定・1つずつ解放(sequential unlock)」フラグ。
+-- true のとき:
+--   - 前提カテゴリ(unlock_prerequisite_key)が無くても段階解放(drip)を適用する。
+--   - 解放方向を sort_order 昇順(先頭=表紙から前へ)にする(既存 drip は降順)。
+--   - progressive_batch_size 未設定時は 1(=1つずつ)として扱う(アプリ側で吸収)。
+-- 既存カテゴリは false(従来挙動)を維持。追加列のみ・後方互換。
+BEGIN;
+
+ALTER TABLE public.preset_categories
+  ADD COLUMN IF NOT EXISTS sequential_unlock BOOLEAN NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.preset_categories.sequential_unlock IS
+  '順番固定の1つずつ解放。true で前提カテゴリ無しでも sort_order 昇順(先頭=表紙)から段階解放。既定 false。';
+
+COMMIT;

--- a/tests/unit/features/collections/collection-settings-payload.test.ts
+++ b/tests/unit/features/collections/collection-settings-payload.test.ts
@@ -1015,4 +1015,30 @@ describe("parseCollectionSettings - 解放お知らせ設定(任意・独立)", 
       if (rStr.ok) expect(rStr.payload.bookCoverPath).toBe("travel/cover.png");
     });
   });
+
+  describe("sequential_unlock(順番固定の1つずつ解放)", () => {
+    test("boolean を受理して payload に載せる", () => {
+      const rTrue = parseCollectionSettings({ sequential_unlock: true }, OFF);
+      expect(rTrue.ok).toBe(true);
+      if (rTrue.ok) expect(rTrue.payload.sequentialUnlock).toBe(true);
+      const rFalse = parseCollectionSettings({ sequential_unlock: false }, OFF);
+      expect(rFalse.ok).toBe(true);
+      if (rFalse.ok) expect(rFalse.payload.sequentialUnlock).toBe(false);
+    });
+
+    test("boolean 以外は拒否", () => {
+      const r = parseCollectionSettings(
+        { sequential_unlock: "yes" as unknown as boolean },
+        OFF,
+      );
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toMatch(/sequential_unlock/);
+    });
+
+    test("未指定なら payload に含めない(no-op)", () => {
+      const r = parseCollectionSettings({}, OFF);
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.payload.sequentialUnlock).toBeUndefined();
+    });
+  });
 });

--- a/tests/unit/features/collections/collection-unlock-announcement.test.ts
+++ b/tests/unit/features/collections/collection-unlock-announcement.test.ts
@@ -30,6 +30,7 @@ function makeCategory(
     isActive: true,
     unlockPrerequisiteKey: null,
     progressiveBatchSize: null,
+    sequentialUnlock: false,
     unlockAnnouncementHeroPath: null,
     unlockAnnouncementInitialBody: null,
     unlockAnnouncementDripBody: null,

--- a/tests/unit/features/collections/collection-unlock-gating.test.ts
+++ b/tests/unit/features/collections/collection-unlock-gating.test.ts
@@ -27,6 +27,7 @@ function makeCategory(
     isActive: true,
     unlockPrerequisiteKey: null,
     progressiveBatchSize: null,
+    sequentialUnlock: false,
     unlockAnnouncementHeroPath: null,
     unlockAnnouncementInitialBody: null,
     unlockAnnouncementDripBody: null,
@@ -193,5 +194,48 @@ describe("applyCollectionUnlockGating", () => {
       "petit-4",
       "petit-5",
     ]);
+  });
+
+  describe("sequential unlock(順番固定・前提なし・先頭=表紙から昇順)", () => {
+    const SEQ_KEY = "travel_to_italy";
+    function seqPresets() {
+      // index0=表紙(sort_order 最小), 1..8=Day1..Day8
+      const cat = makeCategory(SEQ_KEY, {
+        unlockPrerequisiteKey: null,
+        sequentialUnlock: true,
+        progressiveBatchSize: null, // 未設定 → 1扱い
+      });
+      return Array.from({ length: 9 }, (_, i) => makePreset(`p-${i}`, cat));
+    }
+
+    test("生成0: 先頭(表紙)だけ解放、残りは locked", () => {
+      const result = applyCollectionUnlockGating(seqPresets(), {
+        prerequisiteCompletedKeys: new Set(),
+        distinctGeneratedByCategoryKey: new Map([[SEQ_KEY, 0]]),
+      });
+      // 表示順は昇順のまま9枚
+      expect(result.map((p) => p.id)).toEqual([
+        "p-0", "p-1", "p-2", "p-3", "p-4", "p-5", "p-6", "p-7", "p-8",
+      ]);
+      expect(result[0].locked).toBeUndefined(); // 表紙=解放
+      expect(result.slice(1).every((p) => p.locked === true)).toBe(true);
+    });
+
+    test("生成3: 先頭から4枚(表紙+Day1..3)解放、残りは locked", () => {
+      const result = applyCollectionUnlockGating(seqPresets(), {
+        prerequisiteCompletedKeys: new Set(),
+        distinctGeneratedByCategoryKey: new Map([[SEQ_KEY, 3]]),
+      });
+      expect(result.slice(0, 4).every((p) => p.locked === undefined)).toBe(true);
+      expect(result.slice(4).every((p) => p.locked === true)).toBe(true);
+    });
+
+    test("全生成: 全解放", () => {
+      const result = applyCollectionUnlockGating(seqPresets(), {
+        prerequisiteCompletedKeys: new Set(),
+        distinctGeneratedByCategoryKey: new Map([[SEQ_KEY, 9]]),
+      });
+      expect(result.every((p) => p.locked === undefined)).toBe(true);
+    });
   });
 });

--- a/tests/unit/features/collections/collection-unlock-server.test.ts
+++ b/tests/unit/features/collections/collection-unlock-server.test.ts
@@ -38,6 +38,7 @@ function categoryRef(
   key: string,
   unlockPrerequisiteKey: string | null = null,
   progressiveBatchSize: number | null = null,
+  sequentialUnlock = false,
 ): StylePresetPublicSummary["category"] {
   return {
     id: key,
@@ -47,7 +48,7 @@ function categoryRef(
     badgeColor: "#000000",
     badgeTextColor: "#ffffff",
     skipBasePrefix: false,
-    outputAspectRatioMode: "square",
+    outputAspectRatioMode: "source",
     userGuidanceJa: null,
     userGuidanceEn: null,
     showSourceImageTypeControl: true,
@@ -61,6 +62,7 @@ function categoryRef(
     isActive: true,
     unlockPrerequisiteKey,
     progressiveBatchSize,
+    sequentialUnlock,
     unlockAnnouncementHeroPath: null,
     unlockAnnouncementInitialBody: null,
     unlockAnnouncementDripBody: null,
@@ -162,6 +164,20 @@ describe("resolveCollectionUnlockContext", () => {
 
     expect(ctx.prerequisiteCompletedKeys.size).toBe(0);
   });
+
+  it("sequential(前提なし)カテゴリも distinct 集計対象に含める", async () => {
+    const SEQ = "travel_to_italy";
+    setDistinctRpc([{ category_key: SEQ, unique_count: 3 }]);
+    const presets = [
+      presetSummary("p0", categoryRef(SEQ, null, null, true)),
+    ];
+
+    const ctx = await resolveCollectionUnlockContext(presets, "user-1", dummyClient);
+
+    // 前提なしでも sequential は distinct を解決する(= ゲート対象)。
+    expect(ctx.distinctGeneratedByCategoryKey.get(SEQ)).toBe(3);
+    expect(mockCreateAdminClient).toHaveBeenCalled();
+  });
 });
 
 describe("authorizeStylePresetUnlock", () => {
@@ -227,5 +243,47 @@ describe("authorizeStylePresetUnlock", () => {
 
     const result = await authorizeStylePresetUnlock(cat, "unknown", "user-1", dummyClient);
     expect(result).toEqual({ allowed: false, reason: "preset_locked" });
+  });
+
+  // ===== sequential_unlock(前提なし・昇順=先頭[表紙]から1つずつ)=====
+  const SEQ = "travel_to_italy";
+  // index0=表紙(sort_order 最小), 1..8=Day1..Day8
+  const seqIds = ["p0", "p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8"];
+
+  it("sequential: distinct0 では先頭(表紙)のみ許可", async () => {
+    setDistinctRpc([{ category_key: SEQ, unique_count: 0 }]);
+    const cat = categoryRef(SEQ, null, null, true); // batch 未設定 → 1扱い
+    mockListPublished.mockResolvedValue(seqIds.map((id) => presetSummary(id, cat)));
+
+    await expect(
+      authorizeStylePresetUnlock(cat, "p0", "user-1", dummyClient),
+    ).resolves.toEqual({ allowed: true });
+    await expect(
+      authorizeStylePresetUnlock(cat, "p1", "user-1", dummyClient),
+    ).resolves.toEqual({ allowed: false, reason: "preset_locked" });
+  });
+
+  it("sequential: distinct3 では先頭から4枚(表紙+Day1..3)まで許可", async () => {
+    setDistinctRpc([{ category_key: SEQ, unique_count: 3 }]);
+    const cat = categoryRef(SEQ, null, null, true);
+    mockListPublished.mockResolvedValue(seqIds.map((id) => presetSummary(id, cat)));
+
+    await expect(
+      authorizeStylePresetUnlock(cat, "p3", "user-1", dummyClient),
+    ).resolves.toEqual({ allowed: true }); // 昇順 index3 < unlocked 4
+    await expect(
+      authorizeStylePresetUnlock(cat, "p4", "user-1", dummyClient),
+    ).resolves.toEqual({ allowed: false, reason: "preset_locked" }); // index4 >= 4
+  });
+
+  it("sequential: 前提カテゴリの完走チェックは行わない(progress 未設定でも許可)", async () => {
+    // setProgress を呼ばない(hasPrereq=false のため get_collection_progress に依存しない)
+    setDistinctRpc([{ category_key: SEQ, unique_count: 9 }]);
+    const cat = categoryRef(SEQ, null, null, true);
+    mockListPublished.mockResolvedValue(seqIds.map((id) => presetSummary(id, cat)));
+
+    await expect(
+      authorizeStylePresetUnlock(cat, "p8", "user-1", dummyClient),
+    ).resolves.toEqual({ allowed: true });
   });
 });

--- a/tests/unit/lib/style-preset-repository.test.ts
+++ b/tests/unit/lib/style-preset-repository.test.ts
@@ -210,6 +210,7 @@ describe("style-preset repository", () => {
           providerAvatarUrl: null,
           unlockPrerequisiteKey: null,
           progressiveBatchSize: null,
+          sequentialUnlock: false,
           unlockAnnouncementHeroPath: null,
           unlockAnnouncementInitialBody: null,
           unlockAnnouncementDripBody: null,


### PR DESCRIPTION
### 概要
コレクション内プリセットを **sort_order 昇順(先頭=表紙)から1つずつ解放する「sequential unlock」** を追加します。travel_to_italy(book/N=9・表紙=先頭)を「表紙→Day1→…→Day8」の順に解放し、Day3 を先に生成されるのを防ぐためのものです。既存の段階解放(progressive_batch_size)計算と 403 認可基盤を再利用し、既存カテゴリ(ぷち神=前提付き・末尾から)は無改修で温存します。

### 変更内容
- **DB(20260628100000)**: `preset_categories.sequential_unlock`(bool, default false)追加。追加列のみ・後方互換。
- **解放ロジック**: `collection-unlock.ts` に共有ヘルパーを新設。
  - `unlockJudgmentIndex`(sequential=昇順 / 既存=降順)・`sequentialBatchSize`(未設定=1)で、表示ゲートと生成認可の方向ロジックを共有(片側ずれ防止)。
  - `categoryNeedsUnlockContext`(前提付き or sequential)で「ゲート対象か」を一元化。
- **表示ゲート / 生成認可**: `applyCollectionUnlockGating` と `authorizeStylePresetUnlock` を sequential 対応(前提カテゴリ無しでも drip 適用、distinct 集計対象に追加)。
- **呼び出し側の一元化(認可バイパス修正)**: 生成認可(`generate-async/handler.ts`)・/style 配信(`StylePageBody`)・ホームカルーセル(`CachedHomeStylePresetSection`)のガードを共有述語に統一。これまで `unlockPrerequisiteKey` のみで分岐していたため、sequential 単独カテゴリで認可がスキップ(直POSTでロック回避)・表示がカバー固定になっていたのを修正。
- **admin**: preset-category repository/parser/フォームに `sequential_unlock` 切替を追加。
- **テスト**: gating(distinct 0/3/9)+ authorize(sequential 許可/ロック・前提非依存)+ context 集計 + parser を追加。

### 品質
multiround-adversarial-review(2ラウンド)を実施。**MUST-FIX 1 / MUST-ADDRESS 4 + 安価な OPTIONAL 3 を本PRで修正**(認可バイパス・表示固定・docstring・テスト不足等)。

### 実機テスト
- [ ] iOS Safari で主要導線を確認(先頭=表紙のみ解放→生成→次が解放)
- [ ] Android Chrome / PC(Chrome)で主要導線を確認
- [ ] 直POST でロック済みプリセットが 403 になることを確認(認可)
- [ ] 既存コレクション(神コレ/ぷち神)が従来どおり(末尾から)であることを確認(非回帰)
- [ ] admin で sequential_unlock を ON/OFF 設定して反映を確認

### テスト方法
- `npm run lint` / `npm run build -- --webpack`(緑)
- `npm run test`(全テスト 2277 pass / sequential 関連テスト追加)
- migration `20260628100000` は追加列のみ・後方互換(既存挙動に影響なし)

> 注: 本機能は travel_to_italy を go-live 時に `sequential_unlock=true`(+ 表紙プリセット sort_order 最小 / N=9)に設定して有効化します。現状 admin_only・未稼働でユーザー影響なし。
