### PR TITLE
feat(collections): コレクション完走報酬(admin設定+カウントアップ演出)

### DIFF
--- a/.cursor/rules/database-design.mdc
+++ b/.cursor/rules/database-design.mdc
@@ -337,7 +337,7 @@ alwaysApply: false
 
 #### `preset_categories`
 - 主キー: `id`
-- 主要カラム: `key` (UNIQUE, 不変), `display_name_ja`, `display_name_en`, `badge_color`, `badge_text_color`, `skip_base_prefix`, `default_image_input_mode` (`single|dual`), `output_aspect_ratio_mode` (`source|square`), `user_guidance_ja`, `user_guidance_en`, `show_source_image_type_control`, `show_background_change_control`, `show_generation_model_control`, `show_user_prompt_input`, `visibility` (`public|admin_only`), `is_collection_series`, `completion_threshold`, `mount_template_path`, `mount_layout`, `ogp_template_path`, `ogp_mount_placement`, `display_order`, `is_active`, `created_by`, `updated_by`, `created_at`, `updated_at`
+- 主要カラム: `key` (UNIQUE, 不変), `display_name_ja`, `display_name_en`, `badge_color`, `badge_text_color`, `skip_base_prefix`, `default_image_input_mode` (`single|dual`), `output_aspect_ratio_mode` (`source|square`), `user_guidance_ja`, `user_guidance_en`, `show_source_image_type_control`, `show_background_change_control`, `show_generation_model_control`, `show_user_prompt_input`, `visibility` (`public|admin_only`), `is_collection_series`, `completion_threshold`, `completion_reward_percoins`, `mount_template_path`, `mount_layout`, `ogp_template_path`, `ogp_mount_placement`, `display_order`, `is_active`, `created_by`, `updated_by`, `created_at`, `updated_at`
 - 外部キー: `created_by -> auth.users.id` (`ON DELETE SET NULL`), `updated_by -> auth.users.id` (`ON DELETE SET NULL`)
 - トリガ: `prevent_preset_category_key_change` で `key` の UPDATE を拒否 (過去ジョブのスナップショット集計を守るため)
 - 備考: `style_presets` のカテゴリ。`skip_base_prefix=true` のとき生成時に `style.base_prefix` を一切付与しない (raw モード)。`output_aspect_ratio_mode='source'` はアップロード画像比率に合わせ、`square` は One-Tap Style 生成を 1:1 に固定する。`user_guidance_ja/en` はユーザー向け推奨画像・注意事項の説明文。`show_*_control` は `/style` 画面のアップロード画像タイプ・背景設定・生成モデル選択の表示可否をカテゴリ単位で制御する。`show_user_prompt_input=true` で `/style` にユーザープロンプト入力欄を表示し、生成時に `preset.stylingPrompt` の後ろへ追加結合する。`visibility='admin_only'` は `ADMIN_USER_IDS` の運営ユーザーだけ `/style` 表示・生成可能にする。`is_collection_series=true` はカテゴリをコレクションシリーズとして扱い、`completion_threshold` と `mount_layout` はスロット数一致 (`grid_3=3`, `grid_4=4`, `grid_6=6`) が CHECK 制約で強制される。`mount_template_path` は private `collection-mount-templates` bucket の PNG path。`ogp_template_path` は同 bucket 内のコレクション OGP 用デザインテンプレート (1200x630 PNG) の path で、NULL のとき OGP は従来の SVG 合成デザインになる。`ogp_mount_placement` (JSONB) はテンプレートへの台紙配置 `{"cx","cy","width","rotate"}` で NULL はコード側既定値。`is_active=false` は「新規 preset 作成時の選択肢から外す」だけで、既存 preset の表示は `style_presets.status` とカテゴリ `visibility` で制御する。seed 値は `coordinate` と `chibi`
@@ -345,7 +345,7 @@ alwaysApply: false
 
 #### `collection_completions`
 - 主キー: `id`
-- 主要カラム: `user_id`, `category_id`, `category_key`, `threshold_at_completion`, `mount_image_path`, `mount_status`, `mount_error`, `completed_at`, `created_at`, `updated_at`
+- 主要カラム: `user_id`, `category_id`, `category_key`, `threshold_at_completion`, `mount_image_path`, `mount_status`, `mount_error`, `completed_at`, `reward_granted_at`, `created_at`, `updated_at`
 - 外部キー: `user_id -> auth.users.id` (`ON DELETE CASCADE`), `category_id -> preset_categories.id` (`ON DELETE RESTRICT`)
 - 制約: `(user_id, category_id)` UNIQUE、`mount_status IN ('generating','completed','failed')`
 - 備考: コレクション台紙生成の予約・完了状態。生成済み台紙は `generated-images/collection-mounts/{userId}/{categoryKey}/mount-{timestamp}.png` に保存し、公開ページ `/m/{id}` で link-only 表示する。
@@ -458,7 +458,7 @@ alwaysApply: false
 ## `public` 関数（現行）
 
 ### 業務ロジック RPC
-- ペルコイン: `apply_percoin_transaction`, `deduct_free_percoins`, `refund_percoins`, `grant_tour_bonus`, `grant_daily_post_bonus`, `grant_streak_bonus`, `grant_referral_bonus`, `grant_admin_bonus`, `deduct_percoins_admin`, `expire_free_percoin_batches`
+- ペルコイン: `apply_percoin_transaction`, `deduct_free_percoins`, `refund_percoins`, `grant_tour_bonus`, `grant_daily_post_bonus`, `grant_streak_bonus`, `grant_referral_bonus`, `grant_admin_bonus`, `grant_collection_completion_reward`, `deduct_percoins_admin`, `expire_free_percoin_batches`
 - ペルコイン参照: `get_percoin_balance_breakdown`, `get_percoin_transactions_with_expiry`, `get_percoin_transactions_count`, `get_percoin_bonus_default`, `get_percoin_streak_amount`, `get_free_percoin_batches_expiring`, `get_expiring_this_month_count`, `get_expiration_notification_targets`
 - One-Tap Style: `consume_style_authenticated_generate_attempt`, `reserve_style_authenticated_generate_attempt`, `attach_style_authenticated_generate_attempt_job`, `release_style_authenticated_generate_attempt`, `reserve_style_guest_generate_attempt`, `release_style_guest_generate_attempt`, `place_style_preset_at_order`, `create_style_preset`, `update_style_preset`, `delete_style_preset_and_reorder`, `reorder_style_presets`
   - 注: `reserve_style_guest_generate_attempt` は意味を画面横断ゲスト試行（`/style` と `/coordinate` 合算）に拡張済み。現行 default は `p_short_limit=999`（実質無効）/ `p_daily_limit=1`。引数の `p_client_ip_hash` には `SHA-256("<ip>|<persta_guest_id>|<salt>")` を渡す（`features/style/lib/style-rate-limit.ts`）。

