### PR TITLE
fix(collections): book完走のOGPをユーザー生成の表紙に変更

### DIFF
--- a/app/api/collections/mount/route.ts
+++ b/app/api/collections/mount/route.ts
@@ -303,12 +303,17 @@ export async function POST(request: NextRequest) {
       const ogpTwinPath = ogpPathFromMountPath(mountStoragePath);
       if (ogpTwinPath) {
         try {
-          await admin.storage
+          // storage.upload は API レベルの失敗では throw せず { error } を返すため
+          // 明示的に確認する(OGP失敗は完走をブロックしない方針のままログのみ)。
+          const { error: ogpUploadError } = await admin.storage
             .from(GENERATED_IMAGES_BUCKET)
             .upload(ogpTwinPath, coverBuf, {
               contentType: "image/png",
               upsert: false,
             });
+          if (ogpUploadError) {
+            console.error("book OGP twin upload failed:", ogpUploadError);
+          }
         } catch (e) {
           console.error("book OGP twin upload failed:", e);
         }

--- a/app/api/collections/mount/route.ts
+++ b/app/api/collections/mount/route.ts
@@ -296,19 +296,16 @@ export async function POST(request: NextRequest) {
       uploadedPath = mountStoragePath; // 後続失敗時のロールバック対象
       const bookMountPath = mountStoragePath;
 
-      // X シェア用 OGP(横長バナー)は mount のツイン ogp-{ts}.png に保存する(mount モードと同方式)。
-      //   優先: 運営登録のテーマ表紙(ogp_template_path = 旅のきろくバナー)。未設定時は
-      //   はじまり画像を OGP にフォールバック(404 を避ける)。シェアページはこのツインを参照する。
-      const ogpTemplatePath = category.ogp_template_path as string | null;
+      // X シェア用 OGP は mount のツイン ogp-{ts}.png に保存する(mount モードと同方式)。
+      //   book はユーザー生成の「はじまり(表紙)」をそのまま OGP にする(A案 2026-07-11)。
+      //   全員共通テンプレ(ogp_template_path)より「本人のうちの子が主役」を優先する意図。
+      //   縦長画像のため X の大型カードでは中央帯(顔まわり)にクロップされる想定。
       const ogpTwinPath = ogpPathFromMountPath(mountStoragePath);
       if (ogpTwinPath) {
         try {
-          const ogpBuf = ogpTemplatePath
-            ? await downloadBuffer(admin, TEMPLATE_BUCKET, ogpTemplatePath)
-            : coverBuf;
           await admin.storage
             .from(GENERATED_IMAGES_BUCKET)
-            .upload(ogpTwinPath, ogpBuf, {
+            .upload(ogpTwinPath, coverBuf, {
               contentType: "image/png",
               upsert: false,
             });

--- a/app/m/[token]/book/page.tsx
+++ b/app/m/[token]/book/page.tsx
@@ -37,7 +37,9 @@ export async function generateMetadata({
       description: SHARE_DESCRIPTION,
       type: "article",
       siteName: "Persta.AI",
-      images: [{ url: book.ogpImageUrl, alt: title, width: 1200, height: 630 }],
+      // OGP はユーザー生成の「はじまり(表紙)」= 縦長のため、横長1200x630の
+      // サイズヒントは付けない(実寸はクローラーが画像から取得する)。
+      images: [{ url: book.ogpImageUrl, alt: title }],
     },
     twitter: {
       card: "summary_large_image",


### PR DESCRIPTION
### 概要
イタリア旅行(book型)完走のシェアページOGPが、全ユーザー共通の固定テンプレ(旅のきろくバナー)になっており、本人の「うちの子」がシェア面に一切出ていなかった。ユーザー生成の「はじまり(表紙)」画像をそのままOGPにする(A案)。ユーザーごとに動的に変わり、Xシェアで本人のイラストが主役になる。

### 変更内容
- `mount/route.ts`(book経路): OGPツイン(ogp-{ts}.png)への保存を「テンプレ優先」→「常に本人のはじまり画像」へ変更。既存フォールバック経路の昇格なので新規ロジックなし
- `book/page.tsx`: openGraphの `width:1200, height:630` サイズヒントを撤去(縦長画像と矛盾するため。実寸はクローラーが取得)
- 対象は新規完走・作り直しから。既存完走3件はStorage上のOGPファイル差し替えでバックフィル可能(コード外作業)

### 表示の想定(ユーザー確認済み)
Xの大型カードは中央1.91:1クロップのため、縦長表紙の中央帯(顔まわり)が表示される。表紙テンプレはキャラが中央に来る構図のため顔は映る(上部タイトル帯は切れるが、イラスト主役の見せ方として許容)。

### 実機テスト
- [ ] 新規に完走(または作り直し)→ シェアページのog:imageが本人の表紙になっていること
- [ ] X Card Validator等で顔まわりが表示されることを確認
- [ ] mount型(神コレ等)のOGP(テンプレ+台紙合成)に影響がないこと

### テスト方法
- `npm run test` → フルスイート 2335 tests pass / lint・typecheck 変更ファイルクリーン / build exit 0
