### PR TITLE
feat(collections): イタリア遊び方ページにコラボ期間(7/3〜7/12)を追加

### DIFF
--- a/features/collections/components/ItalyTravelGuide.tsx
+++ b/features/collections/components/ItalyTravelGuide.tsx
@@ -181,7 +181,50 @@ export function ItalyTravelGuide({
             <FlagRibbon />
           </div>
         </Reveal>
-        <Reveal delay={220}>
+
+        {/* 会期(イタリア切符風) */}
+        <Reveal delay={210}>
+          <div
+            className="mx-auto mt-6 w-full max-w-[330px] rounded-2xl border-2 border-dashed bg-white/75 px-5 py-3 text-center shadow-[0_4px_14px_rgba(120,90,50,0.10)]"
+            style={{ borderColor: IT_GREEN }}
+          >
+            <div
+              className="text-[11px] font-bold tracking-[0.22em]"
+              style={{ color: IT_RED, fontFamily: HEADING_FONT }}
+            >
+              ✦ コラボ期間 ✦
+            </div>
+            <div
+              className="mt-1 flex items-center justify-center gap-2 whitespace-nowrap text-[15px] font-bold leading-snug text-[#5b4a36]"
+              style={{ fontFamily: HEADING_FONT }}
+            >
+              <span>
+                2026/7/3
+                <span className="text-[11px] font-medium text-[#9a8a78]">(金)</span>{" "}
+                19:00
+              </span>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke={IT_GREEN}
+                strokeWidth="2.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden
+                className="h-4 w-4 shrink-0"
+              >
+                <path d="M5 12h14M13 6l6 6-6 6" />
+              </svg>
+              <span>
+                7/12
+                <span className="text-[11px] font-medium text-[#9a8a78]">(日)</span>{" "}
+                21:59
+              </span>
+            </div>
+          </div>
+        </Reveal>
+
+        <Reveal delay={240}>
           <p className="mt-4 text-sm leading-loose text-[#7a6a58]">
             うちの子と、イタリアをめぐる小さな旅。
             <br />


### PR DESCRIPTION
### 概要
`/collections/italy`(遊び方ページ)のヒーローに**コラボ期間(開催期間)**を追加します。実施日決定に伴う掲載です。

### 変更内容
- ヒーロー(旗リボン直下)にコラボ期間バナーを追加。ページのイタリアテーマに合わせた**切符風デザイン**(緑の破線ボーダー / 赤の「✦ コラボ期間 ✦」ラベル / 紙質背景 / Zen Maru Gothic)。
- 日付: **2026/7/3(金) 19:00 → 7/12(日) 21:59**
- 矢印は SVG 化し flex(items-center)で**縦位置を中央揃え**。

### 実機テスト
- [ ] `/collections/italy` ヒーローにコラボ期間が表示され、デザインが馴染んでいる
- [ ] モバイル/PCで崩れない・矢印が中央

### テスト方法
- `npm run build -- --webpack`(緑・`/collections/italy` 生成)
- ローカルで表示確認済み(スクショ共有済み)

> 補足: 実際の公開ゲート(`preset_categories.collection_display_starts_at/ends_at` + `visibility=public`)は go-live 時に同日付で設定します(別途)。本PRはページ表示のみ。
