### PR TITLE
fix(collections): book完走モーダルの画像を「はじまり」に(OGPバナーは維持・分離)

### DIFF
--- a/app/api/collections/mount/route.ts
+++ b/app/api/collections/mount/route.ts
@@ -235,24 +235,46 @@ export async function POST(request: NextRequest) {
       }
       const bookPagePaths = pageReps.map((r) => r.storagePath);
 
-      // OGP/シェア用の1枚絵は mount-{ts}.png(finalize が許可するパターン)に「必ず実ファイル」をアップロードする。
-      //   優先: 運営登録のテーマ表紙(ogp_template_path)。未設定なら1ページ目を流用してファイルを保証する。
-      // こうして mount_image_path が常に実在オブジェクトを指す(OGP/サムネが404にならない)。
-      const ogpTemplatePath = category.ogp_template_path as string | null;
-      const ogpSourceBuf = ogpTemplatePath
-        ? await downloadBuffer(admin, TEMPLATE_BUCKET, ogpTemplatePath)
-        : await downloadBuffer(admin, GENERATED_IMAGES_BUCKET, bookPagePaths[0]);
-      const { error: ogpUploadErr } = await admin.storage
+      // 完走モーダル/マイページに出す画像 = 「はじまり(表紙=book_page_paths[0])」の生成画像を
+      //   mount-{ts}.png(finalize 許可パターン)にコピーする。縦長なので 3:4 のモーダルにも収まる。
+      //   (旧実装は横長 OGP バナーを敷いていたが、縦長モーダルに合わないため はじまり に変更)
+      const coverBuf = await downloadBuffer(
+        admin,
+        GENERATED_IMAGES_BUCKET,
+        bookPagePaths[0],
+      );
+      const { error: coverUploadErr } = await admin.storage
         .from(GENERATED_IMAGES_BUCKET)
