### PR TITLE
feat(collections): イタリア旅行版「遊び方」ページ新設 + 遊び方リンクのカテゴリ別出し分け

### DIFF
--- a/app/collections/italy/page.tsx
+++ b/app/collections/italy/page.tsx
@@ -1,0 +1,53 @@
+import type { Metadata } from "next";
+import { connection } from "next/server";
+import { getPresetCategoryByKey } from "@/features/style-presets/lib/preset-category-repository";
+import { listPublishedStylePresets } from "@/features/style-presets/lib/style-preset-repository";
+import { ItalyTravelGuide } from "@/features/collections/components/ItalyTravelGuide";
+
+// うちの子のイタリア旅行日記(表紙=はじまり + Day1〜Day8 の全9種)。コラボ企画。
+const ITALY_KEY = "travel_to_italy";
+
+const PAGE_TITLE =
+  "うちの子のイタリア旅行日記｜9種そろえてめくれる旅行日記をつくろう | Persta.AI";
+const PAGE_DESCRIPTION =
+  "うちの子をイタリア旅行へ。表紙「はじまり」から Day1・Day2… と1つずつ解放して全9種をあつめると、1ページずつめくれる旅行日記(本)が完成。ダウンロードして SNS でシェア！";
+
+export const metadata: Metadata = {
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
+  openGraph: {
+    title: "うちの子のイタリア旅行日記｜めくれる旅行日記をつくろう",
+    description:
+      "うちの子をイタリア旅行へ。全9種をあつめて、めくれる旅行日記をつくろう。",
+    type: "website",
+    siteName: "Persta.AI",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "うちの子のイタリア旅行日記｜めくれる旅行日記をつくろう",
+    description:
+      "うちの子をイタリア旅行へ。全9種をあつめて、めくれる旅行日記をつくろう。",
+  },
+};
+
+export default async function ItalyCollectionGuidePage() {
+  await connection();
+
+  // admin_only 期間中もプレビューできるよう includeAdminOnly で取得。
+  const [category, allPresets] = await Promise.all([
+    getPresetCategoryByKey(ITALY_KEY),
+    listPublishedStylePresets({ includeAdminOnly: true }),
+  ]);
+
+  const threshold = category?.completionThreshold ?? 9;
+  // sort_order 昇順(はじまり → Day1 → … → Day8)で取得済み。
+  const presets = allPresets
+    .filter((p) => p.category.key === ITALY_KEY)
+    .map((p) => ({
+      id: p.id,
+      title: p.title,
+      thumbnailImageUrl: p.thumbnailImageUrl,
+    }));
+
+  return <ItalyTravelGuide threshold={threshold} presets={presets} />;
+}

--- a/features/collections/components/CollectionProgressModal.tsx
+++ b/features/collections/components/CollectionProgressModal.tsx
@@ -13,6 +13,7 @@ import { ShareLinkButton } from "@/components/ShareLinkButton";
 import { AchievementBadge } from "@/features/collections/components/AchievementBadge";
 import { CollectionConfetti } from "@/features/collections/components/CollectionConfetti";
 import { CollectionSparkle } from "@/features/collections/components/CollectionSparkle";
+import { collectionGuidePath } from "@/features/collections/lib/collection-guides";
 import { mountAspectForCategory } from "@/features/collections/lib/mount-aspects";
 import type { NormalizedSlotRect } from "@/features/collections/lib/mount-layouts";
 import { MOUNT_SHARE_MESSAGES } from "@/features/collections/lib/mount-share-messages";
@@ -617,7 +618,7 @@ export function CollectionProgressModal({
               </button>
             ) : null}
             <Link
-              href="/collections/wafer"
+              href={collectionGuidePath(celebration.categoryKey)}
               onClick={onClose}
               className="inline-block text-sm font-medium text-pink-400 hover:text-pink-500"
             >
