### PR TITLE
fix(collections): スクラップブック本リーダーの画像上下見切れを修正(object-contain)

### DIFF
--- a/features/catalog/components/BookCover.tsx
+++ b/features/catalog/components/BookCover.tsx
@@ -10,6 +10,11 @@ interface BookCoverProps {
    * front かつ画像ありのときだけ全面の画像表紙にする。
    */
   coverImageUrl?: string | null;
+  /**
+   * スクラップブック(縦長9:16)流用時は true。表紙画像を object-contain で全体表示する
+   * (カタログは既定 false で従来どおり object-cover 全面)。
+   */
+  isScrapbook?: boolean;
 }
 
 /**
@@ -28,6 +33,7 @@ export function BookCover({
   description,
   variant,
   coverImageUrl,
+  isScrapbook = false,
 }: BookCoverProps) {
   // front かつ画像あり → サムネイル画像を全面に敷いた表紙
   if (variant === "front" && coverImageUrl) {
@@ -39,7 +45,7 @@ export function BookCover({
           fill
           unoptimized
           priority
-          className="object-cover"
+          className={isScrapbook ? "object-contain" : "object-cover"}
           sizes="(max-width: 768px) 100vw, 760px"
         />
 

--- a/features/catalog/components/CatalogBookView.tsx
+++ b/features/catalog/components/CatalogBookView.tsx
@@ -37,6 +37,11 @@ interface CatalogBookViewProps {
    * (下スワイプ = true で表示 / 上スワイプ = false で非表示)。
    */
   onChromeVisibilityChange?: (visible: boolean) => void;
+  /**
+   * スクラップブック(縦長9:16)流用時は true。各ページを object-contain で全体表示する
+   * (カタログ=絵師作品は既定 false で従来どおり object-cover 全面)。
+   */
+  isScrapbook?: boolean;
 }
 
 // 本のサイズは利用可能領域 (bookContainerRef) を実測し、その縦横比に合わせて
@@ -143,6 +148,7 @@ export function CatalogBookView({
   campaignDescription,
   campaignCoverImageUrl,
   onChromeVisibilityChange,
+  isScrapbook = false,
 }: CatalogBookViewProps) {
   const [mounted, setMounted] = useState(false);
   const [reducedMotion, setReducedMotion] = useState(false);
@@ -577,6 +583,7 @@ export function CatalogBookView({
                     description={campaignDescription}
                     coverImageUrl={campaignCoverImageUrl}
                     variant="front"
+                    isScrapbook={isScrapbook}
                   />
                 </FlipBookPageWrapper>
 
@@ -586,6 +593,7 @@ export function CatalogBookView({
                     <CatalogPage
                       page={page}
                       pageNumber={i + 1}
+                      isScrapbook={isScrapbook}
                       side={
                         orientation === "portrait"
                           ? "single"

--- a/features/catalog/components/CatalogPage.tsx
+++ b/features/catalog/components/CatalogPage.tsx
@@ -19,13 +19,24 @@ interface CatalogPageProps {
   pageNumber: number;
   /** 見開き時の左右どちらか。中央折り目側の陰影を切り替える */
   side: "left" | "right" | "single";
+  /**
+   * スクラップブック(縦長9:16)流用時は true。画像を object-contain で全体表示し、
+   * 上下/左右が見切れないようにする(カタログ=絵師作品は従来どおり object-cover で全面)。
+   */
+  isScrapbook?: boolean;
 }
 
 /**
- * 本の 1 ページ。表紙 (BookCover) と同じく、作品画像をページ全面に object-cover で
- * 敷き詰め、下部グラデーション上に絵師名・リンク・ページ番号を重ねる。
+ * 本の 1 ページ。表紙 (BookCover) と同じく、作品画像をページに敷き詰める。
+ * カタログ(絵師作品)は object-cover で全面、スクラップブック(9:16)は object-contain で全体表示。
+ * 下部グラデーション上に絵師名・リンク・ページ番号を重ねる(クレジットがある場合のみ)。
  */
-export function CatalogPage({ page, pageNumber, side }: CatalogPageProps) {
+export function CatalogPage({
+  page,
+  pageNumber,
+  side,
+  isScrapbook = false,
+}: CatalogPageProps) {
   // 中央折り目側 (右ページなら左端、左ページなら右端) にうっすら陰影を付ける。
   // single (portrait) は折り目が見えないので陰影なし。
   const gutterShadow =
@@ -47,7 +58,7 @@ export function CatalogPage({ page, pageNumber, side }: CatalogPageProps) {
           // 始まり待ちが出るため eager にして全ページ画像を先読みする。
           // (画像は Storage 変換でリサイズ + WebP 化され十分軽量)
           loading="eager"
-          className="object-cover"
+          className={isScrapbook ? "object-contain" : "object-cover"}
           sizes="(max-width: 768px) 100vw, 760px"
         />
       ) : (

--- a/features/collections/components/ScrapbookReader.tsx
+++ b/features/collections/components/ScrapbookReader.tsx
@@ -116,6 +116,7 @@ export function ScrapbookReader({
           campaignTitle={title}
           campaignCoverImageUrl={coverImageUrl}
           pages={pages}
+          isScrapbook
           onChromeVisibilityChange={(visible) => setChromeVisible(visible)}
         />
       </main>


### PR DESCRIPTION
### 概要
シェアページ(本リーダー `/m/[token]/book`)で、9:16縦長のスクラップブック画像(表紙=はじまり・各ページ)が**上下見切れ**していた問題を修正します。横長画面でページ面のアスペクトが9:16より横長になり、`object-cover` で上下がクロップされていました。

### 変更内容
- `CatalogPage` / `BookCover` に `isScrapbook` prop を追加し、true のとき画像を **object-contain**(全体表示・余白あり)に。
- `ScrapbookReader → CatalogBookView → CatalogPage/BookCover` の経路でのみ `isScrapbook=true` を渡す。
- `/catalog`(絵師カタログ)・`CatalogReaderModal` は**既定 false で従来どおり object-cover 全面**(非回帰)。
- 表紙・各ページ両方に適用。

### 実機テスト
- [ ] `/m/[token]/book`(travel)で表紙・各ページが上下見切れなく全体表示されることを確認(PC横/モバイル縦)
- [ ] `/catalog/[slug]`(絵師カタログ)が従来どおり全面表示(object-cover)で変わらないことを確認(非回帰)

### テスト方法
- `npm run lint` / `npm run build -- --webpack`(緑)
- `npm run test`(catalog/collections 関連 337 pass)
