### PR TITLE
fix(collections): 完走シェアのog:imageにキャッシュバスター(?v=2)を付与

### DIFF
--- a/app/m/[token]/page.tsx
+++ b/app/m/[token]/page.tsx
@@ -7,6 +7,7 @@ import { getUser } from "@/lib/auth";
 import {
   getCollectionBookByToken,
   getPublicMountByToken,
+  withOgpVersion,
 } from "@/features/collections/lib/public-mount-server-api";
 import { mountAspectForCategory } from "@/features/collections/lib/mount-aspects";
 import { MountShareButton } from "@/features/collections/components/MountShareButton";
@@ -77,9 +78,11 @@ export async function generateMetadata({
   // mount-{ts}.png → ogp-{ts}.png の対応(コミット 2026-06-09 以降に作成された
   // 台紙は OGP も併せて生成される)。旧台紙は OGP ファイルが無いので、その
   // 場合のみ縦長 mount をフォールバックに使う(中央クロップで一部が見切れる)。
-  const ogpImageUrl = mount.mountImageUrl.includes("/mount-")
-    ? mount.mountImageUrl.replace("/mount-", "/ogp-")
-    : mount.mountImageUrl;
+  const ogpImageUrl = withOgpVersion(
+    mount.mountImageUrl.includes("/mount-")
+      ? mount.mountImageUrl.replace("/mount-", "/ogp-")
+      : mount.mountImageUrl,
+  );
 
   return {
     ...base,

--- a/features/collections/lib/public-mount-server-api.ts
+++ b/features/collections/lib/public-mount-server-api.ts
@@ -24,7 +24,13 @@ export function withOgpVersion(url: string): string;
 export function withOgpVersion(url: string | null): string | null;
 export function withOgpVersion(url: string | null): string | null {
   if (!url) return null;
-  return `${url}${url.includes("?") ? "&" : "?"}v=${OGP_IMAGE_VERSION}`;
+  try {
+    const parsed = new URL(url);
+    parsed.searchParams.set("v", String(OGP_IMAGE_VERSION));
+    return parsed.toString();
+  } catch {
+    return url;
+  }
 }
 
 export interface PublicMount {

--- a/features/collections/lib/public-mount-server-api.ts
+++ b/features/collections/lib/public-mount-server-api.ts
@@ -15,6 +15,18 @@ export function buildPublicGeneratedImageUrl(path: string | null): string | null
   return `${base}/storage/v1/object/public/${GENERATED_IMAGES_BUCKET}/${path}`;
 }
 
+// X(Twitter)等はカード画像を og:image の URL 単位でキャッシュし、手動パージ手段が無い。
+// Storage 実体を同一パスへ上書きした場合はこの版数を上げて URL を変え、再取得させる。
+const OGP_IMAGE_VERSION = 2;
+
+/** og:image 用 URL にキャッシュバスター(?v=N)を付与する */
+export function withOgpVersion(url: string): string;
+export function withOgpVersion(url: string | null): string | null;
+export function withOgpVersion(url: string | null): string | null {
+  if (!url) return null;
+  return `${url}${url.includes("?") ? "&" : "?"}v=${OGP_IMAGE_VERSION}`;
+}
+
 export interface PublicMount {
   completionId: string;
   ownerId: string;
@@ -158,7 +170,7 @@ export const getCollectionBookByToken = cache(async (
     displayNameJa: catRecord.display_name_ja ?? "",
     coverImageUrl: buildPublicGeneratedImageUrl(catRecord.book_cover_path ?? null),
     pageImageUrls,
-    ogpImageUrl: buildPublicGeneratedImageUrl(bookOgpPath),
+    ogpImageUrl: withOgpVersion(buildPublicGeneratedImageUrl(bookOgpPath)),
     completedAt: (data.completed_at as string | null) ?? null,
   };
 });

--- a/tests/unit/features/collections/public-mount-server-api.test.ts
+++ b/tests/unit/features/collections/public-mount-server-api.test.ts
@@ -1,0 +1,37 @@
+/** @jest-environment node */
+
+jest.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: jest.fn(),
+}));
+
+import { withOgpVersion } from "@/features/collections/lib/public-mount-server-api";
+
+describe("withOgpVersion", () => {
+  it("null はそのまま null を返す", () => {
+    expect(withOgpVersion(null)).toBeNull();
+  });
+
+  it("クエリ無しURLに ?v=N を付与する", () => {
+    expect(
+      withOgpVersion("https://example.supabase.co/storage/v1/object/public/generated-images/a/ogp-123.png"),
+    ).toBe(
+      "https://example.supabase.co/storage/v1/object/public/generated-images/a/ogp-123.png?v=2",
+    );
+  });
+
+  it("既存クエリがあるURLには & で追加し、既存パラメータを保持する", () => {
+    expect(withOgpVersion("https://example.com/img.png?foo=1")).toBe(
+      "https://example.com/img.png?foo=1&v=2",
+    );
+  });
+
+  it("既に v がある場合は重複させず上書きする", () => {
+    expect(withOgpVersion("https://example.com/img.png?v=1")).toBe(
+      "https://example.com/img.png?v=2",
+    );
+  });
+
+  it("URLとして解釈できない文字列はそのまま返す", () => {
+    expect(withOgpVersion("not-a-url")).toBe("not-a-url");
+  });
+});


### PR DESCRIPTION
### 概要
X(Twitter)はカード画像を og:image の URL 単位でキャッシュしており、2022年8月以降 Card Validator による手動リフレッシュ手段も無い。そのため、イタリア旅行完走OGPのバックフィル（Storage 実体を同一パス `ogp-{ts}.png` へ上書き）を行っても、既存シェアポストのカードが旧画像のまま残り続ける問題があった。

og:image の URL にキャッシュバスター `?v=2` を付与して URL 自体を変えることで、X の再クロール時（カードキャッシュ失効後、最大1週間程度）に確実に新画像を取得させる。あわせて Supabase CDN のキャッシュもクエリ違いで回避される。

### 変更内容
- `features/collections/lib/public-mount-server-api.ts`
  - `withOgpVersion()` ヘルパーを追加（`?v=N` を付与。版数は定数 `OGP_IMAGE_VERSION` で管理し、今後 Storage 実体を同一パスで差し替えた際はこの定数を上げるだけで再取得させられる）
  - book 用 `ogpImageUrl` の組み立て箇所で適用（`/m/[token]` と `/m/[token]/book` の両ページに効く）
- `app/m/[token]/page.tsx`
  - mount 経路の `ogpImageUrl` に同ヘルパーを適用

### 実機テスト
- [ ] PC（Chrome）で `/m/<token>` のページソースに `og:image` が `?v=2` 付きで出力されることを確認
- [ ] シェアページの表示（台紙/日記帳）に影響がないことを確認

### テスト方法
- `npm run lint`：変更2ファイルはクリーン（全体149件は変更前後で完全同一＝既存）
- `npm run typecheck`：エラーはすべて `tests/` 配下の既知の既存エラーのみ
- `npm run test`：236 スイート / 2335 件パス
- `npm run build -- --webpack`：成功
- ローカルで production サーバを起動し、実在 completion の3経路（book シェア / mount シェア / book リーダー）で `og:image` / `twitter:image` に `?v=2` が付くことを curl で確認
- バスター付き public URL が 200 / image/png を返し、バックフィル後の新画像（バイトサイズ一致）を返すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwcR7uKsNrx7vB1MeHTx7J