### PR TITLE
fix(style-presets): /styleのプリセット一覧が表示期間を無視する不具合を修正

### DIFF
--- a/features/style-presets/lib/schema.ts
+++ b/features/style-presets/lib/schema.ts
@@ -62,6 +62,9 @@ export interface StylePresetCategoryRef {
   userPromptMaxLength: number | null;
   visibility: StylePresetCategoryVisibility;
   isActive: boolean;
+  /** コレクション表示期間(NULL=無期限)。/style のプリセット一覧公開判定にも使う。 */
+  collectionDisplayStartsAt: string | null;
+  collectionDisplayEndsAt: string | null;
   /**
    * 提供者(クリエイター)の profiles.id。コラボ/提供スタイルのクレジット表示に使う。
    * 未設定(従来カテゴリ)なら null/undefined。リポジトリ層では常に値を埋める optional 属性。

--- a/features/style-presets/lib/style-preset-repository.ts
+++ b/features/style-presets/lib/style-preset-repository.ts
@@ -1,5 +1,6 @@
 import { createAdminClient } from "@/lib/supabase/admin";
 import { normalizeStyleOutputAspectRatioMode } from "@/shared/generation/style-output-aspect-ratio";
+import { isCollectionDisplayPeriodActive } from "@/features/collections/lib/collection-display-period";
 import {
   buildStylePresetSlug,
   normalizeStylePresetOptionalPrompt,
@@ -51,6 +52,8 @@ interface StylePresetCategoryRow {
   user_prompt_max_length?: number | null;
   visibility?: StylePresetCategoryVisibility | string | null;
   is_active: boolean;
+  collection_display_starts_at?: string | null;
+  collection_display_ends_at?: string | null;
   unlock_prerequisite_key?: string | null;
   progressive_batch_size?: number | null;
   sequential_unlock?: boolean | null;
@@ -102,7 +105,7 @@ interface StylePresetRow {
 }
 
 const STYLE_PRESET_WITH_CATEGORY_SELECT =
-  "*, provider:profiles!style_presets_provider_user_id_fkey(id, nickname, avatar_url), category:preset_categories!style_presets_category_id_fkey(id, key, display_name_ja, display_name_en, badge_color, badge_text_color, skip_base_prefix, output_aspect_ratio_mode, user_guidance_ja, user_guidance_en, show_source_image_type_control, show_background_change_control, show_generation_model_control, show_user_prompt_input, user_prompt_label, user_prompt_placeholder, user_prompt_max_length, visibility, is_active, provider_user_id, provider:profiles!preset_categories_provider_user_id_fkey(id, nickname, avatar_url), unlock_prerequisite_key, progressive_batch_size, sequential_unlock, unlock_announcement_hero_path, unlock_announcement_initial_body, unlock_announcement_drip_body, unlock_announcement_accent_color, unlock_announcement_accent_hover_color, unlock_announcement_title_color, unlock_announcement_soft_color)";
+  "*, provider:profiles!style_presets_provider_user_id_fkey(id, nickname, avatar_url), category:preset_categories!style_presets_category_id_fkey(id, key, display_name_ja, display_name_en, badge_color, badge_text_color, skip_base_prefix, output_aspect_ratio_mode, user_guidance_ja, user_guidance_en, show_source_image_type_control, show_background_change_control, show_generation_model_control, show_user_prompt_input, user_prompt_label, user_prompt_placeholder, user_prompt_max_length, visibility, is_active, collection_display_starts_at, collection_display_ends_at, provider_user_id, provider:profiles!preset_categories_provider_user_id_fkey(id, nickname, avatar_url), unlock_prerequisite_key, progressive_batch_size, sequential_unlock, unlock_announcement_hero_path, unlock_announcement_initial_body, unlock_announcement_drip_body, unlock_announcement_accent_color, unlock_announcement_accent_hover_color, unlock_announcement_title_color, unlock_announcement_soft_color)";
 
 function getSupabase(client?: SupabaseClient): SupabaseClient {
   return client ?? createAdminClient();
@@ -118,7 +121,15 @@ function canAccessCategory(
   category: StylePresetCategoryRef,
   options: PublishedStylePresetAccessOptions = {},
 ): boolean {
-  return options.includeAdminOnly === true || category.visibility === "public";
+  if (options.includeAdminOnly === true) return true;
+  if (category.visibility !== "public") return false;
+  // コレクション表示期間(collection_display_starts_at/ends_at)は進捗モーダル等と同様、
+  // /style のプリセット一覧でも尊重する。visibility=public でも期間外なら非表示にする
+  // (visibility 切り替えのタイミングに関わらず、期間外の公開事故を防ぐ)。
+  return isCollectionDisplayPeriodActive({
+    collectionDisplayStartsAt: category.collectionDisplayStartsAt,
+    collectionDisplayEndsAt: category.collectionDisplayEndsAt,
+  });
 }
 
 function mapRpcRow(data: unknown): StylePresetRow | null {
@@ -176,6 +187,8 @@ function mapCategoryRefStrict(
       userPromptMaxLength: null,
       visibility: "public",
       isActive: true,
+      collectionDisplayStartsAt: null,
+      collectionDisplayEndsAt: null,
       providerUserId: null,
       providerNickname: null,
       providerAvatarUrl: null,
@@ -214,6 +227,8 @@ function mapCategoryRefStrict(
     userPromptMaxLength: embedded.user_prompt_max_length ?? null,
     visibility: normalizeCategoryVisibility(embedded.visibility),
     isActive: embedded.is_active,
+    collectionDisplayStartsAt: embedded.collection_display_starts_at ?? null,
+    collectionDisplayEndsAt: embedded.collection_display_ends_at ?? null,
     providerUserId: embedded.provider_user_id ?? null,
     providerNickname: provider?.nickname ?? null,
     providerAvatarUrl: provider?.avatar_url ?? null,

--- a/tests/unit/features/collections/collection-unlock-announcement.test.ts
+++ b/tests/unit/features/collections/collection-unlock-announcement.test.ts
@@ -28,6 +28,8 @@ function makeCategory(
     userPromptMaxLength: null,
     visibility: "public",
     isActive: true,
+    collectionDisplayStartsAt: null,
+    collectionDisplayEndsAt: null,
     unlockPrerequisiteKey: null,
     progressiveBatchSize: null,
     sequentialUnlock: false,

--- a/tests/unit/features/collections/collection-unlock-gating.test.ts
+++ b/tests/unit/features/collections/collection-unlock-gating.test.ts
@@ -25,6 +25,8 @@ function makeCategory(
     userPromptMaxLength: null,
     visibility: "public",
     isActive: true,
+    collectionDisplayStartsAt: null,
+    collectionDisplayEndsAt: null,
     unlockPrerequisiteKey: null,
     progressiveBatchSize: null,
     sequentialUnlock: false,

--- a/tests/unit/features/collections/collection-unlock-server.test.ts
+++ b/tests/unit/features/collections/collection-unlock-server.test.ts
@@ -60,6 +60,8 @@ function categoryRef(
     userPromptMaxLength: null,
     visibility: "public",
     isActive: true,
+    collectionDisplayStartsAt: null,
+    collectionDisplayEndsAt: null,
     unlockPrerequisiteKey,
     progressiveBatchSize,
     sequentialUnlock,

--- a/tests/unit/features/style/style-page-client.test.tsx
+++ b/tests/unit/features/style/style-page-client.test.tsx
@@ -408,6 +408,8 @@ const TEST_COORDINATE_CATEGORY = {
   userPromptMaxLength: null,
   visibility: "public",
   isActive: true,
+  collectionDisplayStartsAt: null,
+  collectionDisplayEndsAt: null,
 } as const;
 
 const presets: readonly StylePresetPublicSummary[] = [

--- a/tests/unit/lib/get-public-style-presets.test.ts
+++ b/tests/unit/lib/get-public-style-presets.test.ts
@@ -53,6 +53,8 @@ describe("get-public-style-presets", () => {
     showUserPromptInput: false,
     visibility: "public",
     isActive: true,
+    collectionDisplayStartsAt: null,
+    collectionDisplayEndsAt: null,
   } as const;
 
   test("getPublishedStylePresets_キャッシュタグを付けて公開一覧を返す", async () => {

--- a/tests/unit/lib/style-preset-repository.test.ts
+++ b/tests/unit/lib/style-preset-repository.test.ts
@@ -205,6 +205,8 @@ describe("style-preset repository", () => {
           userPromptMaxLength: null,
           visibility: "public",
           isActive: true,
+          collectionDisplayStartsAt: null,
+          collectionDisplayEndsAt: null,
           providerUserId: null,
           providerNickname: null,
           providerAvatarUrl: null,


### PR DESCRIPTION
### 概要
travel_to_italy を admin_only → 全ユーザー公開に切り替えた際、表示開始日時(19:00)より前に「旅のはじまり」プリセットが未ログインユーザーにも公開されてしまう事故が発生した。原因調査の結果、`/style` のプリセット一覧が `visibility` のみで公開判定しており、`collection_display_starts_at/ends_at`(表示期間)を一切見ていないことが判明した(コレクション進捗モーダル・図鑑側は元々尊重していたため、判定基準が2系統に分かれていた)。

### 変更内容
- `features/style-presets/lib/schema.ts`: `StylePresetCategoryRef` に `collectionDisplayStartsAt`/`collectionDisplayEndsAt` を追加
- `features/style-presets/lib/style-preset-repository.ts`: `/style` の唯一の公開判定関数 `canAccessCategory()` に、コレクション進捗UIと同じ `isCollectionDisplayPeriodActive()` チェックを追加
  - `visibility: public` でも表示期間外なら非表示(今回の事故を再発防止)
  - admin プレビュー(`includeAdminOnly`)は従来どおり期間を無視して常に閲覧可能
  - 表示期間が未設定(NULL)の通常カテゴリは従来どおり無条件で公開(既存カテゴリの挙動は変えない)
- 既存テストフィクスチャ5ファイルを新フィールドに追従(型エラー解消のみ、ロジック変更なし)

### 実機テスト
- [ ] iOS Safari で主要導線を確認
- [ ] Android Chrome で主要導線を確認
- [ ] PC（Chrome）で主要導線を確認
- [ ] **travel_to_italy を admin_only→public に切り替え、collection_display_starts_at が未来のままの状態で、未ログイン/シークレットウィンドウで /style を開き、プリセットが表示されないことを確認**
- [ ] 表示開始日時を過ぎたカテゴリは通常どおり表示されることを確認
- [ ] admin アカウントでは表示期間に関わらず常に閲覧できることを確認(プレビュー用途)
- [ ] 表示期間が未設定の既存カテゴリ(神コレクション等)が従来どおり表示されることを確認(回帰なし)

### テスト方法
- `npm run test -- tests/unit/features/collections/collection-unlock-announcement.test.ts tests/unit/features/collections/collection-unlock-gating.test.ts tests/unit/features/collections/collection-unlock-server.test.ts tests/unit/lib/get-public-style-presets.test.ts tests/unit/features/style/style-page-client.test.tsx` → 5 suites / 88 tests pass
- `npm run lint` → 変更ファイルは指摘なし
- `npm run typecheck` → この変更由来のエラー0件(既存の他ファイルの型エラーは無関係の既存事象)
- `npm run build -- --webpack` → 成功（exit 0）
- 新しいガード分岐(表示期間チェック)自体への専用ユニットテストは未追加。上記の実機テスト項目で必ず確認すること
