### PR TITLE
feat(collections): 完走フィード投稿(オプトイン) ※全フェーズを本PRに集約・最後にマージ

### DIFF
--- a/app/api/collections/completions/[id]/post/route.ts
+++ b/app/api/collections/completions/[id]/post/route.ts
@@ -30,6 +30,8 @@ function revalidateAfterChange(userId: string, completionId: string, postId?: st
   revalidateTag("search-posts", "max");
   revalidateTag(`user-profile-${userId}`, "max");
   revalidateTag(`my-page-${userId}`, "max");
+  // 投稿ボーナス付与でクレジット残高が変わるため、マイページ残高も失効(通常投稿と同様)
+  revalidateTag(`my-page-credits-${userId}`, "max");
   // 完走モーダルの「投稿済み」状態(CachedMyPageCollections が消費)
   revalidateTag(`collection-completions:${userId}`, "max");
   if (postId) {
@@ -107,16 +109,19 @@ export async function DELETE(
   }
 
   // 取消は is_posted=false(行は保持=再投稿で復活)。RLS により本人行のみ更新可。
-  const { error } = await supabase
+  const { data: updated, error } = await supabase
     .from("generated_images")
     .update({ is_posted: false, posted_at: null, caption: null })
     .eq("completion_id", completionId)
-    .eq("user_id", user.id);
+    .eq("user_id", user.id)
+    .select("id")
+    .maybeSingle();
   if (error) {
     console.error("[completion feed post DELETE] failed:", error.message);
     return NextResponse.json({ error: "cancel_failed" }, { status: 500 });
   }
-  revalidateAfterChange(user.id, completionId);
+  // post-detail-${id} も失効させ、陳腐なメタデータが残らないようにする(MUST-ADDRESS-008)
+  revalidateAfterChange(user.id, completionId, updated?.id);
   return NextResponse.json({ posted: false });
 }
 
@@ -124,6 +129,9 @@ export async function GET(
   _request: Request,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  const denied = flagGuard();
+  if (denied) return denied;
+
   const { id: completionId } = await params;
   const supabase = await createClient();
   const {

--- a/app/api/collections/completions/[id]/post/route.ts
+++ b/app/api/collections/completions/[id]/post/route.ts
@@ -1,0 +1,143 @@
+import { NextResponse } from "next/server";
+import { revalidatePath, revalidateTag } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { isCollectionFeedPostEnabled } from "@/lib/env";
+import { postCompletionToFeed } from "@/features/collections/lib/completion-feed-post";
+
+/**
+ * 完走フィード投稿(オプトイン)API。
+ * - POST  : 完走をホームフィードに投稿(冪等。再投稿は同一行を再活性化)
+ * - DELETE: 投稿を取り消す(is_posted=false。完走本体と /m/<token> は無傷)
+ * - GET   : 当該完走が投稿済みかを返す(モーダルの状態表示用)
+ *
+ * 機能フラグ `NEXT_PUBLIC_COLLECTION_FEED_POST_ENABLED` OFF 時は全メソッド 403。
+ * 所有権は RPC / RLS が auth.uid() で強制(本ルートは body から user を受け取らない)。
+ */
+
+const MAX_CAPTION_LENGTH = 140;
+
+function flagGuard(): NextResponse | null {
+  if (!isCollectionFeedPostEnabled()) {
+    return NextResponse.json({ error: "feature_disabled" }, { status: 403 });
+  }
+  return null;
+}
+
+/** 投稿/取消後にフィード・詳細・マイページ・モーダル状態・シェアページを失効させる。 */
+function revalidateAfterChange(userId: string, completionId: string, postId?: string) {
+  revalidateTag("home-posts", "max");
+  revalidateTag("home-posts-week", "max");
+  revalidateTag("search-posts", "max");
+  revalidateTag(`user-profile-${userId}`, "max");
+  revalidateTag(`my-page-${userId}`, "max");
+  // 完走モーダルの「投稿済み」状態(CachedMyPageCollections が消費)
+  revalidateTag(`collection-completions:${userId}`, "max");
+  if (postId) {
+    revalidateTag(`post-detail-${postId}`, { expire: 0 });
+  }
+  revalidatePath("/");
+  revalidatePath(`/m/${completionId}`);
+  revalidatePath(`/m/${completionId}/book`);
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const denied = flagGuard();
+  if (denied) return denied;
+
+  const { id: completionId } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  let caption: string | null = null;
+  try {
+    const body = (await request.json().catch(() => ({}))) as {
+      caption?: unknown;
+    };
+    if (typeof body.caption === "string") {
+      const trimmed = body.caption.trim().slice(0, MAX_CAPTION_LENGTH);
+      caption = trimmed.length > 0 ? trimmed : null;
+    }
+  } catch {
+    caption = null;
+  }
+
+  try {
+    const { postId } = await postCompletionToFeed(supabase, completionId, caption);
+    revalidateAfterChange(user.id, completionId, postId);
+    return NextResponse.json({ posted: true, postId });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "unknown";
+    // 所有権/状態のDB層エラーをHTTPに写す
+    if (message.includes("forbidden")) {
+      return NextResponse.json({ error: "forbidden" }, { status: 403 });
+    }
+    if (message.includes("not found")) {
+      return NextResponse.json({ error: "not_found" }, { status: 404 });
+    }
+    if (message.includes("not completed") || message.includes("not ready")) {
+      return NextResponse.json({ error: "not_completed" }, { status: 409 });
+    }
+    console.error("[completion feed post POST] failed:", message);
+    return NextResponse.json({ error: "post_failed" }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const denied = flagGuard();
+  if (denied) return denied;
+
+  const { id: completionId } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  // 取消は is_posted=false(行は保持=再投稿で復活)。RLS により本人行のみ更新可。
+  const { error } = await supabase
+    .from("generated_images")
+    .update({ is_posted: false, posted_at: null, caption: null })
+    .eq("completion_id", completionId)
+    .eq("user_id", user.id);
+  if (error) {
+    console.error("[completion feed post DELETE] failed:", error.message);
+    return NextResponse.json({ error: "cancel_failed" }, { status: 500 });
+  }
+  revalidateAfterChange(user.id, completionId);
+  return NextResponse.json({ posted: false });
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id: completionId } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ posted: false, postId: null });
+  }
+  const { data } = await supabase
+    .from("generated_images")
+    .select("id")
+    .eq("completion_id", completionId)
+    .eq("user_id", user.id)
+    .eq("is_posted", true)
+    .maybeSingle();
+  return NextResponse.json({ posted: !!data, postId: data?.id ?? null });
+}

--- a/app/m/[token]/book/page.tsx
+++ b/app/m/[token]/book/page.tsx
@@ -81,6 +81,7 @@ export default async function CollectionBookPage({ params }: BookPageProps) {
       coverImageUrl={coverImageUrl}
       pages={pages}
       isOwner={isOwner}
+      completionId={token}
     />
   );
 }

