### PR TITLE
feat(collections): sequential を「1つ先だけ見せる」表示に(全シークレット一気見せを廃止)

### DIFF
--- a/features/collections/lib/collection-unlock-gating.ts
+++ b/features/collections/lib/collection-unlock-gating.ts
@@ -1,5 +1,6 @@
 import type { StylePresetPublicSummary } from "@/features/style-presets/lib/schema";
 import {
+  computeUnlockedCount,
   isPresetUnlocked,
   sequentialBatchSize,
   unlockJudgmentIndex,
@@ -82,18 +83,35 @@ export function applyCollectionUnlockGating(
       continue;
     }
 
-    // 段階解放。解放数を超えるものは locked にして残す。
-    //  - sequential: 先頭(sort_order 最小=表紙)から昇順で解放。batch 未設定は 1。
-    //  - 既存(前提付き): sort_order の末尾から降順で解放(index 反転)。
     const distinctGenerated =
       context.distinctGeneratedByCategoryKey.get(category.key) ?? 0;
     const total = totalByCategoryKey.get(category.key) ?? 0;
-    const batch = sequential
-      ? sequentialBatchSize(category.progressiveBatchSize)
-      : category.progressiveBatchSize;
-    const unlockIndex = unlockJudgmentIndex(ascendingIndex, total, sequential);
-    const unlocked = isPresetUnlocked(unlockIndex, distinctGenerated, batch, total);
 
+    if (sequential) {
+      // sequential = 先頭(sort_order 最小=表紙)から昇順で解放 + 「1つ先だけ」シークレット表示。
+      //  - index < 解放数            → 解放済み(通常表示)
+      //  - index === 解放数          → 次の1つだけシルエット(ティザー)
+      //  - index > 解放数            → まだ見せない(一覧から除去)
+      // 生成するたびにシークレットが1つずつ現れる(全シルエットを一気に見せない)。
+      const batch = sequentialBatchSize(category.progressiveBatchSize);
+      const unlockedCount = computeUnlockedCount(distinctGenerated, batch, total);
+      if (ascendingIndex < unlockedCount) {
+        result.push(preset);
+      } else if (ascendingIndex === unlockedCount) {
+        result.push({ ...preset, locked: true });
+      }
+      // ascendingIndex > unlockedCount は push しない(非表示)。
+      continue;
+    }
+
+    // 既存(前提カテゴリ付き): sort_order の末尾から降順で解放。未解放は全てシルエットで残す。
+    const unlockIndex = unlockJudgmentIndex(ascendingIndex, total, false);
+    const unlocked = isPresetUnlocked(
+      unlockIndex,
+      distinctGenerated,
+      category.progressiveBatchSize,
+      total,
+    );
     result.push(unlocked ? preset : { ...preset, locked: true });
   }
 

