### PR TITLE
fix(collections): book コレクションの is_collection_series 有効化を阻む CHECK を緩和

### DIFF
--- a/supabase/migrations/20260628110000_relax_collection_settings_check_for_book.sql
+++ b/supabase/migrations/20260628110000_relax_collection_settings_check_for_book.sql
@@ -1,0 +1,25 @@
+-- book(めくれる日記帳)モードのコレクションは台紙テンプレ/レイアウトを使わないため、
+-- collection settings completeness の CHECK を book モードで免除する。
+-- アプリ層の R-02 免除(app/api/admin/preset-categories/collection-settings-payload.ts)に
+-- 対応する DB 側の整合。これが無いと book カテゴリを is_collection_series=true に
+-- できない(直DB更新・admin フォームのどちらでも CHECK 違反になる)。
+--
+-- mount(従来台紙)モードは従来どおり mount_template_path + (mount_layout or mount_slots) を要求。
+-- book モードは completion_threshold(=ページ数 N)のみ必須。追加列なし・制約の緩和のみ・後方互換。
+BEGIN;
+
+ALTER TABLE public.preset_categories
+  DROP CONSTRAINT IF EXISTS preset_categories_collection_settings_complete;
+ALTER TABLE public.preset_categories
+  ADD CONSTRAINT preset_categories_collection_settings_complete
+  CHECK (
+    is_collection_series = false
+    OR (completion_view_mode = 'book' AND completion_threshold IS NOT NULL)
+    OR (
+      completion_threshold IS NOT NULL
+      AND mount_template_path IS NOT NULL
+      AND (mount_layout IS NOT NULL OR mount_slots IS NOT NULL)
+    )
+  );
+
+COMMIT;


### PR DESCRIPTION
### 概要
book(めくれる日記帳)モードのコレクションを `is_collection_series=true` に有効化できない DB 制約のバグを修正します。`preset_categories_collection_settings_complete` の CHECK が「コレクション有効時は台紙テンプレ(mount_template_path)必須」を課しているため、台紙を使わない book モード(travel_to_italy)が**直DB更新でも admin フォームでも CHECK 違反**で有効化できませんでした。アプリ層では book の R-02 を免除済みでしたが、**DB 側の整合が欠落**していたものです。

### 変更内容
- `preset_categories_collection_settings_complete` を DROP+再作成し、**book モード(`completion_view_mode='book'`)は `completion_threshold` のみ必須**に緩和。
- mount(従来台紙)モードは従来どおり `mount_template_path` +(`mount_layout` または `mount_slots`)必須。
- 制約の緩和のみ・追加列なし・後方互換(既存の mount コレクションに影響なし)。

```sql
CHECK (
  is_collection_series = false
  OR (completion_view_mode = 'book' AND completion_threshold IS NOT NULL)
  OR (completion_threshold IS NOT NULL
      AND mount_template_path IS NOT NULL
      AND (mount_layout IS NOT NULL OR mount_slots IS NOT NULL))
)
```

### テスト方法
- `npm run test`(全テスト 2277 pass・SQLのみで影響なし)
- 適用後、travel_to_italy を `is_collection_series=true` / `completion_view_mode='book'` / `completion_threshold=9` に設定できることを確認予定
