### PR TITLE
feat(collections): 本シェアページに全画面表示ボタンを追加

### DIFF
--- a/features/collections/components/ScrapbookReader.tsx
+++ b/features/collections/components/ScrapbookReader.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { X, Share2 } from "lucide-react";
+import { X, Share2, Maximize2, Minimize2 } from "lucide-react";
 import { CatalogBookView } from "@/features/catalog/components/CatalogBookView";
 import type { CatalogPageData } from "@/features/catalog/components/CatalogPage";
 
@@ -25,7 +25,19 @@ export function ScrapbookReader({
   isOwner: boolean;
 }) {
   const router = useRouter();
+  const containerRef = useRef<HTMLDivElement>(null);
   const [chromeVisible, setChromeVisible] = useState(true);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  // Fullscreen API は iOS Safari が要素に非対応(動画のみ)。対応環境だけボタンを出す。
+  // SSR セーフに client 値を取るため useSyncExternalStore を使う(setState-in-effect 回避)。
+  const canFullscreen = useSyncExternalStore(
+    () => () => {},
+    () => {
+      const d = document as Document & { webkitFullscreenEnabled?: boolean };
+      return Boolean(d.fullscreenEnabled ?? d.webkitFullscreenEnabled);
+    },
+    () => false,
+  );
 
   // iOS Safari の rubber band 抑止(CatalogReaderModal と同方針)。
   useEffect(() => {
@@ -44,12 +56,49 @@ export function ScrapbookReader({
     };
   }, []);
 
+  // 全画面状態の同期(Esc やブラウザ UI での解除にも追従)。
+  useEffect(() => {
+    const onChange = () => {
+      const d = document as Document & { webkitFullscreenElement?: Element };
+      setIsFullscreen(Boolean(d.fullscreenElement ?? d.webkitFullscreenElement));
+    };
+    document.addEventListener("fullscreenchange", onChange);
+    document.addEventListener("webkitfullscreenchange", onChange);
+    return () => {
+      document.removeEventListener("fullscreenchange", onChange);
+      document.removeEventListener("webkitfullscreenchange", onChange);
+    };
+  }, []);
+
   const handleClose = () => {
     // 直リンク(履歴なし)で来たゲストは back() が no-op になるため /collections へ。
     if (typeof window !== "undefined" && window.history.length <= 1) {
       router.push("/collections");
     } else {
       router.back();
+    }
+  };
+
+  const handleToggleFullscreen = async () => {
+    try {
+      const d = document as Document & {
+        webkitFullscreenElement?: Element;
+        webkitExitFullscreen?: () => Promise<void> | void;
+      };
+      const active = d.fullscreenElement ?? d.webkitFullscreenElement;
+      if (!active) {
+        const el = containerRef.current as
+          | (HTMLDivElement & {
+              webkitRequestFullscreen?: () => Promise<void> | void;
+            })
+          | null;
+        if (!el) return;
+        await (el.requestFullscreen?.() ?? el.webkitRequestFullscreen?.());
+      } else {
+        await (d.exitFullscreen?.() ?? d.webkitExitFullscreen?.());
+      }
+    } catch {
+      // 失敗(ユーザー操作不足/非対応)は無視
     }
   };
 
@@ -75,6 +124,7 @@ export function ScrapbookReader({
 
   return (
     <div
+      ref={containerRef}
       className="fixed inset-0 z-50 flex h-[100dvh] flex-col select-none bg-slate-50"
       style={{ WebkitTouchCallout: "none" }}
     >
@@ -89,27 +139,46 @@ export function ScrapbookReader({
         <X className="h-5 w-5" />
       </button>
 
-      {isOwner ? (
-        <button
-          type="button"
-          onClick={handleShare}
-          className={chromeCls(
-            "absolute right-4 top-4 z-10 inline-flex items-center gap-1.5 rounded-full bg-amber-500 px-4 py-2 text-sm font-bold text-white shadow-md hover:bg-amber-600",
-          )}
-        >
-          <Share2 className="h-4 w-4" />
-          シェア
-        </button>
-      ) : (
-        <Link
-          href="/collections"
-          className={chromeCls(
-            "absolute right-4 top-4 z-10 inline-flex items-center rounded-full bg-amber-500 px-4 py-2 text-xs font-bold text-white shadow-md hover:bg-amber-600",
-          )}
-        >
-          あなたのうちの子でも作れる！
-        </Link>
-      )}
+      {/* 右上: [全画面表示(対応環境のみ)] [シェア / CTA] */}
+      <div
+        className={chromeCls(
+          "absolute right-4 top-4 z-10 flex items-center gap-2",
+        )}
+      >
+        {canFullscreen ? (
+          <button
+            type="button"
+            onClick={handleToggleFullscreen}
+            aria-label={isFullscreen ? "全画面表示を解除" : "全画面表示"}
+            className="inline-flex items-center gap-1.5 rounded-full bg-stone-900/70 px-3 py-2 text-sm font-bold text-white shadow-md hover:bg-stone-900"
+          >
+            {isFullscreen ? (
+              <Minimize2 className="h-4 w-4" />
+            ) : (
+              <Maximize2 className="h-4 w-4" />
+            )}
+            {isFullscreen ? "全画面解除" : "全画面表示"}
+          </button>
+        ) : null}
+
+        {isOwner ? (
+          <button
+            type="button"
+            onClick={handleShare}
+            className="inline-flex items-center gap-1.5 rounded-full bg-amber-500 px-4 py-2 text-sm font-bold text-white shadow-md hover:bg-amber-600"
+          >
+            <Share2 className="h-4 w-4" />
+            シェア
+          </button>
+        ) : (
+          <Link
+            href="/collections"
+            className="inline-flex items-center rounded-full bg-amber-500 px-4 py-2 text-xs font-bold text-white shadow-md hover:bg-amber-600"
+          >
+            あなたのうちの子でも作れる！
+          </Link>
+        )}
+      </div>
 
       <main className="relative flex flex-1 items-start justify-center overflow-hidden px-3 py-4 sm:px-6">
         <CatalogBookView


### PR DESCRIPTION
### 概要
本のシェアページ(`/m/[token]/book` = `ScrapbookReader`)の右上、シェアボタンの**左側に「全画面表示」ボタン**を追加します。押すとリーダー全体を全画面表示にし、もう一度押す(または Esc)で解除します。

### 変更内容
- `ScrapbookReader` の右上を `[全画面表示][シェア/CTA]` の横並びに再構成。
- Fullscreen API でリーダーのルート要素を `requestFullscreen` / `exitFullscreen`。`fullscreenchange` を購読し、Esc やブラウザ UI での解除にもアイコン/ラベル(全画面表示↔全画面解除)が追従。
- **iOS Safari は要素の Fullscreen API 非対応**(動画のみ)のため、**対応環境(PC / Android Chrome)でのみボタンを表示**(`document.fullscreenEnabled` を `useSyncExternalStore` で SSR セーフに判定)。iOS では従来どおりボタン非表示。
- webkit プレフィックス(デスクトップ Safari)もフォールバック対応。

### 実機テスト
- [ ] PC Chrome:全画面表示ボタン表示 → 押下で全画面 → 再押下/Esc で解除、ラベルが切替
- [ ] Android Chrome:同上
- [ ] iOS Safari:ボタンは非表示(非対応のため)で従来どおり
- [ ] シェアボタン(所有者)/ CTA(ゲスト)が従来どおり動作

### テスト方法
- `npm run lint` / `npm run build -- --webpack`(緑)
- `npm run test`(collections 関連 304 pass)
