### PR TITLE
feat(collections): 完走モーダルを「コンプリート！」+紙吹雪に

### DIFF
--- a/features/collections/components/CollectionProgressModal.tsx
+++ b/features/collections/components/CollectionProgressModal.tsx
@@ -242,6 +242,10 @@ export function CollectionProgressModal({
 
   // ready を effect の deps に入れるため、useEffect より前で算出する(null-safe)。
   const cIsCompleted = celebration?.isCompleted ?? false;
+  // N種到達(台紙/本 未作成でも 100% 達成の瞬間)。紙吹雪はこの時点でも出す。
+  const cReached =
+    (celebration?.toCount ?? 0) >=
+    (celebration?.threshold ?? Number.POSITIVE_INFINITY);
   const cEffect = celebration?.celebrationEffect ?? "confetti";
   const cMountImageUrl = celebration?.mountImageUrl ?? null;
   const cCharacterImageUrl = celebration?.characterImageUrl ?? null;
@@ -347,7 +351,12 @@ export function CollectionProgressModal({
   // ready なら即・未ロードでも CONFETTI_FALLBACK_MS 以内に必ず armed にする。
   // これで初回コンプリート(台紙画像が未キャッシュで ready が遅い)でも取りこぼさない。
   useEffect(() => {
-    if (!open || !celebration || cEffect !== "confetti" || !cIsCompleted) {
+    if (
+      !open ||
+      !celebration ||
+      cEffect !== "confetti" ||
+      !(cIsCompleted || cReached)
+    ) {
       return;
     }
     // ready なら即(次tick)・未ロードでも fallback 以内に発火。
@@ -355,7 +364,7 @@ export function CollectionProgressModal({
     const delay = ready ? 0 : CONFETTI_FALLBACK_MS;
     const timer = window.setTimeout(() => setConfettiArmed(true), delay);
     return () => window.clearTimeout(timer);
-  }, [open, celebration, cEffect, cIsCompleted, ready]);
+  }, [open, celebration, cEffect, cIsCompleted, cReached, ready]);
 
   // ready (全画像ロード完了) を gate にして rAF を開始する。
   // 親が key で再マウントするので state は再初期化される。
@@ -860,7 +869,7 @@ export function CollectionProgressModal({
                   type="button"
                   onClick={() => onCreateMount(celebration)}
                   aria-label={
-                    cIsCompleted ? "カードを更新する" : "カードを作成する"
+                    cIsCompleted ? "カードを更新する" : "コンプリート！"
                   }
                   className={
                     "absolute flex items-center justify-center rounded-full px-4 text-base font-bold focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-orange-300/60" +
@@ -881,7 +890,7 @@ export function CollectionProgressModal({
                       : {}),
                   }}
                 >
-                  {cIsCompleted ? "カードを更新する →" : "カードを作成する →"}
+                  {cIsCompleted ? "カードを更新する →" : "コンプリート！ →"}
                 </button>
               ) : (
                 <Link
@@ -921,7 +930,7 @@ export function CollectionProgressModal({
                   type="button"
                   onClick={() => onCreateMount(celebration)}
                   aria-label={
-                    cIsCompleted ? "カードを更新する" : "カードを作成する"
+                    cIsCompleted ? "カードを更新する" : "コンプリート！"
                   }
                   className={
                     "flex items-center justify-center rounded-full px-6 py-3 text-base font-bold focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-orange-300/60" +
@@ -938,7 +947,7 @@ export function CollectionProgressModal({
                       : {}),
                   }}
                 >
-                  {cIsCompleted ? "カードを更新する →" : "カードを作成する →"}
+                  {cIsCompleted ? "カードを更新する →" : "コンプリート！ →"}
                 </button>
               ) : (
                 <Link

--- a/features/collections/hooks/useCollectionProgress.ts
+++ b/features/collections/hooks/useCollectionProgress.ts
@@ -150,7 +150,8 @@ export function useCollectionProgress() {
             progressModalBadgeBgColor: target.progressModalBadgeBgColor,
             progressModalButtonColor: target.progressModalButtonColor,
             progressModalButtonTextColor: target.progressModalButtonTextColor,
-            celebrationEffect: "sparkle",
+            // 完走(N種到達)時は紙吹雪、収集途中はきらめき。
+            celebrationEffect: toCount >= threshold ? "confetti" : "sparkle",
           });
           return true;
         }
@@ -196,8 +197,9 @@ export function useCollectionProgress() {
           progressModalBadgeBgColor: series.progressModalBadgeBgColor,
           progressModalButtonColor: series.progressModalButtonColor,
           progressModalButtonTextColor: series.progressModalButtonTextColor,
-          // フィードの自動コンプリート祝いはダイヤのきらめき演出にする。
-          celebrationEffect: "sparkle",
+          // 完走(N種到達)時は紙吹雪で祝い、収集途中はきらめき演出にする。
+          celebrationEffect:
+            toCount >= series.completionThreshold ? "confetti" : "sparkle",
         });
         return true;
       }

--- a/tests/unit/features/collections/collection-progress-modal.test.tsx
+++ b/tests/unit/features/collections/collection-progress-modal.test.tsx
@@ -521,7 +521,7 @@ describe("CollectionProgressModal: 達成後 CTA の文言と配色", () => {
     progressModalButtonTextColor: "#FFFFFF",
   };
 
-  test("達成・カード未作成: CTAは「カードを作成する →」で admin色反映、押下でカード生成が呼ばれる", () => {
+  test("達成・カード未作成: CTAは「コンプリート！ →」で admin色反映、押下でカード生成が呼ばれる", () => {
     const onCreateMount = jest.fn();
     render(
       <CollectionProgressModal
@@ -531,8 +531,8 @@ describe("CollectionProgressModal: 達成後 CTA の文言と配色", () => {
         onCreateMount={onCreateMount}
       />,
     );
-    const btn = screen.getByRole("button", { name: "カードを作成する" });
-    expect(btn).toHaveTextContent("カードを作成する →");
+    const btn = screen.getByRole("button", { name: "コンプリート！" });
+    expect(btn).toHaveTextContent("コンプリート！ →");
     // admin 設定のボタン色が inline style に入る(jsdom は rgb 形式で直列化する)
     expect(btn.getAttribute("style")).toContain(
       "background-color: rgb(198, 112, 255)",
@@ -556,8 +556,8 @@ describe("CollectionProgressModal: 達成後 CTA の文言と配色", () => {
       />,
     );
     // buttonRect が無くても(buttonBox=0)、フレーム下に通常配置で CTA が出る
-    const btn = screen.getByRole("button", { name: "カードを作成する" });
-    expect(btn).toHaveTextContent("カードを作成する →");
+    const btn = screen.getByRole("button", { name: "コンプリート！" });
+    expect(btn).toHaveTextContent("コンプリート！ →");
     fireEvent.click(btn);
     expect(onCreateMount).toHaveBeenCalledTimes(1);
   });
@@ -625,7 +625,7 @@ describe("CollectionProgressModal: 達成後 CTA の文言と配色", () => {
         onCreateMount={jest.fn()}
       />,
     );
-    const btn = screen.getByRole("button", { name: "カードを作成する" });
+    const btn = screen.getByRole("button", { name: "コンプリート！" });
     // 塗り色未設定 → backgroundColor の inline 指定はなし(オレンジは class で付与)
     expect(btn.getAttribute("style") ?? "").not.toContain("background-color");
   });


### PR DESCRIPTION
### 概要
完走(N種到達)時の進捗モーダルを、より「達成感」のある演出に変更します。
1. CTA ボタン文言を **「カードを作成する →」→「コンプリート！ →」** に(全コレクション共通)。
2. **完走到達時に紙吹雪(confetti)** が飛ぶように(神コレ等も含む)。

### 変更内容
- `useCollectionProgress`:`celebrationEffect` を **完走(`toCount >= threshold`)= "confetti" / 収集途中 = "sparkle"** に(即時パス・シリーズループ両方)。
- `CollectionProgressModal`:
  - 紙吹雪の発火条件を `cIsCompleted`(台紙/本 作成済み)だけでなく **完走到達 `cReached`(`toCount >= threshold`)でも発火**するよう拡張。これにより、台紙/本が未作成の「100%到達の瞬間」(= スクショの状態)でも紙吹雪が出る。
  - CTA 文言を **未作成時「コンプリート！ →」**(作成済み時は「カードを更新する →」を維持)。
- 適用範囲:**全コレクション共通**(神コレ/ぷち神/travel)。
- テスト期待値を更新。

### 実機テスト
- [ ] travel:9種到達 → 進捗モーダルが「コンプリート！ →」+ 紙吹雪
- [ ] 神コレ/ぷち神(公開時):完走で同様に「コンプリート！」+ 紙吹雪(非回帰=収集途中はきらめきのまま)
- [ ] 収集途中(N未満)では紙吹雪が出ない(きらめきのみ)

### テスト方法
- `npm run lint` / `npm run build -- --webpack`(緑)
- `npm run test`(全テスト 2281 pass・進捗モーダルテスト更新)
