### PR TITLE
feat(posts): 公開閲覧数をviewableインプレッションへ変更(全フェーズ集約)

### DIFF
--- a/app/api/posts/[id]/view/route.ts
+++ b/app/api/posts/[id]/view/route.ts
@@ -2,13 +2,21 @@ import { NextRequest, NextResponse } from "next/server";
 import { incrementViewCount } from "@/features/posts/lib/server-api";
 import { getPost } from "@/features/posts/lib/server-api";
 import { getUser } from "@/lib/auth";
-import { isFullAdmin } from "@/lib/env";
+import { isFullAdmin, isPostImpressionsEnabled } from "@/lib/env";
+import { isCrawler } from "@/lib/utils";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getPopupBannerClientIpHash } from "@/features/popup-banners/lib/popup-banner-client-ip";
 import { getRouteLocale } from "@/lib/api/route-locale";
 import { postsRouteCopy } from "@/features/posts/lib/route-copy";
 
 /**
  * 閲覧数をインクリメントするAPI
  * CachedPostDetailでサーバーキャッシュを使用するため、クライアントから呼び出して閲覧数をカウント
+ *
+ * フラグON時は、詳細到達も viewable インプレッションとして計上する
+ * (docs/planning/post-impressions-implementation-plan.md の v1.1 拡張)。
+ * フィード計測と同じ record_post_impressions RPC / dedup を共有するため、
+ * 「フィードでも詳細でも、同一投稿×同一視聴者×同一日は1回」となり二重カウントしない。
  */
 export async function POST(
   _request: NextRequest,
@@ -45,6 +53,34 @@ export async function POST(
     }
 
     await incrementViewCount(id);
+
+    // 詳細到達のインプレッション計上(view_count の成否・応答には影響させない)。
+    // クローラ/IP不明ゲストは記録しない(EARS-04)。viewer_key はサーバ側で解決(偽装不可)。
+    if (
+      isPostImpressionsEnabled() &&
+      !isCrawler(_request.headers.get("user-agent"))
+    ) {
+      const ipHash = user ? null : getPopupBannerClientIpHash(_request);
+      const viewerKey = user ? `u:${user.id}` : ipHash ? `g:${ipHash}` : null;
+      if (viewerKey) {
+        try {
+          const supabase = createAdminClient();
+          const { error } = await supabase.rpc("record_post_impressions", {
+            p_image_ids: [id],
+            p_viewer_key: viewerKey,
+          });
+          if (error) {
+            console.error("[posts view] impression record failed:", error);
+          }
+        } catch (impressionError) {
+          console.error(
+            "[posts view] impression record failed:",
+            impressionError
+          );
+        }
+      }
+    }
+
     return NextResponse.json({ success: true, counted: true });
   } catch (error) {
     console.error("View count API error:", error);

--- a/app/api/posts/impressions/batch/route.ts
+++ b/app/api/posts/impressions/batch/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getUser } from "@/lib/auth";
+import { isFullAdmin, isPostImpressionsEnabled } from "@/lib/env";
+import { isCrawler } from "@/lib/utils";
+import { getPopupBannerClientIpHash } from "@/features/popup-banners/lib/popup-banner-client-ip";
+
+/**
+ * 投稿インプレッションのバッチ記録API
+ * (計画書: docs/planning/post-impressions-implementation-plan.md)
+ *
+ * フィードで viewable(可視50%×1秒)になったカードの image_id を、クライアントが
+ * デバウンス/離脱時 sendBeacon でまとめて送ってくる。ここで viewer_key をサーバ側で
+ * 解決し(body からは受け取らない=偽装不可)、RPC `record_post_impressions` に委譲する。
+ * dedup(日次×視聴者×投稿)と加算は RPC がバッチ原子実行する。
+ *
+ * - フラグ OFF / admin / クローラ / IP 不明ゲスト は記録せず 204(no-op)。
+ *   クライアントは応答を見ない(EARS-07: 失敗しても UI を妨げない)。
+ * - キャッシュ方針: 書き込み後に revalidate しない。フィード/詳細の表示は
+ *   use cache (cacheLife("minutes")) の自然失効で追いつく(厳密な即時性より負荷軽減を優先)。
+ */
+
+const bodySchema = z.object({
+  image_ids: z.array(z.string().uuid()).min(1).max(100),
+});
+
+function noop(): NextResponse {
+  return new NextResponse(null, { status: 204 });
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    // 段階公開フラグ(ADR-005)。OFF 時は計測自体を行わない。
+    if (!isPostImpressionsEnabled()) {
+      return noop();
+    }
+
+    // クローラ/bot は数えない(EARS-04)。prefetch 対策はクライアント側の
+    // 「可視50%×1秒のみ計測」(ADR-003)で担保される(POST は prefetch されない)。
+    if (isCrawler(request.headers.get("user-agent"))) {
+      return noop();
+    }
+
+    // sendBeacon は Content-Type が text/plain になり得るため request.json() ではなく
+    // text() → JSON.parse でパースする。
+    let parsed: z.infer<typeof bodySchema>;
+    try {
+      const raw = await request.text();
+      const result = bodySchema.safeParse(JSON.parse(raw));
+      if (!result.success) {
+        return NextResponse.json(
+          { error: "invalid body", errorCode: "POSTS_IMPRESSIONS_INVALID_BODY" },
+          { status: 400 },
+        );
+      }
+      parsed = result.data;
+    } catch {
+      return NextResponse.json(
+        { error: "invalid body", errorCode: "POSTS_IMPRESSIONS_INVALID_BODY" },
+        { status: 400 },
+      );
+    }
+
+    const user = await getUser();
+
+    // 管理者の閲覧は監視目的のためカウントしない(view route と同方針)。
+    if (isFullAdmin(user?.id ?? null)) {
+      return noop();
+    }
+
+    // viewer_key はサーバ側でのみ解決(ADR-001): 認証 u:<user_id> / ゲスト g:<ip_hash>。
+    // IP が取れないゲストは dedup 不能なため安全側(数えない)に倒す。
+    let viewerKey: string;
+    if (user) {
+      viewerKey = `u:${user.id}`;
+    } else {
+      const ipHash = getPopupBannerClientIpHash(request);
+      if (!ipHash) {
+        return noop();
+      }
+      viewerKey = `g:${ipHash}`;
+    }
+
+    const supabase = createAdminClient();
+    const { data, error } = await supabase.rpc("record_post_impressions", {
+      p_image_ids: parsed.image_ids,
+      p_viewer_key: viewerKey,
+    });
+
+    if (error) {
+      console.error("[posts impressions batch] RPC failed:", error);
+      return NextResponse.json(
+        { error: "failed", errorCode: "POSTS_IMPRESSIONS_RECORD_FAILED" },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({ recorded: data ?? 0 });
+  } catch (error) {
+    console.error("[posts impressions batch] unexpected error:", error);
+    return NextResponse.json(
+      { error: "failed", errorCode: "POSTS_IMPRESSIONS_RECORD_FAILED" },
+      { status: 500 },
+    );
+  }
+}

--- a/features/generation/lib/database.ts
+++ b/features/generation/lib/database.ts
@@ -18,6 +18,8 @@ export interface GeneratedImageRecord {
   posted_at?: string | null;
   created_at?: string;
   view_count?: number;
+  // 公開閲覧数(viewableインプレッション)。view_count(詳細到達)は内部分析用に併存
+  impression_count?: number;
   // Phase 1で追加されたカラム（optional）
   generation_type?:
     | 'coordinate'

--- a/features/posts/components/CachedHomePostList.tsx
+++ b/features/posts/components/CachedHomePostList.tsx
@@ -24,6 +24,8 @@ export async function CachedHomePostList({ userId }: { userId: string | null }) 
       initialPostsForWeek={weekPosts}
       forceInitialLoading={false}
       skipInitialFetch
+      // viewable インプレッション計測はホームフィードのみ有効(検索等では計測しない)
+      trackImpressions
     />
   );
 }