-        .upload(mountStoragePath, ogpSourceBuf, {
+        .upload(mountStoragePath, coverBuf, {
           contentType: "image/png",
           upsert: false,
         });
-      if (ogpUploadErr) {
-        throw new Error(`book OGP upload failed: ${ogpUploadErr.message}`);
+      if (coverUploadErr) {
+        throw new Error(`book cover upload failed: ${coverUploadErr.message}`);
       }
       uploadedPath = mountStoragePath; // 後続失敗時のロールバック対象
       const bookMountPath = mountStoragePath;
+
+      // X シェア用 OGP(横長バナー)は mount のツイン ogp-{ts}.png に保存する(mount モードと同方式)。
+      //   優先: 運営登録のテーマ表紙(ogp_template_path = 旅のきろくバナー)。未設定時は
+      //   はじまり画像を OGP にフォールバック(404 を避ける)。シェアページはこのツインを参照する。
+      const ogpTemplatePath = category.ogp_template_path as string | null;
+      const ogpTwinPath = ogpPathFromMountPath(mountStoragePath);
+      if (ogpTwinPath) {
+        try {
+          const ogpBuf = ogpTemplatePath
+            ? await downloadBuffer(admin, TEMPLATE_BUCKET, ogpTemplatePath)
+            : coverBuf;
+          await admin.storage
+            .from(GENERATED_IMAGES_BUCKET)
+            .upload(ogpTwinPath, ogpBuf, {
+              contentType: "image/png",
+              upsert: false,
+            });
+        } catch (e) {
+          console.error("book OGP twin upload failed:", e);
+        }
+      }
 
       const bookSharePath = `/m/${completionId}/book`;
 
@@ -309,10 +331,12 @@ export async function POST(request: NextRequest) {
         }
         revalidateTag(`collection-completions:${user.id}`, "max");
         if (previousMountPath && previousMountPath !== bookMountPath) {
+          // 旧 mount-{ts}.png と そのOGPツイン ogp-{ts}.png を削除(ベストエフォート)。
+          const stale = [previousMountPath];
+          const prevOgp = ogpPathFromMountPath(previousMountPath);
+          if (prevOgp) stale.push(prevOgp);
           try {
-            await admin.storage
-              .from(GENERATED_IMAGES_BUCKET)
-              .remove([previousMountPath]);
+            await admin.storage.from(GENERATED_IMAGES_BUCKET).remove(stale);
           } catch {
             // best effort
           }

--- a/features/collections/lib/public-mount-server-api.ts
+++ b/features/collections/lib/public-mount-server-api.ts
@@ -143,6 +143,14 @@ export const getCollectionBookByToken = cache(async (
     book_cover_path?: string | null;
   };
 
+  // OGP(Xシェア画像)は横長バナー。book は mount_image_path(=はじまり/縦長)とは別に、
+  // ツイン ogp-{ts}.png にバナーを保存しているのでそちらを参照する(mount モードと同方式)。
+  const mountPath = (data.mount_image_path as string | null) ?? null;
+  const bookOgpPath =
+    mountPath && mountPath.includes("/mount-")
+      ? mountPath.replace("/mount-", "/ogp-")
+      : mountPath;
+
   return {
     completionId: data.id as string,
     ownerId: data.user_id as string,
@@ -150,9 +158,7 @@ export const getCollectionBookByToken = cache(async (
     displayNameJa: catRecord.display_name_ja ?? "",
     coverImageUrl: buildPublicGeneratedImageUrl(catRecord.book_cover_path ?? null),
     pageImageUrls,
-    ogpImageUrl: buildPublicGeneratedImageUrl(
-      (data.mount_image_path as string | null) ?? null,
-    ),
+    ogpImageUrl: buildPublicGeneratedImageUrl(bookOgpPath),
     completedAt: (data.completed_at as string | null) ?? null,
   };
 });


### PR DESCRIPTION
### 概要
book(めくれる旅行日記)完走モーダル/マイページの画像を「**はじまり(表紙)**」の生成画像に変更します。これまで `mount_image_path` に**横長の OGP バナー(旅のきろく)**を敷いていたため、**3:4 縦長の完走モーダルに横長画像**が入って合っていませんでした。OGP(Xシェア画像)はバナーのまま維持し、表示用と OGP 用を分離します。

### 変更内容
- `app/api/collections/mount/route.ts`(book 分岐):
  - `mount_image_path` = 「はじまり(= `book_page_paths[0]`)」の生成画像(縦長)を `mount-{ts}.png` にコピー。→ 完走モーダル・マイページのサムネが縦長画像に。
  - X シェア用 OGP(横長バナー = `ogp_template_path`)は mount のツイン `ogp-{ts}.png` に保存(mount モードと同方式)。未設定時ははじまり画像にフォールバック。
  - 作り直し(isUpdate)時は旧 `mount-{ts}.png` と OGP ツインも削除。
- `features/collections/lib/public-mount-server-api.ts`:
  - `getCollectionBookByToken` の `ogpImageUrl` を mount のツイン `ogp-{ts}.png`(=バナー)参照に変更。

### 結果
- **完走モーダル / マイページ** → 「はじまり」(縦長) ✅
- **OGP(Xシェア)** → 旅のきろくバナー(横長)のまま ✅
- **本の表紙(/m/<id>/book の0ページ目)** → `book_page_paths[0]` = はじまり のまま(不変) ✅

### 注意(運用)
- **すでにコンプリート済み**の完走は旧画像(バナー)のままです。完走モーダルの「カードを更新する」を押すと新仕様(はじまり)に差し替わります。
- **これから完走する人**は自動で新仕様になります。

### 実機テスト
- [ ] 既存完走で「カードを更新する」→ 完走モーダルが はじまり(縦長)になることを確認
- [ ] 新規完走で 完走モーダルが はじまり になることを確認
- [ ] X シェア(OGP)が 旅のきろくバナー(横長)のままであることを確認
- [ ] /m/<id>/book の表紙が はじまり のままであることを確認

### テスト方法
- `npm run lint` / `npm run build -- --webpack`(緑)
- `npm run test`(collections 関連 302 pass)