@@ -982,7 +983,7 @@ export function CollectionProgressModal({
               シールを生成する
             </Link>
             <Link
-              href="/collections/wafer"
+              href={collectionGuidePath(celebration.categoryKey)}
               onClick={onClose}
               className="inline-block text-sm font-medium text-pink-400 hover:text-pink-500"
             >

--- a/features/collections/components/ItalyTravelGuide.tsx
+++ b/features/collections/components/ItalyTravelGuide.tsx
@@ -1,0 +1,329 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useEffect, useRef, useState, type ReactNode } from "react";
+
+/* eslint-disable @next/next/no-page-custom-font -- 日本語の動的サブセットを使うため意図的に <link> で読み込む */
+
+// うちの子のイタリア旅行日記(book / sequential / 全9種)の遊び方ページ。
+// 神コレ(WaferGuide)と同じトーン(手づくり感の丸ゴシック + Reveal アニメ)を踏襲しつつ、
+// イタリア🇮🇹(グリーン/ホワイト/レッド)+ 旅日記(セピア・地図)の世界観に寄せる。
+
+const EASE = "cubic-bezier(0.16, 1, 0.3, 1)";
+const HEADING_FONT = "'Zen Maru Gothic', system-ui, sans-serif";
+
+// イタリア国旗の3色(アクセント)
+const IT_GREEN = "#0E8A4F";
+const IT_RED = "#CE2B37";
+
+function Reveal({
+  children,
+  delay = 0,
+  className,
+}: {
+  children: ReactNode;
+  delay?: number;
+  className?: string;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [shown, setShown] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      queueMicrotask(() => setShown(true));
+      return;
+    }
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) {
+          if (e.isIntersecting) {
+            setShown(true);
+            io.disconnect();
+            break;
+          }
+        }
+      },
+      { threshold: 0.15, rootMargin: "0px 0px -10% 0px" },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, []);
+
+  return (
+    <div
+      ref={ref}
+      className={className}
+      style={{
+        opacity: shown ? 1 : 0,
+        transform: shown ? "none" : "translateY(28px)",
+        transition: `opacity 900ms ${EASE} ${delay}ms, transform 900ms ${EASE} ${delay}ms`,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** イタリア国旗の細いリボン(緑/白/赤)。 */
+function FlagRibbon({ className }: { className?: string }) {
+  return (
+    <span
+      aria-hidden
+      className={`inline-flex h-1.5 w-16 overflow-hidden rounded-full ${className ?? ""}`}
+    >
+      <span className="h-full flex-1" style={{ background: IT_GREEN }} />
+      <span className="h-full flex-1 bg-white" />
+      <span className="h-full flex-1" style={{ background: IT_RED }} />
+    </span>
+  );
+}
+
+interface GuidePreset {
+  id: string;
+  title: string;
+  thumbnailImageUrl: string;
+}
+
+export function ItalyTravelGuide({
+  threshold,
+  presets,
+}: {
+  threshold: number;
+  presets: GuidePreset[];
+}) {
+  // 先頭 = 表紙(はじまり)。残り = 中身(Day1〜)。
+  const cover = presets[0] ?? null;
+  const days = presets.slice(1);
+
+  const steps: { n: string; t: string; b: string }[] = [
+    {
+      n: "01",
+      t: "表紙「はじまり」を生成",
+      b: "まずは旅のはじまり。One-Tap Style で「はじまり」を選んで、うちの子の旅行日記の表紙をつくろう。",
+    },
+    {
+      n: "02",
+      t: "1日ずつ解放されていく",
+      b: "生成するたびに、次の1日(Day)がひらきます。Day1 → Day2 …と、順番に旅が進んでいきます。",
+    },
+    {
+      n: "03",
+      t: `全${threshold}種そろえてコンプリート`,
+      b: `表紙(はじまり)+ Day1〜Day${Math.max(1, threshold - 1)} をそろえると、旅の記録がコンプリート！`,
+    },
+    {
+      n: "04",
+      t: "めくれる旅行日記が完成",
+      b: "完成すると、1ページずつ“めくれる”旅行日記(本)に。そのままシェアして旅の思い出を自慢しよう！",
+    },
+  ];
+
+  return (
+    <main className="overflow-x-hidden bg-[#FBF5E9] text-[#5b4b3a]">
+      <style>{`
+        @keyframes it-float { 0%,100% { transform: translateY(0) } 50% { transform: translateY(-9px) } }
+        .it-float { animation: it-float 7s ease-in-out infinite; }
+        @media (prefers-reduced-motion: reduce){ .it-float { animation:none } }
+      `}</style>
+      <link
+        href="https://fonts.googleapis.com/css2?family=Zen+Maru+Gothic:wght@500;700&display=swap"
+        rel="stylesheet"
+      />
+
+      {/* ===== Hero ===== */}
+      <section className="relative overflow-hidden px-6 pb-14 pt-12 text-center">
+        <Reveal>
+          <span
+            className="inline-flex items-center gap-2 rounded-full border-2 border-dashed px-4 py-1 text-xs font-bold"
+            style={{ borderColor: IT_GREEN, color: IT_GREEN, background: "rgba(255,255,255,0.7)", fontFamily: HEADING_FONT }}
+          >
+            🇮🇹 全{threshold}種 ✦ うちの子のイタリア旅行
+          </span>
+        </Reveal>
+        <Reveal delay={100}>
+          <h1
+            className="mt-5 text-3xl leading-[1.4] sm:text-4xl"
+            style={{
+              fontFamily: HEADING_FONT,
+              background: `linear-gradient(90deg, ${IT_GREEN}, #b08d57, ${IT_RED})`,
+              WebkitBackgroundClip: "text",
+              backgroundClip: "text",
+              color: "transparent",
+            }}
+          >
+            うちの子の
+            <br />
+            イタリア旅行日記
+          </h1>
+        </Reveal>
+        <Reveal delay={180}>
+          <div className="mt-4 flex justify-center">
+            <FlagRibbon />
+          </div>
+        </Reveal>
+        <Reveal delay={220}>
+          <p className="mt-4 text-sm leading-loose text-[#7a6a58]">
+            うちの子と、イタリアをめぐる小さな旅。
+            <br />
+            表紙から1日ずつあつめて、めくれる旅行日記をコンプリート。
+          </p>
+        </Reveal>
+
+        {/* 表紙プレビュー(はじまり) */}
+        {cover ? (
+          <Reveal delay={300}>
+            <div className="mx-auto mt-8 w-full max-w-[260px]">
+              <div className="relative aspect-[9/16] overflow-hidden rounded-2xl border border-[#e3d4b5] bg-white shadow-[0_8px_24px_rgba(120,90,50,0.16)]">
+                <Image
+                  src={cover.thumbnailImageUrl}
+                  alt="表紙「はじまり」のサンプル"
+                  fill
+                  sizes="(max-width: 480px) 70vw, 260px"
+                  className="object-cover"
+                />
+                <span
+                  className="absolute left-3 top-3 rounded-full px-2.5 py-1 text-[11px] font-bold text-white shadow"
+                  style={{ background: IT_GREEN }}
+                >
+                  表紙 ・ はじまり
+                </span>
+              </div>
+              <p className="mt-2 text-xs text-[#9a8a78]">＼ 旅のはじまり ／</p>
+            </div>
+          </Reveal>
+        ) : null}
+
+        <Reveal delay={380}>
+          <Link
+            href="/style"
+            className="mt-9 inline-flex items-center gap-2 rounded-full px-8 py-3.5 text-base font-bold text-white shadow-[0_5px_0_rgba(14,138,79,0.3)] transition-transform hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-emerald-200"
+            style={{ background: IT_GREEN, fontFamily: HEADING_FONT }}
+          >
+            いますぐはじめる
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden className="h-5 w-5">
+              <path d="M5 12h14M13 6l6 6-6 6" />
+            </svg>
+          </Link>
+          <p className="mt-3 text-xs text-[#9a8a78]">
+            企画がスタートしたら対象の「イタリア旅行」シリーズが表示されます！
+          </p>
+        </Reveal>
+      </section>
+
+      {/* ===== あつめる Day たち ===== */}
+      {days.length > 0 ? (
+        <section className="bg-white/70 px-6 py-16">
+          <div className="mx-auto max-w-3xl">
+            <Reveal>
+              <h2 className="text-center text-2xl text-[#4a3b2c]" style={{ fontFamily: HEADING_FONT }}>
+                あつめる、{days.length}日間の旅
+              </h2>
+            </Reveal>
+            <Reveal delay={100}>
+              <p className="mt-2 text-center text-sm text-[#7a6a58]">
+                表紙のあと、Day1 から順番に解放されます。1日ずつめくる楽しみを。
+              </p>
+            </Reveal>
+
+            <div className="mt-10 grid grid-cols-2 gap-4 sm:grid-cols-3">
+              {days.map((d, i) => (
+                <Reveal key={d.id} delay={i * 70}>
+                  <div className="relative rounded-2xl border border-[#ecdcc0] bg-white p-3 shadow-[0_6px_18px_rgba(120,90,50,0.08)]">
+                    <span
+                      className="absolute -top-2 left-1/2 h-5 w-16 -translate-x-1/2 -rotate-3 rounded-sm"
+                      style={{ background: "rgba(14,138,79,0.18)" }}
+                      aria-hidden
+                    />
+                    <div className="relative aspect-[9/16] overflow-hidden rounded-xl border border-[#e3d4b5] bg-[#faf3e6]">
+                      <Image
+                        src={d.thumbnailImageUrl}
+                        alt={d.title}
+                        fill
+                        sizes="(max-width: 640px) 44vw, 200px"
+                        className="object-cover"
+                      />
+                    </div>
+                    <p className="mt-3 text-center text-xs font-bold tracking-widest" style={{ color: IT_GREEN }}>
+                      Day {String(i + 1).padStart(2, "0")}
+                    </p>
+                    <p className="mt-0.5 line-clamp-1 text-center text-sm text-[#4a3b2c]" style={{ fontFamily: HEADING_FONT }}>
+                      {d.title}
+                    </p>
+                  </div>
+                </Reveal>
+              ))}
+            </div>
+          </div>
+        </section>
+      ) : null}
+
+      {/* ===== あそびかた ===== */}
+      <section className="px-6 py-16">
+        <div className="mx-auto max-w-2xl">
+          <Reveal>
+            <h2 className="text-center text-2xl text-[#4a3b2c]" style={{ fontFamily: HEADING_FONT }}>
+              あそびかた
+            </h2>
+          </Reveal>
+          <div className="mt-10 space-y-4">
+            {steps.map((s, i) => (
+              <Reveal key={s.n} delay={i * 80}>
+                <div className="flex items-start gap-4 rounded-3xl border border-[#ecdcc0] bg-white/80 p-5">
+                  <span
+                    className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full text-lg text-white"
+                    style={{ background: IT_GREEN, fontFamily: HEADING_FONT }}
+                  >
+                    {s.n}
+                  </span>
+                  <div>
+                    <p className="text-lg text-[#4a3b2c]" style={{ fontFamily: HEADING_FONT }}>
+                      {s.t}
+                    </p>
+                    <p className="mt-1 text-sm leading-relaxed text-[#7a6a58]">{s.b}</p>
+                  </div>
+                </div>
+              </Reveal>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ===== CTA ===== */}
+      <section className="bg-white/70 px-6 pb-20 pt-14 text-center">
+        <Reveal>
+          <div className="mx-auto flex justify-center">
+            <FlagRibbon />
+          </div>
+        </Reveal>
+        <Reveal delay={70}>
+          <p
+            className="mx-auto mb-6 mt-5 max-w-md text-base font-bold"
+            style={{ color: IT_GREEN, fontFamily: HEADING_FONT }}
+          >
+            うちの子の旅行日記、つくってシェアしよう！
+          </p>
+        </Reveal>
+        <Reveal delay={140}>
+          <Link
+            href="/style"
+            className="inline-flex items-center gap-2 rounded-full px-10 py-4 text-lg font-bold text-white shadow-[0_5px_0_rgba(14,138,79,0.3)] transition-transform hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-emerald-200"
+            style={{ background: IT_GREEN, fontFamily: HEADING_FONT }}
+          >
+            いますぐはじめる
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden className="h-5 w-5">
+              <path d="M5 12h14M13 6l6 6-6 6" />
+            </svg>
+          </Link>
+        </Reveal>
+        <Reveal delay={100}>
+          <p className="mx-auto mt-6 max-w-sm text-xs leading-relaxed text-[#9a8a78]">
+            ※ あつめる・日記の保存にはログインが必要です（未ログインでも一枚お試し生成できます）。
+          </p>
+        </Reveal>
+      </section>
+    </main>
+  );
+}

--- a/features/collections/lib/collection-guides.ts
+++ b/features/collections/lib/collection-guides.ts
@@ -1,0 +1,25 @@
+/**
+ * コレクション「遊び方(ガイド)」ページの URL をカテゴリ key から解決する。
+ *
+ * 遊び方ページは各カテゴリごとに用意したコード上のルート(例: app/collections/italy)。
+ * リンク先(=ルート)はページ実体と密結合のため、DB ではなくこのコードマップで一元管理する。
+ * 新しいコラボを足すときは「ガイドページを作る + ここに1行足す」だけで出し分けできる。
+ *
+ * 未登録カテゴリは従来の神コレ(ウエハース)ガイドにフォールバックする。
+ */
+const COLLECTION_GUIDE_PATHS: Record<string, string> = {
+  travel_to_italy: "/collections/italy",
+};
+
+/** 未登録カテゴリのフォールバック先(神コレの遊び方)。 */
+export const DEFAULT_COLLECTION_GUIDE_PATH = "/collections/wafer";
+
+/** カテゴリ key から遊び方ページの URL を返す。未登録は神コレのガイドにフォールバック。 */
+export function collectionGuidePath(
+  categoryKey: string | null | undefined,
+): string {
+  if (categoryKey && COLLECTION_GUIDE_PATHS[categoryKey]) {
+    return COLLECTION_GUIDE_PATHS[categoryKey];
+  }
+  return DEFAULT_COLLECTION_GUIDE_PATH;
+}


### PR DESCRIPTION
### 概要
コレクション完走モーダルの「遊び方をみる ›」リンクが**神コレ(`/collections/wafer`)固定**だったのを、**カテゴリ別に出し分け**できるようにし、**うちの子のイタリア旅行版の遊び方ページを新設**します。

### 変更内容
- `features/collections/lib/collection-guides.ts`(新規):`categoryKey → 遊び方URL` のコードマップ + 解決関数。未登録カテゴリは従来の `/collections/wafer` にフォールバック。新コラボは「ページを作る + 1行足す」だけで出し分け可能。
  - ※ 遊び方ページはコード上のルート実体と密結合のため、DB列ではなくコードマップで一元管理(リンクとページが同じ場所に揃う)。DBで動的編集したい要件が出れば後でDB化可能。
- `CollectionProgressModal`:「遊び方をみる」2箇所の固定リンクを `collectionGuidePath(celebration.categoryKey)` に差し替え(神コレ等は従来どおり)。
- `app/collections/italy` + `ItalyTravelGuide`(新規):**うちの子のイタリア旅行日記**の遊び方ページ。
  - 🇮🇹 イタリア配色(グリーン/ホワイト/レッド)+ 旅日記トーン(セピア・手づくり感の丸ゴシック)。
  - **実プリセットのサムネ(はじまり + Day1〜Day8)を使って画像リッチ**に表示(static アセット不要)。
  - `sequential`(1日ずつ解放)と `book`(めくれる旅行日記)の体験を説明。
  - `travel_to_italy → /collections/italy` を map に登録。

### 実機テスト
- [ ] `/collections/italy` が表示され、はじまり+Day一覧・あそびかた・CTA が見えること
- [ ] travel_to_italy の完走モーダル「遊び方をみる ›」が `/collections/italy` に飛ぶこと
- [ ] 神コレ/ぷち神の「遊び方をみる ›」が従来どおり `/collections/wafer` に飛ぶこと(非回帰)

### テスト方法
- `npm run lint` / `npm run build -- --webpack`(緑・`/collections/italy` 生成確認)
- `npm run test`(全テスト 2279 pass)

> 補足: 文言・配色・載せる画像は第一版です。コピーや追加アセット(完成本のサンプル等)で随時ブラッシュアップできます。
