### PR TITLE
fix(my-page): 完走フィード投稿を生成一覧から除外

### DIFF
--- a/features/my-page/lib/server-api.ts
+++ b/features/my-page/lib/server-api.ts
@@ -249,6 +249,12 @@ export const getMyImagesServer = cache(async (
       .select("*")
       .eq("user_id", userId);
 
+    // 完走フィード投稿(completion_id 付き)はツール生成ではないため「生成一覧」には出さない
+    // (ホームフィード/完了台紙アルバム専用)。「投稿(posted)」グリッドには引き続き含める。
+    if (filter !== "posted") {
+      query = query.is("completion_id", null);
+    }
+
     if (filter === "posted") {
       query = query.eq("is_posted", true).order("posted_at", { ascending: false });
     } else if (filter === "unposted") {

--- a/tests/unit/lib/my-page-server-api.test.ts
+++ b/tests/unit/lib/my-page-server-api.test.ts
@@ -44,6 +44,7 @@ type QueryCalls = {
   select: unknown[][];
   eq: unknown[][];
   in: unknown[][];
+  is: unknown[][];
   order: unknown[][];
   range: unknown[][];
   single: number;
@@ -54,6 +55,7 @@ type QueryControl = {
     select: jest.Mock;
     eq: jest.Mock;
     in: jest.Mock;
+    is: jest.Mock;
     order: jest.Mock;
     range: jest.Mock;
     single: jest.Mock;
@@ -79,6 +81,7 @@ function createAsyncQuery(config: QueryConfig = {}): QueryControl {
     select: [],
     eq: [],
     in: [],
+    is: [],
     order: [],
     range: [],
     single: 0,
@@ -95,6 +98,10 @@ function createAsyncQuery(config: QueryConfig = {}): QueryControl {
     }),
     in: jest.fn((...args: unknown[]) => {
       calls.in.push(args);
+      return builder;
+    }),
+    is: jest.fn((...args: unknown[]) => {
+      calls.is.push(args);
       return builder;
     }),
     order: jest.fn((...args: unknown[]) => {


### PR DESCRIPTION
### 概要
完走フィード投稿(オプトイン)を行うと、**マイページの「生成一覧」に完走画像(はじまり/台紙)が出てしまう**副作用を修正します。

### 原因
完走投稿は既存基盤(いいね/コメント/フィード)流用のため `generated_images` の1行として作成される。一方 `getMyImagesServer`(生成一覧)は user_id で全 `generated_images` を返すため、完走投稿も混入していた。

### 変更内容
- `getMyImagesServer`:`filter !== "posted"`(=生成一覧 all/未投稿)のとき **`completion_id IS NULL` のみ**に絞り、完走投稿を除外。
- 「投稿(posted)」フィルタ(投稿タブ/プロフィールの投稿グリッド)・ホームフィード・完了台紙アルバムには**引き続き表示**(影響なし)。

### 実機テスト
- [ ] 完走投稿後、マイページ生成一覧に完走画像が出ない
- [ ] ホームフィード/台紙アルバム/投稿タブには従来どおり表示
- [ ] 通常の生成画像は生成一覧に従来どおり表示

### テスト方法
- `npm run build -- --webpack`(緑) / `npm run test`(my-page 10 pass)
