### PR TITLE
perf(collections): 段階解放モーダルの表示待ちを先読みで短縮

### DIFF
--- a/features/collections/components/CollectionUnlockDripListener.tsx
+++ b/features/collections/components/CollectionUnlockDripListener.tsx
@@ -12,6 +12,7 @@ import {
   writeUnlockSeen,
 } from "@/features/collections/lib/collection-unlock-seen";
 import { setUnlockAnnouncerActive } from "@/features/collections/lib/unlock-announcer-signal";
+import { getUnlockAnnouncements } from "@/features/collections/lib/unlock-announcements-prefetch";
 import { COLLECTION_PROGRESS_DISMISSED_EVENT } from "@/features/collections/hooks/useCollectionProgress";
 
 interface ActiveDrip {
@@ -51,13 +52,10 @@ export function CollectionUnlockDripListener() {
 
       fetchingRef.current = true;
       try {
-        const res = await fetch("/api/collections/unlock-announcements", {
-          cache: "no-store",
-        });
-        if (!res.ok || cancelled) return;
-        const data = (await res.json()) as {
-          announcements?: CollectionUnlockAnnouncement[];
-        };
+        // 進捗モーダル表示中に先読み済みならそれを再利用し(体感待ちほぼゼロ)、
+        // 無ければここでフォールバック取得する(従来と同じ待ち時間)。
+        const data = await getUnlockAnnouncements();
+        if (cancelled) return;
         const announcement = (data.announcements ?? []).find(
           (a) => a.categoryKey === categoryKey,
         );

--- a/features/collections/hooks/useCollectionProgress.ts
+++ b/features/collections/hooks/useCollectionProgress.ts
@@ -8,6 +8,7 @@ import {
   getCollectionAck as getAck,
   setCollectionAck as setAck,
 } from "@/features/collections/lib/collection-ack";
+import { prefetchUnlockAnnouncements } from "@/features/collections/lib/unlock-announcements-prefetch";
 
 const POLL_INTERVAL_MS = 10000;
 /** style 画面などからの即時再チェック用イベント */
@@ -251,6 +252,16 @@ export function useCollectionProgress() {
       if (await evaluate()) return;
     }
   }, [evaluate]);
+
+  // celebration(進捗モーダル)表示中に、閉じた後で出す段階解放モーダル(B)用の
+  // お知らせをバックグラウンド先読みしておく。dismiss を待たずに開始することで、
+  // ユーザーが進捗モーダルを見ている間にネットワーク待ちを終わらせ、
+  // 閉じた瞬間の体感待ちをほぼゼロにする(実データは dismiss 側で消費)。
+  useEffect(() => {
+    if (celebration) {
+      prefetchUnlockAnnouncements();
+    }
+  }, [celebration]);
 
   const dismiss = useCallback(() => {
     // 閉じたカテゴリ key を控えてからモーダルを閉じ、段階解放モーダル(B)の判定用に通知する。

--- a/features/collections/lib/unlock-announcements-prefetch.ts
+++ b/features/collections/lib/unlock-announcements-prefetch.ts
@@ -1,0 +1,80 @@
+import type { CollectionUnlockAnnouncement } from "@/features/collections/lib/collection-unlock-announcement";
+
+/**
+ * `/api/collections/unlock-announcements` の先読みキャッシュ。
+ *
+ * 段階解放モーダル(B)は、進捗モーダルを閉じた直後(`COLLECTION_PROGRESS_DISMISSED_EVENT`)に
+ * このエンドポイントを叩いてから表示するため、閉じてから数秒の体感待ちが発生していた。
+ * 進捗モーダルの celebration が立った時点(ユーザーがまだモーダルを見ている間)で
+ * バックグラウンド取得を始めておき、閉じた瞬間はその結果を再利用することで待ちを隠す。
+ *
+ * `useCollectionProgress`(celebration 表示時に prefetch を起動)と
+ * `CollectionUnlockDripListener`(dismiss 時に消費)の橋渡し役。
+ */
+
+interface UnlockAnnouncementsResponse {
+  announcements?: CollectionUnlockAnnouncement[];
+}
+
+interface PendingEntry {
+  promise: Promise<UnlockAnnouncementsResponse>;
+  startedAt: number;
+}
+
+// 先読み結果の使い回しを許容する最大経過時間。長時間放置された進捗モーダルの
+// 解放状況が古いまま使われないよう、実用上十分短い値にする。
+const MAX_REUSE_MS = 30_000;
+
+let pending: PendingEntry | null = null;
+
+function isFresh(entry: PendingEntry): boolean {
+  return Date.now() - entry.startedAt < MAX_REUSE_MS;
+}
+
+function fetchAnnouncements(): Promise<UnlockAnnouncementsResponse> {
+  return fetch("/api/collections/unlock-announcements", {
+    cache: "no-store",
+  }).then((res) => {
+    if (!res.ok) throw new Error(`unlock-announcements fetch failed: ${res.status}`);
+    return res.json() as Promise<UnlockAnnouncementsResponse>;
+  });
+}
+
+/**
+ * 進捗モーダル表示中にバックグラウンドで解放お知らせを先読みする(結果は呼び捨てでよい)。
+ * 直近の先読みがまだ新しければ二重取得しない。
+ */
+export function prefetchUnlockAnnouncements(): void {
+  if (pending && isFresh(pending)) return;
+  const promise = fetchAnnouncements();
+  const entry: PendingEntry = { promise, startedAt: Date.now() };
+  pending = entry;
+  promise.catch(() => {
+    // 先読み失敗はここでは無視する。消費側の getUnlockAnnouncements が
+    // (使い回し不可と判断して)自前で再取得する。
+    if (pending === entry) pending = null;
+  });
+}
+
+/**
+ * 段階解放モーダル判定用に解放お知らせを取得する。
+ * 直近の prefetch が有効ならそれを再利用し(先読み済みなら体感待ちほぼゼロ)、
+ * 無ければその場で取得する(フォールバック、prefetch 前と同じ待ち時間)。
+ */
+export function getUnlockAnnouncements(): Promise<UnlockAnnouncementsResponse> {
+  if (pending && isFresh(pending)) {
+    const entry = pending;
+    // 一度使ったら消費済みにする(次の celebration で改めて先読みさせる)。
+    pending = null;
+    return entry.promise;
+  }
+  return fetchAnnouncements();
+}
+
+/**
+ * テスト専用: module スコープの先読みキャッシュをクリアする。
+ * 本番コードから呼ばないこと(テストファイル間の状態リークを防ぐためだけに存在する)。
+ */
+export function resetUnlockAnnouncementsPrefetchForTests(): void {
+  pending = null;
+}

--- a/tests/unit/features/collections/collection-unlock-drip-listener.test.tsx
+++ b/tests/unit/features/collections/collection-unlock-drip-listener.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * CollectionUnlockDripListener の回帰テスト。
+ *
+ * - 進捗モーダル表示中に先読み済み(prefetchUnlockAnnouncements)なら、
+ *   dismiss イベント後の表示で追加 fetch を行わない(体感待ち短縮の要)。
+ * - 先読みが無ければ、従来どおり dismiss イベントを受けてから fetch する(フォールバック)。
+ * - いずれの経路でも、段階解放(drip)の判定結果(newlyUnlocked)は同じになる。
+ */
+
+import { act, render, screen, waitFor } from "@testing-library/react";
+import type { CollectionUnlockAnnouncement } from "@/features/collections/lib/collection-unlock-announcement";
+import {
+  prefetchUnlockAnnouncements,
+  resetUnlockAnnouncementsPrefetchForTests,
+} from "@/features/collections/lib/unlock-announcements-prefetch";
+import { COLLECTION_PROGRESS_DISMISSED_EVENT } from "@/features/collections/hooks/useCollectionProgress";
+
+const dripSpy = jest.fn();
+
+jest.mock("@/features/collections/components/UnlockModals", () => ({
+  UnlockDripModal: (props: unknown) => {
+    dripSpy(props);
+    return <div data-testid="drip-modal" />;
+  },
+}));
+
+import { CollectionUnlockDripListener } from "@/features/collections/components/CollectionUnlockDripListener";
+
+const CATEGORY_KEY = "travel_to_italy";
+
+function makeAnnouncement(
+  overrides: Partial<CollectionUnlockAnnouncement> = {},
+): CollectionUnlockAnnouncement {
+  return {
+    categoryKey: CATEGORY_KEY,
+    categoryDisplayName: "うちの子のイタリア旅行",
+    unlockedCount: 2,
+    totalCount: 9,
+    unlockedPresets: [
+      { id: "p0", title: "はじまり", thumbnailUrl: "https://x/p0.png" },
+      { id: "p1", title: "Day1", thumbnailUrl: "https://x/p1.png" },
+    ],
+    prerequisiteKey: "",
+    prerequisiteAckCount: 0,
+    // sequential: baseline=1(表紙は常時解放) → 初回生成から drip 対象になる。
+    baselineUnlockedCount: 1,
+    unitLabel: "日",
+    heroImagePath: null,
+    initialBody: null,
+    dripBody: null,
+    accentColor: null,
+    accentHoverColor: null,
+    titleColor: null,
+    softColor: null,
+    ...overrides,
+  };
+}
+
+function mockFetchOnce(announcements: CollectionUnlockAnnouncement[]) {
+  return jest.fn().mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    json: async () => ({ announcements }),
+  });
+}
+
+function dispatchDismissed() {
+  act(() => {
+    window.dispatchEvent(
+      new CustomEvent(COLLECTION_PROGRESS_DISMISSED_EVENT, {
+        detail: { categoryKey: CATEGORY_KEY },
+      }),
+    );
+  });
+}
+
+describe("CollectionUnlockDripListener", () => {
+  beforeEach(() => {
+    resetUnlockAnnouncementsPrefetchForTests();
+    dripSpy.mockClear();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("先読み済みなら dismiss 後に追加 fetch せず段階解放モーダルを表示する", async () => {
+    const fetchMock = mockFetchOnce([makeAnnouncement()]);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    // 進捗モーダル表示中に相当する先読み。
+    prefetchUnlockAnnouncements();
+
+    render(<CollectionUnlockDripListener />);
+    dispatchDismissed();
+
+    await waitFor(() => expect(screen.getByTestId("drip-modal")).toBeInTheDocument());
+
+    // 先読みの1回だけで、dismiss 後に追加のfetchは発生しない。
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const props = dripSpy.mock.calls[0][0];
+    expect(props.newlyUnlocked).toEqual([
+      { id: "p1", title: "Day1", thumbnailUrl: "https://x/p1.png" },
+    ]);
+  });
+
+  it("先読みが無ければ dismiss イベントを受けてから fetch する(フォールバック)", async () => {
+    const fetchMock = mockFetchOnce([makeAnnouncement()]);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<CollectionUnlockDripListener />);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    dispatchDismissed();
+
+    await waitFor(() => expect(screen.getByTestId("drip-modal")).toBeInTheDocument());
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("該当カテゴリの解放お知らせが無ければ表示しない", async () => {
+    const fetchMock = mockFetchOnce([
+      makeAnnouncement({ categoryKey: "other-category" }),
+    ]);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<CollectionUnlockDripListener />);
+    dispatchDismissed();
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.queryByTestId("drip-modal")).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/features/collections/unlock-announcements-prefetch.test.ts
+++ b/tests/unit/features/collections/unlock-announcements-prefetch.test.ts
@@ -1,0 +1,118 @@
+/**
+ * `/api/collections/unlock-announcements` 先読みキャッシュの回帰テスト。
+ *
+ * - prefetch 直後の getUnlockAnnouncements は同一 Promise を再利用する(fetch 1回のみ)。
+ * - 一度 get すると消費済みになり、次の get は再フェッチする。
+ * - 先読みが無い/古い(30秒超)場合は getUnlockAnnouncements がその場で fetch する。
+ * - 先読みの fetch が失敗しても getUnlockAnnouncements は自前で再取得できる。
+ *
+ * モジュールはリクエスト横断の先読みキャッシュを module スコープで保持するため、
+ * テスト専用の resetUnlockAnnouncementsPrefetchForTests で各テストの先頭を必ず空にする。
+ */
+import {
+  getUnlockAnnouncements,
+  prefetchUnlockAnnouncements,
+  resetUnlockAnnouncementsPrefetchForTests,
+} from "@/features/collections/lib/unlock-announcements-prefetch";
+
+function mockFetchOnce(body: unknown, ok = true) {
+  return jest.fn().mockResolvedValueOnce({
+    ok,
+    status: ok ? 200 : 500,
+    json: async () => body,
+  });
+}
+
+describe("unlock-announcements-prefetch", () => {
+  beforeEach(() => {
+    resetUnlockAnnouncementsPrefetchForTests();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it("prefetch 済みなら getUnlockAnnouncements は追加 fetch せず同じ結果を返す", async () => {
+    const fetchMock = mockFetchOnce({ announcements: [{ categoryKey: "a" }] });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    prefetchUnlockAnnouncements();
+    const data = await getUnlockAnnouncements();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(data.announcements).toEqual([{ categoryKey: "a" }]);
+  });
+
+  it("get で一度消費すると、次の get は再フェッチする", async () => {
+    const first = mockFetchOnce({ announcements: [{ categoryKey: "a" }] });
+    global.fetch = first as unknown as typeof fetch;
+    prefetchUnlockAnnouncements();
+    await getUnlockAnnouncements();
+
+    const second = mockFetchOnce({ announcements: [{ categoryKey: "b" }] });
+    global.fetch = second as unknown as typeof fetch;
+    const data = await getUnlockAnnouncements();
+
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(data.announcements).toEqual([{ categoryKey: "b" }]);
+  });
+
+  it("prefetch していなければ getUnlockAnnouncements がその場で fetch する(フォールバック)", async () => {
+    const fetchMock = mockFetchOnce({ announcements: [] });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const data = await getUnlockAnnouncements();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(data.announcements).toEqual([]);
+  });
+
+  it("短時間の連続 prefetch 呼び出しは二重フェッチしない", async () => {
+    const fetchMock = mockFetchOnce({ announcements: [] });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    prefetchUnlockAnnouncements();
+    prefetchUnlockAnnouncements();
+    prefetchUnlockAnnouncements();
+    await getUnlockAnnouncements();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("30秒以上経過した先読みは古いとみなし、get はその場で再取得する", async () => {
+    jest.useFakeTimers();
+    const stale = mockFetchOnce({ announcements: [{ categoryKey: "old" }] });
+    global.fetch = stale as unknown as typeof fetch;
+    prefetchUnlockAnnouncements();
+
+    jest.advanceTimersByTime(31_000);
+
+    const fresh = mockFetchOnce({ announcements: [{ categoryKey: "fresh" }] });
+    global.fetch = fresh as unknown as typeof fetch;
+    const data = await getUnlockAnnouncements();
+
+    expect(fresh).toHaveBeenCalledTimes(1);
+    expect(data.announcements).toEqual([{ categoryKey: "fresh" }]);
+  });
+
+  it("先読みの fetch が失敗しても getUnlockAnnouncements は自前で再取得して復帰できる", async () => {
+    const failing = jest.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ announcements: [] }),
+    });
+    global.fetch = failing as unknown as typeof fetch;
+    prefetchUnlockAnnouncements();
+    // prefetch の内部失敗ハンドリング(promise.catch)が走るのを待つ。
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const recovery = mockFetchOnce({ announcements: [{ categoryKey: "ok" }] });
+    global.fetch = recovery as unknown as typeof fetch;
+    const data = await getUnlockAnnouncements();
+
+    expect(recovery).toHaveBeenCalledTimes(1);
+    expect(data.announcements).toEqual([{ categoryKey: "ok" }]);
+  });
+});


### PR DESCRIPTION
### 概要
travel_to_italy 等の段階解放モーダル(B)は、進捗モーダルを閉じてから `/api/collections/unlock-announcements` を取得していたため、表示まで体感2秒ほど待ちが発生していた。調査の結果、意図的な待機ではなく実際のAPI処理時間(認証チェック+2並列RPC)が原因と判明。進捗モーダル表示中にバックグラウンド先読みしておくことで、この待ちを隠す。

### 変更内容
- `features/collections/lib/unlock-announcements-prefetch.ts` を新規追加(先読みキャッシュ、30秒TTL)
- `useCollectionProgress.ts`: 進捗モーダル(celebration)が立った時点で先読みを起動
- `CollectionUnlockDripListener.tsx`: dismiss後のfetchを先読み結果の再利用に変更(先読みが無ければ従来どおりその場で取得するフォールバックを維持)
- テスト追加: 先読みキャッシュの単体テスト6件、DripListenerの結合テスト3件(新規ファイル、従来カバレッジ0件だった)

### 実機テスト
- [ ] iOS Safari で主要導線を確認
- [ ] Android Chrome で主要導線を確認
- [ ] PC（Chrome）で主要導線を確認
- [ ] travel_to_italy(admin_only)で1枚生成→進捗モーダルを閉じた直後に段階解放モーダル(B)が即表示されることを確認
- [ ] 進捗モーダルを表示後すぐ閉じた場合(先読みが間に合わない極端なケース)でも解放モーダルが正しく表示されることを確認

### テスト方法
- `npm run test -- tests/unit/features/collections/` → 314/314 pass(新規9件含む)
- `npm run lint` → 変更ファイルは指摘なし
- `npm run typecheck` → プロダクトコードエラーなし(新規テストの型指摘は既存の jest-dom 型問題)
- `npm run build -- --webpack` → 成功（exit 0）
