### PR TITLE
fix(posts): sessionStorageアクセス例外でインプレッション計測が壊れないよう保護

### DIFF
--- a/features/posts/lib/impressions-client.ts
+++ b/features/posts/lib/impressions-client.ts
@@ -26,11 +26,15 @@ function readSentIds(): Set<string> {
   if (typeof window === "undefined") {
     return new Set<string>();
   }
-  const raw = window.sessionStorage.getItem(SESSION_KEY);
-  if (!raw) {
-    return new Set<string>();
-  }
+  // sessionStorage はプロパティアクセス自体が SecurityError を投げ得る
+  // (Cookie無効設定・一部のプライベートモード等)ため、全体を try-catch で守る。
+  // 読めない環境では空Set(=セッションdedupなし)にフォールバックし、
+  // 整合性は DB 日次 UNIQUE(最終防波堤)に委ねる。
   try {
+    const raw = window.sessionStorage.getItem(SESSION_KEY);
+    if (!raw) {
+      return new Set<string>();
+    }
     const parsed = JSON.parse(raw) as string[];
     return new Set(Array.isArray(parsed) ? parsed : []);
   } catch {

--- a/tests/unit/features/posts/impressions-client.test.ts
+++ b/tests/unit/features/posts/impressions-client.test.ts
@@ -150,6 +150,11 @@ describe("impressions-client", () => {
     } finally {
       if (original) {
         Object.defineProperty(window, "sessionStorage", original);
+      } else {
+        // jsdom のバージョンによっては sessionStorage が Window.prototype 側に
+        // 定義されており descriptor が取れない。その場合は自前の override を
+        // 削除してプロトタイプ参照に戻す(throwする getter を残さない)。
+        delete (window as { sessionStorage?: unknown }).sessionStorage;
       }
     }
   });

--- a/tests/unit/features/posts/impressions-client.test.ts
+++ b/tests/unit/features/posts/impressions-client.test.ts
@@ -31,6 +31,8 @@ const ID_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
 function loadModule(): Mod {
   let mod: Mod;
   jest.isolateModules(() => {
+    // jest.isolateModules 内での同期ロードには require が必要(dynamic import は非同期で不可)
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     mod = require("@/features/posts/lib/impressions-client") as Mod;
   });
   return mod!;
@@ -125,6 +127,31 @@ describe("impressions-client", () => {
     window.dispatchEvent(new Event("visibilitychange"));
 
     expect(beaconMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("sessionStorageアクセスが例外を投げる環境でもクラッシュせず送信できる", () => {
+    // Cookie無効設定等では window.sessionStorage への「プロパティアクセス自体」が
+    // SecurityError を投げる。dedupは諦めて(DB日次UNIQUEに委ねて)送信は継続する。
+    const original = Object.getOwnPropertyDescriptor(window, "sessionStorage");
+    Object.defineProperty(window, "sessionStorage", {
+      configurable: true,
+      get() {
+        throw new Error("SecurityError: access denied");
+      },
+    });
+    try {
+      const { queuePostImpression } = loadModule();
+      expect(() => queuePostImpression(ID_A)).not.toThrow();
+      jest.advanceTimersByTime(1500);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(
+        JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string),
+      ).toEqual({ image_ids: [ID_A] });
+    } finally {
+      if (original) {
+        Object.defineProperty(window, "sessionStorage", original);
+      }
+    }
   });
 
   it("フラグOFFでは何もしない", () => {


### PR DESCRIPTION
### 概要
PR #407(インプレッション機能)の Gemini Code Assist レビュー指摘のうち、有効と判断した1件(sessionStorage アクセス例外の保護)を追いかけ対応する。他3件は理由を添えて不同意を返信済み(詳細は #407 の各コメントスレッド)。

### 変更内容
- `impressions-client.ts`: `readSentIds` 全体を try-catch で保護。Cookie無効設定や一部プライベートモードでは `window.sessionStorage` への**プロパティアクセス自体**が SecurityError を投げるため。読めない環境では空Set(セッションdedupなし)にフォールバックし、整合性は DB 日次 UNIQUE が担保する
- 回帰テスト追加(sessionStorage アクセスが throw しても送信継続)
- 同テストの `require()`(jest.isolateModules 内の同期ロードに必要)へ理由コメント付き lint disable を追加

### 実機テスト
- [ ] 通常環境でホームフィードの計測が従来どおり動くこと(回帰なし)
- [ ] (可能なら)Cookieブロック環境でホームを開いてもコンソールエラーが出ないこと

### テスト方法
- `npm run test -- tests/unit/features/posts/impressions-client.test.ts` → 7/7 pass(新規1件含む)
- `npm run lint` → 対象ファイルの指摘解消
- `npm run typecheck` → クリーン
