### PR TITLE
fix(collections): 本完走の「シェアページへ」を没入ルート直行にしchromeチラつきを解消

### DIFF
--- a/features/collections/hooks/useCollectionProgress.ts
+++ b/features/collections/hooks/useCollectionProgress.ts
@@ -26,6 +26,20 @@ function buildPublicMountUrl(path: string | null): string | null {
   return `${base}/storage/v1/object/public/generated-images/${path}`;
 }
 
+/**
+ * 完了モーダルの「シェアページへ」遷移先。book は redirect 元の /m/<id>(chrome付き)を
+ * 経由するとアプリシェルがチラつくため、最初から没入の /m/<id>/book へ直接遷移させる。
+ */
+function collectionSharePath(
+  completionId: string | null,
+  viewMode: "mount" | "book" | undefined,
+): string | null {
+  if (!completionId) return null;
+  return viewMode === "book"
+    ? `/m/${completionId}/book`
+    : `/m/${completionId}`;
+}
+
 export interface CollectionComposerTarget {
   categoryKey: string;
   displayName: string;
@@ -126,10 +140,12 @@ export function useCollectionProgress() {
             mountImageUrl: completed
               ? buildPublicMountUrl(target.mountImagePath)
               : null,
-            sharePath:
-              completed && target.completionId
-                ? `/m/${target.completionId}`
-                : null,
+            sharePath: completed
+              ? collectionSharePath(
+                  target.completionId,
+                  target.completionViewMode,
+                )
+              : null,
             completionId: completed ? target.completionId : null,
             mountTemplateWidth: target.mountTemplateWidth,
             mountTemplateHeight: target.mountTemplateHeight,
@@ -179,7 +195,10 @@ export function useCollectionProgress() {
           mountImageUrl: buildPublicMountUrl(series.mountImagePath),
           // 完了台紙が確定しているシリーズはシェア導線(台紙シェア/シェアページ)を出す。
           // マイページの完了サムネタップ(openMountModal)と同じ挙動に揃える。
-          sharePath: series.completionId ? `/m/${series.completionId}` : null,
+          sharePath: collectionSharePath(
+            series.completionId,
+            series.completionViewMode,
+          ),
           completionId: series.completionId,
           mountTemplateWidth: series.mountTemplateWidth,
           mountTemplateHeight: series.mountTemplateHeight,

--- a/features/collections/lib/collection-progress-repository.ts
+++ b/features/collections/lib/collection-progress-repository.ts
@@ -115,6 +115,7 @@ function mapProgressRow(row: CollectionProgressRow): CollectionProgress {
     mountStatus: row.mount_status,
     mountImagePath: row.mount_image_path,
     completedAt: row.completed_at,
+    completionViewMode: "mount",
     characterImageUrl: null,
     collectedImageUrls: [],
     completionId: null,
@@ -211,7 +212,7 @@ async function attachCharacterImages(
   const { data, error } = await supabase
     .from("preset_categories")
     .select(
-      "id, collection_character_path, mount_template_width, mount_template_height, progress_modal_frame_path, progress_modal_frame_width, progress_modal_frame_height, progress_modal_slots, progress_modal_button, progress_modal_center, progress_modal_ring_color, progress_modal_badge_color, progress_modal_badge_text_color, progress_modal_badge_bg_color, progress_modal_button_color, progress_modal_button_text_color",
+      "id, completion_view_mode, collection_character_path, mount_template_width, mount_template_height, progress_modal_frame_path, progress_modal_frame_width, progress_modal_frame_height, progress_modal_slots, progress_modal_button, progress_modal_center, progress_modal_ring_color, progress_modal_badge_color, progress_modal_badge_text_color, progress_modal_badge_bg_color, progress_modal_button_color, progress_modal_button_text_color",
     )
     .in("id", categoryIds);
   if (error) {
@@ -219,6 +220,7 @@ async function attachCharacterImages(
     return items;
   }
   const pathById = new Map<string, string | null>();
+  const viewModeById = new Map<string, "mount" | "book">();
   const dimsById = new Map<
     string,
     { width: number | null; height: number | null }
@@ -244,6 +246,10 @@ async function attachCharacterImages(
     pathById.set(
       row.id as string,
       (row.collection_character_path as string | null) ?? null,
+    );
+    viewModeById.set(
+      row.id as string,
+      (row.completion_view_mode as string | null) === "book" ? "book" : "mount",
     );
     dimsById.set(row.id as string, {
       width: (row.mount_template_width as number | null) ?? null,
@@ -275,6 +281,7 @@ async function attachCharacterImages(
     const modal = modalById.get(i.categoryId);
     return {
       ...i,
+      completionViewMode: viewModeById.get(i.categoryId) ?? "mount",
       characterImageUrl: buildPublicGeneratedImageUrl(
         pathById.get(i.categoryId) ?? null,
       ),

--- a/features/collections/lib/collection-types.ts
+++ b/features/collections/lib/collection-types.ts
@@ -14,6 +14,11 @@ export interface CollectionProgress {
   mountStatus: "generating" | "completed" | "failed" | null;
   mountImagePath: string | null;
   completedAt: string | null;
+  /**
+   * 完走表示モード(mount=台紙 / book=めくれる日記帳)。シェア導線の遷移先分岐に使う。
+   * book は redirect 元の /m/<token> を経由せず /m/<token>/book(没入)へ直接遷移させる。
+   */
+  completionViewMode: "mount" | "book";
   /** 進捗リング中央に表示するシリーズ用キャラ画像の公開URL(無ければ null) */
   characterImageUrl: string | null;
   /** 集めたシール(衣装ごと最新1枚)の公開URL。display_order 昇順。モーダルのシール一覧用 */


### PR DESCRIPTION
### 概要
本(travel)の**再訪時の完走モーダル**「シェアページへ」をタップした際に、遷移途中で**アプリシェル(下部ナビ → ヘッダー＋フッター)が一瞬チラつく**不具合を修正します。

### 原因(動画フレーム解析で特定)
- 「シェアページへ」の遷移先 `sharePath` が、book でも **`/m/<id>`**(= chrome 付きの台紙シェアページ。book では `/m/<id>/book` へ **redirect** する)を指していた。
- そのため遷移は「`/m/<id>`(chromeあり・loading 中は下部ナビ表示/redirect 中はヘッダー+フッターの空シェル) → redirect → `/m/<id>/book`(没入)」となり、chrome がチラついていた。
- ※ book の**作成直後**は finalize が `/m/<id>/book` を返し `router.push` で直行するため元々クリーン。**再訪時の完走モーダル経由のみ**の問題。

### 変更内容
- `CollectionProgress.completionViewMode`(`mount` / `book`)を追加。
- `collection-progress-repository`:`mapProgressRow` 既定 `mount` + `attachCharacterImages` で `completion_view_mode` を取得して上書き。
- `useCollectionProgress`:`collectionSharePath()` を追加し、**book は最初から没入の `/m/<id>/book` へ直接遷移**(redirect とそれに伴う chrome を一切経由しない)。mount は従来どおり `/m/<id>`。

これにより「シェアページへ」→ 没入の本リーダー(スケルトン → 本)に直結し、下部ナビ/ヘッダー/フッターのチラつきが出なくなります(先の `loading.tsx` 追加 #391 と合わせ、没入スケルトンのみが見える)。

### 実機テスト
- [ ] 既に完走済みアカウントで本の完走モーダル →「シェアページへ」→ chrome のチラつきなしで本リーダーに繋がる
- [ ] 台紙系(神コレ)の「シェアページへ」は従来どおり `/m/<id>`
- [ ] 本作成直後の自動遷移も従来どおり没入で表示

### テスト方法
- `npm run lint` / `npm run build -- --webpack`(緑)
- `npm run test`(全 2281 pass)
