### PR TITLE
fix(collections): イタリア遊び方ページの文言修正(2箇所)

### DIFF
--- a/features/collections/components/ItalyTravelGuide.tsx
+++ b/features/collections/components/ItalyTravelGuide.tsx
@@ -228,7 +228,7 @@ export function ItalyTravelGuide({
           <p className="mt-4 text-sm leading-loose text-[#7a6a58]">
             うちの子と、イタリアをめぐる小さな旅。
             <br />
-            表紙から1日ずつあつめて、めくれる旅行日記をコンプリート。
+            1日ずつあつめて、めくれる旅行日記を完成させよう。
           </p>
         </Reveal>
 
@@ -427,7 +427,7 @@ export function ItalyTravelGuide({
         </Reveal>
         <Reveal delay={100}>
           <p className="mx-auto mt-6 max-w-sm text-xs leading-relaxed text-[#9a8a78]">
-            ※ あつめる・日記の保存にはログインが必要です（未ログインでも一枚お試し生成できます）。
+            ※ あつめる・日記の保存にはログインが必要です。
           </p>
         </Reveal>
       </section>


### PR DESCRIPTION
### 概要
`/collections/italy`(遊び方ページ)の文言を2箇所修正します。

### 変更内容
- ヒーロー説明:
  - 旧「表紙から1日ずつあつめて、めくれる旅行日記をコンプリート。」
  - 新「**1日ずつあつめて、めくれる旅行日記を完成させよう。**」
- CTA下の注記:
  - 旧「※ あつめる・日記の保存にはログインが必要です（未ログインでも一枚お試し生成できます）。」
  - 新「**※ あつめる・日記の保存にはログインが必要です。**」

### テスト方法
- `npm run build -- --webpack`(緑・`/collections/italy` 生成)
