### PR TITLE
feat(collections): シェアボタン文言の汎用化+シェアページ遷移ローディング追加

### DIFF
--- a/app/m/[token]/book/loading.tsx
+++ b/app/m/[token]/book/loading.tsx
@@ -1,0 +1,24 @@
+/**
+ * 本(スクラップブック)シェアページのローディング UI。
+ *
+ * /m/[token]/book はサーバーコンポーネントでデータ取得(getCollectionBookByToken)を行うため、
+ * 遷移直後の数百ms、親(app/loading.tsx = 通常のアプリシェル)が一瞬見えてしまう
+ * (英語ホーム風のチラつき)。ここに没入スケルトンを置くことで、リーダーと同じ全画面の
+ * 背景でローディングを覆い、チラつきを防ぐ。ScrapbookReader と同じ bg-slate-50 / 全画面。
+ */
+export default function BookLoading() {
+  return (
+    <div className="fixed inset-0 z-50 flex h-[100dvh] flex-col items-center justify-center gap-6 bg-slate-50">
+      {/* 本(縦長 9:16 風)のスケルトン */}
+      <div className="relative aspect-[3/4] w-[min(72vw,300px)] overflow-hidden rounded-2xl border border-stone-200 bg-stone-100 shadow-md">
+        <div className="absolute inset-0 animate-pulse bg-gradient-to-b from-stone-100 via-stone-200/70 to-stone-100" />
+      </div>
+      <div className="flex items-center gap-2 text-stone-400">
+        <span className="h-2 w-2 animate-bounce rounded-full bg-stone-300 [animation-delay:-0.2s]" />
+        <span className="h-2 w-2 animate-bounce rounded-full bg-stone-300 [animation-delay:-0.1s]" />
+        <span className="h-2 w-2 animate-bounce rounded-full bg-stone-300" />
+        <span className="ml-2 text-sm font-medium">本を準備中…</span>
+      </div>
+    </div>
+  );
+}

--- a/app/m/[token]/loading.tsx
+++ b/app/m/[token]/loading.tsx
@@ -1,0 +1,23 @@
+/**
+ * シェアページ(/m/[token])のローディング UI。
+ *
+ * /m/[token] はサーバーで getCollectionBookByToken 等を解決し、book 完走は
+ * /m/[token]/book へ redirect する。この解決中、loading.tsx が無いと親
+ * (app/loading.tsx = 通常アプリシェル)が一瞬見え、英語ホーム風のチラつきが出る。
+ * ここに全画面の没入スケルトンを置いて覆う。book/台紙 どちらにも遷移しうるため中立文言。
+ */
+export default function ShareLoading() {
+  return (
+    <div className="fixed inset-0 z-50 flex h-[100dvh] flex-col items-center justify-center gap-6 bg-slate-50">
+      <div className="relative aspect-[3/4] w-[min(72vw,300px)] overflow-hidden rounded-2xl border border-stone-200 bg-stone-100 shadow-md">
+        <div className="absolute inset-0 animate-pulse bg-gradient-to-b from-stone-100 via-stone-200/70 to-stone-100" />
+      </div>
+      <div className="flex items-center gap-2 text-stone-400">
+        <span className="h-2 w-2 animate-bounce rounded-full bg-stone-300 [animation-delay:-0.2s]" />
+        <span className="h-2 w-2 animate-bounce rounded-full bg-stone-300 [animation-delay:-0.1s]" />
+        <span className="h-2 w-2 animate-bounce rounded-full bg-stone-300" />
+        <span className="ml-2 text-sm font-medium">読み込み中…</span>
+      </div>
+    </div>
+  );
+}

--- a/features/collections/components/CollectionProgressModal.tsx
+++ b/features/collections/components/CollectionProgressModal.tsx
@@ -596,7 +596,7 @@ export function CollectionProgressModal({
                 />
               </div>
             </div>
-            {/* 上(オレンジ=主CTA)=「シェアページへ」、中(白)=「カードをシェアする」。
+            {/* 上(オレンジ=主CTA)=「シェアページへ」、中(白)=「シェアする」。
                ボタンの色の位置は固定し、ラベル/動作だけ入れ替えている。 */}
             {celebration.sharePath ? (
               <Link
@@ -615,7 +615,7 @@ export function CollectionProgressModal({
                 onShared={() => trackMountShareEvent(completionId)}
                 className="h-auto w-full rounded-full border-2 border-amber-300 bg-white px-6 py-3 text-base font-bold text-amber-600 transition-colors hover:bg-amber-50"
               >
-                カードをシェアする
+                シェアする
               </ShareLinkButton>
             ) : null}
             {/* 選び直す余地がある(いずれかの衣装で2枚以上生成済み)ときだけ表示 */}


### PR DESCRIPTION
### 概要
2点を改善します。
1. 完走モーダルの白ボタン文言 **「カードをシェアする」→「シェアする」**(本/台紙どちらにも使えるよう汎用化)。
2. シェアページ遷移時の **ローディング(没入スケルトン)** を追加。これまで `/m/[token]`・`/m/[token]/book` に `loading.tsx` が無く、遷移直後に親の `app/loading.tsx`(英語ホーム風シェル)が一瞬見えてチラついていた。

### 変更内容
- `CollectionProgressModal`:白CTAの文言を「シェアする」に。
- `app/m/[token]/loading.tsx`(新規):全画面の没入スケルトン(`bg-slate-50` + カードスケルトン + ドットローダー「読み込み中…」)。**book 完走は `/m/[token]` から `/m/[token]/book` へ redirect するため、チラつきの発生元である redirect 元の `/m/[token]` 段階を覆う**のが要点。
- `app/m/[token]/book/loading.tsx`(新規):同様の没入スケルトン(文言「本を準備中…」)。

### 実機テスト
- [ ] 完走モーダルの白ボタンが「シェアする」表記
- [ ] 「シェアページへ」タップ時、英語ホーム等のチラつきが出ず、スケルトン → 本リーダーに繋がる
- [ ] 台紙系シェア(/m/[token])でもチラつかない

### テスト方法
- `npm run lint` / `npm run build -- --webpack`(緑・`/m/[token]`,`/m/[token]/book` 生成)
- `npm run test`(進捗モーダル 19 pass)