--- a/features/posts/components/CachedPostDetail.tsx
+++ b/features/posts/components/CachedPostDetail.tsx
@@ -6,6 +6,7 @@ import {
   getImageAspectRatio,
   getPostDisplayUrl,
   getPostOriginalUrl,
+  getPublicViewCount,
 } from "../lib/utils";
 import { PostDetailContent } from "./PostDetailContent";
 import { createAdminClient } from "@/lib/supabase/admin";
@@ -101,7 +102,7 @@ export async function CachedPostDetail({
       postId={post.id || ""}
       initialLikeCount={post.like_count || 0}
       initialCommentCount={post.comment_count || 0}
-      initialViewCount={post.view_count || 0}
+      initialViewCount={getPublicViewCount(post)}
       ownerId={post.user_id}
       imageUrl={imageUrl}
       originalImageUrl={originalImageUrl}

--- a/features/posts/components/PostCard.tsx
+++ b/features/posts/components/PostCard.tsx
@@ -8,7 +8,7 @@ import { useInView } from "react-intersection-observer";
 import { Card, CardContent } from "@/components/ui/card";
 import { Eye, MessageCircle, User } from "lucide-react";
 import { PostCardLikeButton } from "./PostCardLikeButton";
-import { getPostThumbUrl } from "../lib/utils";
+import { getPostThumbUrl, getPublicViewCount } from "../lib/utils";
 import { queuePostImpression } from "../lib/impressions-client";
 import type { Post } from "../types";
 import type { Locale } from "@/i18n/config";
@@ -230,9 +230,10 @@ export function PostCard({
             )}
             <div className="flex shrink-0 items-center gap-1">
               <Eye className="h-4 w-4 text-gray-500" />
-              {(post.view_count || 0) > 0 && (
+              {/* フラグON時は impression_count、OFF時は view_count(getPublicViewCount) */}
+              {getPublicViewCount(post) > 0 && (
                 <span className="text-xs font-medium tabular-nums text-gray-600">
-                  {formatCountEnUS(post.view_count || 0)}
+                  {formatCountEnUS(getPublicViewCount(post))}
                 </span>
               )}
             </div>

--- a/features/posts/components/PostCard.tsx
+++ b/features/posts/components/PostCard.tsx
@@ -1,24 +1,33 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { useLocale, useTranslations } from "next-intl";
+import { useInView } from "react-intersection-observer";
 import { Card, CardContent } from "@/components/ui/card";
 import { Eye, MessageCircle, User } from "lucide-react";
 import { PostCardLikeButton } from "./PostCardLikeButton";
 import { getPostThumbUrl } from "../lib/utils";
+import { queuePostImpression } from "../lib/impressions-client";
 import type { Post } from "../types";
 import type { Locale } from "@/i18n/config";
 import { getPostCardHref } from "@/lib/url-utils";
 import { PostModerationMenu } from "@/features/moderation/components/PostModerationMenu";
 import { cn, formatCountEnUS } from "@/lib/utils";
+import { isPostImpressionsEnabled } from "@/lib/env";
 
 interface PostCardProps {
   post: Post;
   currentUserId?: string | null;
   isHighlighted?: boolean;
   prioritizeImage?: boolean;
+  /**
+   * viewable インプレッション計測(可視50%×1秒)を行うか。
+   * ホームフィード(CachedHomePostList→PostList)のみ true。他画面(検索等)での
+   * 混入を防ぐため既定 false(docs/planning/post-impressions-implementation-plan.md)。
+   */
+  trackImpressions?: boolean;
 }
 
 export function PostCard({
@@ -26,10 +35,31 @@ export function PostCard({
   currentUserId,
   isHighlighted = false,
   prioritizeImage = false,
+  trackImpressions = false,
 }: PostCardProps) {
   const t = useTranslations("posts");
   const locale = useLocale() as Locale;
   const [isHidden, setIsHidden] = useState(false);
+
+  // viewable インプレッション計測(ADR-003: マウントでは数えない)。
+  // 可視50%(threshold:0.5)になってから1秒継続したときだけキューに積む。
+  // 1秒未満で画面外に出たら cleanup でタイマーを破棄する(高速スクロールは数えない)。
+  // StrictMode/BFCache の二重実行は queuePostImpression 内の sessionStorage dedup が吸収。
+  const impressionsActive = trackImpressions && isPostImpressionsEnabled();
+  const { ref: impressionRef, inView: impressionInView } = useInView({
+    threshold: 0.5,
+    skip: !impressionsActive,
+  });
+  const postId = post.id;
+  useEffect(() => {
+    if (!impressionsActive || !impressionInView || !postId) {
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      queuePostImpression(postId);
+    }, 1000);
+    return () => window.clearTimeout(timer);
+  }, [impressionsActive, impressionInView, postId]);
   // Supabase Storageから画像URLを生成（WebPサムネイル優先、フォールバック付き）
   const imageUrl = getPostThumbUrl(post);
 
@@ -94,7 +124,8 @@ export function PostCard({
           "border-emerald-300 bg-emerald-50/40 ring-2 ring-emerald-300/70 shadow-[0_18px_40px_-24px_rgba(16,185,129,0.65)]"
       )}
     >
-      <div className="relative">
+      {/* viewable 判定はカード面積の大半を占める画像エリアで行う(構造変更を避けるため既存 div に ref を付与) */}
+      <div className="relative" ref={impressionRef}>
         {post.id ? (
           // prefetch を有効化して詳細ページへの遷移を高速化する。
           // ロケール付きパス（/ja/posts/xxx 等）を直接指定し、proxy の

--- a/features/posts/components/PostDetail.tsx
+++ b/features/posts/components/PostDetail.tsx
@@ -20,7 +20,7 @@ import { PostActions } from "./PostActions";
 import { CommentInput } from "./CommentInput";
 import { CommentList, type CommentListRef } from "./CommentList";
 import { PostMetaLine } from "./PostMetaLine";
-import { getPostImageUrl, getPostBeforeImageUrl } from "../lib/utils";
+import { getPostImageUrl, getPostBeforeImageUrl, getPublicViewCount } from "../lib/utils";
 import { copyTextToClipboard } from "../lib/copy-to-clipboard";
 import { useToast } from "@/components/ui/use-toast";
 import { FollowButton } from "@/features/users/components/FollowButton";
@@ -267,7 +267,7 @@ export function PostDetail({ post, currentUserId }: PostDetailProps) {
               postId={post.id || ""}
               initialLikeCount={post.like_count || 0}
               initialCommentCount={commentCount}
-              initialViewCount={post.view_count || 0}
+              initialViewCount={getPublicViewCount(post)}
               currentUserId={currentUserId}
               ownerId={post.user_id}
               isPosted={post.is_posted}

--- a/features/posts/components/PostList.tsx
+++ b/features/posts/components/PostList.tsx
@@ -28,6 +28,8 @@ interface PostListProps {
   forceInitialLoading?: boolean;
   /** 親がデータを提供している場合、初回の loadPosts をスキップ（キャッシュ表示の最適化用） */
   skipInitialFetch?: boolean;
+  /** viewable インプレッション計測を有効にする(ホームフィードのみ true) */
+  trackImpressions?: boolean;
 }
 
 export function PostList({
@@ -35,6 +37,7 @@ export function PostList({
   initialPostsForWeek = [],
   forceInitialLoading = false,
   skipInitialFetch = false,
+  trackImpressions = false,
 }: PostListProps) {
   const postsT = useTranslations("posts");
   const { toast } = useToast();
@@ -420,6 +423,7 @@ export function PostList({
           currentUserId={currentUserId}
           isHighlighted={post.id === highlightPostId}
           prioritizeImage={index < 2}
+          trackImpressions={trackImpressions}
         />
       </div>
     ))}

--- a/features/posts/lib/impressions-client.ts
+++ b/features/posts/lib/impressions-client.ts
@@ -1,0 +1,142 @@
+/**
+ * 投稿インプレッションのクライアント送信バッファ
+ * (計画書: docs/planning/post-impressions-implementation-plan.md)
+ *
+ * PostCard が viewable(可視50%×1秒)を達成した image_id をここに積み、
+ * デバウンスで `POST /api/posts/impressions/batch` へまとめて送る。
+ * ページ離脱時(visibilitychange: hidden / pagehide)は sendBeacon で flush する。
+ *
+ * 過剰加算ガード(ADR-002/003):
+ * - sessionStorage(`post-impressions-sent-v1`)で「このセッションで送信済み」を抑止。
+ *   キュー投入時点で記録するため、StrictMode 二重実行・BFCache 復帰・再マウントでも
+ *   二重送信しない(送信失敗時の取りこぼしは DB 日次 dedup と翌セッションに委ねる)。
+ * - サーバ側でも (image_id, viewer_key, event_date) UNIQUE が最終防波堤。
+ */
+
+import { isPostImpressionsEnabled } from "@/lib/env";
+
+const SESSION_KEY = "post-impressions-sent-v1";
+const BATCH_ENDPOINT = "/api/posts/impressions/batch";
+/** デバウンス間隔。スクロール中でもこの間隔ごとにまとめて送る。 */
+const FLUSH_DEBOUNCE_MS = 1500;
+/** API/RPC の上限(100)に合わせた1回あたりの最大送信件数。 */
+const MAX_BATCH_SIZE = 100;
+
+function readSentIds(): Set<string> {
+  if (typeof window === "undefined") {
+    return new Set<string>();
+  }
+  const raw = window.sessionStorage.getItem(SESSION_KEY);
+  if (!raw) {
+    return new Set<string>();
+  }
+  try {
+    const parsed = JSON.parse(raw) as string[];
+    return new Set(Array.isArray(parsed) ? parsed : []);
+  } catch {
+    return new Set<string>();
+  }
+}
+
+function writeSentIds(ids: Set<string>): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  try {
+    window.sessionStorage.setItem(SESSION_KEY, JSON.stringify(Array.from(ids)));
+  } catch {
+    // sessionStorage 不可(プライベートモード等)でも計測は継続する
+    // (このセッション中の dedup はモジュール内 Set が担う)。
+  }
+}
+
+// モジュールスコープの送信バッファ(ホーム滞在中に跨って共有)。
+const pending = new Set<string>();
+let flushTimer: number | null = null;
+let lifecycleRegistered = false;
+
+function sendBatch(imageIds: string[], useBeacon: boolean): void {
+  const payload = JSON.stringify({ image_ids: imageIds });
+
+  if (useBeacon && typeof navigator !== "undefined" && navigator.sendBeacon) {
+    const ok = navigator.sendBeacon(
+      BATCH_ENDPOINT,
+      new Blob([payload], { type: "application/json" }),
+    );
+    if (ok) {
+      return;
+    }
+    // beacon がキューに乗らなかった場合は keepalive fetch にフォールバック。
+  }
+
+  // 失敗は静かに握りつぶす(EARS-07)。DB dedup が整合性を守るため再送管理はしない。
+  void fetch(BATCH_ENDPOINT, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: payload,
+    keepalive: true,
+  }).catch(() => {});
+}
+
+/** バッファの内容を送信する。離脱時は useBeacon=true で呼ぶ。 */
+export function flushPostImpressions(useBeacon = false): void {
+  if (flushTimer !== null) {
+    window.clearTimeout(flushTimer);
+    flushTimer = null;
+  }
+  if (pending.size === 0) {
+    return;
+  }
+  const ids = Array.from(pending);
+  pending.clear();
+  for (let i = 0; i < ids.length; i += MAX_BATCH_SIZE) {
+    sendBatch(ids.slice(i, i + MAX_BATCH_SIZE), useBeacon);
+  }
+}
+
+function registerLifecycleFlush(): void {
+  if (lifecycleRegistered || typeof window === "undefined") {
+    return;
+  }
+  lifecycleRegistered = true;
+  // タブ非表示/離脱時に未送信分を beacon で flush する(EARS-05)。
+  window.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "hidden") {
+      flushPostImpressions(true);
+    }
+  });
+  window.addEventListener("pagehide", () => {
+    flushPostImpressions(true);
+  });
+}
+
+/**
+ * viewable 達成した投稿をバッファに積む(セッション内で未送信のもののみ)。
+ * デバウンス後にまとめて送信される。
+ */
+export function queuePostImpression(imageId: string): void {
+  if (typeof window === "undefined" || !isPostImpressionsEnabled()) {
+    return;
+  }
+  if (!imageId || pending.has(imageId)) {
+    return;
+  }
+
+  const sent = readSentIds();
+  if (sent.has(imageId)) {
+    return;
+  }
+  // キュー投入時点で「送信済み」として記録する(二重送信防止を最優先)。
+  sent.add(imageId);
+  writeSentIds(sent);
+
+  pending.add(imageId);
+  registerLifecycleFlush();
+
+  if (flushTimer === null) {
+    flushTimer = window.setTimeout(() => {
+      flushTimer = null;
+      flushPostImpressions(false);
+    }, FLUSH_DEBOUNCE_MS);
+  }
+}

--- a/features/posts/lib/server-api.ts
+++ b/features/posts/lib/server-api.ts
@@ -378,6 +378,9 @@ async function enrichPosts(
       like_count: likeCounts[postId] || 0,
       comment_count: commentCounts[postId] || 0,
       view_count: safePost.view_count || 0,
+      // 公開閲覧数(viewableインプレッション)。select("*")で取得済みの列を正規化するだけ。
+      // 反映はフィードの use cache (cacheLife) 自然失効に委ねる(即時 revalidate しない)
+      impression_count: safePost.impression_count || 0,
       range_like_count: rangeLikeCounts ? rangeLikeCounts[postId] || 0 : undefined,
     };
   });
@@ -867,6 +870,7 @@ export const getPost = cache(async (
     like_count: likeCount,
     comment_count: commentCount,
     view_count: updatedViewCount,
+    impression_count: data.impression_count || 0,
     width,
     height,
     input_image_url_fallback: inputImageUrlFallback,

--- a/features/posts/lib/utils.ts
+++ b/features/posts/lib/utils.ts
@@ -3,6 +3,7 @@
  */
 
 import type { SortType } from "../types";
+import { isPostImpressionsEnabled } from "@/lib/env";
 
 /**
  * SortTypeの型ガード関数
@@ -11,6 +12,21 @@ import type { SortType } from "../types";
 export function isValidSortType(value: string): value is SortType {
   const validSorts: SortType[] = ["newest", "following", "daily", "week", "month", "popular"];
   return validSorts.includes(value as SortType);
+}
+
+/**
+ * 👁 に表示する公開閲覧数を返す(クライアント・サーバー両対応)。
+ * フラグON時は impression_count(viewableインプレッション)、OFF時は従来の
+ * view_count(詳細到達)。切替は表示のみで、view_count の内部加算は継続する
+ * (docs/planning/post-impressions-implementation-plan.md EARS-03/06)。
+ */
+export function getPublicViewCount(post: {
+  view_count?: number | null;
+  impression_count?: number | null;
+}): number {
+  return isPostImpressionsEnabled()
+    ? post.impression_count || 0
+    : post.view_count || 0;
 }
 
 /**

--- a/features/posts/types.ts
+++ b/features/posts/types.ts
@@ -33,6 +33,9 @@ export interface Post extends GeneratedImageRecord {
   like_count?: number;
   comment_count?: number;
   view_count?: number;
+  // 公開閲覧数(viewableインプレッション)。フラグON時に👁の表示元となる。
+  // view_count(詳細到達)は内部分析用に併存(docs/planning/post-impressions-implementation-plan.md)
+  impression_count?: number;
   moderation_status?: "visible" | "pending" | "removed";
   // 完走フィード投稿(オプトイン)の識別とタップ先解決用。
   // completion_id があれば「コンプリート」バッジ + 没入シェアページ(/m/<id>[/book])へ遷移。

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -70,6 +70,10 @@ const envSchema = {
   // ホームカルーセル個別フラグ（ADR-013）。'true' のときだけホームに露出する
   NEXT_PUBLIC_INSPIRE_HOME_CAROUSEL_ENABLED:
     process.env.NEXT_PUBLIC_INSPIRE_HOME_CAROUSEL_ENABLED,
+  // 投稿インプレッション計測+表示切替の段階公開フラグ(ADR-005)。
+  // 'true' のとき計測が有効になり、👁の表示元が view_count → impression_count に切替わる
+  NEXT_PUBLIC_POST_IMPRESSIONS_ENABLED:
+    process.env.NEXT_PUBLIC_POST_IMPRESSIONS_ENABLED,
   // プレビュー生成で運営側のテストキャラ画像 URL（private bucket、サーバー専用）
   INSPIRE_TEST_CHARACTER_IMAGE_URL:
     process.env.INSPIRE_TEST_CHARACTER_IMAGE_URL,
@@ -175,6 +179,8 @@ function getEnv() {
       envSchema.NEXT_PUBLIC_COLLECTION_FEED_POST_ENABLED || "",
     NEXT_PUBLIC_INSPIRE_HOME_CAROUSEL_ENABLED:
       envSchema.NEXT_PUBLIC_INSPIRE_HOME_CAROUSEL_ENABLED || "",
+    NEXT_PUBLIC_POST_IMPRESSIONS_ENABLED:
+      envSchema.NEXT_PUBLIC_POST_IMPRESSIONS_ENABLED || "",
     INSPIRE_TEST_CHARACTER_IMAGE_URL:
       envSchema.INSPIRE_TEST_CHARACTER_IMAGE_URL || "",
     INSPIRE_SUBMISSION_ALLOWED_USER_IDS:
@@ -370,6 +376,13 @@ export function isInspireFeatureEnabled(): boolean {
  */
 export function isCollectionFeedPostEnabled(): boolean {
   return env.NEXT_PUBLIC_COLLECTION_FEED_POST_ENABLED === "true";
+}
+
+/**
+ * 投稿インプレッション計測+表示切替の有効/無効を判定(段階公開フラグ、ADR-005)
+ */
+export function isPostImpressionsEnabled(): boolean {
+  return env.NEXT_PUBLIC_POST_IMPRESSIONS_ENABLED === "true";
 }
 
 /**

--- a/supabase/migrations/20260705120000_add_post_impressions.sql
+++ b/supabase/migrations/20260705120000_add_post_impressions.sql
@@ -1,0 +1,103 @@
+-- 公開「閲覧数」を viewable インプレッションへ変更(計画書: docs/planning/post-impressions-implementation-plan.md)
+--
+-- - generated_images.impression_count: 公開数値(フィードで軽く読める公開カウンタ列)。
+--   既存 RLS(is_posted=true AND moderation_status='visible')で読むため列追加のみ。
+-- - post_impressions: 重複除外(dedup)表。(image_id, viewer_key, event_date) UNIQUE で
+--   「1日1回/視聴者/投稿」を担保(ADR-001/002)。将来の日次集計(adminチャート)も兼ねる。
+-- - record_post_impressions RPC: バッチ原子実行(dedup INSERT → 新規分のみ加算)で
+--   ホット行 UPDATE を緩和(ADR-001)。
+-- - ベースライン補填(ADR-004): impression_count := view_count を初期1回実行。
+--   ※go-live(フラグON)時に GREATEST(impression_count, view_count) で再ベースラインを
+--     実行すること(適用〜公開の間の view_count 増加による見かけの減少を防ぐ)。
+
+-- 1) 公開カウンタ列
+ALTER TABLE public.generated_images
+  ADD COLUMN impression_count integer NOT NULL DEFAULT 0 CHECK (impression_count >= 0);
+
+COMMENT ON COLUMN public.generated_images.impression_count IS
+  '公開閲覧数(viewableインプレッション)。フィード可視50%×1秒で加算。view_count(詳細到達)は内部分析用に併存';
+
+-- 2) dedup表(公開SELECT禁止: RLS有効・ポリシー無し = service role/RPC のみ)
+CREATE TABLE public.post_impressions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  image_id uuid NOT NULL REFERENCES public.generated_images(id) ON DELETE CASCADE,
+  viewer_key text NOT NULL,
+  event_date date NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT post_impressions_dedup_unique UNIQUE (image_id, viewer_key, event_date)
+);
+
+CREATE INDEX idx_post_impressions_image_date
+  ON public.post_impressions (image_id, event_date DESC);
+
+ALTER TABLE public.post_impressions ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE public.post_impressions IS
+  '投稿インプレッションの重複除外表(日次×視聴者×投稿)。viewer_key: 認証 u:<user_id> / ゲスト g:<ip_hash>。公開SELECT禁止(service role専用)';
+
+-- 3) バッチ記録RPC: dedup INSERT ON CONFLICT DO NOTHING → 新規行の分だけ impression_count を加算
+--    - p_image_ids は上限100(APIのZodと二重ガード)
+--    - 存在しない/未投稿/非表示の image_id は無視(FK違反での全体失敗と、非公開投稿への計上を防ぐ)
+--    - event_date は JST(ADR-001)
+CREATE OR REPLACE FUNCTION public.record_post_impressions(
+  p_image_ids uuid[],
+  p_viewer_key text
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_event_date date := timezone('Asia/Tokyo', now())::date;
+  v_inserted integer := 0;
+BEGIN
+  IF p_viewer_key IS NULL OR length(p_viewer_key) = 0 OR length(p_viewer_key) > 128 THEN
+    RAISE EXCEPTION 'Invalid viewer key';
+  END IF;
+  IF p_image_ids IS NULL OR array_length(p_image_ids, 1) IS NULL THEN
+    RETURN 0;
+  END IF;
+  IF array_length(p_image_ids, 1) > 100 THEN
+    RAISE EXCEPTION 'Too many image ids in one batch (max 100)';
+  END IF;
+
+  WITH candidate AS (
+    -- 公開中の投稿のみ対象(存在しないIDはここで消え、FK違反も起きない)
+    SELECT gi.id AS image_id
+    FROM public.generated_images gi
+    WHERE gi.id = ANY (p_image_ids)
+      AND gi.is_posted = true
+      AND gi.moderation_status = 'visible'
+  ),
+  inserted AS (
+    INSERT INTO public.post_impressions (image_id, viewer_key, event_date)
+    SELECT DISTINCT c.image_id, p_viewer_key, v_event_date
+    FROM candidate c
+    ON CONFLICT (image_id, viewer_key, event_date) DO NOTHING
+    RETURNING image_id
+  ),
+  bumped AS (
+    -- dedup を新規に通過した投稿のみ +1(1行/投稿/日/視聴者 なので常に+1)
+    UPDATE public.generated_images gi
+    SET impression_count = gi.impression_count + 1
+    FROM inserted i
+    WHERE gi.id = i.image_id
+    RETURNING gi.id
+  )
+  SELECT count(*) INTO v_inserted FROM bumped;
+
+  RETURN v_inserted;
+END;
+$$;
+
+-- service role 専用(クライアント直呼び不可。API route が viewer_key をサーバ側で解決して呼ぶ)
+REVOKE ALL ON FUNCTION public.record_post_impressions(uuid[], text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.record_post_impressions(uuid[], text) FROM anon;
+REVOKE ALL ON FUNCTION public.record_post_impressions(uuid[], text) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.record_post_impressions(uuid[], text) TO service_role;
+
+-- 4) ベースライン補填(ADR-004): 既存の詳細到達数を下限として引き継ぐ(初期1回)
+UPDATE public.generated_images
+SET impression_count = view_count
+WHERE view_count > 0;

--- a/tests/unit/app/api/posts/impressions-batch-route.test.ts
+++ b/tests/unit/app/api/posts/impressions-batch-route.test.ts
@@ -1,0 +1,183 @@
+/** @jest-environment node */
+
+/**
+ * POST /api/posts/impressions/batch のガードと viewer_key 解決の回帰テスト。
+ * (docs/planning/post-impressions-implementation-plan.md EARS-02/04)
+ *
+ * - フラグOFF/admin/クローラ/IP不明ゲストは 204 no-op(RPC を呼ばない)
+ * - viewer_key はサーバ側で解決: 認証 u:<user_id> / ゲスト g:<ip_hash>
+ * - 不正 body / 上限超過は 400
+ */
+
+jest.mock("@/lib/auth", () => ({
+  getUser: jest.fn(),
+}));
+
+jest.mock("@/lib/env", () => ({
+  isFullAdmin: jest.fn(() => false),
+  isPostImpressionsEnabled: jest.fn(() => true),
+}));
+
+jest.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: jest.fn(),
+}));
+
+jest.mock("@/features/popup-banners/lib/popup-banner-client-ip", () => ({
+  getPopupBannerClientIpHash: jest.fn(),
+}));
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/posts/impressions/batch/route";
+import { getUser } from "@/lib/auth";
+import { isFullAdmin, isPostImpressionsEnabled } from "@/lib/env";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getPopupBannerClientIpHash } from "@/features/popup-banners/lib/popup-banner-client-ip";
+
+const mockGetUser = getUser as jest.MockedFunction<typeof getUser>;
+const mockIsFullAdmin = isFullAdmin as jest.MockedFunction<typeof isFullAdmin>;
+const mockFlag = isPostImpressionsEnabled as jest.MockedFunction<
+  typeof isPostImpressionsEnabled
+>;
+const mockCreateAdminClient = createAdminClient as jest.MockedFunction<
+  typeof createAdminClient
+>;
+const mockIpHash = getPopupBannerClientIpHash as jest.MockedFunction<
+  typeof getPopupBannerClientIpHash
+>;
+
+const IMAGE_ID = "11111111-1111-4111-8111-111111111111";
+
+function createRequest(
+  body: unknown,
+  headers: Record<string, string> = {},
+): NextRequest {
+  return new NextRequest("http://localhost/api/posts/impressions/batch", {
+    method: "POST",
+    body: typeof body === "string" ? body : JSON.stringify(body),
+    headers: { "content-type": "application/json", ...headers },
+  });
+}
+
+function mockRpc(returnValue: number) {
+  const rpc = jest.fn().mockResolvedValue({ data: returnValue, error: null });
+  mockCreateAdminClient.mockReturnValue({ rpc } as unknown as ReturnType<
+    typeof createAdminClient
+  >);
+  return rpc;
+}
+
+describe("POST /api/posts/impressions/batch", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFlag.mockReturnValue(true);
+    mockIsFullAdmin.mockReturnValue(false);
+    mockGetUser.mockResolvedValue(null);
+    mockIpHash.mockReturnValue("hash123");
+  });
+
+  test("フラグOFFは204 no-op(RPCを呼ばない)", async () => {
+    mockFlag.mockReturnValue(false);
+    const rpc = mockRpc(0);
+    const res = await POST(createRequest({ image_ids: [IMAGE_ID] }));
+    expect(res.status).toBe(204);
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  test("クローラUAは204 no-op", async () => {
+    const rpc = mockRpc(0);
+    const res = await POST(
+      createRequest({ image_ids: [IMAGE_ID] }, { "user-agent": "Googlebot/2.1" }),
+    );
+    expect(res.status).toBe(204);
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  test("adminは204 no-op", async () => {
+    mockGetUser.mockResolvedValue({ id: "admin-user" } as Awaited<
+      ReturnType<typeof getUser>
+    >);
+    mockIsFullAdmin.mockReturnValue(true);
+    const rpc = mockRpc(0);
+    const res = await POST(createRequest({ image_ids: [IMAGE_ID] }));
+    expect(res.status).toBe(204);
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  test("認証ユーザーは u:<user_id> でRPCを呼び recorded を返す", async () => {
+    mockGetUser.mockResolvedValue({ id: "user-1" } as Awaited<
+      ReturnType<typeof getUser>
+    >);
+    const rpc = mockRpc(1);
+    const res = await POST(createRequest({ image_ids: [IMAGE_ID] }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ recorded: 1 });
+    expect(rpc).toHaveBeenCalledWith("record_post_impressions", {
+      p_image_ids: [IMAGE_ID],
+      p_viewer_key: "u:user-1",
+    });
+  });
+
+  test("ゲストは g:<ip_hash> でRPCを呼ぶ", async () => {
+    mockIpHash.mockReturnValue("abcdef");
+    const rpc = mockRpc(1);
+    const res = await POST(createRequest({ image_ids: [IMAGE_ID] }));
+    expect(res.status).toBe(200);
+    expect(rpc).toHaveBeenCalledWith("record_post_impressions", {
+      p_image_ids: [IMAGE_ID],
+      p_viewer_key: "g:abcdef",
+    });
+  });
+
+  test("IPが取れないゲストは204 no-op(安全側=数えない)", async () => {
+    mockIpHash.mockReturnValue(null);
+    const rpc = mockRpc(0);
+    const res = await POST(createRequest({ image_ids: [IMAGE_ID] }));
+    expect(res.status).toBe(204);
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  test("uuidでない/空/101件のbodyは400", async () => {
+    mockRpc(0);
+    const notUuid = await POST(createRequest({ image_ids: ["not-a-uuid"] }));
+    expect(notUuid.status).toBe(400);
+
+    const empty = await POST(createRequest({ image_ids: [] }));
+    expect(empty.status).toBe(400);
+
+    const tooMany = await POST(
+      createRequest({ image_ids: Array.from({ length: 101 }, () => IMAGE_ID) }),
+    );
+    expect(tooMany.status).toBe(400);
+
+    const broken = await POST(createRequest("{not json"));
+    expect(broken.status).toBe(400);
+  });
+
+  test("sendBeacon相当(text/plainのContent-Type)でもJSONとしてパースできる", async () => {
+    mockGetUser.mockResolvedValue({ id: "user-1" } as Awaited<
+      ReturnType<typeof getUser>
+    >);
+    const rpc = mockRpc(1);
+    const res = await POST(
+      createRequest(JSON.stringify({ image_ids: [IMAGE_ID] }), {
+        "content-type": "text/plain",
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(rpc).toHaveBeenCalledTimes(1);
+  });
+
+  test("RPCエラー時は500(クライアントは静かに無視する契約=EARS-07)", async () => {
+    mockGetUser.mockResolvedValue({ id: "user-1" } as Awaited<
+      ReturnType<typeof getUser>
+    >);
+    const rpc = jest
+      .fn()
+      .mockResolvedValue({ data: null, error: { message: "boom" } });
+    mockCreateAdminClient.mockReturnValue({ rpc } as unknown as ReturnType<
+      typeof createAdminClient
+    >);
+    const res = await POST(createRequest({ image_ids: [IMAGE_ID] }));
+    expect(res.status).toBe(500);
+  });
+});

--- a/tests/unit/app/api/posts/view-route-impressions.test.ts
+++ b/tests/unit/app/api/posts/view-route-impressions.test.ts
@@ -1,0 +1,179 @@
+/** @jest-environment node */
+
+/**
+ * POST /api/posts/[id]/view の詳細到達インプレッション計上(v1.1拡張)の回帰テスト。
+ *
+ * - フラグON+非admin: view_count加算に加えて record_post_impressions を呼ぶ
+ *   (viewer_keyはサーバ解決: 認証 u:<id> / ゲスト g:<ip_hash>)
+ * - フラグOFF/クローラ/IP不明ゲスト: インプレッションは記録しないが view_count は従来どおり
+ * - admin: 従来どおり何もカウントしない
+ * - RPC失敗: view応答(200 counted:true)に影響させない
+ */
+
+jest.mock("@/lib/auth", () => ({
+  getUser: jest.fn(),
+}));
+
+jest.mock("@/lib/env", () => ({
+  isFullAdmin: jest.fn(() => false),
+  isPostImpressionsEnabled: jest.fn(() => true),
+}));
+
+jest.mock("@/lib/utils", () => ({
+  ...jest.requireActual("@/lib/utils"),
+  isCrawler: jest.fn(() => false),
+}));
+
+jest.mock("@/features/posts/lib/server-api", () => ({
+  getPost: jest.fn(),
+  incrementViewCount: jest.fn(),
+}));
+
+jest.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: jest.fn(),
+}));
+
+jest.mock("@/features/popup-banners/lib/popup-banner-client-ip", () => ({
+  getPopupBannerClientIpHash: jest.fn(),
+}));
+
+jest.mock("@/lib/api/route-locale", () => ({
+  getRouteLocale: jest.fn(() => "ja"),
+}));
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/posts/[id]/view/route";
+import { getUser } from "@/lib/auth";
+import { isFullAdmin, isPostImpressionsEnabled } from "@/lib/env";
+import { isCrawler } from "@/lib/utils";
+import { getPost, incrementViewCount } from "@/features/posts/lib/server-api";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getPopupBannerClientIpHash } from "@/features/popup-banners/lib/popup-banner-client-ip";
+
+const mockGetUser = getUser as jest.MockedFunction<typeof getUser>;
+const mockIsFullAdmin = isFullAdmin as jest.MockedFunction<typeof isFullAdmin>;
+const mockFlag = isPostImpressionsEnabled as jest.MockedFunction<
+  typeof isPostImpressionsEnabled
+>;
+const mockIsCrawler = isCrawler as jest.MockedFunction<typeof isCrawler>;
+const mockGetPost = getPost as jest.MockedFunction<typeof getPost>;
+const mockIncrementViewCount = incrementViewCount as jest.MockedFunction<
+  typeof incrementViewCount
+>;
+const mockCreateAdminClient = createAdminClient as jest.MockedFunction<
+  typeof createAdminClient
+>;
+const mockIpHash = getPopupBannerClientIpHash as jest.MockedFunction<
+  typeof getPopupBannerClientIpHash
+>;
+
+const POST_ID = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+
+function createRequest(): NextRequest {
+  return new NextRequest(`http://localhost/api/posts/${POST_ID}/view`, {
+    method: "POST",
+  });
+}
+
+function callRoute() {
+  return POST(createRequest(), { params: Promise.resolve({ id: POST_ID }) });
+}
+
+function mockRpc() {
+  const rpc = jest.fn().mockResolvedValue({ data: 1, error: null });
+  mockCreateAdminClient.mockReturnValue({ rpc } as unknown as ReturnType<
+    typeof createAdminClient
+  >);
+  return rpc;
+}
+
+describe("POST /api/posts/[id]/view のインプレッション計上", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFlag.mockReturnValue(true);
+    mockIsFullAdmin.mockReturnValue(false);
+    mockIsCrawler.mockReturnValue(false);
+    mockGetUser.mockResolvedValue(null);
+    mockGetPost.mockResolvedValue({ id: POST_ID } as Awaited<
+      ReturnType<typeof getPost>
+    >);
+    mockIncrementViewCount.mockResolvedValue(undefined as never);
+    mockIpHash.mockReturnValue("hash123");
+  });
+
+  test("認証ユーザー: view加算 + u:<id> でインプレッション記録", async () => {
+    mockGetUser.mockResolvedValue({ id: "user-1" } as Awaited<
+      ReturnType<typeof getUser>
+    >);
+    const rpc = mockRpc();
+    const res = await callRoute();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true, counted: true });
+    expect(mockIncrementViewCount).toHaveBeenCalledWith(POST_ID);
+    expect(rpc).toHaveBeenCalledWith("record_post_impressions", {
+      p_image_ids: [POST_ID],
+      p_viewer_key: "u:user-1",
+    });
+  });
+
+  test("ゲスト: g:<ip_hash> でインプレッション記録", async () => {
+    const rpc = mockRpc();
+    await callRoute();
+    expect(rpc).toHaveBeenCalledWith("record_post_impressions", {
+      p_image_ids: [POST_ID],
+      p_viewer_key: "g:hash123",
+    });
+  });
+
+  test("フラグOFF: viewは加算するがインプレッションは記録しない", async () => {
+    mockFlag.mockReturnValue(false);
+    const rpc = mockRpc();
+    const res = await callRoute();
+    expect(res.status).toBe(200);
+    expect(mockIncrementViewCount).toHaveBeenCalledTimes(1);
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  test("クローラ: viewは従来どおり加算、インプレッションは記録しない", async () => {
+    mockIsCrawler.mockReturnValue(true);
+    const rpc = mockRpc();
+    await callRoute();
+    expect(mockIncrementViewCount).toHaveBeenCalledTimes(1);
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  test("IP不明ゲスト: viewは加算、インプレッションは記録しない", async () => {
+    mockIpHash.mockReturnValue(null);
+    const rpc = mockRpc();
+    await callRoute();
+    expect(mockIncrementViewCount).toHaveBeenCalledTimes(1);
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  test("admin: 従来どおり何もカウントしない(counted:false)", async () => {
+    mockGetUser.mockResolvedValue({ id: "admin-1" } as Awaited<
+      ReturnType<typeof getUser>
+    >);
+    mockIsFullAdmin.mockReturnValue(true);
+    const rpc = mockRpc();
+    const res = await callRoute();
+    expect(await res.json()).toEqual({ success: true, counted: false });
+    expect(mockIncrementViewCount).not.toHaveBeenCalled();
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  test("RPC失敗でも view応答は 200 counted:true のまま", async () => {
+    mockGetUser.mockResolvedValue({ id: "user-1" } as Awaited<
+      ReturnType<typeof getUser>
+    >);
+    const rpc = jest
+      .fn()
+      .mockResolvedValue({ data: null, error: { message: "boom" } });
+    mockCreateAdminClient.mockReturnValue({ rpc } as unknown as ReturnType<
+      typeof createAdminClient
+    >);
+    const res = await callRoute();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true, counted: true });
+  });
+});

--- a/tests/unit/features/posts/get-public-view-count.test.ts
+++ b/tests/unit/features/posts/get-public-view-count.test.ts
@@ -1,0 +1,42 @@
+/**
+ * getPublicViewCount(👁表示元のフラグ切替)の回帰テスト。
+ * (docs/planning/post-impressions-implementation-plan.md EARS-03)
+ *
+ * lib/env をモックするため、他の utils テストと分離した専用ファイルにしている。
+ */
+
+jest.mock("@/lib/env", () => ({
+  isPostImpressionsEnabled: jest.fn(() => false),
+}));
+
+import { getPublicViewCount } from "@/features/posts/lib/utils";
+import { isPostImpressionsEnabled } from "@/lib/env";
+
+const mockFlag = isPostImpressionsEnabled as jest.MockedFunction<
+  typeof isPostImpressionsEnabled
+>;
+
+describe("getPublicViewCount", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("フラグOFF: 従来の view_count を返す", () => {
+    mockFlag.mockReturnValue(false);
+    expect(getPublicViewCount({ view_count: 12, impression_count: 340 })).toBe(12);
+  });
+
+  it("フラグON: impression_count を返す", () => {
+    mockFlag.mockReturnValue(true);
+    expect(getPublicViewCount({ view_count: 12, impression_count: 340 })).toBe(340);
+  });
+
+  it("値が未定義/nullなら0にフォールバックする", () => {
+    mockFlag.mockReturnValue(true);
+    expect(getPublicViewCount({})).toBe(0);
+    expect(getPublicViewCount({ impression_count: null })).toBe(0);
+
+    mockFlag.mockReturnValue(false);
+    expect(getPublicViewCount({ view_count: null })).toBe(0);
+  });
+});

--- a/tests/unit/features/posts/impressions-client.test.ts
+++ b/tests/unit/features/posts/impressions-client.test.ts
@@ -1,0 +1,138 @@
+/**
+ * 投稿インプレッション送信バッファの回帰テスト。
+ * (docs/planning/post-impressions-implementation-plan.md EARS-01/05, ADR-002/003)
+ *
+ * - queue → デバウンス(1.5s)後に1回のバッチ fetch にまとまる
+ * - sessionStorage(post-impressions-sent-v1)でセッション内の二重送信を抑止
+ * - 離脱 flush は sendBeacon を優先
+ * - フラグOFFでは何もしない
+ *
+ * モジュールスコープの状態(バッファ/タイマー/リスナー登録)を持つため、
+ * jest.resetModules + require で各テスト独立のモジュールインスタンスを使う
+ * (React 非依存モジュールなので resetModules の副作用はない)。
+ */
+
+jest.mock("@/lib/env", () => ({
+  isPostImpressionsEnabled: jest.fn(() => true),
+}));
+
+import { isPostImpressionsEnabled } from "@/lib/env";
+
+const mockFlag = isPostImpressionsEnabled as jest.MockedFunction<
+  typeof isPostImpressionsEnabled
+>;
+
+type Mod = typeof import("@/features/posts/lib/impressions-client");
+
+const SESSION_KEY = "post-impressions-sent-v1";
+const ID_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const ID_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+function loadModule(): Mod {
+  let mod: Mod;
+  jest.isolateModules(() => {
+    mod = require("@/features/posts/lib/impressions-client") as Mod;
+  });
+  return mod!;
+}
+
+describe("impressions-client", () => {
+  let fetchMock: jest.Mock;
+  let beaconMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockFlag.mockReturnValue(true);
+    window.sessionStorage.clear();
+    fetchMock = jest.fn().mockResolvedValue({ ok: true });
+    global.fetch = fetchMock as unknown as typeof fetch;
+    beaconMock = jest.fn().mockReturnValue(true);
+    Object.defineProperty(navigator, "sendBeacon", {
+      value: beaconMock,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it("queue後、デバウンスで1回のバッチfetchにまとまり、sessionStorageに記録される", () => {
+    const { queuePostImpression } = loadModule();
+    queuePostImpression(ID_A);
+    queuePostImpression(ID_B);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1500);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/posts/impressions/batch");
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      image_ids: [ID_A, ID_B],
+    });
+    expect((init as RequestInit).keepalive).toBe(true);
+
+    const sent = JSON.parse(window.sessionStorage.getItem(SESSION_KEY) ?? "[]");
+    expect(sent).toEqual([ID_A, ID_B]);
+  });
+
+  it("同一IDの再queueは送信されない(セッション内dedup)", () => {
+    const { queuePostImpression } = loadModule();
+    queuePostImpression(ID_A);
+    jest.advanceTimersByTime(1500);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // 送信済みIDを再queueしても新たな送信は発生しない
+    queuePostImpression(ID_A);
+    jest.advanceTimersByTime(3000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("sessionStorageに既送信のIDはqueueされない(BFCache/StrictMode吸収)", () => {
+    window.sessionStorage.setItem(SESSION_KEY, JSON.stringify([ID_A]));
+    const { queuePostImpression } = loadModule();
+    queuePostImpression(ID_A);
+    jest.advanceTimersByTime(3000);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("flushPostImpressions(true) は sendBeacon を優先して即時送信する", () => {
+    const { queuePostImpression, flushPostImpressions } = loadModule();
+    queuePostImpression(ID_A);
+    flushPostImpressions(true);
+
+    expect(beaconMock).toHaveBeenCalledTimes(1);
+    expect(beaconMock.mock.calls[0][0]).toBe("/api/posts/impressions/batch");
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    // 既に送信済みのためデバウンスタイマー経過後も再送しない
+    jest.advanceTimersByTime(3000);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("visibilitychange(hidden) で未送信分が beacon flush される(EARS-05)", () => {
+    const { queuePostImpression } = loadModule();
+    queuePostImpression(ID_A);
+
+    Object.defineProperty(document, "visibilityState", {
+      value: "hidden",
+      configurable: true,
+    });
+    window.dispatchEvent(new Event("visibilitychange"));
+
+    expect(beaconMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("フラグOFFでは何もしない", () => {
+    mockFlag.mockReturnValue(false);
+    const { queuePostImpression } = loadModule();
+    queuePostImpression(ID_A);
+    jest.advanceTimersByTime(3000);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(window.sessionStorage.getItem(SESSION_KEY)).toBeNull();
+  });
+});

--- a/tests/unit/features/posts/post-card-impressions.test.tsx
+++ b/tests/unit/features/posts/post-card-impressions.test.tsx
@@ -1,0 +1,146 @@
+/** @jest-environment jsdom */
+
+/**
+ * PostCard の viewable インプレッション計測(可視50%×1秒)の回帰テスト。
+ * (docs/planning/post-impressions-implementation-plan.md EARS-01, ADR-003)
+ *
+ * - inView(50%)が1秒継続したときだけ queuePostImpression が呼ばれる
+ * - 1秒未満で画面外に出たらキャンセル(高速スクロールは数えない)
+ * - trackImpressions=false / フラグOFF では計測しない(マウントでは数えない)
+ */
+
+import { act, render } from "@testing-library/react";
+import type { Post } from "@/features/posts/types";
+
+const queueSpy = jest.fn();
+let mockInView = false;
+const useInViewSpy = jest.fn();
+
+jest.mock("react-intersection-observer", () => ({
+  useInView: (options: unknown) => {
+    useInViewSpy(options);
+    return { ref: jest.fn(), inView: mockInView };
+  },
+}));
+
+jest.mock("@/features/posts/lib/impressions-client", () => ({
+  queuePostImpression: (...args: unknown[]) => queueSpy(...args),
+}));
+
+jest.mock("@/lib/env", () => ({
+  isPostImpressionsEnabled: jest.fn(() => true),
+}));
+
+jest.mock("next-intl", () => ({
+  useLocale: () => "ja",
+  useTranslations: () => (key: string) => key,
+}));
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: { src: string; alt: string }) => {
+    // eslint-disable-next-line @next/next/no-img-element
+    return <img src={props.src} alt={props.alt} />;
+  },
+}));
+
+jest.mock("@/features/posts/components/PostCardLikeButton", () => ({
+  PostCardLikeButton: () => <div data-testid="like-button" />,
+}));
+
+jest.mock("@/features/moderation/components/PostModerationMenu", () => ({
+  PostModerationMenu: () => <div data-testid="moderation-menu" />,
+}));
+
+import { PostCard } from "@/features/posts/components/PostCard";
+import { isPostImpressionsEnabled } from "@/lib/env";
+
+const mockFlag = isPostImpressionsEnabled as jest.MockedFunction<
+  typeof isPostImpressionsEnabled
+>;
+
+const POST_ID = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+
+function makePost(): Post {
+  return {
+    id: POST_ID,
+    user_id: "user-1",
+    image_url: "https://example.com/image.png",
+    storage_path: "user-1/image.png",
+    prompt: "",
+    is_posted: true,
+    view_count: 10,
+    impression_count: 20,
+  } as Post;
+}
+
+describe("PostCard の viewable 計測", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    mockFlag.mockReturnValue(true);
+    mockInView = false;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("inViewが1秒継続したら queuePostImpression が1回呼ばれる", () => {
+    mockInView = true;
+    render(<PostCard post={makePost()} trackImpressions />);
+
+    // マウント直後(1秒未満)では数えない
+    act(() => {
+      jest.advanceTimersByTime(999);
+    });
+    expect(queueSpy).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(queueSpy).toHaveBeenCalledTimes(1);
+    expect(queueSpy).toHaveBeenCalledWith(POST_ID);
+  });
+
+  it("1秒未満で画面外に出たらキャンセルされる(高速スクロール)", () => {
+    mockInView = true;
+    const { rerender } = render(<PostCard post={makePost()} trackImpressions />);
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    // 画面外へ(inView=false で再レンダー) → クリーンアップでタイマー破棄
+    mockInView = false;
+    rerender(<PostCard post={makePost()} trackImpressions />);
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(queueSpy).not.toHaveBeenCalled();
+  });
+
+  it("trackImpressions=false では計測しない(useInView も skip)", () => {
+    mockInView = true;
+    render(<PostCard post={makePost()} />);
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(queueSpy).not.toHaveBeenCalled();
+    expect(useInViewSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ skip: true }),
+    );
+  });
+
+  it("フラグOFFでは trackImpressions=true でも計測しない", () => {
+    mockFlag.mockReturnValue(false);
+    mockInView = true;
+    render(<PostCard post={makePost()} trackImpressions />);
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(queueSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/features/posts/post-detail.test.tsx
+++ b/tests/unit/features/posts/post-detail.test.tsx
@@ -42,6 +42,9 @@ jest.mock("@/components/ui/use-toast", () => ({
 jest.mock("@/features/posts/lib/utils", () => ({
   getPostImageUrl: (...args: unknown[]) => mockGetPostImageUrl(...args),
   getPostBeforeImageUrl: () => null,
+  // フラグOFF時の従来挙動(view_count 表示)に合わせる
+  getPublicViewCount: (post: { view_count?: number | null }) =>
+    post.view_count || 0,
 }));
 
 jest.mock("@/features/posts/components/CollapsibleText", () => ({


### PR DESCRIPTION
### 概要
ホーム/詳細の公開「閲覧数」(👁)を、詳細到達数(リーチ)から **viewableインプレッション**(フィードで実際に画面に入った回数)へ変更する。母数が広がることでアプリの賑わいが正直な形で可視化される。計画書 `docs/planning/post-impressions-implementation-plan.md` (PR #395) の全フェーズを本PRに集約。

**カウント条件(ADR-003・最重要)**: 20件先読みされてもカウントは「**可視50%×連続1秒**」を達成したカードのみ。マウント・prefetch・1秒未満の高速スクロール通過では数えない。

### 変更内容
- **Phase 1 (DB)**: `generated_images.impression_count` 列 / `post_impressions` dedup表((image_id, viewer_key, event_date) UNIQUE・RLSポリシー無し=service role専用) / RPC `record_post_impressions`(公開中投稿のみ対象→dedup INSERT→新規分のみ加算をバッチ原子実行・上限100) / ベースライン補填 `impression_count := view_count`
- **Phase 2 (サーバ)**: `POST /api/posts/impressions/batch`(Zod検証、viewer_keyはサーバ解決=偽装不可: 認証`u:<id>`/ゲスト`g:<ip_hash>`、フラグOFF/admin/クローラ/IP不明ゲストは204 no-op、sendBeacon対応) / `getPosts`・`getPost` が `impression_count` を返す
- **Phase 3 (計測)**: `PostCard` に `useInView(threshold:0.5)`+1秒タイマー / 送信バッファ+1.5秒デバウンス+離脱時sendBeacon / sessionStorage でセッション内dedup(StrictMode/BFCache吸収) / `trackImpressions` prop で**ホームフィードのみ**計測(検索は対象外)
- **Phase 4 (表示)**: `getPublicViewCount()` ヘルパーでフラグON時 `impression_count`/OFF時 `view_count` に切替(PostCard/詳細)。詳細ページの内部 `view_count` 加算は分析用に維持
- **Phase 5 (テスト)**: 新規22テスト(routeガード/バッファ/表示分岐/viewableタイミング)
- **v1.1 (詳細到達も計上)**: `POST /api/posts/[id]/view` にインプレッション記録を追加。シェアリンク等での `/posts/[id]` 直接到達も公開👁に反映される。フィード計測とdedupを共有するため「フィードでも詳細でも同一投稿×同一人×同一日は1回」で二重カウントしない(+テスト7件)

### 段階公開・go-live手順
1. マージ後、migration `20260705120000_add_post_impressions.sql` を本番へ適用
2. Vercel **Preview 環境のみ** `NEXT_PUBLIC_POST_IMPRESSIONS_ENABLED=true` で実機検証
3. 問題なければ Production にもフラグ設定 + **再ベースライン**を1回実行:
   `UPDATE generated_images SET impression_count = GREATEST(impression_count, view_count);`
   (適用〜公開の間の view_count 増加による見かけの減少を防ぐ)
4. 異常時はフラグOFFで即時に従来表示・計測停止へ復帰(ADR-005)

### 実機テスト
- [ ] iOS Safari で主要導線を確認
- [ ] Android Chrome で主要導線を確認
- [ ] PC（Chrome）で主要導線を確認
- [ ] Preview(フラグON): ホームで先読み20件中、実際に可視化したカードのみ計上されること(スクロールせず数秒待機→下へスクロール→DBの post_impressions 行数と突合)
- [ ] 高速スクロール通過で計上されないこと
- [ ] リロード/BFCache復帰で二重計上されないこと(同一セッション)
- [ ] 詳細ページ直接到達で impression_count が増えること(同一人は1日1回まで。フィードで既に計上済みの投稿は増えない=dedup共有の確認)
- [ ] admin アカウントで計上されないこと
- [ ] フラグOFF(Production 現状)で従来表示のままであること

### テスト方法
- `npm run test` → フルスイート 235 suites / 2326 tests pass(新規29件含む)
- `npm run lint` → 変更ファイルは指摘なし
- `npm run typecheck` → 変更ファイル起因のエラーなし
- `npm run build -- --webpack` → 成功（exit 0）