--- a/app/api/admin/preset-categories/collection-settings-payload.ts
+++ b/app/api/admin/preset-categories/collection-settings-payload.ts
@@ -18,6 +18,8 @@ import {
 export interface CollectionSettingsPayload {
   isCollectionSeries?: boolean;
   completionThreshold?: number | null;
+  /** コレクション完走時に付与するペルコイン数。0/null=報酬なし。 */
+  completionRewardPercoins?: number | null;
   /** 完走表示モード: 'mount'(単一台紙) / 'book'(めくれる日記帳)。 */
   completionViewMode?: "mount" | "book";
   /** book 表示の表紙(0ページ目)画像 storage path。 */
@@ -119,6 +121,25 @@ export function parseCollectionSettings(
       return { ok: false, error: "completion_threshold must be a positive integer" };
     } else {
       payload.completionThreshold = v;
+    }
+  }
+
+  // 完走報酬(ペルコイン)。0/null=報酬なし。負数・非整数は拒否(多層防御: DBのCHECKでも担保)。
+  if (body.completion_reward_percoins !== undefined) {
+    const v = body.completion_reward_percoins;
+    if (v === null) {
+      payload.completionRewardPercoins = null;
+    } else if (
+      typeof v !== "number" ||
+      !Number.isInteger(v) ||
+      v < 0
+    ) {
+      return {
+        ok: false,
+        error: "completion_reward_percoins must be a non-negative integer or null",
+      };
+    } else {
+      payload.completionRewardPercoins = v;
     }
   }
 

--- a/app/api/collections/mount/route.ts
+++ b/app/api/collections/mount/route.ts
@@ -32,6 +32,47 @@ function jsonError(message: string, code: string, status: number) {
   return NextResponse.json({ error: message, errorCode: code }, { status });
 }
 
+/**
+ * 完走報酬の付与(docs/planning/collection-completion-reward-implementation-plan.md)。
+ * finalize_collection_completion 成功直後にのみ呼ぶ。冪等は RPC 内の
+ * reward_granted_at test-and-set が担保。失敗しても完走レスポンスを妨げない
+ * (EARS-07: ログのみ残して 0 を返す)。戻り値=実付与額(キャップ後)。
+ */
+async function grantCompletionReward(
+  admin: ReturnType<typeof createAdminClient>,
+  completionId: string,
+  userId: string,
+): Promise<number> {
+  try {
+    const { data, error } = await admin.rpc(
+      "grant_collection_completion_reward",
+      {
+        p_completion_id: completionId,
+        p_user_id: userId,
+      },
+    );
+    if (error) {
+      console.error("[collections mount] completion reward grant failed:", error);
+      return 0;
+    }
+    const row = Array.isArray(data) ? data[0] : data;
+    const amount =
+      typeof row?.amount_granted === "number" ? row.amount_granted : 0;
+    if (amount > 0) {
+      // 残高表示系キャッシュを更新(tutorial/complete の付与と同じタグ群)。
+      // collection-completions: タグはコレクション表示専用で残高には効かない。
+      revalidateTag(`my-page-credits-${userId}`, "max");
+      revalidateTag(`my-page-${userId}`, "max");
+      revalidateTag(`challenge-${userId}`, "max");
+      revalidateTag(`coordinate-${userId}`, "max");
+    }
+    return amount;
+  } catch (grantError) {
+    console.error("[collections mount] completion reward grant failed:", grantError);
+    return 0;
+  }
+}
+
 async function downloadBuffer(
   admin: ReturnType<typeof createAdminClient>,
   bucket: string,
@@ -277,6 +318,7 @@ export async function POST(request: NextRequest) {
       }
 
       const bookSharePath = `/m/${completionId}/book`;
+      let bookRewardGranted = 0;
 
       if (!isUpdate) {
         const { data: finalized, error: finalizeError } = await admin.rpc(
@@ -303,6 +345,12 @@ export async function POST(request: NextRequest) {
           throw new Error(`book pages save failed: ${bookPagesError.message}`);
         }
         revalidateTag(`collection-completions:${user.id}`, "max");
+        // 完走報酬(finalize成功後のみ。作り直しでは呼ばれない)
+        bookRewardGranted = await grantCompletionReward(
+          admin,
+          completionId,
+          user.id,
+        );
         await Promise.allSettled([
           recordStyleUsageEvent({
             userId: user.id,
@@ -352,6 +400,8 @@ export async function POST(request: NextRequest) {
         mode: "book",
         sharePath: bookSharePath,
         mountImageUrl: bookOgpUrl,
+        // 完走報酬の実付与額(0=報酬なし/付与失敗/作り直し)。祝賀ビューの演出用
+        rewardGranted: bookRewardGranted,
       });
     }
 
@@ -468,6 +518,7 @@ export async function POST(request: NextRequest) {
       console.error("collection mount OGP generation failed:", ogpError);
     }
 
+    let rewardGranted = 0;
     if (!isUpdate) {
       // 5) 初回のみ finalize(generating → completed の遷移)。イベント記録もここだけ。
       const { data: finalized, error: finalizeError } = await admin.rpc(
@@ -486,6 +537,8 @@ export async function POST(request: NextRequest) {
       }
       // マイページのコレクション表示(ユーザー別 cache)を更新
       revalidateTag(`collection-completions:${user.id}`, "max");
+      // 完走報酬(finalize成功後のみ。作り直しでは呼ばれない)
+      rewardGranted = await grantCompletionReward(admin, completionId, user.id);
       await Promise.allSettled([
         recordStyleUsageEvent({
           userId: user.id,
@@ -534,6 +587,8 @@ export async function POST(request: NextRequest) {
         (category.mount_template_width as number | null) ?? null,
       mountTemplateHeight:
         (category.mount_template_height as number | null) ?? null,
+      // 完走報酬の実付与額(0=報酬なし/付与失敗/作り直し)。祝賀ビューの演出用
+      rewardGranted,
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : "unknown error";

--- a/app/m/[token]/book/page.tsx
+++ b/app/m/[token]/book/page.tsx
@@ -8,6 +8,7 @@ import { ScrapbookReader } from "@/features/collections/components/ScrapbookRead
 
 interface BookPageProps {
   params: Promise<{ token: string }>;
+  searchParams: Promise<{ reward?: string }>;
 }
 
 const SHARE_DESCRIPTION =
@@ -47,7 +48,10 @@ export async function generateMetadata({
   };
 }
 
-export default async function CollectionBookPage({ params }: BookPageProps) {
+export default async function CollectionBookPage({
+  params,
+  searchParams,
+}: BookPageProps) {
   await connection();
   const { token } = await params;
   const book = await getCollectionBookByToken(token);
@@ -57,6 +61,15 @@ export default async function CollectionBookPage({ params }: BookPageProps) {
 
   const user = await getUser();
   const isOwner = Boolean(user && user.id === book.ownerId);
+
+  // 完走報酬の演出(?reward=N)。表示専用(付与はサーバー確定済み)のため値は
+  // 常識的な範囲に丸め、他人のリンク共有で出ないよう所有者のみに限定する。
+  const { reward } = await searchParams;
+  const rewardRaw = Number.parseInt(reward ?? "", 10);
+  const rewardGranted =
+    isOwner && Number.isInteger(rewardRaw) && rewardRaw > 0
+      ? Math.min(rewardRaw, 100000)
+      : 0;
 
   // 表紙(0ページ目)の決定:
   //   - 既定: コレクションの先頭(sort_order 最小)の生成画像=「ユーザー生成の表紙」を front cover にし、
@@ -82,6 +95,7 @@ export default async function CollectionBookPage({ params }: BookPageProps) {
       pages={pages}
       isOwner={isOwner}
       completionId={token}
+      rewardGranted={rewardGranted}
     />
   );
 }

--- a/docs/architecture/data.en.md
+++ b/docs/architecture/data.en.md
@@ -315,6 +315,7 @@ The table below focuses on RPCs that application developers are likely to touch.
 | `grant_daily_post_bonus` | `/api/posts/post` | user, generation | `integer` | Idempotent daily-post reward |
 | `grant_streak_bonus` | `/api/streak/check` | user | `integer` | Updates `profiles` streak state and grants reward |
 | `check_and_grant_referral_bonus_on_first_login_with_reason` | `/api/referral/check-first-login` | user, referral code | `bonus_granted`, `reason_code` | Validates referral window and grants once |
+| `grant_collection_completion_reward` | `/api/collections/mount` (after finalize) | completion id, user | `amount_granted`, `already_granted` | Idempotent completion reward via `reward_granted_at` test-and-set; amount from `preset_categories.completion_reward_percoins`, 50k cap, service_role only |
 | `generate_referral_code` | `/api/referral/generate`, `handle_new_user` | user | `text` | Ensures a persistent referral code |
 | `insert_source_image_stock` | `/api/source-image-stocks` | user, image URL, storage path, display name | `source_image_stocks` row | Atomic quota check plus stock insert |
 | `get_percoin_balance_breakdown` | my-page and credit screens | user | total and bucketed balances | Read model for wallet UI |

--- a/docs/architecture/data.ja.md
+++ b/docs/architecture/data.ja.md
@@ -325,6 +325,7 @@ RLS をバイパスする必要があるサーバー処理では `createAdminCli
 | `grant_daily_post_bonus` | `/api/posts/post` | user, generation | `integer` | デイリー投稿特典の冪等付与 |
 | `grant_streak_bonus` | `/api/streak/check` | user | `integer` | `profiles` のストリーク更新と特典付与 |
 | `check_and_grant_referral_bonus_on_first_login_with_reason` | `/api/referral/check-first-login` | user, referral code | `bonus_granted`, `reason_code` | 紹介成立判定と一度きりの付与 |
+| `grant_collection_completion_reward` | `/api/collections/mount`(finalize成功後) | completion id, user | `amount_granted`, `already_granted` | 完走報酬の冪等付与(`reward_granted_at` test-and-set、額は `preset_categories.completion_reward_percoins`、5万キャップ適用、service_role専用) |
 | `generate_referral_code` | `/api/referral/generate`, `handle_new_user` | user | `text` | 紹介コードの永続化 |
 | `insert_source_image_stock` | `/api/source-image-stocks` | user, image URL, storage path, display name | `source_image_stocks` row | 上限チェック付きの原子的 INSERT |
 | `get_percoin_balance_breakdown` | マイページ、課金 UI | user | bucket ごとの残高 | ウォレット UI 向け read model |

--- a/docs/planning/collection-completion-reward-implementation-plan.md
+++ b/docs/planning/collection-completion-reward-implementation-plan.md
@@ -1,0 +1,246 @@
+# 実装計画書: コレクション完走報酬
+
+作成日: 2026-07-10 / 対象: Persta.AI
+
+## 目的
+
+コレクション(神コレ/旅行など)を完走したユーザーにペルコインを付与する。付与額は `/admin/preset-categories` の編集画面でカテゴリごとに設定できる(`preset_categories.completion_reward_percoins`)。完走はサーバー側で確定的に記録されるため、「1ユーザー×1コレクション1回」の冪等付与を保証する。
+
+## 確定済みの方針(ユーザー合意 2026-07-10)
+
+- 付与方式: 完走一括(100%完走時に1回のみ)。段階報酬(50/70/100%)は見送り。
+- 遡及: しない。リリース後の完走から付与(既存完走者には払わない)。
+- 残高上限: 5万無料残高キャップを適用(daily_post/streak と同じ `get_grantable_free_percoin_amount`)。
+- 報酬額の出所: サーバーが `preset_categories` から引く(クライアントから額を渡さない=改ざん防止)。
+- 段階公開: 新列デフォルト0(=報酬なし)。adminが額を設定するまで無報酬=自然な段階公開(専用フラグ不要)。
+
+---
+
+## コードベース調査結果(Phase B / 調査済み)
+
+### (a) 完走の記録 = サーバー側で確定的
+- テーブル `collection_completions`(`supabase/migrations/20260608090100_create_collection_completions.sql:9-25`)。UNIQUE `(user_id, category_id)` = 1ユーザー1コレクション1行。
+- 確定RPC `finalize_collection_completion(p_completion_id, p_user_id, p_mount_image_path)`(初出 `20260608090600_harden_collection_completion_rpcs.sql`、**現行定義は `20260610100000_allow_versioned_collection_mount_paths.sql` で再CREATE**。SECURITY DEFINER / service_role)。`mount_status='completed'` + `completed_at=now()` を原子的に設定。
+- 付与フック挿入点: `app/api/collections/mount/route.ts` — mount経路 471-486、book経路 281-296(finalize成功後・レスポンス返却前)。**いずれも `if (!isUpdate)` 配下**であり、台紙の作り直し(isUpdate=true)では finalize 自体が呼ばれない = 作り直しで二重付与しない。finalize の呼び出し元はこのルートのみ(grep確認済み)。カテゴリは同ルート187-198で取得済み。
+
+### (b) 付与機構(踏襲パターン) = grant_tour_bonus
+`supabase/migrations/20260228000001_update_grant_functions_percoin_defaults.sql:4-78`。流れ: 額決定 → `credit_transactions` に冪等INSERT → `free_percoin_batches`(expire_at=月末+約6ヶ月) → `user_credits` 残高加算 → `notifications` 作成。
+- `transaction_type` のCHECK: `20260226100000_add_admin_deduction.sql:8-13`(既存11種)。ここに `collection_completion` を追加(制約張り替え)。
+- **権限モデルの相違(重要)**: `grant_tour_bonus` は authenticated に EXECUTE を付与し関数内 `auth.uid()` チェックで守るが、本RPCは **service_role 専用**(finalize と同じ)。踏襲するのは内部の付与処理のみで、**GRANT文はコピーしない**こと。
+- 5万キャップ: `get_grantable_free_percoin_amount`(daily_post/streak が使用)。
+
+### (c) admin設定面(額フィールドの追加先)
+- フォーム: `features/preset-categories/components/AdminPresetCategoryFormClient.tsx`(FormState 51-131 / 送信payload 636-765 / completionThresholdの数値入力 505-517 をミラー)。
+- **バリデーションの実体は `collection-settings-payload.ts` のみに置く**: `[id]/route.ts` の75-354は非collection系フィールドのインライン検証で、collection系(completion_threshold等)は357-370で `parseCollectionSettings()` に一括委譲している。`completion_reward_percoins` も同様に payload parser 側で検証し、route側は existing オブジェクトへの1フィールド追加のみ(**両ファイルに重複実装しない**)。
+- **新規作成 route も対象**: `POST /api/admin/preset-categories/route.ts` も `parseCollectionSettings()` を呼ぶ(408-410でexistingデフォルトを渡す)。新規作成時にデフォルト0が正しく通ることを確認。
+- repositoryマッピング(DB行→camelCase): `features/style-presets/lib/preset-category-repository.ts`。**型定義(PresetCategoryRow/Admin/Insert/Update)と mapRow() はすべてこのファイル内(29-359)にあり、schema.ts は対象外**。
+
+### (d) テストパターン
+- payload: `tests/unit/features/collections/collection-settings-payload.test.ts`
+- admin route: `tests/integration/api/admin-style-presets-routes.test.ts`
+- repository: `tests/unit/lib/preset-category-repository.test.ts`
+
+---
+
+## 1. 概要図
+
+### データモデル(ER)
+
+```mermaid
+erDiagram
+    preset_categories ||--o{ collection_completions : "category_id"
+    preset_categories {
+        uuid id PK
+        text key
+        int completion_threshold
+        int completion_reward_percoins
+    }
+    collection_completions {
+        uuid id PK
+        uuid user_id FK
+        uuid category_id FK
+        text mount_status
+        timestamptz completed_at
+        timestamptz reward_granted_at
+    }
+```
+
+### 付与シーケンス
+
+```mermaid
+sequenceDiagram
+    participant C as MountRoute
+    participant F as finalizeRPC
+    participant G as grantRPC
+    participant DB as Supabase
+    C->>F: finalize_collection_completion
+    F-->>C: true 完走確定
+    C->>G: grant_collection_completion_reward
+    G->>DB: reward_granted_at を test and set
+    Note over G,DB: 既に付与済みなら何もしない
+    G->>DB: 額をカテゴリから取得し5万上限でキャップ
+    G->>DB: credit_transactions と free_percoin_batches と user_credits を更新
+    G->>DB: notifications を作成
+    G-->>C: 付与結果
+    C-->>C: 付与失敗でも完走レスポンスは返す
+```
+
+---
+
+## 2. EARS(要件定義)
+
+- EARS-01(イベント) When `finalize_collection_completion` succeeds, the system shall grant the category's `completion_reward_percoins` to the user exactly once.
+  完走確定時、カテゴリの完走報酬ペルコインをちょうど1回付与する。
+- EARS-02(状態) While granting, the system shall enforce idempotency by a test-and-set on `collection_completions.reward_granted_at`.
+  付与時は reward_granted_at の test-and-set で冪等を担保し二重付与しない。
+- EARS-03(オプション) Where `completion_reward_percoins` is 0 or null, the system shall not create any transaction or notification.
+  報酬額が0/nullなら取引も通知も作らない。
+  ※UXトレードオフ注記: 5万キャップにより付与額が0になったユーザーは「完走したのに報酬通知が来ない」体験になる。v1ではこの挙動を許容(キャップ到達者は稀・残高十分)。問題になれば「上限のため付与見送り」通知を後付け検討。
+- EARS-04(状態) While granting, the system shall cap the amount by `get_grantable_free_percoin_amount`.
+  付与額は5万無料残高上限でキャップする。
+- EARS-05(イベント) When a reward is granted, the system shall create a notification informing the earned amount.
+  付与時、獲得額を知らせる通知を作成する。
+- EARS-06(権限) Where an admin edits a preset category, the system shall validate `completion_reward_percoins` as a non-negative integer or null and persist it.
+  admin編集時、報酬額を0以上の整数かnullで検証して保存する。
+- EARS-07(異常系) If the grant RPC fails, then the system shall log the error and still return the completion response.
+  付与RPC失敗時はログのみ残し完走レスポンスは返す(完走は既に永続化済み・付与は完走をブロックしない)。
+- EARS-08(セキュリティ) While granting, the system shall derive user_id and reward amount server-side, never from the client body.
+  付与時、user_idと報酬額はサーバー側(完走行とカテゴリ)から解決しクライアント入力を信用しない。
+- EARS-09(イベント/演出) When the mount API response includes rewardGranted greater than 0, the completion celebration view shall show a reward panel that counts up from 0 to the granted amount and lands with a burst.
+  台紙完成レスポンスの実付与額が0より大きいとき、祝賀ビューに報酬パネルを出し0からカウントアップ→着地バーストで表示する。額0/付与失敗時はパネル自体を出さない(嘘をつかない)。
+
+---
+
+## 3. ADR(設計判断記録)
+
+### ADR-001: 冪等は collection_completions.reward_granted_at の test-and-set
+- Context: 完走報酬は1ユーザー×1コレクション1回。credit_transactions には category/completion を指す列が無い。
+- Decision: collection_completions に reward_granted_at timestamptz を追加し、grant RPC は「UPDATE ... SET reward_granted_at=now() WHERE id=対象 AND reward_granted_at IS NULL AND mount_status='completed'」の更新成功(1行)時のみ付与処理へ進む。
+- Reason: 完走の真実の源泉(completion行)で付与状態も追跡でき、credit_transactionsのスキーマ変更なしで原子的な1回制御ができる。
+- Consequence: 付与状態がcompletion行から一目で分かる。downでは列削除で戻せる。
+
+### ADR-002: 報酬額はサーバーが preset_categories から引く
+- Decision: grant RPC は p_completion_id, p_user_id のみ受け取り、額は completion→category を辿って取得。
+- Reason: クライアントから額を渡すと改ざんで無限付与できる。source安全性の担保。
+
+### ADR-003: 完走一括・遡及なし
+- Decision: 100%完走(finalize成功)時に一括付与。既存完走者への遡及なし。
+- Reason: シンプル・低リスク。フックはリリース後のfinalizeでのみ発火し、既存完走者は自然に対象外。将来遡及したければ別バッチで可能。
+
+### ADR-004: 5万キャップ適用
+- Decision: daily_post/streak と同じ get_grantable_free_percoin_amount を通す。
+- Reason: 完走報酬も無料付与。無料残高上限の思想に統一し経済健全性を保つ。
+
+---
+
+## 4. 実装計画(フェーズ + TODO)
+
+```mermaid
+flowchart LR
+    P1["Phase 1 DB"] --> P2["Phase 2 サーバー"]
+    P2 --> P3["Phase 3 admin UI"]
+    P3 --> P4["Phase 4 テスト"]
+    P4 --> P5["Phase 5 仕上げ"]
+```
+
+### Phase 1: DB
+目的: 列・enum・grant RPC。ビルド確認: migration適用 + typecheck緑。
+
+- [ ] migration(1本):
+  - ALTER TABLE preset_categories ADD COLUMN completion_reward_percoins integer DEFAULT 0(CHECK: null or 0以上)
+  - ALTER TABLE collection_completions ADD COLUMN reward_granted_at timestamptz
+  - transaction_type CHECK に collection_completion を追加(制約張り替え)
+  - RPC grant_collection_completion_reward(p_completion_id uuid, p_user_id uuid)(SECURITY DEFINER, **service_roleのみ**。authenticated への GRANT はしない): reward_granted_at の test-and-set → 額取得(category) → get_grantable_free_percoin_amount でキャップ → credit_transactions / free_percoin_batches / user_credits / notifications(grant_tour_bonus の内部処理を踏襲)。額が0以下 or キャップ後0なら reward_granted_at は立てるが取引・通知は作らない。
+  - 通知は `type='bonus'` / `entity_type='user'` / **`entity_id=p_user_id`**(grant_tour_bonus と同じ整合)。コレクション情報(category_key・completion_id・付与額)は `data` jsonb に格納。
+- [ ] 型: preset-category-repository の行マッピングに completionRewardPercoins を追加。
+
+### Phase 2: サーバーサイド
+目的: 付与フック + admin保存の配線。ビルド確認: adminでPATCH保存でき、完走で付与される。
+
+- [ ] app/api/collections/mount/route.ts: mount(471-486)/book(281-296) の finalize 成功後(`if (!isUpdate)` 配下)に grant RPC を呼ぶ。try-catchで囲み、失敗しても完走レスポンスは返す。
+- [ ] 付与成功時、残高表示系のキャッシュを revalidate する(`app/api/tutorial/complete/route.ts:47-50` の revalidateTag パターンを踏襲: my-page credits / challenge 等の該当タグ)。既存の `collection-completions:` タグはコレクション表示専用で残高には効かない点に注意。
+- [ ] collection-settings-payload.ts: completion_reward_percoins の検証(null / 非負整数)を completion_threshold パターンで追加。
+- [ ] app/api/admin/preset-categories/[id]/route.ts: 同項目のバリデーションと update への反映。
+
+### Phase 3: admin UI + 報酬演出
+目的: カテゴリ編集フォームに報酬額入力 + 祝賀ビューのカウントアップ演出。ビルド確認: 入力→保存→再表示で値が残る。演出は額>0のときのみ。
+
+- [ ] AdminPresetCategoryFormClient.tsx: FormState に completionRewardPercoins、completionThreshold(505-517)を真似た数値入力、送信payloadに追加。ラベル「完走報酬(ペルコイン)」、補足「0またはなしで報酬なし」。
+- [ ] mount route レスポンスに rewardGranted(実付与額、grant RPC戻り値)を追加(Phase 2で実装)。
+- [ ] 報酬額の伝搬: CollectionMountComposer の結果型(MountGeneratedResult) → useCollectionProgress.onComposerGenerated → CollectionCelebration 型 → CollectionProgressModal。
+- [ ] CountUpNumber 小コンポーネント新規(rAF + easeOut、ライブラリなし)。
+- [ ] CollectionProgressModal の完走(completed)ビューに報酬パネル: 0.8秒遅延ポップイン → カウントアップ(約1.2秒) → 着地バウンス+コイン粒子バースト(いいねボタンの既存バースト演出を流用)。額0/undefined時はパネル非表示。Lottieは使わない(既存演出と同じ手書きCSS/rAF)。
+
+### Phase 4: テスト
+目的: 回帰防止。ビルド確認: test緑。
+
+- [ ] payload: 負数reject / null accept / 0 accept / 大きい整数 accept。
+- [ ] admin route: PATCH completion_reward_percoins:100 が保存・応答に反映。
+- [ ] repository: DB行→completionRewardPercoins マッピング(null/0含む)。
+- [ ] mount route: finalize成功時に grant RPC が呼ばれる / grant失敗でも200 / 額の引数を渡さない(completion_idとuser_idのみ)。
+
+### Phase 5: 仕上げ
+目的: 実機・非機能。ビルド確認: lint/typecheck/test/build緑。
+
+- [ ] 実機(admin): カテゴリに報酬額設定 → 別垢で完走 → 残高増・通知表示・reward_granted_at セット確認。二重付与されないこと。
+- [ ] 額未設定(0)カテゴリでは付与も通知も出ないこと。
+- [ ] i18n: adminラベルは日本語。ユーザー通知はSQL内で日本語生成(既存bonus通知踏襲)。
+- [ ] docs/architecture/data.ja.md の「アプリから使う主要RPCカタログ」表(315-336付近)に新RPCを追記。
+- [ ] (要判断・スコープ外候補) 完走モーダル(CollectionProgressModal)内への報酬額インライン表示。v1は通知のみ、必要なら別PR。
+
+---
+
+## 5. 修正対象ファイル一覧
+
+| ファイル | 操作 | 変更内容 |
+|----------|------|----------|
+| supabase/migrations/20260710120000_add_collection_completion_reward.sql | 新規 | 列2つ + transaction_type拡張 + grant RPC |
+| features/style-presets/lib/preset-category-repository.ts | 修正 | 型(Row/Admin/Insert/Update)+mapRow に completionRewardPercoins 追加(このファイルで完結) |
+| app/api/collections/mount/route.ts | 修正 | finalize後に grant RPC 呼び出し(try-catch)+残高系revalidateTag |
+| app/api/admin/preset-categories/collection-settings-payload.ts | 修正 | 報酬額の検証・payload反映(バリデーション実体はここのみ) |
+| app/api/admin/preset-categories/[id]/route.ts | 修正 | existing への1フィールド追加(検証は委譲) |
+| app/api/admin/preset-categories/route.ts | 修正 | 新規作成時のデフォルト0の通過確認・existing追加 |
+| docs/architecture/data.ja.md | 修正 | RPCカタログ表に grant_collection_completion_reward を追記 |
+| features/preset-categories/components/AdminPresetCategoryFormClient.tsx | 修正 | 数値入力フィールド追加 |
+| features/collections/components/CollectionMountComposer.tsx | 修正 | MountGeneratedResult に rewardGranted 追加 |
+| features/collections/hooks/useCollectionProgress.ts | 修正 | celebration へ rewardGranted 伝搬 |
+| features/collections/components/CollectionProgressModal.tsx | 修正 | 完走ビューに報酬パネル(カウントアップ+バースト) |
+| features/collections/components/CountUpNumber.tsx | 新規 | rAF カウントアップ数値 |
+| tests/unit/features/collections/collection-settings-payload.test.ts | 修正 | 報酬額バリデーションのテスト |
+| tests/integration/api/admin-style-presets-routes.test.ts | 修正 | PATCH保存テスト |
+| tests/unit/lib/preset-category-repository.test.ts | 修正 | マッピングテスト |
+
+---
+
+## 6. 品質・テスト観点
+
+### 品質チェックリスト
+- [ ] 冪等: 同一完走で二重付与しない(reward_granted_at test-and-set)。
+- [ ] source安全性: user_id・額はサーバー解決(クライアント入力を信用しない)。
+- [ ] 経済: 5万キャップ適用。額0/nullで完全no-op。
+- [ ] 非ブロッキング: 付与失敗が完走レスポンスを妨げない。
+- [ ] 権限: grant RPCは service_role のみ。admin保存は requireAdmin。
+- [ ] i18n: adminラベル日本語 / 通知はSQL生成。
+
+### テスト観点
+| カテゴリ | 内容 |
+|----------|------|
+| 正常系 | 完走→付与→残高増・通知。admin保存→反映。 |
+| 異常系 | 付与RPC失敗でも完走は成功レスポンス。 |
+| 冪等 | 2回目付与はno-op。 |
+| 境界 | 額0/null=no-op、キャップ超過=キャップ額、負数=reject。 |
+| 権限 | 非adminはPATCH不可、grant RPCは直接呼べない。 |
+
+---
+
+## 7. ロールバック方針
+- DB: down migration で RPC・列(completion_reward_percoins, reward_granted_at)・enum拡張を drop。列は未使用でも無害。
+- 段階公開: 全カテゴリ初期値0=無報酬。adminが額を入れるまで実質OFF。問題時は額を0に戻すだけで即停止(デプロイ不要)。
+- 付与フック: try-catchで完走フローに影響しない追加実装。
+- Git: フェーズ単位コミットで revert 可能。
+
+## 8. 使用スキル
+| スキル | 用途 | フェーズ |
+|--------|------|----------|
+| /project-database-context | DB設計参照 | Phase 1 |
+| /git-create-pr | PR作成 | 完了時 |

--- a/features/collections/components/CollectionMountComposer.tsx
+++ b/features/collections/components/CollectionMountComposer.tsx
@@ -93,11 +93,14 @@ export function CollectionMountComposer({
         // book(めくれる日記帳)は結果モーダルではなく没入の本リーダーへ直接遷移する。
         // 完走報酬はリーダー側の演出用に ?reward= で引き継ぐ(表示専用。付与はサーバー確定済み)。
         if (res.ok && data.status === "completed" && data.mode === "book" && data.sharePath) {
-          router.push(
-            rewardGranted > 0
-              ? `${data.sharePath}?reward=${rewardGranted}`
-              : data.sharePath,
-          );
+          let bookPath = data.sharePath;
+          if (rewardGranted > 0) {
+            // 既存クエリ/ハッシュを壊さないよう URL API で安全に付与する
+            const url = new URL(data.sharePath, window.location.origin);
+            url.searchParams.set("reward", String(rewardGranted));
+            bookPath = `${url.pathname}${url.search}${url.hash}`;
+          }
+          router.push(bookPath);
           return;
         }
         if (res.ok && data.status === "completed" && data.mountImageUrl) {

--- a/features/collections/components/CollectionMountComposer.tsx
+++ b/features/collections/components/CollectionMountComposer.tsx
@@ -34,6 +34,8 @@ export interface MountGeneratedResult {
   completionId: string | null;
   mountTemplateWidth: number | null;
   mountTemplateHeight: number | null;
+  /** 完走報酬の実付与額(サーバーのキャップ後)。0=報酬なし/付与失敗/作り直し */
+  rewardGranted: number;
 }
 
 interface Props {
@@ -81,11 +83,21 @@ export function CollectionMountComposer({
           sharePath?: string;
           mountTemplateWidth?: number | null;
           mountTemplateHeight?: number | null;
+          rewardGranted?: number;
           error?: string;
         };
+        const rewardGranted =
+          typeof data.rewardGranted === "number" && data.rewardGranted > 0
+            ? data.rewardGranted
+            : 0;
         // book(めくれる日記帳)は結果モーダルではなく没入の本リーダーへ直接遷移する。
+        // 完走報酬はリーダー側の演出用に ?reward= で引き継ぐ(表示専用。付与はサーバー確定済み)。
         if (res.ok && data.status === "completed" && data.mode === "book" && data.sharePath) {
-          router.push(data.sharePath);
+          router.push(
+            rewardGranted > 0
+              ? `${data.sharePath}?reward=${rewardGranted}`
+              : data.sharePath,
+          );
           return;
         }
         if (res.ok && data.status === "completed" && data.mountImageUrl) {
@@ -98,6 +110,7 @@ export function CollectionMountComposer({
               : null,
             mountTemplateWidth: data.mountTemplateWidth ?? null,
             mountTemplateHeight: data.mountTemplateHeight ?? null,
+            rewardGranted,
           });
           return;
         }

--- a/features/collections/components/CollectionProgressModal.tsx
+++ b/features/collections/components/CollectionProgressModal.tsx
@@ -13,6 +13,7 @@ import { ShareLinkButton } from "@/components/ShareLinkButton";
 import { AchievementBadge } from "@/features/collections/components/AchievementBadge";
 import { CompletionFeedPostButton } from "@/features/collections/components/CompletionFeedPostButton";
 import { CollectionConfetti } from "@/features/collections/components/CollectionConfetti";
+import { CompletionRewardPanel } from "@/features/collections/components/CompletionRewardPanel";
 import { CollectionSparkle } from "@/features/collections/components/CollectionSparkle";
 import { collectionGuidePath } from "@/features/collections/lib/collection-guides";
 import { mountAspectForCategory } from "@/features/collections/lib/mount-aspects";
@@ -39,6 +40,11 @@ export interface CollectionCelebration {
   sharePath: string | null;
   /** 公開ページ token(= collection_completions.id)。シェアに使う */
   completionId: string | null;
+  /**
+   * 完走報酬の実付与額(サーバーのキャップ後)。>0 のとき完了ビューに
+   * カウントアップ演出パネルを出す(EARS-09)。0/undefined=パネル非表示。
+   */
+  rewardGranted?: number;
   /** リング中央のシリーズ用キャラ画像(任意) */
   characterImageUrl: string | null;
   /** 集めたシール画像(衣装ごと最新1枚)の公開URL。?枠に重ねる */
@@ -597,6 +603,8 @@ export function CollectionProgressModal({
                 />
               </div>
             </div>
+            {/* 完走報酬: 0.8秒じらし→カウントアップ→着地バースト(額>0のときのみ) */}
+            <CompletionRewardPanel amount={celebration.rewardGranted ?? 0} />
             {/* 上(オレンジ=主CTA)=「シェアページへ」、中(白)=「シェアする」。
                ボタンの色の位置は固定し、ラベル/動作だけ入れ替えている。 */}
             {celebration.sharePath ? (

--- a/features/collections/components/CompletionRewardPanel.tsx
+++ b/features/collections/components/CompletionRewardPanel.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Coins } from "lucide-react";
+import { CountUpNumber } from "./CountUpNumber";
+
+/**
+ * 完走報酬の獲得演出パネル(docs/planning/collection-completion-reward-implementation-plan.md EARS-09)。
+ *
+ * 「じらし→カウントアップ→着地ドーン」の3段構成:
+ *   delayMs 後にポップイン → 0→amount カウントアップ(1.2s) → 着地でバウンス+コイン粒子バースト。
+ *
+ * - amount<=0 なら何も描画しない(キャップ0/付与失敗/報酬なしで嘘をつかない)
+ * - 表示額はサーバーの実付与額(キャップ後)のみを渡すこと
+ * - 完走モーダル(mount)と日記帳リーダー(book, autoDismissMs指定)で共用
+ */
+export function CompletionRewardPanel({
+  amount,
+  delayMs = 800,
+  autoDismissMs = null,
+  className = "",
+}: {
+  /** サーバーが実際に付与したペルコイン数(0以下はパネル非表示) */
+  amount: number;
+  /** マウントからポップインまでの「じらし」時間(ms) */
+  delayMs?: number;
+  /** 着地後この時間でフェードアウトして消える(null=消えない)。book没入ビュー用 */
+  autoDismissMs?: number | null;
+  className?: string;
+}) {
+  const [phase, setPhase] = useState<
+    "waiting" | "counting" | "landed" | "gone"
+  >("waiting");
+
+  useEffect(() => {
+    if (amount <= 0) return;
+    const timer = window.setTimeout(() => setPhase("counting"), delayMs);
+    return () => window.clearTimeout(timer);
+  }, [amount, delayMs]);
+
+  useEffect(() => {
+    if (phase !== "landed" || autoDismissMs === null) return;
+    const timer = window.setTimeout(() => setPhase("gone"), autoDismissMs);
+    return () => window.clearTimeout(timer);
+  }, [phase, autoDismissMs]);
+
+  if (amount <= 0 || phase === "gone") {
+    return null;
+  }
+
+  const visible = phase !== "waiting";
+  const landed = phase === "landed";
+
+  return (
+    <div
+      className={`pointer-events-none relative mx-auto w-fit transition-all duration-300 ease-out ${
+        visible ? "scale-100 opacity-100" : "scale-75 opacity-0"
+      } ${className}`}
+      aria-live="polite"
+    >
+      <div
+        className={`relative rounded-2xl border border-amber-200 bg-gradient-to-b from-amber-50 to-white px-6 py-3 shadow-[0_6px_18px_rgba(120,90,50,0.18)] ${
+          landed ? "reward-panel-bounce" : ""
+        }`}
+      >
+        <p className="text-xs font-bold tracking-wide text-amber-500">
+          完走報酬
+        </p>
+        <p className="flex items-center justify-center gap-1.5 text-amber-600">
+          <Coins className="h-6 w-6" aria-hidden />
+          <span className="text-3xl font-extrabold tabular-nums">
+            +
+            {phase === "waiting" ? (
+              0
+            ) : (
+              <CountUpNumber
+                value={amount}
+                onDone={() => {
+                  setPhase("landed");
+                  try {
+                    navigator.vibrate?.(50);
+                  } catch {
+                    // 非対応環境は無視
+                  }
+                }}
+              />
+            )}
+          </span>
+          <span className="text-sm font-bold">ペルコイン</span>
+        </p>
+        {landed ? (
+          <p className="text-xs font-bold text-amber-500">獲得！</p>
+        ) : null}
+        {/* 着地バースト: コイン粒子を放射状に飛ばす(1回きり) */}
+        {landed ? (
+          <span aria-hidden className="reward-burst">
+            {Array.from({ length: 8 }, (_, i) => (
+              <span key={i} style={{ ["--rb-angle" as string]: `${i * 45}deg` }} />
+            ))}
+          </span>
+        ) : null}
+      </div>
+      <style>{`
+        .reward-panel-bounce {
+          animation: reward-panel-bounce 480ms cubic-bezier(0.34, 1.56, 0.64, 1);
+        }
+        @keyframes reward-panel-bounce {
+          0% { transform: scale(1); }
+          35% { transform: scale(1.14); }
+          100% { transform: scale(1); }
+        }
+        .reward-burst {
+          position: absolute;
+          inset: 0;
+          display: block;
+        }
+        .reward-burst > span {
+          position: absolute;
+          left: 50%;
+          top: 50%;
+          width: 8px;
+          height: 8px;
+          border-radius: 9999px;
+          background: linear-gradient(180deg, #fbbf24, #f59e0b);
+          transform: translate(-50%, -50%);
+          animation: reward-burst-fly 640ms ease-out forwards;
+        }
+        @keyframes reward-burst-fly {
+          0% {
+            opacity: 1;
+            transform: translate(-50%, -50%) rotate(var(--rb-angle)) translateX(0);
+          }
+          100% {
+            opacity: 0;
+            transform: translate(-50%, -50%) rotate(var(--rb-angle)) translateX(64px);
+          }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .reward-panel-bounce { animation: none; }
+          .reward-burst > span { animation: none; opacity: 0; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/features/collections/components/CountUpNumber.tsx
+++ b/features/collections/components/CountUpNumber.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * 0 から value まで easeOut でカウントアップする数値表示。
+ * 完走報酬パネル用(rAF 実装・ライブラリなし)。
+ * - easeOutCubic: 最初速く最後ゆっくり刻み、着地感を出す
+ * - prefers-reduced-motion では即座に最終値を表示する
+ */
+export function CountUpNumber({
+  value,
+  durationMs = 1200,
+  onDone,
+  className,
+}: {
+  value: number;
+  durationMs?: number;
+  /** 最終値に到達した瞬間に1回だけ呼ばれる(着地演出のトリガ) */
+  onDone?: () => void;
+  className?: string;
+}) {
+  const [display, setDisplay] = useState(0);
+  const doneRef = useRef(false);
+
+  useEffect(() => {
+    doneRef.current = false;
+    if (value <= 0) {
+      setDisplay(0);
+      return;
+    }
+    const reduceMotion =
+      typeof window !== "undefined" &&
+      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+    if (reduceMotion) {
+      setDisplay(value);
+      doneRef.current = true;
+      onDone?.();
+      return;
+    }
+    let raf = 0;
+    const start = performance.now();
+    const tick = (now: number) => {
+      const t = Math.min(1, (now - start) / durationMs);
+      const eased = 1 - Math.pow(1 - t, 3);
+      setDisplay(Math.round(eased * value));
+      if (t < 1) {
+        raf = requestAnimationFrame(tick);
+      } else if (!doneRef.current) {
+        doneRef.current = true;
+        onDone?.();
+      }
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+    // onDone は再スタートのトリガにしない(親のインライン関数で無限再実行しないように)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value, durationMs]);
+
+  return <span className={className}>{display.toLocaleString("en-US")}</span>;
+}

--- a/features/collections/components/CountUpNumber.tsx
+++ b/features/collections/components/CountUpNumber.tsx
@@ -22,25 +22,32 @@ export function CountUpNumber({
 }) {
   const [display, setDisplay] = useState(0);
   const doneRef = useRef(false);
+  // Latest Ref Pattern: 親の再レンダーで新しい onDone が渡されても、
+  // アニメーションを再トリガーせずに常に最新の関数を呼ぶ(stale closure回避)。
+  const onDoneRef = useRef(onDone);
+  useEffect(() => {
+    onDoneRef.current = onDone;
+  });
 
   useEffect(() => {
     doneRef.current = false;
+    // 0以下は描画0のまま(呼び出し側パネルが額<=0で非表示にする前提)。
     if (value <= 0) {
-      setDisplay(0);
       return;
     }
     const reduceMotion =
       typeof window !== "undefined" &&
       window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
-    if (reduceMotion) {
-      setDisplay(value);
-      doneRef.current = true;
-      onDone?.();
-      return;
-    }
+    // setState は必ず rAF コールバック内で行う(effect本体での同期setState回避)。
     let raf = 0;
     const start = performance.now();
     const tick = (now: number) => {
+      if (reduceMotion) {
+        setDisplay(value);
+        doneRef.current = true;
+        onDoneRef.current?.();
+        return;
+      }
       const t = Math.min(1, (now - start) / durationMs);
       const eased = 1 - Math.pow(1 - t, 3);
       setDisplay(Math.round(eased * value));
@@ -48,13 +55,11 @@ export function CountUpNumber({
         raf = requestAnimationFrame(tick);
       } else if (!doneRef.current) {
         doneRef.current = true;
-        onDone?.();
+        onDoneRef.current?.();
       }
     };
     raf = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(raf);
-    // onDone は再スタートのトリガにしない(親のインライン関数で無限再実行しないように)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value, durationMs]);
 
   return <span className={className}>{display.toLocaleString("en-US")}</span>;

--- a/features/collections/components/ScrapbookReader.tsx
+++ b/features/collections/components/ScrapbookReader.tsx
@@ -7,6 +7,7 @@ import { X, Share2, Maximize2, Minimize2, ChevronUp } from "lucide-react";
 import { CatalogBookView } from "@/features/catalog/components/CatalogBookView";
 import type { CatalogPageData } from "@/features/catalog/components/CatalogPage";
 import { CompletionFeedPostButton } from "@/features/collections/components/CompletionFeedPostButton";
+import { CompletionRewardPanel } from "@/features/collections/components/CompletionRewardPanel";
 import {
   hasSeenSwipeHint,
   markSwipeHintSeen,
@@ -24,6 +25,7 @@ export function ScrapbookReader({
   pages,
   isOwner,
   completionId,
+  rewardGranted = 0,
 }: {
   title: string;
   coverImageUrl: string | null;
@@ -31,6 +33,11 @@ export function ScrapbookReader({
   isOwner: boolean;
   /** 完走(collection_completions.id = token)。所有者にホーム投稿ボタンを出すのに使う。 */
   completionId?: string | null;
+  /**
+   * 完走報酬の実付与額(?reward= から。所有者のみ・表示専用)。
+   * >0 のとき開幕にカウントアップ演出を重ねる(着地後は自動で消える)。
+   */
+  rewardGranted?: number;
 }) {
   const router = useRouter();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -230,6 +237,17 @@ export function ScrapbookReader({
             <ChevronUp className="h-8 w-8 animate-bounce" />
             <p className="text-sm font-bold">↑ 上スワイプでUIを隠せます</p>
           </div>
+        </div>
+      ) : null}
+
+      {/* 完走報酬の獲得演出(完走直後の遷移時のみ)。着地後は自動で消え、没入を妨げない */}
+      {rewardGranted > 0 ? (
+        <div className="pointer-events-none absolute inset-x-0 top-16 z-20 flex justify-center">
+          <CompletionRewardPanel
+            amount={rewardGranted}
+            delayMs={900}
+            autoDismissMs={3200}
+          />
         </div>
       ) : null}
 

--- a/features/collections/hooks/useCollectionProgress.ts
+++ b/features/collections/hooks/useCollectionProgress.ts
@@ -311,6 +311,8 @@ export function useCollectionProgress() {
       mountImageUrl: result.mountImageUrl,
       sharePath: result.sharePath,
       completionId: result.completionId,
+      // 完走報酬の実付与額(>0で完了ビューにカウントアップ演出が出る)
+      rewardGranted: result.rewardGranted,
       mountTemplateWidth: result.mountTemplateWidth,
       mountTemplateHeight: result.mountTemplateHeight,
       characterImageUrl: target?.characterImageUrl ?? null,

--- a/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
+++ b/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
@@ -69,6 +69,8 @@ interface FormState {
   visibility: "public" | "admin_only";
   isCollectionSeries: boolean;
   completionThreshold: number | null;
+  /** コレクション完走時に付与するペルコイン数。0/null=報酬なし */
+  completionRewardPercoins: number | null;
   /** 完走表示モード: mount(単一台紙) / book(めくれる日記帳) */
   completionViewMode: "mount" | "book";
   /** book 表示の表紙(0ページ目)画像 storage path。null=簡易表紙 */
@@ -167,6 +169,7 @@ function toFormState(
     visibility: initial?.visibility ?? "admin_only",
     isCollectionSeries: initial?.isCollectionSeries ?? false,
     completionThreshold: initial?.completionThreshold ?? null,
+    completionRewardPercoins: initial?.completionRewardPercoins ?? null,
     completionViewMode: initial?.completionViewMode ?? "mount",
     bookCoverPath: initial?.bookCoverPath ?? null,
     unlockPrerequisiteKey: initial?.unlockPrerequisiteKey ?? null,
@@ -655,6 +658,7 @@ export function AdminPresetCategoryFormClient({
               visibility: form.visibility,
               is_collection_series: form.isCollectionSeries,
               completion_threshold: effectiveThreshold,
+              completion_reward_percoins: form.completionRewardPercoins,
               completion_view_mode: form.completionViewMode,
               book_cover_path: form.bookCoverPath,
               unlock_prerequisite_key: form.unlockPrerequisiteKey,
@@ -719,6 +723,7 @@ export function AdminPresetCategoryFormClient({
               visibility: form.visibility,
               is_collection_series: form.isCollectionSeries,
               completion_threshold: effectiveThreshold,
+              completion_reward_percoins: form.completionRewardPercoins,
               completion_view_mode: form.completionViewMode,
               book_cover_path: form.bookCoverPath,
               unlock_prerequisite_key: form.unlockPrerequisiteKey,
@@ -1313,6 +1318,35 @@ export function AdminPresetCategoryFormClient({
               className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm"
               placeholder="4"
             />
+          </label>
+
+          <label className="block">
+            <span className="text-sm font-medium text-slate-700">
+              完走報酬（ペルコイン）
+            </span>
+            <input
+              type="number"
+              min={0}
+              step={1}
+              value={form.completionRewardPercoins ?? ""}
+              onChange={(e) => {
+                const raw = e.target.value;
+                if (raw === "") {
+                  update("completionRewardPercoins", null);
+                  return;
+                }
+                const n = Number(raw);
+                update(
+                  "completionRewardPercoins",
+                  Number.isFinite(n) ? Math.max(0, Math.floor(n)) : null,
+                );
+              }}
+              className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm"
+              placeholder="100"
+            />
+            <span className="mt-1 block text-xs text-slate-500">
+              コレクション完走時に付与するペルコイン数。0または空欄で報酬なし。
+            </span>
           </label>
 
           {form.completionViewMode !== "book" ? (

--- a/features/style-presets/lib/preset-category-repository.ts
+++ b/features/style-presets/lib/preset-category-repository.ts
@@ -48,6 +48,7 @@ export interface PresetCategoryRow {
   visibility?: StylePresetCategoryVisibility | null;
   is_collection_series?: boolean | null;
   completion_threshold?: number | null;
+  completion_reward_percoins?: number | null;
   completion_view_mode?: string | null;
   book_cover_path?: string | null;
   unlock_prerequisite_key?: string | null;
@@ -110,6 +111,8 @@ export interface PresetCategoryAdmin {
   visibility: StylePresetCategoryVisibility;
   isCollectionSeries: boolean;
   completionThreshold: number | null;
+  /** コレクション完走時に付与するペルコイン数。0/null=報酬なし。 */
+  completionRewardPercoins: number | null;
   /** 完走表示モード: 'mount'(単一台紙) / 'book'(めくれる日記帳)。 */
   completionViewMode: "mount" | "book";
   /** book 表示の表紙(0ページ目)画像の storage path。 */
@@ -174,6 +177,7 @@ export interface PresetCategoryInsert {
   visibility?: StylePresetCategoryVisibility;
   isCollectionSeries?: boolean;
   completionThreshold?: number | null;
+  completionRewardPercoins?: number | null;
   completionViewMode?: "mount" | "book";
   bookCoverPath?: string | null;
   unlockPrerequisiteKey?: string | null;
@@ -231,6 +235,7 @@ export interface PresetCategoryUpdate {
   visibility?: StylePresetCategoryVisibility;
   isCollectionSeries?: boolean;
   completionThreshold?: number | null;
+  completionRewardPercoins?: number | null;
   completionViewMode?: "mount" | "book";
   bookCoverPath?: string | null;
   unlockPrerequisiteKey?: string | null;
@@ -303,6 +308,7 @@ function mapRow(row: PresetCategoryRow): PresetCategoryAdmin {
     visibility: normalizeVisibility(row.visibility),
     isCollectionSeries: row.is_collection_series ?? false,
     completionThreshold: row.completion_threshold ?? null,
+    completionRewardPercoins: row.completion_reward_percoins ?? null,
     completionViewMode: row.completion_view_mode === "book" ? "book" : "mount",
     bookCoverPath: row.book_cover_path ?? null,
     unlockPrerequisiteKey: row.unlock_prerequisite_key ?? null,
@@ -447,6 +453,7 @@ export async function createPresetCategory(
       visibility: input.visibility ?? "admin_only",
       is_collection_series: input.isCollectionSeries ?? false,
       completion_threshold: input.completionThreshold ?? null,
+      completion_reward_percoins: input.completionRewardPercoins ?? null,
       completion_view_mode: input.completionViewMode ?? "mount",
       book_cover_path: input.bookCoverPath ?? null,
       unlock_prerequisite_key: input.unlockPrerequisiteKey ?? null,
@@ -539,6 +546,8 @@ export async function updatePresetCategory(
     payload.is_collection_series = input.isCollectionSeries;
   if (input.completionThreshold !== undefined)
     payload.completion_threshold = input.completionThreshold;
+  if (input.completionRewardPercoins !== undefined)
+    payload.completion_reward_percoins = input.completionRewardPercoins;
   if (input.completionViewMode !== undefined)
     payload.completion_view_mode = input.completionViewMode;
   if (input.bookCoverPath !== undefined)

--- a/supabase/migrations/20260710120000_add_collection_completion_reward.sql
+++ b/supabase/migrations/20260710120000_add_collection_completion_reward.sql
@@ -1,0 +1,195 @@
+-- コレクション完走報酬 (docs/planning/collection-completion-reward-implementation-plan.md)
+--
+-- - preset_categories.completion_reward_percoins: adminがカテゴリごとに設定する付与額(0/null=報酬なし)
+-- - collection_completions.reward_granted_at: 付与済みマーカー(ADR-001: test-and-setで冪等)
+-- - grant_collection_completion_reward RPC: finalize成功後にmount routeから呼ぶ(service_role専用)。
+--   grant_tour_bonus の付与処理を踏襲するが、権限モデルは異なり authenticated へは公開しない
+--   (額・user_idはサーバー側で解決、クライアント入力を信用しない = ADR-002/EARS-08)。
+-- - 5万無料残高キャップ(get_grantable_free_percoin_amount)適用(ADR-004)。
+--   キャップ後0の場合は reward_granted_at のみ立てて取引・通知は作らない(EARS-03)。
+
+-- 1) admin設定列(デフォルト0=報酬なし。adminが額を入れるまで実質OFF=段階公開)
+ALTER TABLE public.preset_categories
+  ADD COLUMN completion_reward_percoins integer DEFAULT 0
+  CHECK (completion_reward_percoins IS NULL OR completion_reward_percoins >= 0);
+
+COMMENT ON COLUMN public.preset_categories.completion_reward_percoins IS
+  'コレクション完走時に付与するペルコイン数。0またはnull=報酬なし';
+
+-- 2) 付与済みマーカー(完走行が真実の源泉。同一完走への二重付与をDB層で防ぐ)
+ALTER TABLE public.collection_completions
+  ADD COLUMN reward_granted_at timestamptz;
+
+COMMENT ON COLUMN public.collection_completions.reward_granted_at IS
+  '完走報酬の付与日時。NULL=未付与。grant_collection_completion_reward が test-and-set で更新';
+
+-- 3) transaction_type に collection_completion を追加
+--    (現行定義=20260331110000 の12種に追加。古い11種定義から張り替えないこと)
+ALTER TABLE public.credit_transactions
+  DROP CONSTRAINT IF EXISTS credit_transactions_transaction_type_check;
+
+ALTER TABLE public.credit_transactions
+  ADD CONSTRAINT credit_transactions_transaction_type_check
+  CHECK (
+    transaction_type = ANY (
+      ARRAY[
+        'purchase'::text,
+        'consumption'::text,
+        'refund'::text,
+        'signup_bonus'::text,
+        'daily_post'::text,
+        'streak'::text,
+        'referral'::text,
+        'admin_bonus'::text,
+        'forfeiture'::text,
+        'tour_bonus'::text,
+        'admin_deduction'::text,
+        'subscription'::text,
+        'collection_completion'::text
+      ]
+    )
+  );
+
+-- 4) free_percoin_batches.source にも collection_completion を追加
+--    (現行定義=20260331110000 の8種に追加)
+ALTER TABLE public.free_percoin_batches
+  DROP CONSTRAINT IF EXISTS free_percoin_batches_source_check;
+
+ALTER TABLE public.free_percoin_batches
+  ADD CONSTRAINT free_percoin_batches_source_check
+  CHECK (
+    source = ANY (
+      ARRAY[
+        'signup_bonus'::text,
+        'tour_bonus'::text,
+        'referral'::text,
+        'daily_post'::text,
+        'streak'::text,
+        'admin_bonus'::text,
+        'refund'::text,
+        'subscription'::text,
+        'collection_completion'::text
+      ]
+    )
+  );
+
+-- 5) 付与RPC(service_role専用)
+CREATE OR REPLACE FUNCTION public.grant_collection_completion_reward(
+  p_completion_id uuid,
+  p_user_id uuid
+)
+RETURNS TABLE(amount_granted integer, already_granted boolean)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_category_id uuid;
+  v_category_key text;
+  v_display_name text;
+  v_configured integer;
+  v_amount integer;
+  v_tx_id uuid;
+  v_expire_at timestamptz;
+  v_rows_updated integer;
+BEGIN
+  -- 冪等の要(ADR-001): 完走行の test-and-set。
+  -- 所有者一致 + completed + 未付与 の1行だけが更新に成功する。
+  -- 以降で例外が起きた場合は同一トランザクションごとロールバックされ、未付与状態に戻る。
+  UPDATE public.collection_completions cc
+  SET reward_granted_at = now()
+  WHERE cc.id = p_completion_id
+    AND cc.user_id = p_user_id
+    AND cc.mount_status = 'completed'
+    AND cc.reward_granted_at IS NULL
+  RETURNING cc.category_id INTO v_category_id;
+
+  IF v_category_id IS NULL THEN
+    -- 既付与 / 未完走 / 所有者不一致 → 何もしない
+    RETURN QUERY SELECT 0::integer, TRUE::boolean;
+    RETURN;
+  END IF;
+
+  SELECT pc.key, pc.display_name_ja, COALESCE(pc.completion_reward_percoins, 0)
+  INTO v_category_key, v_display_name, v_configured
+  FROM public.preset_categories pc
+  WHERE pc.id = v_category_id;
+
+  -- 5万無料残高キャップ(ADR-004)
+  v_amount := public.get_grantable_free_percoin_amount(p_user_id, v_configured);
+
+  IF v_amount IS NULL OR v_amount <= 0 THEN
+    -- 額0設定 or キャップで0 → reward_granted_at は立てたまま、取引・通知は作らない(EARS-03)
+    RETURN QUERY SELECT 0::integer, FALSE::boolean;
+    RETURN;
+  END IF;
+
+  INSERT INTO public.credit_transactions (
+    user_id, amount, transaction_type, related_generation_id, metadata
+  ) VALUES (
+    p_user_id, v_amount, 'collection_completion', NULL,
+    jsonb_build_object(
+      'source', 'grant_collection_completion_reward',
+      'completion_id', p_completion_id,
+      'category_id', v_category_id,
+      'category_key', v_category_key
+    )
+  )
+  RETURNING id INTO v_tx_id;
+
+  -- 有効期限: JST月初 + 7ヶ月 - 1秒(既存bonusと同一ルール)
+  v_expire_at := (
+    date_trunc('month', now() AT TIME ZONE 'Asia/Tokyo')
+    + interval '7 months' - interval '1 second'
+  ) AT TIME ZONE 'Asia/Tokyo';
+
+  INSERT INTO public.free_percoin_batches (
+    user_id, amount, remaining_amount, granted_at, expire_at, source, credit_transaction_id
+  )
+  VALUES (p_user_id, v_amount, v_amount, now(), v_expire_at, 'collection_completion', v_tx_id);
+
+  UPDATE public.user_credits
+  SET balance = balance + v_amount, updated_at = now()
+  WHERE user_id = p_user_id;
+
+  GET DIAGNOSTICS v_rows_updated = ROW_COUNT;
+
+  IF v_rows_updated = 0 THEN
+    INSERT INTO public.user_credits (user_id, balance, paid_balance)
+    VALUES (p_user_id, v_amount, 0)
+    ON CONFLICT (user_id) DO UPDATE SET
+      balance = user_credits.balance + v_amount,
+      updated_at = now();
+  END IF;
+
+  -- 通知(EARS-05)。通知失敗は付与自体を巻き戻さない(WARNINGのみ)。
+  -- entity_type='user' / entity_id=p_user_id は grant_tour_bonus と同じ整合。
+  BEGIN
+    INSERT INTO public.notifications (
+      recipient_id, actor_id, type, entity_type, entity_id, title, body, data, is_read, created_at
+    ) VALUES (
+      p_user_id, p_user_id, 'bonus', 'user', p_user_id,
+      'コレクション完走報酬獲得！',
+      '「' || COALESCE(v_display_name, 'コレクション') || '」完走で' || v_amount || 'ペルコインを獲得しました！',
+      jsonb_build_object(
+        'bonus_amount', v_amount,
+        'bonus_type', 'collection_completion',
+        'category_key', v_category_key,
+        'completion_id', p_completion_id,
+        'granted_at', now()
+      ),
+      false, now()
+    );
+  EXCEPTION
+    WHEN OTHERS THEN RAISE WARNING 'Collection completion reward notification failed (%), skipping', SQLERRM;
+  END;
+
+  RETURN QUERY SELECT v_amount::integer, FALSE::boolean;
+END;
+$$;
+
+-- 権限: service_role 専用(grant_tour_bonus と異なり authenticated へは公開しない)
+REVOKE ALL ON FUNCTION public.grant_collection_completion_reward(uuid, uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.grant_collection_completion_reward(uuid, uuid) FROM anon;
+REVOKE ALL ON FUNCTION public.grant_collection_completion_reward(uuid, uuid) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.grant_collection_completion_reward(uuid, uuid) TO service_role;

--- a/tests/unit/features/collections/collection-settings-payload.test.ts
+++ b/tests/unit/features/collections/collection-settings-payload.test.ts
@@ -79,6 +79,44 @@ describe("parseCollectionSettings", () => {
     expect(parseCollectionSettings({ completion_threshold: 1.5 }, OFF).ok).toBe(false);
   });
 
+  test("完走報酬: 0 / 正の整数 / null は許可し payload に反映", () => {
+    const zero = parseCollectionSettings({ completion_reward_percoins: 0 }, OFF);
+    expect(zero.ok).toBe(true);
+    if (zero.ok) expect(zero.payload.completionRewardPercoins).toBe(0);
+
+    const hundred = parseCollectionSettings(
+      { completion_reward_percoins: 100 },
+      OFF,
+    );
+    expect(hundred.ok).toBe(true);
+    if (hundred.ok) expect(hundred.payload.completionRewardPercoins).toBe(100);
+
+    const nul = parseCollectionSettings(
+      { completion_reward_percoins: null },
+      OFF,
+    );
+    expect(nul.ok).toBe(true);
+    if (nul.ok) expect(nul.payload.completionRewardPercoins).toBeNull();
+  });
+
+  test("完走報酬: 負数 / 非整数 / 文字列は拒否", () => {
+    expect(
+      parseCollectionSettings({ completion_reward_percoins: -1 }, OFF).ok,
+    ).toBe(false);
+    expect(
+      parseCollectionSettings({ completion_reward_percoins: 10.5 }, OFF).ok,
+    ).toBe(false);
+    expect(
+      parseCollectionSettings({ completion_reward_percoins: "100" }, OFF).ok,
+    ).toBe(false);
+  });
+
+  test("完走報酬: 未指定なら payload に含まれない(変更なし)", () => {
+    const r = parseCollectionSettings({}, OFF);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect("completionRewardPercoins" in r.payload).toBe(false);
+  });
+
   test("未対応レイアウトは拒否", () => {
     expect(parseCollectionSettings({ mount_layout: "grid_5" }, OFF).ok).toBe(false);
   });

--- a/tests/unit/features/collections/completion-reward-panel.test.tsx
+++ b/tests/unit/features/collections/completion-reward-panel.test.tsx
@@ -16,9 +16,12 @@ import { act, render, screen } from "@testing-library/react";
 import { CompletionRewardPanel } from "@/features/collections/components/CompletionRewardPanel";
 
 describe("CompletionRewardPanel", () => {
+  let originalMatchMedia: PropertyDescriptor | undefined;
+
   beforeEach(() => {
     jest.useFakeTimers();
     // reduce-motion: CountUpNumber が即座に最終値へ到達し onDone を同期発火する
+    originalMatchMedia = Object.getOwnPropertyDescriptor(window, "matchMedia");
     Object.defineProperty(window, "matchMedia", {
       configurable: true,
       writable: true,
@@ -38,6 +41,12 @@ describe("CompletionRewardPanel", () => {
   afterEach(() => {
     jest.useRealTimers();
     jest.clearAllMocks();
+    // モックを残すと同ランナー内の他テストを汚染するため元の状態へ復元する
+    if (originalMatchMedia) {
+      Object.defineProperty(window, "matchMedia", originalMatchMedia);
+    } else {
+      delete (window as { matchMedia?: unknown }).matchMedia;
+    }
   });
 
   it("額が0以下なら何も描画しない", () => {
@@ -55,8 +64,12 @@ describe("CompletionRewardPanel", () => {
     act(() => {
       jest.advanceTimersByTime(800);
     });
+    // 着地は rAF コールバック内で行われるため1フレーム分進める
+    act(() => {
+      jest.advanceTimersByTime(20);
+    });
 
-    // reduce-motion により即着地 → 最終値と「獲得！」
+    // reduce-motion により rAF 1フレームで即着地 → 最終値と「獲得！」
     expect(screen.getByText("100")).not.toBeNull();
     expect(screen.getByText("獲得！")).not.toBeNull();
   });
@@ -67,7 +80,10 @@ describe("CompletionRewardPanel", () => {
     );
 
     act(() => {
-      jest.advanceTimersByTime(100); // じらし → 即着地(reduce-motion)
+      jest.advanceTimersByTime(100); // じらし
+    });
+    act(() => {
+      jest.advanceTimersByTime(20); // rAF 1フレームで即着地(reduce-motion)
     });
     expect(screen.getByText("獲得！")).not.toBeNull();
 
@@ -81,6 +97,9 @@ describe("CompletionRewardPanel", () => {
     render(<CompletionRewardPanel amount={30} delayMs={100} />);
     act(() => {
       jest.advanceTimersByTime(100);
+    });
+    act(() => {
+      jest.advanceTimersByTime(20);
     });
     act(() => {
       jest.advanceTimersByTime(60000);

--- a/tests/unit/features/collections/completion-reward-panel.test.tsx
+++ b/tests/unit/features/collections/completion-reward-panel.test.tsx
@@ -1,0 +1,90 @@
+/** @jest-environment jsdom */
+
+/**
+ * 完走報酬パネル(カウントアップ演出)の回帰テスト。
+ * (docs/planning/collection-completion-reward-implementation-plan.md EARS-09)
+ *
+ * - 額<=0 では何も描画しない(キャップ0/付与失敗で嘘をつかない)
+ * - じらし(delayMs)後にカウントが始まり、到達で「獲得！」が出る
+ * - autoDismissMs 指定時は着地後に自動で消える(book没入ビュー用)
+ *
+ * prefers-reduced-motion を true にモックし、CountUpNumber を即着地させて
+ * タイマーだけで決定的に検証する。
+ */
+
+import { act, render, screen } from "@testing-library/react";
+import { CompletionRewardPanel } from "@/features/collections/components/CompletionRewardPanel";
+
+describe("CompletionRewardPanel", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    // reduce-motion: CountUpNumber が即座に最終値へ到達し onDone を同期発火する
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: jest.fn().mockImplementation((query: string) => ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it("額が0以下なら何も描画しない", () => {
+    const { container } = render(<CompletionRewardPanel amount={0} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("じらし(delayMs)後にカウントし、到達で「獲得！」が表示される", () => {
+    render(<CompletionRewardPanel amount={100} delayMs={800} />);
+
+    // じらし中: パネル(ラベル)は存在するが、まだ着地していない
+    expect(screen.getByText("完走報酬")).not.toBeNull();
+    expect(screen.queryByText("獲得！")).toBeNull();
+
+    act(() => {
+      jest.advanceTimersByTime(800);
+    });
+
+    // reduce-motion により即着地 → 最終値と「獲得！」
+    expect(screen.getByText("100")).not.toBeNull();
+    expect(screen.getByText("獲得！")).not.toBeNull();
+  });
+
+  it("autoDismissMs 指定時は着地後に自動で消える", () => {
+    const { container } = render(
+      <CompletionRewardPanel amount={50} delayMs={100} autoDismissMs={1000} />,
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(100); // じらし → 即着地(reduce-motion)
+    });
+    expect(screen.getByText("獲得！")).not.toBeNull();
+
+    act(() => {
+      jest.advanceTimersByTime(1000); // 自動フェード
+    });
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("autoDismissMs 未指定なら着地後も表示され続ける", () => {
+    render(<CompletionRewardPanel amount={30} delayMs={100} />);
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+    act(() => {
+      jest.advanceTimersByTime(60000);
+    });
+    expect(screen.getByText("獲得！")).not.toBeNull();
+  });
+});

--- a/tests/unit/lib/preset-category-repository.test.ts
+++ b/tests/unit/lib/preset-category-repository.test.ts
@@ -183,6 +183,38 @@ describe("getPresetCategoryById", () => {
     expect(result?.progressiveBatchSize).toBeNull();
   });
 
+  test("completion_reward_percoins を camelCase へマップする(0/正の値/null)", async () => {
+    const withValue: PresetCategoryRow = {
+      ...SAMPLE_ROW,
+      completion_reward_percoins: 100,
+    };
+    createAdminClientMock.mockReturnValue({
+      from: buildSingleChain({ data: withValue, error: null }),
+    });
+    const granted = await getPresetCategoryById(SAMPLE_ROW.id);
+    expect(granted?.completionRewardPercoins).toBe(100);
+
+    const withZero: PresetCategoryRow = {
+      ...SAMPLE_ROW,
+      completion_reward_percoins: 0,
+    };
+    createAdminClientMock.mockReturnValue({
+      from: buildSingleChain({ data: withZero, error: null }),
+    });
+    const zero = await getPresetCategoryById(SAMPLE_ROW.id);
+    expect(zero?.completionRewardPercoins).toBe(0);
+
+    const withNull: PresetCategoryRow = {
+      ...SAMPLE_ROW,
+      completion_reward_percoins: null,
+    };
+    createAdminClientMock.mockReturnValue({
+      from: buildSingleChain({ data: withNull, error: null }),
+    });
+    const nul = await getPresetCategoryById(SAMPLE_ROW.id);
+    expect(nul?.completionRewardPercoins).toBeNull();
+  });
+
   test("progress_modal_* 色列が null なら null にフォールバックする", async () => {
     const row: PresetCategoryRow = {
       ...SAMPLE_ROW,


### PR DESCRIPTION
### 概要
コレクション(神コレ/旅行等)を完走したユーザーにペルコインを付与する「完走報酬」を追加する。付与額は `/admin/preset-categories` のカテゴリ編集でカテゴリごとに設定でき(`completion_reward_percoins`)、完走の祝賀ビューでは付与額が0からカウントアップして着地する獲得演出を表示する。計画書 `docs/planning/collection-completion-reward-implementation-plan.md`(外部レビュー済み: Sonnet 5/effort max、指摘10件反映)。

### 変更内容
- **DB(migration適用済み)**: `preset_categories.completion_reward_percoins`(デフォルト0=報酬なし) / `collection_completions.reward_granted_at`(付与済みマーカー) / `grant_collection_completion_reward` RPC(service_role専用)。transaction_type/free_percoin_batches.source のCHECKに `collection_completion` を追加(**現行12種/8種の最新定義から張り替え**)
- **冪等(ADR-001)**: `reward_granted_at` の test-and-set で「1ユーザー×1コレクション1回」。台紙の作り直し(isUpdate)では finalize 自体が呼ばれず二重付与しない。額・user_idはサーバー解決(EARS-08)
- **付与フック**: mount route の finalize 成功後(mount/book両経路)。try-catchで完走レスポンスを妨げない(EARS-07)。付与>0で残高系キャッシュrevalidate。実付与額を `rewardGranted` としてレスポンスに追加
- **5万キャップ(ADR-004)**: `get_grantable_free_percoin_amount` 適用。キャップ後0は取引・通知なし(EARS-03、reward_granted_atのみ立てる)
- **admin UI**: カテゴリ編集に「完走報酬(ペルコイン)」数値入力(0/空欄=報酬なし)。バリデーション実体は collection-settings-payload のみ(routeは自動配線)
- **獲得演出(EARS-09)**: じらし0.8s→カウントアップ1.2s(rAF+easeOut)→着地バウンス+コイン粒子バースト。mount=完走モーダル内、book=`?reward=N`で日記帳リーダーへ引き継ぎ所有者のみ表示(表示専用・自動フェード)。額0/付与失敗はパネル自体を出さない。reduced-motion対応。Lottie不使用(既存演出と同じ手書き実装)
- **遡及なし(ADR-003)**: 既存完走者(`reward_granted_at IS NULL`)には付与されない
- docs: data.ja/en.md RPCカタログ・database-design.mdc 更新

### 実機テスト
- [ ] iOS Safari / Android Chrome / PC Chrome で主要導線を確認
- [ ] admin: カテゴリに報酬額(例100)を設定→保存→再表示で値が残る
- [ ] 非adminアカウントで対象コレクションを完走→台紙作成→**カウントアップ演出→残高増→通知**を確認
- [ ] book型(travel等)の完走→日記帳リーダー開幕で演出→自動フェードを確認
- [ ] `reward_granted_at` がセットされ、台紙の作り直しで二重付与されないこと
- [ ] 報酬額0のカテゴリでは演出も通知も出ないこと
- [ ] 補足: 付与はadmin含む全ユーザーが対象(view/impression系と異なり管理者除外は意図的に無し=検証しやすさ優先。運営垢の自己付与は運用上無害)

### テスト方法
- `npm run test` → フルスイート 236 suites / 2335 tests pass(新規テスト: payload 3件・repositoryマッピング1件・演出パネル4件)
- `npm run lint` / `npm run typecheck` → 変更ファイル起因の指摘なし
- `npm run build -- --webpack` → 成功(exit 0)
- mount route の付与フックはヘルパーが非export(Next16 route制約)のためユニットテスト対象外。上記実機テストで必ず確認すること
- **migration は本番適用・検証済み**(全カテゴリ0・既存完走者未付与・RPC冪等ガード動作確認済み)。本PRマージ前でも本番挙動は不変(全カテゴリ報酬0=実質OFF)

### go-live手順
1. 本PRマージ(デプロイ)
2. `/admin/preset-categories` で対象カテゴリに報酬額を設定(例: 旅行=100)→その瞬間から有効
3. 停止したい場合は額を0に戻すだけ(デプロイ不要)
