### PR TITLE
feat(collections): 段階解放モーダルのボタンを「OK」単体に変更

### DIFF
--- a/features/collections/components/UnlockModals.tsx
+++ b/features/collections/components/UnlockModals.tsx
@@ -227,7 +227,15 @@ export function UnlockDripModal({
           </div>
         )}
 
-        <UnlockModalActions onClose={onClose} />
+        <div className="mt-6">
+          <button
+            type="button"
+            onClick={onClose}
+            className="w-full rounded-full bg-[var(--ann-accent)] px-4 py-2.5 text-sm font-bold text-white transition hover:bg-[var(--ann-accent-hover)]"
+          >
+            OK
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/tests/unit/features/collections/unlock-modals.test.tsx
+++ b/tests/unit/features/collections/unlock-modals.test.tsx
@@ -171,4 +171,20 @@ describe("UnlockDripModal", () => {
     fireEvent.click(screen.getByLabelText("閉じる"));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  test("OK ボタンで onClose が呼ばれ、A の「つくりに行く/あとで」は持たない", () => {
+    const onClose = jest.fn();
+    render(
+      <UnlockDripModal
+        title="ぷち神"
+        newlyUnlocked={newlyUnlocked}
+        onClose={onClose}
+      />,
+    );
+    // B(段階解放)は単一の OK ボタンのみ。A の「つくりに行く/あとで」は出さない。
+    expect(screen.queryByText("つくりに行く")).not.toBeInTheDocument();
+    expect(screen.queryByText("あとで")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "OK" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
### 概要
コレクションの段階解放モーダル(B / `UnlockDripModal`)は、生成後に「つくりに行く」「あとで」の2ボタンを表示していた。段階解放の演出では追加導線が不要との判断で、閉じるだけの「OK」ボタン単体に簡素化する。

### 変更内容
- `UnlockDripModal`(B) の下部アクションを **「OK」ボタン単体**（紫塗り・幅いっぱい・押すと閉じるだけ）に変更
  - 「つくりに行く」(`/style` への遷移リンク)を削除
  - 「あとで」→「OK」に変更(アクションは `onClose` のみ)
- 初回解放モーダル(A / `InitialUnlockModal`)は**据え置き**。共用していた `UnlockModalActions`（つくりに行く/あとで）は A 用にそのまま残置
- 反映先: `UnlockDripModal` を使う `CollectionUnlockDripListener`(travel_to_italy 等の段階解放) と `PetitUnlockAnnouncer`(ぷち神ホームの段階解放) の両方
- テスト追加: B が「OK」で閉じ、「つくりに行く/あとで」を持たないことを検証

### 実機テスト
- [ ] iOS Safari で主要導線を確認
- [ ] Android Chrome で主要導線を確認
- [ ] PC（Chrome）で主要導線を確認
- [ ] レスポンシブ表示崩れがないことを確認
- [ ] 段階解放モーダル(B)で「OK」ボタンのみ表示され、押すと閉じることを確認
- [ ] 初回解放モーダル(A)は従来どおり「つくりに行く / あとで」が表示されることを確認

### テスト方法
- `npm run test -- tests/unit/features/collections/unlock-modals.test.tsx` → 8/8 pass（B の新仕様テスト含む）
- `npm run lint` → 変更ファイルは指摘なし
- `npm run typecheck` → プロダクトコード(`UnlockModals.tsx`)エラーなし（テストの型指摘は既存の jest-dom 型問題）
- `npm run build -- --webpack` → 成功（exit 0）
