### PR TITLE
fix(admin): 前提付き報酬コレクション(ぷち神)を管理画面に常時表示

### DIFF
--- a/app/(app)/admin/page.tsx
+++ b/app/(app)/admin/page.tsx
@@ -66,8 +66,11 @@ export default async function AdminDashboardPage({
   let collectionSeries: AdminCollectionSeries[] = [];
   if (tab === "collections") {
     const categories = await listPresetCategories({ includeInactive: true });
+    // コレクションシリーズに加え、前提付きの報酬コレクション(例: ぷち神=
+    // unlock_prerequisite_key あり / is_collection_series=false)も admin では常に表示する。
+    // データ(完走・生成)は残るため、開催期間が終わっても KPI を確認できるようにする。
     collectionSeries = categories
-      .filter((c) => c.isCollectionSeries)
+      .filter((c) => c.isCollectionSeries || c.unlockPrerequisiteKey != null)
       .map((c) => ({
         key: c.key,
         displayName: c.displayNameJa,

--- a/app/api/admin/collections/route.ts
+++ b/app/api/admin/collections/route.ts
@@ -45,7 +45,11 @@ export async function GET(request: NextRequest) {
   }
 
   const category = await getPresetCategoryByKey(categoryKey);
-  if (!category || !category.isCollectionSeries) {
+  // コレクションシリーズ or 前提付き報酬コレクション(例: ぷち神)を admin KPI 対象にする。
+  if (
+    !category ||
+    (!category.isCollectionSeries && category.unlockPrerequisiteKey == null)
+  ) {
     return NextResponse.json(
       { error: "not a collection series" },
       { status: 404 },


### PR DESCRIPTION
### 概要
管理ダッシュボードのコレクションタブ(`/admin?tab=collections`)で、**ぷち神コレクションが表示されない**問題を修正します。「データを見たいので常に表示してほしい」というご要望に対応。

### 原因(調査結果)
- コレクションタブの一覧は **`is_collection_series === true`** のみを対象にしていた(`app/(app)/admin/page.tsx`)。KPIルートも `isCollectionSeries` 必須で404(`app/api/admin/collections/route.ts`)。
- **ぷち神(`collectible_wafer_sticker_god_petit_6p`)は `is_collection_series=false`**(unlock_prerequisite_key=神コレ の報酬コレクション)。→ 一覧から除外されていた。
- ※「期間終了で非表示」ではなく(管理画面の一覧に期間フィルタは無い)、**この `is_collection_series` 条件が原因**。データは残存(完走12件・生成93件)。

### 変更内容
- 一覧・KPIルートの対象条件を **`isCollectionSeries || unlockPrerequisiteKey != null`** に緩和(= コレクションシリーズ + 前提付き報酬コレクション)。
- `getCollectionKpi` は category_key/id 集計で `is_collection_series` 非依存のため、ぷち神でも KPI/完走者一覧が表示可能。
- **admin 専用の変更**でユーザー向け挙動(進捗モーダル/図鑑/公開)には影響なし(`is_collection_series` フラグ自体は変更していない)。

### 実機テスト
- [ ] `/admin?tab=collections` でぷち神が一覧に出る
- [ ] ぷち神選択で KPI・完走者一覧・生成ファネルが表示される
- [ ] 神コレ等の既存表示は従来どおり

### テスト方法
- `npm run build -- --webpack`(緑)