--- a/tests/unit/features/collections/collection-unlock-gating.test.ts
+++ b/tests/unit/features/collections/collection-unlock-gating.test.ts
@@ -208,33 +208,53 @@ describe("applyCollectionUnlockGating", () => {
       return Array.from({ length: 9 }, (_, i) => makePreset(`p-${i}`, cat));
     }
 
-    test("生成0: 先頭(表紙)だけ解放、残りは locked", () => {
+    test("生成0: 表紙だけ解放 + 次の1つ(Day1)だけシルエット、その先は非表示", () => {
       const result = applyCollectionUnlockGating(seqPresets(), {
         prerequisiteCompletedKeys: new Set(),
         distinctGeneratedByCategoryKey: new Map([[SEQ_KEY, 0]]),
       });
-      // 表示順は昇順のまま9枚
-      expect(result.map((p) => p.id)).toEqual([
-        "p-0", "p-1", "p-2", "p-3", "p-4", "p-5", "p-6", "p-7", "p-8",
-      ]);
+      // 表示は2枚だけ: p-0(解放) + p-1(ティザー)。p-2..p-8 は出さない。
+      expect(result.map((p) => p.id)).toEqual(["p-0", "p-1"]);
       expect(result[0].locked).toBeUndefined(); // 表紙=解放
-      expect(result.slice(1).every((p) => p.locked === true)).toBe(true);
+      expect(result[1].locked).toBe(true); // 次の1つだけシークレット
     });
 
-    test("生成3: 先頭から4枚(表紙+Day1..3)解放、残りは locked", () => {
+    test("生成3: 表紙+Day1..3 解放 + 次の1つ(index4)だけシルエット", () => {
       const result = applyCollectionUnlockGating(seqPresets(), {
         prerequisiteCompletedKeys: new Set(),
         distinctGeneratedByCategoryKey: new Map([[SEQ_KEY, 3]]),
       });
+      // 解放4枚(index0..3)+ ティザー1枚(index4)= 5枚表示。index5.. は非表示。
+      expect(result.map((p) => p.id)).toEqual(["p-0", "p-1", "p-2", "p-3", "p-4"]);
       expect(result.slice(0, 4).every((p) => p.locked === undefined)).toBe(true);
-      expect(result.slice(4).every((p) => p.locked === true)).toBe(true);
+      expect(result[4].locked).toBe(true);
     });
 
-    test("全生成: 全解放", () => {
+    test("生成7: 8枚解放 + 最後の1つ(Day8)だけシルエット", () => {
+      const result = applyCollectionUnlockGating(seqPresets(), {
+        prerequisiteCompletedKeys: new Set(),
+        distinctGeneratedByCategoryKey: new Map([[SEQ_KEY, 7]]),
+      });
+      expect(result.length).toBe(9); // 8解放 + 最後の1ティザー
+      expect(result.slice(0, 8).every((p) => p.locked === undefined)).toBe(true);
+      expect(result[8].locked).toBe(true);
+    });
+
+    test("生成8: 最後も解放済み(生成可)・ティザーなし", () => {
+      const result = applyCollectionUnlockGating(seqPresets(), {
+        prerequisiteCompletedKeys: new Set(),
+        distinctGeneratedByCategoryKey: new Map([[SEQ_KEY, 8]]),
+      });
+      expect(result.length).toBe(9); // 全9枚 解放(最後は未生成だが生成可=シルエットでない)
+      expect(result.every((p) => p.locked === undefined)).toBe(true);
+    });
+
+    test("全生成: 全解放(ティザーなし)", () => {
       const result = applyCollectionUnlockGating(seqPresets(), {
         prerequisiteCompletedKeys: new Set(),
         distinctGeneratedByCategoryKey: new Map([[SEQ_KEY, 9]]),
       });
+      expect(result.length).toBe(9);
       expect(result.every((p) => p.locked === undefined)).toBe(true);
     });
   });


### PR DESCRIPTION
### 概要
sequential(順番固定)コレクションの表示を「**1つ先だけ見せる(reveal one-ahead)**」に変更します。これまで未解放プリセットを**全部シルエットで一気に表示**していたため「シークレットが全部見えてしまう」状態でした。今後は **解放済み + 次の1つだけをシルエット(ティザー)** で表示し、その先は一覧に出しません。生成するたびに次のシークレットが1つずつ現れます。

### 変更内容
- `applyCollectionUnlockGating` の sequential 分岐:
  - `index < 解放数` → 解放済み(通常表示)
  - `index === 解放数` → 次の1つだけシルエット(ティザー)
  - `index > 解放数` → 一覧に出さない(非表示)
- 生成認可(サーバ側 403)は**不変**=セキュリティ影響なし(隠れたプリセットも直POSTは従来どおり拒否)。
- 既存の前提カテゴリ付き drip(ぷち神=末尾から全シルエット)は**不変**。

### 例(travel_to_italy / N=9 / はじまり→Day1→…→Day8)
- 生成0: 表示は「はじまり(生成可)＋ Day1(シルエット)」の2枚のみ
- はじまり生成後: 「はじまり・Day1(生成可)＋ Day2(シルエット)」
- … と1つずつ増え、最後は全9枚

### 実機テスト
- [ ] travel_to_italy の /style で、未生成時に「はじまり＋次の1シルエット」だけ表示されることを確認
- [ ] 生成するたびに次のシルエットが1つずつ現れることを確認
- [ ] 既存コレクション(神コレ/ぷち神)が従来どおり(全シルエット・末尾から)であることを確認(非回帰)

### テスト方法
- `npm run lint` / `npm run build -- --webpack`(緑)
- `npm run test`(全テスト 2279 pass / gating テストを reveal-one-ahead に更新)
