### PR TITLE
feat(collections): イタリア遊び方ページにクリエイター相談リンク(控えめ)を追加

### DIFF
--- a/features/collections/components/ItalyTravelGuide.tsx
+++ b/features/collections/components/ItalyTravelGuide.tsx
@@ -431,6 +431,16 @@ export function ItalyTravelGuide({
           </p>
         </Reveal>
       </section>
+
+      {/* ===== クリエイター相談(控えめなフッターリンク) ===== */}
+      <div className="px-6 pb-10 text-center">
+        <Link
+          href="/creators"
+          className="text-xs text-[#b3a794] underline underline-offset-2 transition-colors hover:text-[#8a7c66]"
+        >
+          コラボご希望の方・プロンプト掲載のご相談はこちら ›
+        </Link>
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
### 概要
`/collections/italy`(遊び方ページ)の**最下部に、控えめなクリエイター相談リンク**を追加します。

### 変更内容
- CTA セクションの下に、目立たないフッターリンクを追加:
  - 文言: **「コラボご希望の方・プロンプト掲載のご相談はこちら ›」**
  - 遷移先: **`/creators`**(= https://www.persta.ai/creators と同一ページ。同一サイト内なので内部 Link)
  - スタイル: 小さめ(text-xs)・くすみ色(#b3a794)・下線 → 既存の集める/はじめる導線を邪魔しない控えめさ

### 実機テスト
- [ ] `/collections/italy` 最下部にリンクが控えめに表示される
- [ ] タップで /creators(クリエイター募集ページ)に遷移

### テスト方法
- `npm run build -- --webpack`(緑・`/collections/italy` 生成)