--- a/app/m/[token]/page.tsx
+++ b/app/m/[token]/page.tsx
@@ -11,6 +11,7 @@ import {
 import { mountAspectForCategory } from "@/features/collections/lib/mount-aspects";
 import { MountShareButton } from "@/features/collections/components/MountShareButton";
 import { MountCelebrationBackground } from "@/features/collections/components/MountCelebrationBackground";
+import { CompletionFeedPostButton } from "@/features/collections/components/CompletionFeedPostButton";
 
 interface PublicMountPageProps {
   params: Promise<{ token: string }>;
@@ -149,10 +150,17 @@ export default async function PublicMountPage({
       </div>
 
       {isOwner ? (
-        <MountShareButton
-          completionId={mount.completionId}
-          mountImageUrl={mount.mountImageUrl}
-        />
+        <div className="flex w-full max-w-sm flex-col items-center gap-3">
+          <MountShareButton
+            completionId={mount.completionId}
+            mountImageUrl={mount.mountImageUrl}
+          />
+          <CompletionFeedPostButton
+            completionId={mount.completionId}
+            displayName={mount.displayNameJa}
+            variant="cta"
+          />
+        </div>
       ) : null}
 
       <section className="w-full rounded-xl bg-gray-50 p-5 text-center">

--- a/app/posts/[id]/page.tsx
+++ b/app/posts/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { connection } from "next/server";
+import { redirect } from "next/navigation";
 import type { Metadata } from "next";
 import { getLocale } from "next-intl/server";
 import { getPost } from "@/features/posts/lib/server-api";
@@ -134,6 +135,31 @@ export default async function PostDetailPage({ params }: PostDetailPageProps) {
   } catch (error) {
     // 認証エラーは無視（ゲストユーザーとして扱う）
     console.error("Auth error:", error);
+  }
+
+  // 完走フィード投稿は没入シェアページが正規の表示先。/posts/<id>(通知ディープリンク・
+  // 直接URL)で来た場合は /m/<token>(book は /book)へリダイレクトする(MUST-ADDRESS-007)。
+  // redirect() は内部で例外を投げるため try/catch の外で呼ぶ。
+  let completionRedirect: string | null = null;
+  try {
+    const supabase = await createClient();
+    const { data: post } = await supabase
+      .from("generated_images")
+      .select("completion_id, completion_view_mode")
+      .eq("id", id)
+      .maybeSingle();
+    if (post?.completion_id) {
+      completionRedirect =
+        post.completion_view_mode === "book"
+          ? `/m/${post.completion_id}/book`
+          : `/m/${post.completion_id}`;
+    }
+  } catch (error) {
+    // 取得失敗時は通常の詳細表示にフォールバック
+    console.error("completion redirect check failed:", error);
+  }
+  if (completionRedirect) {
+    redirect(completionRedirect);
   }
 
   // use cache でキャッシュして即時表示を優先（閲覧数はキャッシュ時スキップ）

--- a/app/posts/[id]/page.tsx
+++ b/app/posts/[id]/page.tsx
@@ -61,8 +61,14 @@ export async function generateMetadata({ params }: PostDetailPageProps): Promise
   }
 
   const siteUrl = getSiteUrl();
+  // 完走投稿の正規URLは没入シェアページ。canonical/OG をそちらへ向ける(MUST-ADDRESS-005)。
+  const completionPath = post.completion_id
+    ? `/m/${post.completion_id}${post.completion_view_mode === "book" ? "/book" : ""}`
+    : null;
   const postUrl = siteUrl
-    ? `${siteUrl}${localizePublicPath(`/posts/${id}`, locale)}`
+    ? completionPath
+      ? `${siteUrl}${completionPath}`
+      : `${siteUrl}${localizePublicPath(`/posts/${id}`, locale)}`
     : "";
   const imageUrl = getPostDisplayUrl(post);
 
@@ -138,17 +144,14 @@ export default async function PostDetailPage({ params }: PostDetailPageProps) {
   }
 
   // 完走フィード投稿は没入シェアページが正規の表示先。/posts/<id>(通知ディープリンク・
-  // 直接URL)で来た場合は /m/<token>(book は /book)へリダイレクトする(MUST-ADDRESS-007)。
-  // redirect() は内部で例外を投げるため try/catch の外で呼ぶ。
+  // 直接URL)で来た場合は /m/<token>(book は /book)へリダイレクトする。
+  // - is_posted=true のときだけ発火(取消済みは通常詳細にフォールバック: MUST-ADDRESS-007)
+  // - 既存のキャッシュ済み getPost を再利用し、余分なDB往復を避ける(MUST-ADDRESS-006)
+  // - redirect() は内部で例外を投げるため try/catch の外で呼ぶ
   let completionRedirect: string | null = null;
   try {
-    const supabase = await createClient();
-    const { data: post } = await supabase
-      .from("generated_images")
-      .select("completion_id, completion_view_mode")
-      .eq("id", id)
-      .maybeSingle();
-    if (post?.completion_id) {
+    const post = await getPost(id, currentUserId, true);
+    if (post?.completion_id && post.is_posted) {
       completionRedirect =
         post.completion_view_mode === "book"
           ? `/m/${post.completion_id}/book`

--- a/features/collections/components/CollectionProgressModal.tsx
+++ b/features/collections/components/CollectionProgressModal.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/dialog";
 import { ShareLinkButton } from "@/components/ShareLinkButton";
 import { AchievementBadge } from "@/features/collections/components/AchievementBadge";
+import { CompletionFeedPostButton } from "@/features/collections/components/CompletionFeedPostButton";
 import { CollectionConfetti } from "@/features/collections/components/CollectionConfetti";
 import { CollectionSparkle } from "@/features/collections/components/CollectionSparkle";
 import { collectionGuidePath } from "@/features/collections/lib/collection-guides";
@@ -605,6 +606,13 @@ export function CollectionProgressModal({
               >
                 シェアページへ
               </Link>
+            ) : null}
+            {completionId ? (
+              <CompletionFeedPostButton
+                completionId={completionId}
+                displayName={displayName}
+                variant="cta"
+              />
             ) : null}
             {completionId ? (
               /* posts / /m と同じ共有 UI(モバイル=シェアシート、PC=コピー/Web Share

--- a/features/collections/components/CompletionFeedPostButton.tsx
+++ b/features/collections/components/CompletionFeedPostButton.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Home, Check } from "lucide-react";
+
+/**
+ * 完走をホームフィードに投稿する(オプトイン)ボタン。
+ * - 完走モーダル(variant="cta": 全幅ピル)と没入シェアページ(variant="chrome": 小型)で再利用。
+ * - 機能フラグ NEXT_PUBLIC_COLLECTION_FEED_POST_ENABLED が 'true' のときだけ描画(OFFは null)。
+ * - マウント時に投稿済みかを取得し、未投稿=「ホームに投稿する」/ 投稿済み=「投稿済み ✓ + 取り消す」。
+ * - 所有権・冪等性はサーバ(RPC/RLS)が担保するため、本コンポーネントは状態表示と送信のみ。
+ */
+const ENABLED =
+  process.env.NEXT_PUBLIC_COLLECTION_FEED_POST_ENABLED === "true";
+
+export function CompletionFeedPostButton({
+  completionId,
+  displayName,
+  variant = "cta",
+}: {
+  completionId: string;
+  displayName?: string;
+  variant?: "cta" | "chrome";
+}) {
+  const [posted, setPosted] = useState<boolean | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const [caption, setCaption] = useState("");
+
+  useEffect(() => {
+    if (!ENABLED) return;
+    let cancelled = false;
+    fetch(`/api/collections/completions/${completionId}/post`, {
+      cache: "no-store",
+    })
+      .then((r) => (r.ok ? r.json() : { posted: false }))
+      .then((d: { posted?: boolean }) => {
+        if (!cancelled) setPosted(Boolean(d.posted));
+      })
+      .catch(() => {
+        if (!cancelled) setPosted(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [completionId]);
+
+  if (!ENABLED || posted === null) return null;
+
+  async function submit() {
+    setBusy(true);
+    try {
+      const res = await fetch(
+        `/api/collections/completions/${completionId}/post`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ caption: caption.trim() || undefined }),
+        },
+      );
+      if (res.ok) {
+        setPosted(true);
+        setExpanded(false);
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function cancelPost() {
+    setBusy(true);
+    try {
+      const res = await fetch(
+        `/api/collections/completions/${completionId}/post`,
+        { method: "DELETE" },
+      );
+      if (res.ok) setPosted(false);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const isChrome = variant === "chrome";
+
+  // 投稿済み表示
+  if (posted) {
+    return (
+      <div
+        className={
+          isChrome
+            ? "inline-flex items-center gap-1.5 rounded-full bg-white/90 px-3 py-2 text-sm font-bold text-emerald-600 shadow-md"
+            : "flex w-full items-center justify-center gap-2 rounded-full border-2 border-emerald-200 bg-emerald-50 px-6 py-3 text-base font-bold text-emerald-600"
+        }
+      >
+        <Check className="h-4 w-4" />
+        ホームに投稿済み
+        <button
+          type="button"
+          onClick={cancelPost}
+          disabled={busy}
+          className="ml-1 text-xs font-medium text-emerald-500 underline hover:text-emerald-700 disabled:opacity-50"
+        >
+          取り消す
+        </button>
+      </div>
+    );
+  }
+
+  // 未投稿: キャプション入力を開く前
+  if (!expanded) {
+    return (
+      <button
+        type="button"
+        onClick={() => setExpanded(true)}
+        className={
+          isChrome
+            ? "inline-flex items-center gap-1.5 rounded-full bg-white/90 px-3 py-2 text-sm font-bold text-pink-500 shadow-md transition-transform hover:-translate-y-0.5"
+            : "flex w-full items-center justify-center gap-2 rounded-full border-2 border-pink-300 bg-white px-6 py-3 text-base font-bold text-pink-500 transition-colors hover:bg-pink-50"
+        }
+      >
+        <Home className="h-4 w-4" />
+        ホームに投稿する
+      </button>
+    );
+  }
+
+  // 未投稿: キャプション入力(任意)
+  return (
+    <div className="w-full rounded-2xl border-2 border-pink-200 bg-white p-3 text-left">
+      <textarea
+        value={caption}
+        onChange={(e) => setCaption(e.target.value)}
+        maxLength={140}
+        rows={2}
+        placeholder={`『${displayName ?? ""}』をコンプリート！`}
+        className="w-full resize-none rounded-lg border border-pink-100 bg-pink-50/40 px-3 py-2 text-sm text-stone-700 outline-none focus:border-pink-300"
+      />
+      <div className="mt-2 flex gap-2">
+        <button
+          type="button"
+          onClick={submit}
+          disabled={busy}
+          className="flex-1 rounded-full bg-pink-500 px-4 py-2 text-sm font-bold text-white transition-colors hover:bg-pink-600 disabled:opacity-50"
+        >
+          {busy ? "投稿中…" : "ホームに投稿する"}
+        </button>
+        <button
+          type="button"
+          onClick={() => setExpanded(false)}
+          disabled={busy}
+          className="rounded-full px-4 py-2 text-sm font-medium text-stone-400 hover:bg-stone-100 disabled:opacity-50"
+        >
+          やめる
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/features/collections/components/CompletionFeedPostButton.tsx
+++ b/features/collections/components/CompletionFeedPostButton.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { Home, Check } from "lucide-react";
+import { useToast } from "@/components/ui/use-toast";
 
 /**
  * 完走をホームフィードに投稿する(オプトイン)ボタン。
@@ -26,6 +27,7 @@ export function CompletionFeedPostButton({
   const [busy, setBusy] = useState(false);
   const [expanded, setExpanded] = useState(false);
   const [caption, setCaption] = useState("");
+  const { toast } = useToast();
 
   useEffect(() => {
     if (!ENABLED) return;
@@ -61,7 +63,18 @@ export function CompletionFeedPostButton({
       if (res.ok) {
         setPosted(true);
         setExpanded(false);
+        toast({ title: "ホームに投稿しました" });
+      } else {
+        toast({
+          variant: "destructive",
+        title: "投稿に失敗しました。時間をおいて再度お試しください。",
+        });
       }
+    } catch {
+      toast({
+        variant: "destructive",
+        title: "通信に失敗しました。電波の良い場所でお試しください。",
+      });
     } finally {
       setBusy(false);
     }
@@ -74,7 +87,19 @@ export function CompletionFeedPostButton({
         `/api/collections/completions/${completionId}/post`,
         { method: "DELETE" },
       );
-      if (res.ok) setPosted(false);
+      if (res.ok) {
+        setPosted(false);
+      } else {
+        toast({
+          variant: "destructive",
+        title: "取り消しに失敗しました。時間をおいて再度お試しください。",
+        });
+      }
+    } catch {
+      toast({
+        variant: "destructive",
+        title: "通信に失敗しました。電波の良い場所でお試しください。",
+      });
     } finally {
       setBusy(false);
     }

--- a/features/collections/components/ScrapbookReader.tsx
+++ b/features/collections/components/ScrapbookReader.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { X, Share2, Maximize2, Minimize2 } from "lucide-react";
 import { CatalogBookView } from "@/features/catalog/components/CatalogBookView";
 import type { CatalogPageData } from "@/features/catalog/components/CatalogPage";
+import { CompletionFeedPostButton } from "@/features/collections/components/CompletionFeedPostButton";
 
 /**
  * コレクション完走の「めくれる日記帳(スクラップブック)」没入ビュー。
@@ -18,11 +19,14 @@ export function ScrapbookReader({
   coverImageUrl,
   pages,
   isOwner,
+  completionId,
 }: {
   title: string;
   coverImageUrl: string | null;
   pages: CatalogPageData[];
   isOwner: boolean;
+  /** 完走(collection_completions.id = token)。所有者にホーム投稿ボタンを出すのに使う。 */
+  completionId?: string | null;
 }) {
   const router = useRouter();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -190,6 +194,22 @@ export function ScrapbookReader({
           onChromeVisibilityChange={(visible) => setChromeVisible(visible)}
         />
       </main>
+
+      {/* 所有者向け: ホームフィードへの投稿(没入ページにも常設)。chrome と同期して出し入れ。 */}
+      {isOwner && completionId ? (
+        <div
+          className={
+            "absolute bottom-5 left-1/2 z-10 -translate-x-1/2 transition-opacity duration-300 " +
+            (chromeVisible ? "opacity-100" : "pointer-events-none opacity-0")
+          }
+        >
+          <CompletionFeedPostButton
+            completionId={completionId}
+            displayName={title}
+            variant="chrome"
+          />
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/features/collections/lib/completion-feed-post.ts
+++ b/features/collections/lib/completion-feed-post.ts
@@ -1,0 +1,64 @@
+import "server-only";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { uploadWebPVariants } from "@/features/generation/lib/webp-storage";
+import { buildPublicGeneratedImageUrl } from "@/features/collections/lib/public-mount-server-api";
+
+/**
+ * 完走(collection_completions)をホームフィードに投稿する(オプトイン)サーバ helper。
+ *
+ * 流れ(計画 Phase 2 / MRAR-003 反映):
+ *  1. 完走の mount_image_path を取得(admin read。所有権は後段 RPC が auth.uid() で強制)。
+ *  2. **INSERT 前**に WebP variants を確保(`uploadWebPVariants` は DB 行に依存しない)。
+ *     失敗時はここで throw し、generated_images 行を作らない(EARS-07: 部分行を作らない)。
+ *  3. RPC `create_collection_completion_post` を**セッションクライアント**経由で呼ぶ
+ *     (admin client だと auth.uid() が NULL になり所有権チェックが失敗するため)。
+ */
+export async function postCompletionToFeed(
+  sessionSupabase: SupabaseClient,
+  completionId: string,
+  caption: string | null,
+): Promise<{ postId: string }> {
+  const admin = createAdminClient();
+  const { data: completion, error } = await admin
+    .from("collection_completions")
+    .select("mount_image_path, mount_status")
+    .eq("id", completionId)
+    .maybeSingle();
+
+  if (error) throw new Error(`completion fetch failed: ${error.message}`);
+  if (!completion) throw new Error("completion not found");
+  if (
+    completion.mount_status !== "completed" ||
+    !completion.mount_image_path
+  ) {
+    throw new Error("completion not ready");
+  }
+
+  const storagePath = completion.mount_image_path as string;
+  const imageUrl = buildPublicGeneratedImageUrl(storagePath);
+  if (!imageUrl) throw new Error("image url unresolved");
+
+  // INSERT 前に WebP variants を確保(失敗時は投稿しない)。
+  const { thumbPath, displayPath } = await uploadWebPVariants(
+    imageUrl,
+    storagePath,
+  );
+
+  const { data: postId, error: rpcError } = await sessionSupabase.rpc(
+    "create_collection_completion_post",
+    {
+      p_completion_id: completionId,
+      p_caption: caption,
+      p_image_url: imageUrl,
+      p_storage_path: storagePath,
+      p_storage_path_display: displayPath,
+      p_storage_path_thumb: thumbPath,
+    },
+  );
+
+  if (rpcError) throw new Error(rpcError.message);
+  if (!postId) throw new Error("post creation returned no id");
+  return { postId: postId as string };
+}

--- a/features/collections/lib/completion-feed-post.ts
+++ b/features/collections/lib/completion-feed-post.ts
@@ -1,7 +1,6 @@
 import "server-only";
 
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { createAdminClient } from "@/lib/supabase/admin";
 import { uploadWebPVariants } from "@/features/generation/lib/webp-storage";
 import { buildPublicGeneratedImageUrl } from "@/features/collections/lib/public-mount-server-api";
 
@@ -20,8 +19,9 @@ export async function postCompletionToFeed(
   completionId: string,
   caption: string | null,
 ): Promise<{ postId: string }> {
-  const admin = createAdminClient();
-  const { data: completion, error } = await admin
+  // 所有権チェック前に重い WebP 処理が走らないよう、セッションクライアントで読む
+  // (collection_completions は本人のみ RLS = 非所有者は data=null で弾かれる)。
+  const { data: completion, error } = await sessionSupabase
     .from("collection_completions")
     .select("mount_image_path, mount_status")
     .eq("id", completionId)

--- a/features/posts/components/PostCard.tsx
+++ b/features/posts/components/PostCard.tsx
@@ -70,8 +70,18 @@ export function PostCard({
           {t("noImage")}
         </div>
       )}
+      {post.completion_id ? (
+        <span className="absolute left-2 top-2 z-10 rounded-full bg-gradient-to-r from-amber-400 to-orange-500 px-2 py-0.5 text-[11px] font-bold text-white shadow">
+          {locale === "en" ? "Complete" : "コンプリート"}
+        </span>
+      ) : null}
     </div>
   );
+
+  // 完走投稿は没入シェアページへ(通常投稿は従来の詳細ページ)。
+  const detailHref = post.completion_id
+    ? `/m/${post.completion_id}${post.completion_view_mode === "book" ? "/book" : ""}`
+    : getPostDetailLocalizedPath(post.id ?? "", locale);
 
   return (
     <Card
@@ -99,10 +109,7 @@ export function PostCard({
           // 閲覧数は増えない。過去の「閲覧数が異常に増える」不具合は
           // サーバーレンダー中にカウントしていた旧実装が原因であり、
           // 現行構成では prefetch を有効化しても再発しない。
-          <Link
-            href={getPostDetailLocalizedPath(post.id, locale)}
-            prefetch
-          >
+          <Link href={detailHref} prefetch={!post.completion_id}>
             {imageContent}
           </Link>
         ) : (

--- a/features/posts/components/PostCard.tsx
+++ b/features/posts/components/PostCard.tsx
@@ -10,7 +10,7 @@ import { PostCardLikeButton } from "./PostCardLikeButton";
 import { getPostThumbUrl } from "../lib/utils";
 import type { Post } from "../types";
 import type { Locale } from "@/i18n/config";
-import { getPostDetailLocalizedPath } from "@/lib/url-utils";
+import { getPostCardHref } from "@/lib/url-utils";
 import { PostModerationMenu } from "@/features/moderation/components/PostModerationMenu";
 import { cn, formatCountEnUS } from "@/lib/utils";
 
@@ -79,9 +79,7 @@ export function PostCard({
   );
 
   // 完走投稿は没入シェアページへ(通常投稿は従来の詳細ページ)。
-  const detailHref = post.completion_id
-    ? `/m/${post.completion_id}${post.completion_view_mode === "book" ? "/book" : ""}`
-    : getPostDetailLocalizedPath(post.id ?? "", locale);
+  const detailHref = getPostCardHref(post, locale);
 
   return (
     <Card

--- a/features/posts/components/PostCard.tsx
+++ b/features/posts/components/PostCard.tsx
@@ -185,14 +185,18 @@ export function PostCard({
                 currentUserId={currentUserId}
               />
             )}
-            <div className="flex shrink-0 items-center gap-1">
-              <MessageCircle className="h-4 w-4 text-gray-500" />
-              {(post.comment_count || 0) > 0 && (
-                <span className="text-xs font-medium tabular-nums text-gray-600">
-                  {formatCountEnUS(post.comment_count || 0)}
-                </span>
-              )}
-            </div>
+            {/* 完走投稿のタップ先(没入シェアページ)にはコメントUIが無いため、
+                操作不能なコメント数は出さない(MUST-ADDRESS-011)。 */}
+            {!post.completion_id && (
+              <div className="flex shrink-0 items-center gap-1">
+                <MessageCircle className="h-4 w-4 text-gray-500" />
+                {(post.comment_count || 0) > 0 && (
+                  <span className="text-xs font-medium tabular-nums text-gray-600">
+                    {formatCountEnUS(post.comment_count || 0)}
+                  </span>
+                )}
+              </div>
+            )}
             <div className="flex shrink-0 items-center gap-1">
               <Eye className="h-4 w-4 text-gray-500" />
               {(post.view_count || 0) > 0 && (

--- a/features/posts/types.ts
+++ b/features/posts/types.ts
@@ -34,6 +34,10 @@ export interface Post extends GeneratedImageRecord {
   comment_count?: number;
   view_count?: number;
   moderation_status?: "visible" | "pending" | "removed";
+  // 完走フィード投稿(オプトイン)の識別とタップ先解決用。
+  // completion_id があれば「コンプリート」バッジ + 没入シェアページ(/m/<id>[/book])へ遷移。
+  completion_id?: string | null;
+  completion_view_mode?: "mount" | "book" | null;
   // Before 画像の楽観表示用フォールバック。
   // pre_generation_storage_path が無い間（生成完了直後の永続化処理中など）に
   // image_jobs.input_image_url で代替表示する。永続化完了後は null になる。

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -64,6 +64,9 @@ const envSchema = {
   // Inspire（ユーザー投稿スタイルテンプレート機能）
   // 機能全体の kill switch
   NEXT_PUBLIC_INSPIRE_ENABLED: process.env.NEXT_PUBLIC_INSPIRE_ENABLED,
+  // 完走フィード投稿(オプトイン)機能の段階公開フラグ。'true' のときだけ導線/APIを開放
+  NEXT_PUBLIC_COLLECTION_FEED_POST_ENABLED:
+    process.env.NEXT_PUBLIC_COLLECTION_FEED_POST_ENABLED,
   // ホームカルーセル個別フラグ（ADR-013）。'true' のときだけホームに露出する
   NEXT_PUBLIC_INSPIRE_HOME_CAROUSEL_ENABLED:
     process.env.NEXT_PUBLIC_INSPIRE_HOME_CAROUSEL_ENABLED,
@@ -168,6 +171,8 @@ function getEnv() {
     CONTACT_EMAIL: envSchema.CONTACT_EMAIL || "yuh.products@gmail.com",
     RESEND_FROM_EMAIL: envSchema.RESEND_FROM_EMAIL || "",
     NEXT_PUBLIC_INSPIRE_ENABLED: envSchema.NEXT_PUBLIC_INSPIRE_ENABLED || "",
+    NEXT_PUBLIC_COLLECTION_FEED_POST_ENABLED:
+      envSchema.NEXT_PUBLIC_COLLECTION_FEED_POST_ENABLED || "",
     NEXT_PUBLIC_INSPIRE_HOME_CAROUSEL_ENABLED:
       envSchema.NEXT_PUBLIC_INSPIRE_HOME_CAROUSEL_ENABLED || "",
     INSPIRE_TEST_CHARACTER_IMAGE_URL:
@@ -358,6 +363,13 @@ export function getInspireSubmissionAllowedUserIds(): string[] {
  */
 export function isInspireFeatureEnabled(): boolean {
   return env.NEXT_PUBLIC_INSPIRE_ENABLED === "true";
+}
+
+/**
+ * 完走フィード投稿(オプトイン)機能の有効/無効を判定(段階公開フラグ)
+ */
+export function isCollectionFeedPostEnabled(): boolean {
+  return env.NEXT_PUBLIC_COLLECTION_FEED_POST_ENABLED === "true";
 }
 
 /**

--- a/lib/url-utils.ts
+++ b/lib/url-utils.ts
@@ -19,6 +19,27 @@ export function getPostDetailLocalizedPath(
   return localizePublicPath(getPostDetailPath(postId), locale);
 }
 
+/**
+ * フィードカード(PostCard)のタップ先パスを返す。
+ * 完走フィード投稿(`completion_id` あり)は没入シェアページ(`/m/<token>`、
+ * book は `/m/<token>/book`)へ。通常投稿は従来のロケール付き詳細パス。
+ */
+export function getPostCardHref(
+  post: {
+    id?: string | null;
+    completion_id?: string | null;
+    completion_view_mode?: "mount" | "book" | null;
+  },
+  locale: Locale
+): string {
+  if (post.completion_id) {
+    return post.completion_view_mode === "book"
+      ? `/m/${post.completion_id}/book`
+      : `/m/${post.completion_id}`;
+  }
+  return getPostDetailLocalizedPath(post.id ?? "", locale);
+}
+
 export function getPostDetailUrl(postId: string, locale?: Locale): string {
   const path = getPostDetailPath(postId);
   const localizedPath = locale ? localizePublicPath(path, locale) : path;

--- a/supabase/migrations/20260629140000_add_completion_feed_post.sql
+++ b/supabase/migrations/20260629140000_add_completion_feed_post.sql
@@ -1,0 +1,131 @@
+-- ===============================================
+-- コレクション完走のホームフィード投稿(オプトイン) Phase 1: DB
+-- ===============================================
+-- 計画: docs/planning/collection-completion-feed-post-implementation-plan.md
+--
+-- 完走(collection_completions)を、ユーザー任意で「posts(= generated_images)」の1行として
+-- フィードに出せるようにする。いいね/コメント/モデレーション/投稿ボーナス/フィード取得は
+-- すべて generated_images.id 起点のため、完走を1行で表現すれば無改修で流用できる。
+--
+-- 設計判断(計画 ADR / MRAR 反映):
+--  - 識別子 `completion_id`(→ collection_completions.id)。バッジ/タップ先/重複判定に使う。
+--  - 重複投稿防止は completion_id の部分 UNIQUE(1完走=1post、RPCは冪等)。
+--  - タップ先(mount/book)解決のため `completion_view_mode` を **post 行に非正規化**保存する。
+--    collection_completions は本人のみ RLS のため、他者のフィードでは join しても NULL になる。
+--    post 行(generated_images)は公開 read 可なので、ここに持たせるのが公開安全かつ join 不要。
+--  - generation_type='one_tap_style'(プロンプト秘匿の defense-in-depth)、generation_metadata=NULL
+--    (コレクションクエリは metadata->oneTapStyle->>id の AND 条件のため除外され安全)。
+--  - posted_at=now()(NULL だと NULLS FIRST で新着先頭固定 + 時間タブ除外になるため必須)。
+-- ===============================================
+
+-- 1) 列追加: 完走への逆引きと、タップ先解決用の view mode スナップショット
+ALTER TABLE public.generated_images
+  ADD COLUMN IF NOT EXISTS completion_id UUID NULL
+    REFERENCES public.collection_completions(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS completion_view_mode TEXT NULL
+    CHECK (completion_view_mode IN ('mount', 'book'));
+
+COMMENT ON COLUMN public.generated_images.completion_id IS '完走投稿の場合の collection_completions.id。NULL は通常の生成画像投稿';
+COMMENT ON COLUMN public.generated_images.completion_view_mode IS '完走投稿のタップ先解決用(mount=台紙 / book=本)。post行に非正規化保存(公開read可・join不要)';
+
+-- 2) 1完走=1post(重複投稿防止)。RPC はこの制約を前提に冪等動作する。
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_generated_images_completion_id
+  ON public.generated_images (completion_id)
+  WHERE completion_id IS NOT NULL;
+
+-- 3) RPC: 完走を post として作成/再活性化(所有権を DB 層で強制・冪等・ボーナス付与)
+--    p_user_id は受け取らず auth.uid() で解決(クライアント body 不可)。
+--    画像列(image_url/storage_path/display/thumb)は呼び出し側 helper が WebP 確保後に渡す。
+--    呼び出しは「セッションクライアント」経由のこと(admin client だと auth.uid() が NULL)。
+CREATE OR REPLACE FUNCTION public.create_collection_completion_post(
+  p_completion_id uuid,
+  p_caption text,
+  p_image_url text,
+  p_storage_path text,
+  p_storage_path_display text,
+  p_storage_path_thumb text
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_uid uuid := auth.uid();
+  v_owner uuid;
+  v_status text;
+  v_view_mode text;
+  v_existing_id uuid;
+  v_existing_posted boolean;
+  v_post_id uuid;
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'auth required';
+  END IF;
+
+  -- 完走の所有者・状態・view mode(カテゴリ由来)を取得
+  SELECT cc.user_id, cc.mount_status, pc.completion_view_mode
+    INTO v_owner, v_status, v_view_mode
+    FROM public.collection_completions cc
+    JOIN public.preset_categories pc ON pc.id = cc.category_id
+    WHERE cc.id = p_completion_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'completion not found';
+  END IF;
+  IF v_owner <> v_uid THEN
+    RAISE EXCEPTION 'forbidden: not completion owner';
+  END IF;
+  IF v_status <> 'completed' THEN
+    RAISE EXCEPTION 'completion not completed';
+  END IF;
+
+  -- 冪等: 同一 completion の既存 post があれば再活性化(取消後の再投稿)or そのまま返す
+  SELECT id, is_posted INTO v_existing_id, v_existing_posted
+    FROM public.generated_images
+    WHERE completion_id = p_completion_id;
+
+  IF FOUND THEN
+    v_post_id := v_existing_id;
+    IF NOT v_existing_posted THEN
+      UPDATE public.generated_images
+        SET is_posted = true,
+            posted_at = now(),
+            moderation_status = 'visible',
+            caption = p_caption,
+            completion_view_mode = v_view_mode
+        WHERE id = v_post_id;
+    END IF;
+  ELSE
+    INSERT INTO public.generated_images (
+      user_id, image_url, storage_path, storage_path_display, storage_path_thumb,
+      prompt, caption, is_posted, posted_at, moderation_status,
+      generation_type, generation_metadata, completion_id, completion_view_mode
+    ) VALUES (
+      v_uid, p_image_url, p_storage_path, p_storage_path_display, p_storage_path_thumb,
+      '', p_caption, true, now(), 'visible',
+      'one_tap_style', NULL, p_completion_id, v_view_mode
+    )
+    RETURNING id INTO v_post_id;
+  END IF;
+
+  -- 日次投稿ボーナス(1日1回 JST・同一 generation_id でべき等)
+  PERFORM public.grant_daily_post_bonus(v_uid, v_post_id);
+
+  RETURN v_post_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.create_collection_completion_post(uuid, text, text, text, text, text) TO authenticated;
+
+COMMENT ON FUNCTION public.create_collection_completion_post(uuid, text, text, text, text, text)
+  IS '完走(collection_completions)を generated_images の1行として投稿/再活性化する。所有権を auth.uid() で強制、completion_id 部分UNIQUEで冪等、日次投稿ボーナスを付与';
+
+-- ===============================================
+-- DOWN(手動):
+--   DROP FUNCTION IF EXISTS public.create_collection_completion_post(uuid, text, text, text, text, text);
+--   DROP INDEX IF EXISTS public.uniq_generated_images_completion_id;
+--   ALTER TABLE public.generated_images
+--     DROP COLUMN IF EXISTS completion_view_mode,
+--     DROP COLUMN IF EXISTS completion_id;
+-- ===============================================

--- a/supabase/migrations/20260629150000_fix_completion_feed_post_rpc.sql
+++ b/supabase/migrations/20260629150000_fix_completion_feed_post_rpc.sql
@@ -1,0 +1,110 @@
+-- ===============================================
+-- 完走フィード投稿 RPC の修正(MRAR コードレビュー反映)
+-- ===============================================
+-- MUST-FIX-001(security): 再投稿(再活性化)時に moderation_status='visible' を無条件
+--   セットしていたため、admin が 'removed' にした投稿をキャンセル→再投稿で復活できた。
+--   → 再活性化 UPDATE から moderation_status の上書きを削除(既存値を維持)。
+--   これにより removed の投稿は再投稿しても removed のまま(管理者判断を尊重)。
+--   既存の postImageServer(通常投稿の再投稿)も moderation_status を触らない方針と一致。
+-- MUST-ADDRESS-003(defect): SELECT→INSERT に競合の穴(同時POSTで unique_violation→500)。
+--   → INSERT を EXCEPTION WHEN unique_violation で保護し、競合時は既存行を取得して
+--     冪等に再活性化する(冪等契約を満たす)。
+-- ===============================================
+
+CREATE OR REPLACE FUNCTION public.create_collection_completion_post(
+  p_completion_id uuid,
+  p_caption text,
+  p_image_url text,
+  p_storage_path text,
+  p_storage_path_display text,
+  p_storage_path_thumb text
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_uid uuid := auth.uid();
+  v_owner uuid;
+  v_status text;
+  v_view_mode text;
+  v_existing_id uuid;
+  v_existing_posted boolean;
+  v_post_id uuid;
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'auth required';
+  END IF;
+
+  SELECT cc.user_id, cc.mount_status, pc.completion_view_mode
+    INTO v_owner, v_status, v_view_mode
+    FROM public.collection_completions cc
+    JOIN public.preset_categories pc ON pc.id = cc.category_id
+    WHERE cc.id = p_completion_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'completion not found';
+  END IF;
+  IF v_owner <> v_uid THEN
+    RAISE EXCEPTION 'forbidden: not completion owner';
+  END IF;
+  IF v_status <> 'completed' THEN
+    RAISE EXCEPTION 'completion not completed';
+  END IF;
+
+  SELECT id, is_posted INTO v_existing_id, v_existing_posted
+    FROM public.generated_images
+    WHERE completion_id = p_completion_id;
+
+  IF FOUND THEN
+    v_post_id := v_existing_id;
+    IF NOT v_existing_posted THEN
+      -- 再活性化: moderation_status は触らない(removed は removed のまま=MUST-FIX-001)
+      UPDATE public.generated_images
+        SET is_posted = true,
+            posted_at = now(),
+            caption = p_caption,
+            completion_view_mode = v_view_mode
+        WHERE id = v_post_id;
+    END IF;
+  ELSE
+    BEGIN
+      INSERT INTO public.generated_images (
+        user_id, image_url, storage_path, storage_path_display, storage_path_thumb,
+        prompt, caption, is_posted, posted_at, moderation_status,
+        generation_type, generation_metadata, completion_id, completion_view_mode
+      ) VALUES (
+        v_uid, p_image_url, p_storage_path, p_storage_path_display, p_storage_path_thumb,
+        '', p_caption, true, now(), 'visible',
+        'one_tap_style', NULL, p_completion_id, v_view_mode
+      )
+      RETURNING id INTO v_post_id;
+    EXCEPTION WHEN unique_violation THEN
+      -- 競合(同時POST): 別リクエストが先に作成済み。既存行を取得して冪等に扱う。
+      SELECT id, is_posted INTO v_existing_id, v_existing_posted
+        FROM public.generated_images
+        WHERE completion_id = p_completion_id;
+      v_post_id := v_existing_id;
+      IF NOT v_existing_posted THEN
+        UPDATE public.generated_images
+          SET is_posted = true,
+              posted_at = now(),
+              caption = p_caption,
+              completion_view_mode = v_view_mode
+          WHERE id = v_post_id;
+      END IF;
+    END;
+  END IF;
+
+  PERFORM public.grant_daily_post_bonus(v_uid, v_post_id);
+
+  RETURN v_post_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.create_collection_completion_post(uuid, text, text, text, text, text) TO authenticated;
+
+-- ===============================================
+-- DOWN(手動): 直前定義(20260629140000)に戻す場合はそのファイルの関数本体を再適用。
+-- ===============================================

--- a/tests/unit/lib/url-utils.test.ts
+++ b/tests/unit/lib/url-utils.test.ts
@@ -6,6 +6,7 @@ jest.mock("@/lib/public-env", () => ({
 
 import { getSiteUrlForClient } from "@/lib/public-env";
 import {
+  getPostCardHref,
   getPostDetailLocalizedPath,
   getPostDetailPath,
   getPostDetailUrl,
@@ -30,6 +31,45 @@ describe("UrlUtils unit tests from EARS specs", () => {
     test("getPostDetailPath_予約文字を含む場合_エンコード済みパスを返す", () => {
       // Spec: URLUTIL-001
       expect(getPostDetailPath("abc/def?x=1")).toBe("/posts/abc%2Fdef%3Fx%3D1");
+    });
+  });
+
+  describe("URLUTIL-101 getPostCardHref(完走フィード投稿のタップ先分岐)", () => {
+    test("通常投稿(completion_idなし)_ロケール付き詳細パスを返す", () => {
+      expect(getPostCardHref({ id: "post-1" }, "ja")).toBe(
+        getPostDetailLocalizedPath("post-1", "ja"),
+      );
+    });
+
+    test("完走投稿(mount)_台紙の没入シェアページへ", () => {
+      expect(
+        getPostCardHref(
+          { id: "post-2", completion_id: "cmp-9", completion_view_mode: "mount" },
+          "ja",
+        ),
+      ).toBe("/m/cmp-9");
+    });
+
+    test("完走投稿(book)_本の没入シェアページへ", () => {
+      expect(
+        getPostCardHref(
+          { id: "post-3", completion_id: "cmp-7", completion_view_mode: "book" },
+          "en",
+        ),
+      ).toBe("/m/cmp-7/book");
+    });
+
+    test("完走投稿は locale に依存せず /m パスを返す", () => {
+      const ja = getPostCardHref(
+        { id: "p", completion_id: "c", completion_view_mode: "mount" },
+        "ja",
+      );
+      const en = getPostCardHref(
+        { id: "p", completion_id: "c", completion_view_mode: "mount" },
+        "en",
+      );
+      expect(ja).toBe("/m/c");
+      expect(en).toBe("/m/c");
     });
   });
 


### PR DESCRIPTION
### 概要
「コレクション完走のホームフィード投稿(オプトイン)」の **Phase 1(DB)** です(計画: `docs/planning/collection-completion-feed-post-implementation-plan.md`、MRAR反映済み)。

### 変更内容
- `generated_images` に列追加:
  - `completion_id UUID NULL → collection_completions(id) ON DELETE SET NULL`(完走への逆引き・バッジ/タップ先/重複判定)
  - `completion_view_mode TEXT NULL CHECK(mount/book)` … タップ先解決用。**post 行(公開read可)に非正規化**(collection_completions は本人のみRLSのため他者フィードでjoinがNULLになる問題を回避)
- `completion_id` の**部分 UNIQUE**(1完走=1post、重複投稿防止)
- RPC `create_collection_completion_post(p_completion_id, p_caption, p_image_url, p_storage_path, p_storage_path_display, p_storage_path_thumb)`:
  - `auth.uid()` で所有権をDB層強制(`p_user_id` を受け取らない)、未完走/非所有は `RAISE EXCEPTION`
  - INSERT は `posted_at=now()` / `generation_type='one_tap_style'` / `generation_metadata=NULL` / `prompt=''`
  - 既存(同 `completion_id`)は再活性化で**冪等**(取消後の再投稿に対応)
  - `grant_daily_post_bonus`(1日1回JST・generation_id冪等)を付与
- `Post` 型に `completion_id` / `completion_view_mode` 追加

### MRAR 指摘の反映
posted_at 必須化 / generation_type=one_tap_style+metadata=NULL / view_mode は公開read可な場所(post行)へ / 冪等な取消・再投稿。

### テスト
- `npm run build -- --webpack` 緑 / `npm run test`(posts 149 pass)
- マイグレーションは追加列・新規RPCのみ(非破壊)。down 手順をコメントに記載。

> 次フェーズ: Phase 2(サーバ: WebP確保helper + 投稿API + getPosts拡張 + /posts/[id]リダイレクト + revalidate)。
