### PR TITLE
feat(collections): 完走モーダルの「シェアページへ」「カードをシェアする」を入れ替え

### DIFF
--- a/features/collections/components/CollectionProgressModal.tsx
+++ b/features/collections/components/CollectionProgressModal.tsx
@@ -596,6 +596,16 @@ export function CollectionProgressModal({
                 />
               </div>
             </div>
+            {/* 上(オレンジ=主CTA)=「シェアページへ」、中(白)=「カードをシェアする」。
+               ボタンの色の位置は固定し、ラベル/動作だけ入れ替えている。 */}
+            {celebration.sharePath ? (
+              <Link
+                href={celebration.sharePath}
+                className="block w-full rounded-full bg-gradient-to-r from-amber-400 to-orange-500 px-6 py-3 text-center text-base font-bold text-white shadow-[0_4px_0_rgba(234,88,12,0.4)] transition-transform hover:-translate-y-0.5"
+              >
+                シェアページへ
+              </Link>
+            ) : null}
             {completionId ? (
               /* posts / /m と同じ共有 UI(モバイル=シェアシート、PC=コピー/Web Share
                  メニュー)。成功時に share-event を計測する。 */
@@ -603,18 +613,10 @@ export function CollectionProgressModal({
                 url={() => buildPublicMountUrl(completionId, mountImageUrl)}
                 messages={MOUNT_SHARE_MESSAGES}
                 onShared={() => trackMountShareEvent(completionId)}
-                className="h-auto w-full rounded-full bg-gradient-to-r from-amber-400 to-orange-500 px-6 py-3 text-base font-bold text-white shadow-[0_4px_0_rgba(234,88,12,0.4)] transition-transform hover:-translate-y-0.5"
+                className="h-auto w-full rounded-full border-2 border-amber-300 bg-white px-6 py-3 text-base font-bold text-amber-600 transition-colors hover:bg-amber-50"
               >
                 カードをシェアする
               </ShareLinkButton>
-            ) : null}
-            {celebration.sharePath ? (
-              <Link
-                href={celebration.sharePath}
-                className="block w-full rounded-full border-2 border-amber-300 bg-white px-6 py-3 text-base font-bold text-amber-600 transition-colors hover:bg-amber-50"
-              >
-                シェアページへ
-              </Link>
             ) : null}
             {/* 選び直す余地がある(いずれかの衣装で2枚以上生成済み)ときだけ表示 */}
             {celebration.canRecompose && onCreateMount ? (


### PR DESCRIPTION
### 概要
完走モーダル(完走済み・カード/本 作成後)のシェア系CTAで、**「シェアページへ」と「カードをシェアする」を入れ替え**ます。ボタンの**色の位置は固定**(上=オレンジ主CTA / 中=白)し、ラベルと動作だけを swap します。

### 変更内容
- 上(オレンジ・主CTA):「カードをシェアする」→ **「シェアページへ」**(共有ページへ遷移)
- 中(白):「シェアページへ」→ **「カードをシェアする」**(共有シート/コピー)
- 下(白)「カードを更新する」・「遊び方をみる ›」は変更なし。

### 実機テスト
- [ ] 完走モーダルで 上=オレンジ「シェアページへ」、中=白「カードをシェアする」になっている
- [ ] 「シェアページへ」→ 本のシェアページに遷移
- [ ] 「カードをシェアする」→ 共有シート/コピーが起動

### テスト方法
- `npm run lint` / `npm run build -- --webpack`(緑)
- `npm run test`(進捗モーダル 19 pass)
