### PR TITLE
fix(collections): マイページ/図鑑の完走モーダルも本は没入ルート直行に(chromeチラつき解消)

### DIFF
--- a/features/collections/components/CollectionCatalogGrid.tsx
+++ b/features/collections/components/CollectionCatalogGrid.tsx
@@ -105,7 +105,12 @@ export function CollectionCatalogGrid({
       mountImageUrl: buildMountUrl(entry.mountImagePath),
       mountTemplateWidth: entry.mountTemplateWidth,
       mountTemplateHeight: entry.mountTemplateHeight,
-      sharePath: entry.completionId ? `/m/${entry.completionId}` : null,
+      // book は redirect 元の /m/<id>(chrome付き)を経由するとチラつくため /m/<id>/book へ直行。
+      sharePath: entry.completionId
+        ? entry.completionViewMode === "book"
+          ? `/m/${entry.completionId}/book`
+          : `/m/${entry.completionId}`
+        : null,
       completionId: entry.completionId,
       characterImageUrl: null,
       collectedImageUrls: [],

--- a/features/collections/lib/collection-catalog-view.ts
+++ b/features/collections/lib/collection-catalog-view.ts
@@ -29,6 +29,8 @@ export interface CollectionCatalogEntry {
   availability: CollectionCatalogAvailability;
   /** 完成台紙(コンプリートモーダル表示用)。未完成は null。 */
   completionId: string | null;
+  /** 完走表示モード(mount=台紙 / book=本)。シェア導線の遷移先分岐に使う。 */
+  completionViewMode: "mount" | "book";
   mountImagePath: string | null;
   mountTemplateWidth: number | null;
   mountTemplateHeight: number | null;
@@ -109,6 +111,7 @@ export function buildCollectionCatalogView(
         state,
         availability,
         completionId: p?.completionId ?? null,
+        completionViewMode: p?.completionViewMode ?? "mount",
         mountImagePath: p?.mountImagePath ?? null,
         mountTemplateWidth: p?.mountTemplateWidth ?? null,
         mountTemplateHeight: p?.mountTemplateHeight ?? null,

--- a/features/my-page/components/CachedMyPageCollections.tsx
+++ b/features/my-page/components/CachedMyPageCollections.tsx
@@ -19,7 +19,7 @@ export async function CachedMyPageCollections({ userId }: { userId: string }) {
   const { data } = await supabase
     .from("collection_completions")
     .select(
-      "id, category_key, mount_image_path, completed_at, preset_categories(display_name_ja, mount_template_width, mount_template_height)",
+      "id, category_key, mount_image_path, completed_at, preset_categories(display_name_ja, mount_template_width, mount_template_height, completion_view_mode)",
     )
     .eq("user_id", userId)
     .eq("mount_status", "completed")
@@ -37,6 +37,7 @@ export async function CachedMyPageCollections({ userId }: { userId: string }) {
             display_name_ja?: string;
             mount_template_width?: number | null;
             mount_template_height?: number | null;
+            completion_view_mode?: string | null;
           }
         | undefined;
       return {
@@ -46,6 +47,8 @@ export async function CachedMyPageCollections({ userId }: { userId: string }) {
         mountImageUrl,
         mountTemplateWidth: catRecord?.mount_template_width ?? null,
         mountTemplateHeight: catRecord?.mount_template_height ?? null,
+        completionViewMode:
+          catRecord?.completion_view_mode === "book" ? "book" : "mount",
       } satisfies CompletedMountView;
     })
     .filter((m): m is CompletedMountView => m !== null);

--- a/features/my-page/components/MyPageCollections.tsx
+++ b/features/my-page/components/MyPageCollections.tsx
@@ -135,6 +135,8 @@ export interface CompletedMountView {
   mountImageUrl: string;
   mountTemplateWidth: number | null;
   mountTemplateHeight: number | null;
+  /** 完走表示モード(mount=台紙 / book=本)。シェア導線の遷移先分岐に使う。 */
+  completionViewMode: "mount" | "book";
 }
 
 /**
@@ -308,7 +310,11 @@ export function MyPageCollections({
       threshold: cached?.threshold ?? 0,
       isCompleted: true,
       mountImageUrl: m.mountImageUrl,
-      sharePath: `/m/${m.completionId}`,
+      // book は redirect 元の /m/<id>(chrome付き)を経由するとチラつくため /m/<id>/book へ直行。
+      sharePath:
+        m.completionViewMode === "book"
+          ? `/m/${m.completionId}/book`
+          : `/m/${m.completionId}`,
       completionId: m.completionId,
       mountTemplateWidth: m.mountTemplateWidth,
       mountTemplateHeight: m.mountTemplateHeight,


### PR DESCRIPTION
### 概要
本(travel)の完走モーダル「シェアページへ」遷移時に、**まだアプリシェル(下部ナビ → ヘッダー＋フッター)がチラつく**問題の残りを修正します。

### 原因(動画フレーム解析で特定)
前回 #392 は `useCollectionProgress` 経由のみ修正していましたが、**実際にユーザーが踏んでいた経路はマイページの完走サムネタップ**(`MyPageCollections.openMountModal`)でした。ここと `CollectionCatalogGrid`(図鑑のコンプリート済みタップ)の `sharePath` が **book でも `/m/<id>`**(= chrome 付き台紙シェア。book では `/m/<id>/book` へ redirect)を指していたため、遷移途中で chrome がチラついていました。

※ #392 のフレーム解析で「下部ナビ付きスケルトン → ヘッダー＋フッターの空シェル」を確認。本番(16:11 デプロイ)後の動画(16:50)でも再現 → 別経路と判明。

### 変更内容(全 sharePath 生成箇所を book 対応に)
- `MyPageCollections` / `CachedMyPageCollections`:`CompletedMountView.completionViewMode` を追加(`collection_completions` の `preset_categories.completion_view_mode` を join)。`openMountModal` の `sharePath` を book は `/m/<id>/book` 直行に。
- `collection-catalog-view` / `CollectionCatalogGrid`:`CollectionCatalogEntry.completionViewMode` を追加(進捗 `p` から流用)し、`sharePath` を book 直行に。
- これで残っていた全 `sharePath` 生成箇所(useCollectionProgress #392 + 本PRのマイページ/図鑑)が book は redirect/chrome を経由せず没入の `/m/<id>/book` に直結。

### 実機テスト
- [ ] マイページの完走サムネをタップ → 完走モーダル →「シェアページへ」→ chrome のチラつきなしで本リーダー
- [ ] 図鑑(/collections)のコンプリート済みタップでも同様
- [ ] 台紙系(神コレ)は従来どおり `/m/<id>`

### テスト方法
- `npm run lint` / `npm run build -- --webpack`(緑)
- `npm run test`(全 2281 pass)
