### PR TITLE
feat(collections): sequential コレクションの解放お知らせ(Day◯が解放)に対応

### DIFF
--- a/features/collections/components/CollectionUnlockDripListener.tsx
+++ b/features/collections/components/CollectionUnlockDripListener.tsx
@@ -63,13 +63,20 @@ export function CollectionUnlockDripListener() {
         );
         if (!announcement) return;
 
-        const seen = getUnlockSeen(announcement.categoryKey);
-        const mode = decideUnlockAnnouncement(seen, announcement.unlockedCount);
-        // 段階解放(drip)のみ担当。初回(seen===null)はホームの A に委ねる。
-        if (mode !== "drip" || seen === null) return;
+        // sequential は baseline(常時解放=表紙)を未記録時の既読とみなす。これにより
+        // 「はじまり生成 → Day1解放」が初回から drip として出る(前提型は従来どおり初回はAに委譲)。
+        const seenRaw = getUnlockSeen(announcement.categoryKey);
+        const baseline = announcement.baselineUnlockedCount ?? 0;
+        const effectiveSeen = seenRaw ?? (baseline > 0 ? baseline : null);
+        const mode = decideUnlockAnnouncement(
+          effectiveSeen,
+          announcement.unlockedCount,
+        );
+        // 段階解放(drip)のみ担当。初回(effectiveSeen===null=前提型で未記録)はホームの A に委ねる。
+        if (mode !== "drip" || effectiveSeen === null) return;
 
         const newlyUnlocked = announcement.unlockedPresets.slice(
-          seen,
+          effectiveSeen,
           announcement.unlockedCount,
         );
         if (newlyUnlocked.length === 0 || cancelled) return;
@@ -116,6 +123,14 @@ export function CollectionUnlockDripListener() {
       title={active.announcement.categoryDisplayName}
       newlyUnlocked={active.newlyUnlocked}
       onClose={close}
+      body={active.announcement.dripBody}
+      colors={{
+        accent: active.announcement.accentColor,
+        accentHover: active.announcement.accentHoverColor,
+        title: active.announcement.titleColor,
+        soft: active.announcement.softColor,
+      }}
+      unitLabel={active.announcement.unitLabel}
     />,
     document.body,
   );

--- a/features/collections/components/PetitUnlockAnnouncer.tsx
+++ b/features/collections/components/PetitUnlockAnnouncer.tsx
@@ -59,13 +59,23 @@ function resolveActiveAnnouncement(
       continue;
     }
 
-    const seen = getUnlockSeen(announcement.categoryKey);
-    const mode = decideUnlockAnnouncement(seen, announcement.unlockedCount);
+    // sequential は baseline(常時解放=表紙)分を「未記録時の既読」とみなし、
+    // baseline 超の解放だけを drip 告知する(表紙の初回バナーは出さない)。
+    const seenRaw = getUnlockSeen(announcement.categoryKey);
+    const baseline = announcement.baselineUnlockedCount ?? 0;
+    const effectiveSeen = seenRaw ?? (baseline > 0 ? baseline : null);
+    const mode = decideUnlockAnnouncement(
+      effectiveSeen,
+      announcement.unlockedCount,
+    );
     if (mode === "none") continue;
 
     const newlyUnlocked =
-      mode === "drip" && seen !== null
-        ? announcement.unlockedPresets.slice(seen, announcement.unlockedCount)
+      mode === "drip" && effectiveSeen !== null
+        ? announcement.unlockedPresets.slice(
+            effectiveSeen,
+            announcement.unlockedCount,
+          )
         : announcement.unlockedPresets.slice(0, announcement.unlockedCount);
 
     return { mode, announcement, newlyUnlocked };
