### PR TITLE
fix(collections): 解放お知らせAPIの sequential 見落としで Day解放モーダルが出ない不具合を修正

### DIFF
--- a/app/api/collections/unlock-announcements/route.ts
+++ b/app/api/collections/unlock-announcements/route.ts
@@ -4,6 +4,7 @@ import { isAdminViewer } from "@/lib/env";
 import { getPublishedStylePresets } from "@/features/style-presets/lib/get-public-style-presets";
 import { resolveCollectionUnlockContext } from "@/features/collections/lib/collection-unlock-server";
 import { buildCollectionUnlockAnnouncements } from "@/features/collections/lib/collection-unlock-announcement";
+import { categoryNeedsUnlockContext } from "@/features/collections/lib/collection-unlock";
 
 /**
  * GET /api/collections/unlock-announcements
@@ -29,8 +30,10 @@ export async function GET() {
 
   try {
     const presets = await getPublishedStylePresets({ includeAdminOnly: isAdmin });
-    const hasGatedCategory = presets.some(
-      (preset) => preset.category.unlockPrerequisiteKey != null,
+    // 前提カテゴリ付き or sequential が対象。sequential を見落とすと、公開中の前提
+    // カテゴリが無いとき(例: ぷち神が非公開)に travel(sequential)の告知が作られない。
+    const hasGatedCategory = presets.some((preset) =>
+      categoryNeedsUnlockContext(preset.category),
     );
     if (!hasGatedCategory) {
       return NextResponse.json({ announcements: [] });


### PR DESCRIPTION
### 概要
本(travel)の **進捗モーダルを閉じても「Day◯が解放」モーダルが出ない**不具合を修正します。

### 原因(再現確認済み)
`/api/collections/unlock-announcements`(生成直後の `CollectionUnlockDripListener` が叩く)の早期returnガードが **`unlockPrerequisiteKey != null` だけ**を判定していました。実データ上、前提カテゴリ型の **ぷち神は現在 published=0(非公開)**、travel は **sequential(前提なし)で published=9**。そのため `hasGatedCategory=false` となり、ルートが **即 `{announcements: []}` を返却** → travel の告知が一切作られず、進捗モーダルを閉じても解放モーダルが出ませんでした。

他の呼び出し側(generate-async/handler・StylePageBody・ホーム)は既に共有述語 `categoryNeedsUnlockContext`(前提付き or sequential)に統一済みでしたが、**このAPIルートだけ漏れていました**。

### 変更内容
- ガードを `presets.some((p) => categoryNeedsUnlockContext(p.category))` に変更(sequential も対象に)。

### 実機テスト
- [ ] travel で Day を生成 → 進捗モーダルを閉じる → 「新たに1日 解放！(Day◯)」モーダルが出る
- [ ] ぷち神(復刻・公開時)が従来どおり解放お知らせを出す(非回帰)
- ※ 同一ブラウザでアカウント切替時は localStorage 既読が残るため、テストはシークレット/別ブラウザ推奨(既知の制約)

### テスト方法
- `npm run lint` / `npm run build -- --webpack`(緑)
- `npm run test`(collections 関連 304 pass)
