### PR TITLE
fix(generation): OpenAI請求上限エラーの生英語メッセージを案内文に変換

### DIFF
--- a/features/generation/lib/normalize-generation-error.ts
+++ b/features/generation/lib/normalize-generation-error.ts
@@ -55,6 +55,13 @@ export function normalizeUserFacingGenerationError(
     return copy.genericGenerationFailed;
   }
 
+  // OpenAI 組織の請求上限到達(2026-07-04 の障害で確認)。内部事情(請求)を出さず
+  // 「混雑」として案内する。"Billing hard limit has been reached." 等、
+  // OpenAI がタグ無しの生メッセージで返すため個別にパターンマッチする。
+  if (/billing.*hard limit|hard limit.*reached/i.test(errorMessage)) {
+    return copy.providerBusy;
+  }
+
   // OpenAI 側の非リトライ系エラー（組織未検証 / API key 不正 / 残高不足 /
   // 401・403 / GIF 拒否 / OPENAI_API_KEY 未設定）は upstream の生メッセージを
   // 表に出さず汎用文言に差し替える。詳細は Edge Function ログ参照。

--- a/features/generation/lib/route-copy.ts
+++ b/features/generation/lib/route-copy.ts
@@ -28,6 +28,7 @@ export const generationRouteCopy = {
       "安全性ポリシーにより生成できませんでした。\n内容を変更して再試行してください。",
     genericGenerationFailed:
       "画像生成に失敗しました。しばらくしてから、もう一度お試しください。",
+    providerBusy: "現在混み合っています。しばらく経ってからお試しください。",
     modelTemporarilyUnavailable:
       "選択した生成モデルは現在ご利用いただけません。別のモデルを選択してください。",
     webpMissingParams: "imageUrl, imageId, storagePath が必要です",
@@ -76,6 +77,8 @@ export const generationRouteCopy = {
       "The request was blocked by the safety policy.\nPlease revise the content and try again.",
     genericGenerationFailed:
       "Image generation failed. Please try again in a little while.",
+    providerBusy:
+      "We're currently experiencing high demand. Please try again in a little while.",
     modelTemporarilyUnavailable:
       "The selected generation model is currently unavailable. Please choose another model.",
     webpMissingParams: "imageUrl, imageId, and storagePath are required.",
@@ -124,6 +127,8 @@ export const generationRouteCopy = {
       "The request was blocked by the safety policy.\nPlease revise the content and try again.",
     genericGenerationFailed:
       "Image generation failed. Please try again in a little while.",
+    providerBusy:
+      "We're currently experiencing high demand. Please try again in a little while.",
     modelTemporarilyUnavailable:
       "The selected generation model is currently unavailable. Please choose another model.",
     webpMissingParams: "imageUrl, imageId, and storagePath are required.",
@@ -172,6 +177,8 @@ export const generationRouteCopy = {
       "The request was blocked by the safety policy.\nPlease revise the content and try again.",
     genericGenerationFailed:
       "Image generation failed. Please try again in a little while.",
+    providerBusy:
+      "We're currently experiencing high demand. Please try again in a little while.",
     modelTemporarilyUnavailable:
       "The selected generation model is currently unavailable. Please choose another model.",
     webpMissingParams: "imageUrl, imageId, and storagePath are required.",
@@ -220,6 +227,8 @@ export const generationRouteCopy = {
       "The request was blocked by the safety policy.\nPlease revise the content and try again.",
     genericGenerationFailed:
       "Image generation failed. Please try again in a little while.",
+    providerBusy:
+      "We're currently experiencing high demand. Please try again in a little while.",
     modelTemporarilyUnavailable:
       "The selected generation model is currently unavailable. Please choose another model.",
     webpMissingParams: "imageUrl, imageId, and storagePath are required.",
@@ -268,6 +277,8 @@ export const generationRouteCopy = {
       "The request was blocked by the safety policy.\nPlease revise the content and try again.",
     genericGenerationFailed:
       "Image generation failed. Please try again in a little while.",
+    providerBusy:
+      "We're currently experiencing high demand. Please try again in a little while.",
     modelTemporarilyUnavailable:
       "The selected generation model is currently unavailable. Please choose another model.",
     webpMissingParams: "imageUrl, imageId, and storagePath are required.",
@@ -316,6 +327,8 @@ export const generationRouteCopy = {
       "The request was blocked by the safety policy.\nPlease revise the content and try again.",
     genericGenerationFailed:
       "Image generation failed. Please try again in a little while.",
+    providerBusy:
+      "We're currently experiencing high demand. Please try again in a little while.",
     modelTemporarilyUnavailable:
       "The selected generation model is currently unavailable. Please choose another model.",
     webpMissingParams: "imageUrl, imageId, and storagePath are required.",
@@ -364,6 +377,8 @@ export const generationRouteCopy = {
       "The request was blocked by the safety policy.\nPlease revise the content and try again.",
     genericGenerationFailed:
       "Image generation failed. Please try again in a little while.",
+    providerBusy:
+      "We're currently experiencing high demand. Please try again in a little while.",
     modelTemporarilyUnavailable:
       "The selected generation model is currently unavailable. Please choose another model.",
     webpMissingParams: "imageUrl, imageId, and storagePath are required.",
@@ -412,6 +427,8 @@ export const generationRouteCopy = {
       "The request was blocked by the safety policy.\nPlease revise the content and try again.",
     genericGenerationFailed:
       "Image generation failed. Please try again in a little while.",
+    providerBusy:
+      "We're currently experiencing high demand. Please try again in a little while.",
     modelTemporarilyUnavailable:
       "The selected generation model is currently unavailable. Please choose another model.",
     webpMissingParams: "imageUrl, imageId, and storagePath are required.",
@@ -460,6 +477,8 @@ export const generationRouteCopy = {
       "The request was blocked by the safety policy.\nPlease revise the content and try again.",
     genericGenerationFailed:
       "Image generation failed. Please try again in a little while.",
+    providerBusy:
+      "We're currently experiencing high demand. Please try again in a little while.",
     modelTemporarilyUnavailable:
       "The selected generation model is currently unavailable. Please choose another model.",
     webpMissingParams: "imageUrl, imageId, and storagePath are required.",
@@ -508,6 +527,8 @@ export const generationRouteCopy = {
       "The request was blocked by the safety policy.\nPlease revise the content and try again.",
     genericGenerationFailed:
       "Image generation failed. Please try again in a little while.",
+    providerBusy:
+      "We're currently experiencing high demand. Please try again in a little while.",
     modelTemporarilyUnavailable:
       "The selected generation model is currently unavailable. Please choose another model.",
     webpMissingParams: "imageUrl, imageId, and storagePath are required.",
@@ -556,6 +577,8 @@ export const generationRouteCopy = {
       "The request was blocked by the safety policy.\nPlease revise the content and try again.",
     genericGenerationFailed:
       "Image generation failed. Please try again in a little while.",
+    providerBusy:
+      "We're currently experiencing high demand. Please try again in a little while.",
     modelTemporarilyUnavailable:
       "The selected generation model is currently unavailable. Please choose another model.",
     webpMissingParams: "imageUrl, imageId, and storagePath are required.",
@@ -604,6 +627,8 @@ export const generationRouteCopy = {
       "The request was blocked by the safety policy.\nPlease revise the content and try again.",
     genericGenerationFailed:
       "Image generation failed. Please try again in a little while.",
+    providerBusy:
+      "We're currently experiencing high demand. Please try again in a little while.",
     modelTemporarilyUnavailable:
       "The selected generation model is currently unavailable. Please choose another model.",
     webpMissingParams: "imageUrl, imageId, and storagePath are required.",
@@ -652,6 +677,8 @@ export const generationRouteCopy = {
       "The request was blocked by the safety policy.\nPlease revise the content and try again.",
     genericGenerationFailed:
       "Image generation failed. Please try again in a little while.",
+    providerBusy:
+      "We're currently experiencing high demand. Please try again in a little while.",
     modelTemporarilyUnavailable:
       "The selected generation model is currently unavailable. Please choose another model.",
     webpMissingParams: "imageUrl, imageId, and storagePath are required.",
@@ -700,6 +727,8 @@ export const generationRouteCopy = {
       "The request was blocked by the safety policy.\nPlease revise the content and try again.",
     genericGenerationFailed:
       "Image generation failed. Please try again in a little while.",
+    providerBusy:
+      "We're currently experiencing high demand. Please try again in a little while.",
     modelTemporarilyUnavailable:
       "The selected generation model is currently unavailable. Please choose another model.",
     webpMissingParams: "imageUrl, imageId, and storagePath are required.",
@@ -746,6 +775,8 @@ export const generationRouteCopy = {
     noImagesGenerated: string;
     safetyBlocked: string;
     genericGenerationFailed: string;
+    /** プロバイダ側の請求上限到達等、内部事情を出さず「混雑」として案内する文言 */
+    providerBusy: string;
     modelTemporarilyUnavailable: string;
     webpMissingParams: string;
     webpFailed: string;

--- a/tests/unit/app/api/generation-status/normalize-error.test.ts
+++ b/tests/unit/app/api/generation-status/normalize-error.test.ts
@@ -123,6 +123,26 @@ describe("normalizeUserFacingGenerationError", () => {
     ).toBe(copy.modelTemporarilyUnavailable);
   });
 
+  it("maps OpenAI billing hard limit messages to copy.providerBusy", () => {
+    expect(
+      normalizeUserFacingGenerationError(
+        "failed",
+        "Billing hard limit has been reached.",
+        copy,
+      ),
+    ).toBe(copy.providerBusy);
+  });
+
+  it("maps billing hard limit messages case-insensitively", () => {
+    expect(
+      normalizeUserFacingGenerationError(
+        "failed",
+        "billing HARD LIMIT reached for this organization",
+        copy,
+      ),
+    ).toBe(copy.providerBusy);
+  });
+
   it("passes through unknown failed messages unchanged", () => {
     const message = "Something completely unexpected happened";
     expect(


### PR DESCRIPTION
### 概要
2026-07-04、OpenAI組織の請求上限(hard limit)到達により画像生成が全面停止する障害が発生した(上限額引き上げで復旧済み)。調査の過程で、"Billing hard limit has been reached." という生の英語エラーメッセージがそのまま /style 画面のユーザーに表示されていたことが判明した。内部の請求事情を露出せず、分かりやすい案内文に差し替える。

### 変更内容
- `features/generation/lib/route-copy.ts`: 全15ロケールに `providerBusy` を追加
  - ja: 「現在混み合っています。しばらく経ってからお試しください。」
  - en含む14ロケール: "We're currently experiencing high demand. Please try again in a little while."
- `features/generation/lib/normalize-generation-error.ts`: `normalizeUserFacingGenerationError()` に `/billing.*hard limit|hard limit.*reached/i` のパターンマッチを追加し、`copy.providerBusy` を返すようにした(既存の safety_policy_blocked / openai_provider_error 等の分類より前段でチェック)
- テスト追加(実際のOpenAI文言 + 大文字小文字違いパターンの2件)

### 実機テスト
- [ ] iOS Safari で主要導線を確認
- [ ] Android Chrome で主要導線を確認
- [ ] PC（Chrome）で主要導線を確認
- [ ] (可能であれば)OpenAI側で再現困難なため、実機テストはロジックのユニットテストで代替。将来同種の障害が起きた際に日本語/英語の案内文が出ることを確認

### テスト方法
- `npm run test -- tests/unit/app/api/generation-status/normalize-error.test.ts` → 15/15 pass(新規2件含む)
- `npm run lint` → 変更ファイルは指摘なし
- `npm run typecheck` → クリーン
- `npm run build -- --webpack` → 成功（exit 0）