@@ -190,6 +200,7 @@ export function PetitUnlockAnnouncer({
         onClose={acknowledge}
         body={ann.dripBody}
         colors={colors}
+        unitLabel={ann.unitLabel}
       />
     );
 

--- a/features/collections/components/UnlockModals.tsx
+++ b/features/collections/components/UnlockModals.tsx
@@ -170,6 +170,7 @@ export function UnlockDripModal({
   onClose,
   body,
   colors,
+  unitLabel,
 }: {
   title: string;
   newlyUnlocked: CollectionUnlockAnnouncement["unlockedPresets"];
@@ -178,9 +179,12 @@ export function UnlockDripModal({
   body?: string | null;
   /** 配色(未指定なら標準の紫基調)。 */
   colors?: UnlockAnnouncementColors;
+  /** 見出し「新たに N◯ 解放！」の単位(既定「体」。sequential は「日」など)。 */
+  unitLabel?: string | null;
 }) {
   const { cssVars, titleColor } = resolveColors(colors);
   const count = newlyUnlocked.length;
+  const unit = unitLabel ?? "体";
   const bodyText = body ?? `${title}の続きが登場しました。`;
   return (
     <div
@@ -197,7 +201,8 @@ export function UnlockDripModal({
         <CloseButton onClose={onClose} />
         <NewPill />
         <h2 className="mt-2 text-lg font-bold" style={{ color: titleColor }}>
-          新たに{count}体 解放！
+          新たに{count}
+          {unit} 解放！
         </h2>
         <p className="mt-1 text-sm text-[#7A5A93]">{bodyText}</p>
 

--- a/features/collections/lib/collection-unlock-announcement.ts
+++ b/features/collections/lib/collection-unlock-announcement.ts
@@ -1,5 +1,5 @@
 import type { StylePresetPublicSummary } from "@/features/style-presets/lib/schema";
-import { computeUnlockedCount } from "./collection-unlock";
+import { computeUnlockedCount, sequentialBatchSize } from "./collection-unlock";
 import type { CollectionUnlockContext } from "./collection-unlock-gating";
 
 /**
@@ -31,6 +31,17 @@ export interface CollectionUnlockAnnouncement {
    */
   prerequisiteAckCount: number;
   /**
+   * 「常に解放されている基準数」。sequential では batch(=1)が初期から解放されている
+   * (例: 表紙「はじまり」)ため、その分は告知対象から除外する。クライアントは
+   * localStorage 未記録時にこの値を「既読」とみなし、基準を超えた解放だけを drip 告知する。
+   * 前提カテゴリ型(ぷち神)は 0(従来どおり初回バナーから)。
+   */
+  baselineUnlockedCount: number;
+  /**
+   * 「新たに N◯ 解放！」の単位ラベル。sequential は "日"(Day)、前提型は null(=「体」)。
+   */
+  unitLabel: string | null;
+  /**
    * 解放お知らせモーダルのカスタム表示設定(admin がカテゴリ単位で設定)。
    * いずれも null なら現行ハードコード(画像/文言/紫基調の配色)にフォールバックする。
    * heroImagePath は storage パス(public バケット)。URL 化はクライアントで行う。
@@ -57,31 +68,39 @@ export function buildCollectionUnlockAnnouncements(
   presets: readonly StylePresetPublicSummary[],
   context: CollectionUnlockContext,
 ): CollectionUnlockAnnouncement[] {
-  // 解放ゲート付き かつ 前提完走済み のカテゴリだけを、出現順(sort_order 昇順)に集約する。
-  // 注: sequential_unlock(前提なし・昇順)カテゴリは「解放お知らせ」未対応。意図的にここで
-  //   スキップする(prerequisite が無いため下の continue で除外)。対応する場合は下の .reverse()
-  //   と progressiveBatchSize 前提(降順)を sequential 用に見直すこと。
+  // 告知対象を sort_order 昇順で集約する。対象は2系統:
+  //  - 前提カテゴリ付き(例: ぷち神): 前提カテゴリ完走済みのときのみ。解放順は末尾(sort_order最大)から。
+  //  - sequential(例: travel): 前提なしでも対象。解放順は先頭(sort_order最小=表紙)から昇順。
   const itemsByCategoryKey = new Map<string, StylePresetPublicSummary[]>();
   for (const preset of presets) {
-    const prerequisite = preset.category.unlockPrerequisiteKey;
-    if (!prerequisite) continue;
-    if (!context.prerequisiteCompletedKeys.has(prerequisite)) continue;
-    const items = itemsByCategoryKey.get(preset.category.key);
+    const cat = preset.category;
+    const prerequisite = cat.unlockPrerequisiteKey;
+    const sequential = cat.sequentialUnlock === true;
+    if (prerequisite) {
+      if (!context.prerequisiteCompletedKeys.has(prerequisite)) continue;
+    } else if (!sequential) {
+      continue; // 前提も sequential も無い従来カテゴリは告知しない
+    }
+    const items = itemsByCategoryKey.get(cat.key);
     if (items) items.push(preset);
-    else itemsByCategoryKey.set(preset.category.key, [preset]);
+    else itemsByCategoryKey.set(cat.key, [preset]);
   }
 
   const announcements: CollectionUnlockAnnouncement[] = [];
   for (const [categoryKey, items] of itemsByCategoryKey) {
+    const category = items[0].category;
+    const sequential = category.sequentialUnlock === true;
     const total = items.length;
     const distinctGenerated =
       context.distinctGeneratedByCategoryKey.get(categoryKey) ?? 0;
-    const batchSize = items[0].category.progressiveBatchSize;
+    const batchSize = sequential
+      ? sequentialBatchSize(category.progressiveBatchSize)
+      : category.progressiveBatchSize;
     const unlockedCount = computeUnlockedCount(distinctGenerated, batchSize, total);
     if (unlockedCount <= 0) continue;
 
-    // 解放順(末尾=sort_order 最大 から)。items は sort_order 昇順なので reverse。
-    const unlockOrder = items.slice().reverse();
+    // 解放順: sequential=先頭から昇順(items はそのまま) / 前提型=末尾から(reverse)。
+    const unlockOrder = sequential ? items.slice() : items.slice().reverse();
     const unlockedPresets = unlockOrder
       .slice(0, unlockedCount)
       .map((preset) => ({
@@ -90,11 +109,16 @@ export function buildCollectionUnlockAnnouncements(
         thumbnailUrl: preset.thumbnailImageUrl,
       }));
 
-    const prerequisiteKey = items[0].category.unlockPrerequisiteKey ?? "";
-    const prerequisiteAckCount =
-      context.prerequisiteUniqueCountByKey?.get(prerequisiteKey) ?? 0;
+    const prerequisiteKey = category.unlockPrerequisiteKey ?? "";
+    // sequential は前提が無いので ack ゲート無し(0)。前提型は完走演出確認後に出す。
+    const prerequisiteAckCount = sequential
+      ? 0
+      : (context.prerequisiteUniqueCountByKey?.get(prerequisiteKey) ?? 0);
+    // sequential は batch 分(=先頭の表紙)が常時解放のため告知の基準とし、それ超だけ drip 告知。
+    const baselineUnlockedCount = sequential
+      ? sequentialBatchSize(category.progressiveBatchSize)
+      : 0;
 
-    const category = items[0].category;
     announcements.push({
       categoryKey,
       categoryDisplayName: category.displayNameJa,
@@ -103,6 +127,8 @@ export function buildCollectionUnlockAnnouncements(
       unlockedPresets,
       prerequisiteKey,
       prerequisiteAckCount,
+      baselineUnlockedCount,
+      unitLabel: sequential ? "日" : null,
       heroImagePath: category.unlockAnnouncementHeroPath,
       initialBody: category.unlockAnnouncementInitialBody,
       dripBody: category.unlockAnnouncementDripBody,

--- a/tests/unit/features/collections/collection-unlock-announcement.test.ts
+++ b/tests/unit/features/collections/collection-unlock-announcement.test.ts
@@ -228,4 +228,45 @@ describe("buildCollectionUnlockAnnouncements", () => {
     expect(a.accentColor).toBeNull();
     expect(a.softColor).toBeNull();
   });
+
+  describe("sequential(前提なし・昇順・baseline)", () => {
+    const SEQ_KEY = "travel_to_italy";
+    function seqPresets() {
+      const cat = makeCategory(SEQ_KEY, {
+        unlockPrerequisiteKey: null,
+        sequentialUnlock: true,
+        progressiveBatchSize: null, // batch 未設定 → 1扱い
+        displayNameJa: "うちの子のイタリア旅行",
+      });
+      // index0=はじまり(表紙), 1..8=Day1..Day8(makePreset は id=title)
+      return ["はじまり", "Day1", "Day2", "Day3", "Day4", "Day5", "Day6", "Day7", "Day8"].map(
+        (t) => makePreset(t, cat),
+      );
+    }
+
+    test("前提なしでも告知対象になり、昇順・baseline=1・単位=日", () => {
+      const result = buildCollectionUnlockAnnouncements(seqPresets(), {
+        prerequisiteCompletedKeys: new Set(),
+        distinctGeneratedByCategoryKey: new Map([[SEQ_KEY, 1]]), // はじまり生成済 → Day1解放
+      });
+      expect(result).toHaveLength(1);
+      const a = result[0];
+      expect(a.unlockedCount).toBe(2); // はじまり + Day1
+      expect(a.baselineUnlockedCount).toBe(1); // 表紙は常時解放
+      expect(a.unitLabel).toBe("日");
+      expect(a.prerequisiteAckCount).toBe(0); // 前提ackゲートなし
+      // 昇順(先頭=はじまり, 次=Day1)
+      expect(a.unlockedPresets.map((p) => p.title)).toEqual(["はじまり", "Day1"]);
+    });
+
+    test("生成0(はじまりのみ解放=baseline)でも対象に出る(クライアントが baseline で抑制)", () => {
+      const result = buildCollectionUnlockAnnouncements(seqPresets(), {
+        prerequisiteCompletedKeys: new Set(),
+        distinctGeneratedByCategoryKey: new Map([[SEQ_KEY, 0]]),
+      });
+      const a = result[0];
+      expect(a.unlockedCount).toBe(1);
+      expect(a.baselineUnlockedCount).toBe(1); // unlockedCount===baseline → クライアント側で none
+    });
+  });
 });


### PR DESCRIPTION
### 概要
コレクション完走/解放のお知らせモーダルを、**sequential(順番固定)コレクションにも対応**させます。これまで「前提カテゴリ型(ぷち神)」専用だったため、travel_to_italy(イタリア旅行)では Day を生成して次が解放されても**お知らせが出ませんでした**。本対応で「**Day◯が解放！**」のお知らせを出せるようにします。

### 変更内容
- **告知ビルダー(`collection-unlock-announcement.ts`)**: sequential を告知対象に追加。
  - 解放順は**昇順**(先頭=表紙から)。
  - `baselineUnlockedCount`(=batch分=常時解放の表紙「はじまり」)を導入し、**表紙の初回バナーは出さず**、その先の Day 解放だけを drip 告知。
  - `unitLabel='日'`(見出し「新たに◯**日** 解放！」)、前提ackゲートなし。
- **`UnlockDripModal`**: 見出しの単位を `unitLabel` で可変化(既定「体」/ sequential「日」)。
- **`PetitUnlockAnnouncer`(ホーム)・`CollectionUnlockDripListener`(生成直後)**: baseline を未記録時の既読とみなし、`はじまり生成→Day1解放` から drip を出す。DripListener にも配色/本文/単位を渡し、ホームと表示を統一。
- 既存ぷち神(降順・前提ack・「体」・初回バナー)は**非回帰**。

### 配色・文言・画像(travel)
- **色**: `/collections/italy` と揃えたイタリア配色(別途 DB 設定: `unlock_announcement_*_color` をグリーン基調)。
- **文言**: `unlock_announcement_drip_body`(DB 設定)+ 見出し「新たに◯日 解放！」。
- **画像**: 解放された Day のプリセットサムネを表示(既存の告知機構どおり)。

### 実機テスト
- [ ] travel で「はじまり」生成 →(ホーム再訪 or 生成直後)「新たに1日 解放！」+ Day1 サムネのモーダルが出る
- [ ] 以降 Day を生成するたびに次の Day が告知される
- [ ] 表紙(はじまり)単体では告知が出ない(baseline 抑止)
- [ ] ぷち神の解放お知らせが従来どおり(「体」・降順・初回バナー)であること(非回帰)

### テスト方法
- `npm run lint` / `npm run build -- --webpack`(緑)
- `npm run test`(全テスト 2281 pass / sequential 告知テスト追加)

> 補足: 生成直後の即時告知(DripListener)は進捗モーダルの dismiss を起点とするため、確実に出るのは公開(public)後。admin_only 期間はホーム再訪時の告知で確認できます。
