### PR TITLE
feat(collections): 本シェアページの離脱先を /style に(コンバージョン優先)

### DIFF
--- a/features/collections/components/ScrapbookReader.tsx
+++ b/features/collections/components/ScrapbookReader.tsx
@@ -71,9 +71,10 @@ export function ScrapbookReader({
   }, []);
 
   const handleClose = () => {
-    // 直リンク(履歴なし)で来たゲストは back() が no-op になるため /collections へ。
+    // 直リンク(履歴なし)で来たゲストは back() が no-op になるため /style へ
+    // (「自分でも作ってみる」導線=コンバージョン優先)。アプリ内遷移時は従来どおり戻る。
     if (typeof window !== "undefined" && window.history.length <= 1) {
-      router.push("/collections");
+      router.push("/style");
     } else {
       router.back();
     }
@@ -172,7 +173,7 @@ export function ScrapbookReader({
           </button>
         ) : (
           <Link
-            href="/collections"
+            href="/style"
             className="inline-flex items-center rounded-full bg-amber-500 px-4 py-2 text-xs font-bold text-white shadow-md hover:bg-amber-600"
           >
             あなたのうちの子でも作れる！


### PR DESCRIPTION
### 概要
本のシェアページ(`/m/[token]/book`)の離脱導線を、コレクション図鑑(`/collections`)から **生成画面(`/style`)** に変更します。シェアを見たユーザーを「自分でも作ってみる」へ直行させ、生成のコンバージョンを高める狙いです。

### 変更内容
- ゲスト向け CTA「**あなたのうちの子でも作れる！**」:`/collections` → **`/style`**。
- 左上「**×**」:直リンク(履歴なし=主に外部シェアから来たゲスト)のフォールバック遷移先を `/collections` → **`/style`** に。アプリ内遷移(履歴あり)時は従来どおり `router.back()`(元の画面に戻る)を維持。
- 所有者の「シェア」ボタンは変更なし(共有シート/コピー)。

### 実機テスト
- [ ] 外部リンクから本ページを開く → 「あなたのうちの子でも作れる！」→ /style に遷移
- [ ] 同上 → 「×」→ /style に遷移(履歴なしのため)
- [ ] アプリ内で本ページに来た場合 → 「×」→ 直前画面に戻る(従来どおり)

### テスト方法
- `npm run lint` / `npm run build -- --webpack`(緑)
- `npm run test`(collections 関連 304 pass)
