### PR TITLE
feat(home): ホームに「開催中の企画」棚を追加

### DIFF
--- a/docs/planning/home-event-shelf-implementation-plan.md
+++ b/docs/planning/home-event-shelf-implementation-plan.md
@@ -1,0 +1,257 @@
+# ホーム「開催中の企画」棚（イベント棚）実装計画書
+
+作成日: 2026-07-11
+モック: https://claude.ai/code/artifact/a603d5d0-f184-4e6a-a0d3-7a64722f5f61
+関連検討メモ: メモリ `persta-home-discovery-revamp`
+
+## ゴール
+
+ホームの「プロンプトなしでお着替え！」カルーセルの**上**に、開催中のコレクション企画（例: イタリア旅行）専用の横スクロール棚を追加し、企画スタイルの発見性と参加率を高める。
+
+## 確定済みの設計判断（ヒアリング結果）
+
+- 配置: お着替え行の**上**。非開催時は棚ごと非表示（従来ホームに戻る）
+- 並び順: **NEW（今生成できる）→ シルエット（次の1枚のみ）→ ✓済み（生成済み・薄め表示）**
+- シルエットの見せ方: `/style` の現行 `dripLocked` 表示（黒つぶし+🔒+「あとでとうじょう」ラベル）を**そのまま流用**。次の1枚だけ見せ、その先は出さない（ネタバレ防止方針を踏襲）
+- 解放は日付ではなく**ユーザー進捗ベース**（1つ生成すると次が解放。`sequential_unlock` の既存挙動）
+- シルエットタップ → 「1つ生成すると解放されます」トースト
+- 見出しに進捗カウンター（例: 2/9）、開催終了間際は赤いカウントダウンバッジ（余裕がある間はグレー）
+- 全コンプ後: 先頭に🎉お祝いカード（/collections へのリンク）
+- 未ログイン: 生成数0の初日状態（表紙NEW+シルエット）で表示。生成時のログイン誘導は既存 `/style` の仕組みに任せる
+- 複数企画同時開催: 企画ごとに棚を複数行表示
+- 「すべて見る」リンクは**付けない**
+- データモデル: **既存コレクション（`preset_categories.is_collection_series=true`）を流用。新テーブル・マイグレーション不要**
+
+## コードベース調査結果
+
+| 対象 | ファイル | 発見事項 |
+|------|----------|----------|
+| ホーム構成 | `app/[locale]/page.tsx` | セクションごとに Suspense + Cached*Section の合成。`getUser()` / `isAdminViewer` はページ側で解決して props 渡し |
+| Style行 | `features/home/components/CachedHomeStylePresetSection.tsx` | **鍵となる発見**: プリセット取得（`getPublishedStylePresets`、キャッシュ済）→ ユーザー別解放コンテキスト解決（`resolveCollectionUnlockContext`）→ ゲート適用（`applyCollectionUnlockGating`）までホームで実施済み。現状は `locked` を**表示できないため除外**している（ここに棚を挿す） |
+| カルーセル | `features/home/components/HomeStylePresetCarousel.tsx` | Swiper(FreeMode) + `StylePresetPreviewCard` を流用。クライアントコンポーネント |
+| 解放ゲート | `features/collections/lib/collection-unlock-gating.ts` | `sequential_unlock=true`: sort_order 昇順（先頭=表紙）から解放、`index < unlockedCount`=解放済み / `index === unlockedCount`=locked（次の1枚ティザー）/ それ以降=非表示。`unlockedCount = distinctGenerated + batch(既定1)` |
+| シルエットUI | `features/style/components/StylePresetPreviewCard.tsx:138-153` | `dripLocked`: 実サムネに `grayscale+brightness(0.18)+blur(2px)` + 🔒 + ラベル。i18nキー `styleDripLockedLabel` |
+| カテゴリ情報 | `features/style-presets/lib/schema.ts` / `style-preset-repository.ts` | summary の category に `collectionDisplayStartsAt/EndsAt`・`sequentialUnlock` は**あり**。`isCollectionSeries`・`completionThreshold` は**未公開**（select と mapping への追加が必要） |
+| DB実値 | `preset_categories`（本番） | travel_to_italy: `sequential_unlock=true`, `progressive_batch_size=null`(=1), `completion_threshold=9`, 表示期間 7/3〜7/12 |
+| 図鑑 | `app/collections/page.tsx` | 存在する。コンプお祝いカードのリンク先に使える |
+
+## 概要図
+
+### ユーザーフロー
+
+```mermaid
+flowchart TD
+    A["ホームを開く"] --> B{"開催中の企画があるか"}
+    B -->|なし| C["従来ホーム表示"]
+    B -->|あり| D["企画棚を表示 お着替え行の上"]
+    D --> E{"タップしたカード"}
+    E -->|NEWカード| F["style画面の該当プリセットへ遷移"]
+    E -->|シルエット| G["トースト表示 1つ生成すると解放されます"]
+    E -->|済みカード| F
+    E -->|コンプお祝いカード| H["collectionsページへ遷移"]
+    F --> I["生成すると次の1枚が解放"]
+    I --> D
+```
+
+### データフロー（サーバー側）
+
+```mermaid
+sequenceDiagram
+    participant P as HomePage
+    participant S as CachedHomeStylePresetSection
+    participant C as PresetCache
+    participant U as UnlockContext
+    P->>S: userId と isAdminViewer を渡す
+    S->>C: getPublishedStylePresets キャッシュ済
+    C-->>S: 全公開プリセット
+    S->>U: resolveCollectionUnlockContext ログイン時のみ
+    U-->>S: distinct生成数マップ
+    S->>S: applyCollectionUnlockGating 既存処理
+    S->>S: deriveEventShelves 新規の純関数
+    S-->>P: 企画棚 と 通常カルーセル を描画
+```
+
+### 棚の状態遷移（ユーザー進捗ベース）
+
+```mermaid
+stateDiagram-v2
+    [*] --> Initial: 企画開始
+    Initial --> InProgress: 1つ生成
+    InProgress --> InProgress: さらに生成
+    InProgress --> Completed: threshold個生成
+    Completed --> [*]: 表示期間終了で棚ごと消える
+    Initial --> [*]: 表示期間終了
+    InProgress --> [*]: 表示期間終了
+```
+
+- Initial: NEW(表紙) + シルエット1枚。カウンター 0/9
+- InProgress: NEW + シルエット + ✓済み。カウンター k/9
+- Completed: 🎉お祝いカード + ✓済み。カウンター 9/9
+
+## EARS（要件定義）
+
+| # | タイプ | 要件 |
+|---|--------|------|
+| 1 | 状態駆動 | While a collection series category is within its display window (`is_collection_series=true` かつ now が `collection_display_starts_at`〜`ends_at` 内), the system shall render an event shelf above the style preset carousel on Home. / 開催中のコレクション企画がある間、ホームのお着替えカルーセルの上に企画棚を表示する |
+| 2 | 状態駆動 | While no collection series is active, the system shall not render the event shelf section at all. / 開催中企画が無い間は、棚セクション自体を描画しない |
+| 3 | イベント駆動 | When rendering shelf cards, the system shall order them as NEW (unlocked & not yet generated) → silhouette teaser (next locked one only) → generated (✓済み, dimmed). / 棚は NEW → シルエット（次の1枚のみ）→ ✓済み の順に並べる |
+| 4 | イベント駆動 | When the user has generated all `completion_threshold` presets, the system shall show a celebration card first, linking to /collections. / 全数生成済みの場合、先頭に🎉お祝いカードを表示し /collections へリンクする |
+| 5 | イベント駆動 | When a silhouette card is tapped, the system shall show a toast "1つ生成すると解放されます" and shall not navigate. / シルエットタップ時はトーストのみ表示し遷移しない |
+| 6 | イベント駆動 | When a NEW or generated card is tapped, the system shall navigate to /style with the preset selected (existing carousel behavior). / NEW・済みカードのタップで /style の該当プリセットへ遷移する（既存カルーセルと同挙動） |
+| 7 | 状態駆動 | While the user is not logged in, the system shall render the shelf in its initial state (cover as NEW + one silhouette) using the empty unlock context. / 未ログイン時は空コンテキストにより初日状態で表示する |
+| 8 | 状態駆動 | While remaining days are low (当日〜1日), the system shall render the countdown badge in red; otherwise gray. / 残り僅かならカウントダウンを赤、それ以外はグレーで表示する |
+| 9 | オプション | Where multiple series are active simultaneously, the system shall render one shelf per category, stacked vertically. / 複数企画開催中は企画ごとに棚を縦に並べる |
+| 10 | 異常系 | If the unlock context resolution fails, then the system shall fall back to the empty context (initial-state shelf) without breaking the Home render. / 解放コンテキスト解決に失敗しても、空コンテキストで棚を初日状態表示しホーム全体は壊さない（既存挙動踏襲） |
+| 11 | 権限 | 追加のRLS変更なし。既存の `style_presets` 公開RLS（published かつ visibility=public）と、`CachedHomeStylePresetSection` の既存 admin プレビュー挙動をそのまま使う |
+
+## ADR（設計判断記録）
+
+### ADR-001: 「イベント」は既存コレクションを流用し新テーブルを作らない
+
+- **Context**: イベントを新概念（複数スタイルを束ねる新テーブル）にするか、既存の `is_collection_series` カテゴリを流用するか。
+- **Decision**: 既存コレクション流用。棚のUI要素（表示条件・枠数・解放・済み・コンプ・期限）が全て既存カラム/既存ロジックから導出できることを確認済み。
+- **Reason**: 新テーブル＋admin UI＋join追加のコストに対し、現時点で得られる能力の増分がゼロ。
+- **Consequence**: 複数カテゴリを束ねる企画が将来必要になったら、その時点で新概念を導入する。
+
+### ADR-002: 棚の導出は `CachedHomeStylePresetSection` 内で行い、追加クエリを発行しない
+
+- **Context**: ホームは全ユーザーが通る最重要ページで、クエリ追加は避けたい。
+- **Decision**: 既にホームで解決済みの「キャッシュ済プリセット一覧＋ユーザー別解放コンテキスト（distinct生成数）」だけから棚を導出する純関数 `deriveEventShelves` を追加する。gating の結果から locked を除外する**前**のデータを使う。
+- **Reason**: `✓済み = 先頭から distinctGenerated 個`、`NEW = その次の解放済み`、`シルエット = locked の1枚`、`カウンター = distinct/threshold`、`コンプ = distinct >= threshold` と、全て既存取得データの演算で決まる（sequential_unlock は順番にしか生成できないため、この対応は厳密に成立する）。
+- **Consequence**: DBクエリ増ゼロ。`collection_completions` は参照しない（コンプ判定は distinct 数で行う）。
+
+### ADR-003: シルエットは `/style` の `dripLocked` 表示を流用する
+
+- **Context**: モック段階では複数シルエット案もあったが、既存 `/style` は「次の1枚だけ黒つぶしティザー、その先は完全非表示」のネタバレ防止方針。
+- **Decision**: `StylePresetPreviewCard` の `dripLocked` をそのまま使い、`/style` と同一の見た目・同一の情報公開レベルにする。
+- **Consequence**: ホームと `/style` で解放の見え方が完全に一致する。棚のカード枚数は少なめ（初日2枚）になるが、企画枠の装飾（見出し・カウントダウン・専用背景）で棚としての存在感を担保する。
+
+### ADR-004: 機能フラグは導入しない（データ駆動でオンオフ可能なため）
+
+- **Context**: リスク時に即座に消せる手段が必要。
+- **Decision**: 環境変数フラグは追加しない。棚は「開催中企画の有無」だけで出し分けるため、admin から `collection_display_ends_at` を過去日時に更新すれば即座に消える。
+- **Consequence**: 運用オフ手段はデータ更新（既存 admin 画面）。コードのロールバックは PR revert。
+
+## 実装計画（フェーズ＋TODO）
+
+### フェーズ間の依存関係
+
+```mermaid
+flowchart LR
+    P1["Phase 1: データ層の公開項目追加"] --> P2["Phase 2: 棚導出ロジック"]
+    P2 --> P3["Phase 3: 棚UIコンポーネント"]
+    P3 --> P4["Phase 4: ホーム統合とi18n"]
+    P4 --> P5["Phase 5: 検証と仕上げ"]
+```
+
+### Phase 1: データ層の公開項目追加（マイグレーション無し）
+
+目的: 棚の描画に必要な `isCollectionSeries` / `completionThreshold` をプリセット summary の category に載せる。
+ビルド確認: `npm run typecheck`（アプリコード0エラー）＋ `npm run build -- --webpack`。
+
+- [ ] `features/style-presets/lib/style-preset-repository.ts` の埋め込み select（`:108` 付近）に `is_collection_series, completion_threshold` を追加
+- [ ] 同ファイルの mapping（`:230` 付近）に `isCollectionSeries` / `completionThreshold` を追加
+- [ ] `features/style-presets/lib/schema.ts` の category summary 型に2項目を追加
+- [ ] 既存テスト（`tests/unit/features/style-presets/`）のフィクスチャ更新が必要なら追随
+
+### Phase 2: 棚導出ロジック（純関数＋ユニットテスト）
+
+目的: gated プリセット＋解放コンテキストから棚モデルを導出する純関数を作る。
+ビルド確認: `npm run test`（新規テスト含め全緑）。
+
+- [ ] `features/home/lib/derive-event-shelves.ts` 新規。入力=（gating適用済みプリセット一覧, `distinctGeneratedByCategoryKey`, now）、出力=棚モデル配列 `{ category, cards: [{ kind: "new"|"teaser"|"done"|"celebration", preset? }], collected, threshold, endsAt }`
+  - 対象카テゴリ条件: `isCollectionSeries && sequentialUnlock && 表示期間内`（`collection-unlock-gating.ts` の判定ロジックを参考）
+  - 並び順: new → teaser → done（done は sort_order 昇順のまま末尾へ）。collected >= threshold なら celebration を先頭、teaser 無し
+  - 複数カテゴリは `collection_display_ends_at` 昇順（終了が近い順）
+- [ ] `tests/unit/features/home/derive-event-shelves.test.ts` 新規（初日/中盤/コンプ/期間外/未ログイン=空コンテキスト/複数企画 の6ケース以上）
+
+### Phase 3: 棚UIコンポーネント
+
+目的: モックの見た目を実装する。参考: `HomeStylePresetCarousel.tsx`（Swiper構成）と `StylePresetPreviewCard.tsx`（カード）。
+ビルド確認: `npm run lint` ＋ `npm run build -- --webpack`。
+
+- [ ] `features/home/components/HomeEventShelfSection.tsx` 新規（棚1つ分。見出し🔥+企画名+進捗カウンター+カウントダウンバッジ、Swiperレール）
+  - カード描画は `StylePresetPreviewCard` を流用（teaser は `dripLocked` + `styleDripLockedLabel`、done は既存カードに ✓バッジ+減光のラッパー）
+  - NEWバッジは棚側のオーバーレイで付与（`StylePresetPreviewCard` の変更は最小限に）
+  - シルエットタップ → toast（既存の toast 実装を確認して流用。`sonner` 等プロジェクト採用のもの）
+  - コンプお祝いカード → `/collections` への `Link`
+  - カウントダウン: 残り日数を `collectionDisplayEndsAt` から算出。1日以下=赤 / それ以外=グレー
+- [ ] `features/home/components/HomeEventShelfSkeleton.tsx` 新規（既存 `HomeStylePresetCarouselSkeleton.tsx` を参考）
+
+### Phase 4: ホーム統合と i18n
+
+目的: 実データで棚が出るところまで繋ぐ。
+ビルド確認: 検証コマンド4点セット全緑。
+
+- [ ] `features/home/components/CachedHomeStylePresetSection.tsx` 修正: gated（locked除外**前**）から `deriveEventShelves` を呼び、棚があれば `HomeEventShelfSection` 群を**カルーセルの上**に描画。通常カルーセルからは開催中企画のプリセットを除外するか検討（重複表示を避けるなら除外。ヒアリングで最終確認）
+- [ ] i18n: `messages/ja.ts` / `en.ts` ほか全ロケールファイルにキー追加（棚見出し「開催中の企画」、トースト文言、コンプカード文言、カウントダウン書式）。既存キーの追加パターンを踏襲
+- [ ] E2E がホームに依存している場合の追随（`tests/e2e/` でホームのセレクタを grep して確認）
+
+### Phase 5: 検証と仕上げ
+
+目的: 実機確認と品質担保。
+
+- [ ] `npm run lint` / `npm run typecheck` / `npm run test` / `npm run build -- --webpack` 全実行
+- [ ] 実機確認（下記テスト観点表）
+- [ ] `docs/architecture/` への影響なし確認（DB変更なしのため原則不要）
+- [ ] PR作成（`/git-create-pr`、タイトル・本文は日本語）
+
+## 修正対象ファイル一覧
+
+| ファイル | 操作 | 変更内容 |
+|----------|------|----------|
+| `features/style-presets/lib/style-preset-repository.ts` | 修正 | select と mapping に `is_collection_series` / `completion_threshold` 追加 |
+| `features/style-presets/lib/schema.ts` | 修正 | category summary 型に2項目追加 |
+| `features/home/lib/derive-event-shelves.ts` | 新規 | 棚モデル導出の純関数 |
+| `tests/unit/features/home/derive-event-shelves.test.ts` | 新規 | 導出ロジックのユニットテスト |
+| `features/home/components/HomeEventShelfSection.tsx` | 新規 | 棚UI（見出し+カウンター+カウントダウン+レール） |
+| `features/home/components/HomeEventShelfSkeleton.tsx` | 新規 | ローディングスケルトン |
+| `features/home/components/CachedHomeStylePresetSection.tsx` | 修正 | 棚導出の呼び出しと描画の組み込み |
+| `features/style/components/StylePresetPreviewCard.tsx` | 修正(最小) | 必要な場合のみ: doneバッジ/NEWバッジ用の軽微な拡張 |
+| `messages/*.ts`（全ロケール） | 修正 | 棚関連の翻訳キー追加 |
+
+## 品質・テスト観点
+
+### 品質チェックリスト
+
+- [ ] **エラーハンドリング**: 解放コンテキスト解決失敗時に空コンテキストへフォールバック（既存挙動を壊さない）
+- [ ] **権限制御**: RLS変更なし。admin_only カテゴリのプレビュー挙動（`isAdminViewer`）が棚でも既存と同じに保たれる
+- [ ] **データ整合性**: `✓済み=先頭 distinct 個` の導出が sequential_unlock の不変条件（順番にしか生成できない）に依存していることをコードコメントで明記
+- [ ] **パフォーマンス**: 追加DBクエリ0を維持（`deriveEventShelves` は純関数）
+- [ ] **i18n**: 全ロケールのキーが揃う（typecheck で検出される構成か確認）
+
+### テスト観点
+
+| カテゴリ | テスト内容 |
+|----------|-----------|
+| 正常系 | 開催中企画で棚表示、NEW→シルエット→済みの並び、生成後の解放反映、コンプでお祝いカード |
+| 異常系 | 期間外・企画なしで棚非表示、コンテキスト解決失敗時のフォールバック |
+| 権限 | 未ログイン=初日状態、admin_only カテゴリは一般ユーザーに出ない |
+| 実機 | iOS Safari / Android Chrome / PC Chrome、横スクロール操作、トースト表示、シークレット垢での進捗確認（既読は端末単位の点に注意） |
+
+### テスト実装手順
+
+実装完了後、`/test-flow derive-event-shelves` を起点に `/spec-extract` → `/test-generate` → `/test-reviewing` → `/spec-verify` を実施。
+
+## ロールバック方針
+
+- **DB**: 変更なし（ロールバック対象なし）
+- **運用オフ**: admin から対象カテゴリの `collection_display_ends_at` を過去日時に更新すれば棚は即消える（ADR-004）
+- **Git**: フェーズごとにコミットし revert 可能に。UI統合（Phase 4）は単一コミットにまとめ revert 一発で棚が消える状態を保つ
+
+## 使用スキル
+
+| スキル | 用途 | フェーズ |
+|--------|------|----------|
+| `/project-database-context` | データ層確認 | Phase 1 |
+| `/git-create-branch` | ブランチ作成 | 実装開始時 |
+| `/tdd` | 導出ロジックのテスト駆動実装 | Phase 2 |
+| `/test-flow` ほかテスト系 | テスト実装 | Phase 5 |
+| `/git-create-pr` | PR作成（日本語） | Phase 5 |
+
+## 未確定・実装中に確認する事項
+
+1. **通常カルーセルとの重複**: 開催中企画のプリセットを棚に出す場合、下の「プロンプトなしでお着替え！」カルーセルから除外するか（推奨: 除外して重複を避ける）→ 実装前にユーザー確認
+2. **トースト実装**: プロジェクト採用の toast ライブラリを Phase 3 冒頭で確認
+3. **E2E への影響**: ホームのセレクタに依存する既存 E2E の有無を Phase 4 で確認
+4. **計測**: 棚経由の流入を測りたい場合、`style_usage_events` 相当のイベント（棚表示/カードタップ）を追加するか。初期リリースでは「/style 到達後の既存計測」で代替し、必要になったら追加する方針を推奨（受動的な「表示されたが操作されなかった」は未計測となる点は許容）

--- a/features/home/components/CachedHomeStylePresetSection.tsx
+++ b/features/home/components/CachedHomeStylePresetSection.tsx
@@ -13,6 +13,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import {
   collectShelfPresetIds,
   deriveEventShelves,
+  listActiveEventCategoryKeys,
 } from "@/features/home/lib/derive-event-shelves";
 import type { CompletedMountView } from "@/features/my-page/components/MyPageCollections";
 import { HomeEventShelfSection } from "./HomeEventShelfSection";
@@ -62,9 +63,45 @@ export async function CachedHomeStylePresetSection({
   // 開催中のコレクション企画は専用の「企画棚」へ振り分ける(お着替えカルーセルの上)。
   // 棚は locked(次の1枚のシルエット)も表示するため、gated を locked 除外前に渡す。
   const now = new Date();
+
+  // ✓済み判定用: 開催中企画カテゴリの「生成済みプリセットID集合」。
+  // 解放方式(順次/一斉/前提付き)に依存せず厳密に判定するためIDで持つ。
+  // 開催中企画がある場合のみ発行(通常時はクエリ増ゼロ)。失敗時は空集合=全てNEW表示に
+  // フォールバックし、ホーム全体は壊さない。
+  const generatedIdsByKey = new Map<string, ReadonlySet<string>>();
+  const activeEventKeys = listActiveEventCategoryKeys(gated, now);
+  if (userId && activeEventKeys.length > 0) {
+    try {
+      const admin = createAdminClient();
+      const { data, error } = await admin
+        .from("image_jobs")
+        .select("style_template_id, style_preset_category_key")
+        .eq("user_id", userId)
+        .eq("status", "succeeded")
+        .in("style_preset_category_key", activeEventKeys)
+        .not("style_template_id", "is", null)
+        .limit(1000);
+      if (!error) {
+        for (const row of data ?? []) {
+          const key = row.style_preset_category_key as string;
+          const presetId = row.style_template_id as string;
+          const set = generatedIdsByKey.get(key) as Set<string> | undefined;
+          if (set) {
+            set.add(presetId);
+          } else {
+            generatedIdsByKey.set(key, new Set([presetId]));
+          }
+        }
+      }
+    } catch {
+      // 取得失敗は初日状態(全てNEW)で表示継続
+    }
+  }
+
   const eventShelves = deriveEventShelves(
     gated,
     unlockContext.distinctGeneratedByCategoryKey,
+    generatedIdsByKey,
     now,
   );
   const shelfPresetIds = collectShelfPresetIds(eventShelves);

--- a/features/home/components/CachedHomeStylePresetSection.tsx
+++ b/features/home/components/CachedHomeStylePresetSection.tsx
@@ -7,11 +7,14 @@ import { buildCollectionUnlockAnnouncements } from "@/features/collections/lib/c
 import { resolveCollectionUnlockContext } from "@/features/collections/lib/collection-unlock-server";
 import { categoryNeedsUnlockContext } from "@/features/collections/lib/collection-unlock";
 import { PetitUnlockAnnouncer } from "@/features/collections/components/PetitUnlockAnnouncer";
+import { buildPublicGeneratedImageUrl } from "@/features/collections/lib/public-mount-server-api";
 import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
 import {
   collectShelfPresetIds,
   deriveEventShelves,
 } from "@/features/home/lib/derive-event-shelves";
+import type { CompletedMountView } from "@/features/my-page/components/MyPageCollections";
 import { HomeEventShelfSection } from "./HomeEventShelfSection";
 import { HomeStylePresetCarousel } from "./HomeStylePresetCarousel";
 
@@ -72,6 +75,49 @@ export async function CachedHomeStylePresetSection({
     (preset) => !preset.locked && !shelfPresetIds.has(preset.id),
   );
 
+  // 全コンプ済み棚の🎉カードには、マイページと同じ「本人の完成台紙サムネ」を出す。
+  // 完走済み棚がある場合のみ対象カテゴリに絞って取得する(通常時はクエリ増ゼロを維持)。
+  const completedMountByKey = new Map<string, CompletedMountView>();
+  const completedKeys = eventShelves
+    .filter((shelf) => shelf.isCompleted)
+    .map((shelf) => shelf.categoryKey);
+  if (userId && completedKeys.length > 0) {
+    const admin = createAdminClient();
+    const { data } = await admin
+      .from("collection_completions")
+      .select(
+        "id, category_key, mount_image_path, preset_categories(display_name_ja, mount_template_width, mount_template_height, completion_view_mode)",
+      )
+      .eq("user_id", userId)
+      .eq("mount_status", "completed")
+      .in("category_key", completedKeys);
+    for (const row of data ?? []) {
+      const mountImageUrl = buildPublicGeneratedImageUrl(
+        (row.mount_image_path as string | null) ?? null,
+      );
+      if (!mountImageUrl) continue;
+      const cat = (row as { preset_categories?: unknown }).preset_categories;
+      const catRecord = (Array.isArray(cat) ? cat[0] : cat) as
+        | {
+            display_name_ja?: string;
+            mount_template_width?: number | null;
+            mount_template_height?: number | null;
+            completion_view_mode?: string | null;
+          }
+        | undefined;
+      completedMountByKey.set(row.category_key as string, {
+        completionId: row.id as string,
+        categoryKey: row.category_key as string,
+        displayName: catRecord?.display_name_ja ?? "",
+        mountImageUrl,
+        mountTemplateWidth: catRecord?.mount_template_width ?? null,
+        mountTemplateHeight: catRecord?.mount_template_height ?? null,
+        completionViewMode:
+          catRecord?.completion_view_mode === "book" ? "book" : "mount",
+      });
+    }
+  }
+
   // 解放お知らせ(初回バナー / 段階解放モーダル)。解放コンテキストはここで解決済みなので
   // 二重取得を避けて流用する。前提未完走・ゲートなしなら空配列(= 何も出ない)。
   const unlockAnnouncements = buildCollectionUnlockAnnouncements(
@@ -89,6 +135,7 @@ export async function CachedHomeStylePresetSection({
           key={shelf.categoryKey}
           shelf={shelf}
           nowIso={now.toISOString()}
+          completedMount={completedMountByKey.get(shelf.categoryKey) ?? null}
         />
       ))}
       <HomeStylePresetCarousel presets={presets} />

--- a/features/home/components/CachedHomeStylePresetSection.tsx
+++ b/features/home/components/CachedHomeStylePresetSection.tsx
@@ -8,6 +8,11 @@ import { resolveCollectionUnlockContext } from "@/features/collections/lib/colle
 import { categoryNeedsUnlockContext } from "@/features/collections/lib/collection-unlock";
 import { PetitUnlockAnnouncer } from "@/features/collections/components/PetitUnlockAnnouncer";
 import { createClient } from "@/lib/supabase/server";
+import {
+  collectShelfPresetIds,
+  deriveEventShelves,
+} from "@/features/home/lib/derive-event-shelves";
+import { HomeEventShelfSection } from "./HomeEventShelfSection";
 import { HomeStylePresetCarousel } from "./HomeStylePresetCarousel";
 
 // 解放ゲート対象が無い/未ログイン時に使う空コンテキスト(除去・解放判定とも no-op)。
@@ -51,8 +56,21 @@ export async function CachedHomeStylePresetSection({
   }
   const gated = applyCollectionUnlockGating(cachedPresets, unlockContext);
 
-  // ホームは locked(未解放=シルエット)に未対応のため、未解放分は出さない。
-  const presets = gated.filter((preset) => !preset.locked);
+  // 開催中のコレクション企画は専用の「企画棚」へ振り分ける(お着替えカルーセルの上)。
+  // 棚は locked(次の1枚のシルエット)も表示するため、gated を locked 除外前に渡す。
+  const now = new Date();
+  const eventShelves = deriveEventShelves(
+    gated,
+    unlockContext.distinctGeneratedByCategoryKey,
+    now,
+  );
+  const shelfPresetIds = collectShelfPresetIds(eventShelves);
+
+  // お着替えカルーセル: 棚に出した企画プリセットは除外して重複表示を避ける。
+  // locked(未解放=シルエット)は従来どおりカルーセルには出さない。
+  const presets = gated.filter(
+    (preset) => !preset.locked && !shelfPresetIds.has(preset.id),
+  );
 
   // 解放お知らせ(初回バナー / 段階解放モーダル)。解放コンテキストはここで解決済みなので
   // 二重取得を避けて流用する。前提未完走・ゲートなしなら空配列(= 何も出ない)。
@@ -66,6 +84,13 @@ export async function CachedHomeStylePresetSection({
       {unlockAnnouncements.length > 0 && (
         <PetitUnlockAnnouncer announcements={unlockAnnouncements} />
       )}
+      {eventShelves.map((shelf) => (
+        <HomeEventShelfSection
+          key={shelf.categoryKey}
+          shelf={shelf}
+          nowIso={now.toISOString()}
+        />
+      ))}
       <HomeStylePresetCarousel presets={presets} />
     </>
   );

--- a/features/home/components/HomeEventShelfSection.tsx
+++ b/features/home/components/HomeEventShelfSection.tsx
@@ -266,7 +266,6 @@ export function HomeEventShelfSection({
           type="button"
           onClick={() => router.push("/collections")}
           className="flex-shrink-0 text-left"
-          aria-label={t("eventShelfCelebrationAction")}
         >
           <div
             className="flex flex-col items-center justify-center gap-2 overflow-hidden rounded-xl border border-amber-300 bg-gradient-to-br from-amber-50 to-pink-100 shadow-sm transition hover:ring-2 hover:ring-amber-300"
@@ -322,14 +321,16 @@ export function HomeEventShelfSection({
           <div className="opacity-65">
             <StylePresetPreviewCard
               preset={preset}
-              alt={tStyle("styleCardAlt", { name: preset.title })}
+              // ステータス(生成済み)を alt に前置し、視覚バッジは aria-hidden にして
+              // スクリーンリーダーへ二重読み上げにならないようにする。
+              alt={`${t("eventShelfDoneBadge")} - ${tStyle("styleCardAlt", { name: preset.title })}`}
               locale={cardLocale}
               onClick={() => setConfirmingPreset(preset)}
             />
           </div>
           <span
             className="pointer-events-none absolute right-2 top-2 z-10 flex h-6 w-6 items-center justify-center rounded-full bg-green-600 text-xs font-bold text-white shadow"
-            aria-label={t("eventShelfDoneBadge")}
+            aria-hidden="true"
           >
             ✓
           </span>
@@ -342,12 +343,15 @@ export function HomeEventShelfSection({
       <div className="relative">
         <StylePresetPreviewCard
           preset={preset}
-          alt={tStyle("styleCardAlt", { name: preset.title })}
+          alt={`${t("eventShelfNewBadge")} - ${tStyle("styleCardAlt", { name: preset.title })}`}
           locale={cardLocale}
           onClick={() => setConfirmingPreset(preset)}
         />
-        <span className="pointer-events-none absolute left-2 top-2 z-10 rounded-full bg-red-500 px-2 py-0.5 text-[10px] font-bold text-white shadow">
-          NEW
+        <span
+          className="pointer-events-none absolute left-2 top-2 z-10 rounded-full bg-red-500 px-2 py-0.5 text-[10px] font-bold text-white shadow"
+          aria-hidden="true"
+        >
+          {t("eventShelfNewBadge")}
         </span>
       </div>
     );

--- a/features/home/components/HomeEventShelfSection.tsx
+++ b/features/home/components/HomeEventShelfSection.tsx
@@ -184,11 +184,13 @@ export function HomeEventShelfSection({
   return (
     <section className="mb-8">
       <div className="mb-3 flex items-center justify-between gap-2 px-4 sm:px-0">
-        <h2 className="min-w-0 truncate text-lg font-semibold text-gray-900">
-          <span aria-hidden="true">🔥 </span>
-          {displayName}
+        <h2 className="flex min-w-0 items-baseline gap-2 text-lg font-semibold text-gray-900">
+          <span className="min-w-0 truncate">
+            <span aria-hidden="true">🔥 </span>
+            {displayName}
+          </span>
           {shelf.totalCount !== null && (
-            <span className="ml-2 align-middle text-sm font-semibold tabular-nums text-gray-500">
+            <span className="flex-shrink-0 text-sm font-semibold tabular-nums text-gray-500">
               {shelf.collectedCount}/{shelf.totalCount}
             </span>
           )}

--- a/features/home/components/HomeEventShelfSection.tsx
+++ b/features/home/components/HomeEventShelfSection.tsx
@@ -182,7 +182,9 @@ export function HomeEventShelfSection({
   };
 
   return (
-    <section className="mb-8">
+    // overflow-x-hidden: Swiper側は !overflow-visible のため、既存カルーセルと同様に
+    // 外側でスライドのはみ出しを刈り取る(無いとPC幅でカードが左右に飛び出す)。
+    <section className="mb-8 overflow-x-hidden">
       <div className="mb-3 flex items-center justify-between gap-2 px-4 sm:px-0">
         <h2 className="flex min-w-0 items-baseline gap-2 text-lg font-semibold text-gray-900">
           <span className="min-w-0 truncate">

--- a/features/home/components/HomeEventShelfSection.tsx
+++ b/features/home/components/HomeEventShelfSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
@@ -17,8 +17,18 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { useToast } from "@/components/ui/use-toast";
+import {
+  CollectionProgressModal,
+  type CollectionCelebration,
+} from "@/features/collections/components/CollectionProgressModal";
+import {
+  CollectionMountComposer,
+  type MountGeneratedResult,
+} from "@/features/collections/components/CollectionMountComposer";
+import { mountAspectForCategory } from "@/features/collections/lib/mount-aspects";
 import { StylePresetPreviewCard } from "@/features/style/components/StylePresetPreviewCard";
 import type { StylePresetPublicSummary } from "@/features/style-presets/lib/schema";
+import type { CompletedMountView } from "@/features/my-page/components/MyPageCollections";
 import type {
   EventShelf,
   EventShelfCard,
@@ -37,6 +47,12 @@ interface HomeEventShelfSectionProps {
   shelf: EventShelf;
   /** サーバーで解決したリクエスト時刻(ISO)。カウントダウンのSSR/CSR不一致を防ぐ。 */
   nowIso: string;
+  /**
+   * 全コンプ済みユーザーの完成台紙(マイページと同一ソース)。あれば🎉カードの
+   * 代わりに台紙サムネを出し、タップでマイページと同じ完了モーダルを開く。
+   * null(未作成/未ログイン)なら /collections リンクのお祝いカードにフォールバック。
+   */
+  completedMount?: CompletedMountView | null;
 }
 
 /**
@@ -47,6 +63,7 @@ interface HomeEventShelfSectionProps {
 export function HomeEventShelfSection({
   shelf,
   nowIso,
+  completedMount = null,
 }: HomeEventShelfSectionProps) {
   const router = useRouter();
   const t = useTranslations("home");
@@ -55,6 +72,129 @@ export function HomeEventShelfSection({
   const { toast } = useToast();
   const [confirmingPreset, setConfirmingPreset] =
     useState<StylePresetPublicSummary | null>(null);
+
+  // 完成台紙タップ時のモーダル(マイページの openMountModal と同挙動)。
+  const [mountCelebration, setMountCelebration] =
+    useState<CollectionCelebration | null>(null);
+  const [celebrationNonce, setCelebrationNonce] = useState(0);
+  const [composer, setComposer] = useState<{
+    categoryKey: string;
+    displayName: string;
+    threshold: number;
+  } | null>(null);
+  const [recomposeInfo, setRecomposeInfo] = useState<{
+    threshold: number;
+    canRecompose: boolean;
+  } | null>(null);
+
+  // 「台紙を更新する」の表示可否(マイページと同じ /api/collections/options 判定)。
+  const loadRecomposeInfo = useCallback(async () => {
+    if (!completedMount) return null;
+    try {
+      const r = await fetch(
+        `/api/collections/options?categoryKey=${encodeURIComponent(completedMount.categoryKey)}`,
+        { cache: "no-store" },
+      );
+      if (!r.ok) return null;
+      const d = (await r.json()) as {
+        threshold?: number | null;
+        outfits?: { images: unknown[] }[];
+      };
+      const outfits = d.outfits ?? [];
+      const threshold = d.threshold ?? 0;
+      const info = {
+        threshold,
+        canRecompose:
+          threshold > 0 &&
+          outfits.length >= threshold &&
+          outfits.some((o) => o.images.length > 1),
+      };
+      setRecomposeInfo(info);
+      return info;
+    } catch {
+      return null;
+    }
+  }, [completedMount]);
+
+  const openMountModal = useCallback(() => {
+    if (!completedMount) return;
+    setCelebrationNonce((n) => n + 1);
+    setMountCelebration({
+      categoryKey: completedMount.categoryKey,
+      displayName: completedMount.displayName,
+      fromCount: 0,
+      toCount: 0,
+      threshold: recomposeInfo?.threshold ?? 0,
+      isCompleted: true,
+      mountImageUrl: completedMount.mountImageUrl,
+      // book は redirect 元の /m/<id>(chrome付き)を経由するとチラつくため /m/<id>/book へ直行。
+      sharePath:
+        completedMount.completionViewMode === "book"
+          ? `/m/${completedMount.completionId}/book`
+          : `/m/${completedMount.completionId}`,
+      completionId: completedMount.completionId,
+      mountTemplateWidth: completedMount.mountTemplateWidth,
+      mountTemplateHeight: completedMount.mountTemplateHeight,
+      characterImageUrl: null,
+      collectedImageUrls: [],
+      canRecompose: recomposeInfo?.canRecompose ?? false,
+      // 完了済み台紙の見返しなので、紙吹雪ではなくダイヤのきらめき演出にする。
+      celebrationEffect: "sparkle",
+    });
+    if (!recomposeInfo) {
+      void loadRecomposeInfo().then((info) => {
+        if (!info) return;
+        setMountCelebration((prev) =>
+          prev && prev.completionId === completedMount.completionId
+            ? {
+                ...prev,
+                threshold: info.threshold,
+                canRecompose: info.canRecompose,
+              }
+            : prev,
+        );
+      });
+    }
+  }, [completedMount, recomposeInfo, loadRecomposeInfo]);
+
+  // モーダル内「台紙を更新する」→ 画像選択(composer)を開く(マイページと同挙動)。
+  const openComposerFromCelebration = useCallback(
+    (c: CollectionCelebration) => {
+      setMountCelebration(null);
+      setComposer({
+        categoryKey: c.categoryKey,
+        displayName: c.displayName,
+        threshold: c.threshold,
+      });
+    },
+    [],
+  );
+
+  // 台紙の再生成完了 → 完了モーダル(新台紙+シェア)を表示し、サーバー cache を再反映。
+  const handleGenerated = useCallback(
+    (result: MountGeneratedResult) => {
+      const target = composer;
+      setComposer(null);
+      setCelebrationNonce((n) => n + 1);
+      setMountCelebration({
+        categoryKey: result.categoryKey,
+        displayName: target?.displayName ?? "",
+        fromCount: target?.threshold ?? 0,
+        toCount: target?.threshold ?? 0,
+        threshold: target?.threshold ?? 0,
+        isCompleted: true,
+        mountImageUrl: result.mountImageUrl,
+        sharePath: result.sharePath,
+        completionId: result.completionId,
+        mountTemplateWidth: result.mountTemplateWidth,
+        mountTemplateHeight: result.mountTemplateHeight,
+        characterImageUrl: null,
+        collectedImageUrls: [],
+      });
+      router.refresh();
+    },
+    [composer, router],
+  );
 
   const cardLocale = locale === "en" ? "en" : "ja";
   const displayName =
@@ -89,6 +229,38 @@ export function HomeEventShelfSection({
 
   const renderCard = (card: EventShelfCard) => {
     if (card.kind === "celebration") {
+      // 本人の完成台紙があれば、マイページのコレクション欄と同じサムネ+同じタップ挙動
+      // (完了モーダル=台紙拡大+シェア+台紙更新)にする。
+      if (completedMount) {
+        return (
+          <button
+            type="button"
+            onClick={openMountModal}
+            className="relative flex-shrink-0 overflow-hidden rounded-xl border border-amber-300 shadow-sm transition hover:ring-2 hover:ring-amber-300"
+            style={{
+              height: CARD_HEIGHT_PX,
+              aspectRatio: mountAspectForCategory(
+                completedMount.categoryKey,
+                completedMount.mountTemplateWidth,
+                completedMount.mountTemplateHeight,
+              ),
+            }}
+            aria-label={`${completedMount.displayName} のカードを表示`}
+          >
+            <Image
+              src={completedMount.mountImageUrl}
+              alt={`${completedMount.displayName} コンプリートカード`}
+              fill
+              sizes={`${CARD_WIDTH_PX}px`}
+              className="object-cover"
+            />
+            <span className="pointer-events-none absolute left-2 top-2 z-10 rounded-full bg-amber-400 px-2 py-0.5 text-[10px] font-bold text-white shadow">
+              {t("eventShelfCelebrationTitle")}
+            </span>
+          </button>
+        );
+      }
+      // 台紙未作成(または未ログイン)時のフォールバック。
       return (
         <button
           type="button"
@@ -269,6 +441,27 @@ export function HomeEventShelfSection({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+      <CollectionProgressModal
+        key={
+          mountCelebration
+            ? `${mountCelebration.categoryKey}-${celebrationNonce}`
+            : "none"
+        }
+        open={!!mountCelebration}
+        celebration={mountCelebration}
+        onClose={() => setMountCelebration(null)}
+        onCreateMount={openComposerFromCelebration}
+      />
+      {composer ? (
+        <CollectionMountComposer
+          key={composer.categoryKey}
+          categoryKey={composer.categoryKey}
+          displayName={composer.displayName}
+          threshold={composer.threshold}
+          onClose={() => setComposer(null)}
+          onGenerated={handleGenerated}
+        />
+      ) : null}
     </section>
   );
 }

--- a/features/home/components/HomeEventShelfSection.tsx
+++ b/features/home/components/HomeEventShelfSection.tsx
@@ -1,0 +1,270 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { useLocale, useTranslations } from "next-intl";
+import { Swiper, SwiperSlide } from "swiper/react";
+import { FreeMode } from "swiper/modules";
+import { PartyPopper } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { useToast } from "@/components/ui/use-toast";
+import { StylePresetPreviewCard } from "@/features/style/components/StylePresetPreviewCard";
+import type { StylePresetPublicSummary } from "@/features/style-presets/lib/schema";
+import type {
+  EventShelf,
+  EventShelfCard,
+} from "@/features/home/lib/derive-event-shelves";
+
+import "swiper/css";
+import "swiper/css/free-mode";
+
+// StylePresetPreviewCard と同寸(180 x 240+44)。celebration カードのサイズ合わせ用。
+const CARD_WIDTH_PX = 180;
+const CARD_HEIGHT_PX = 284;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+interface HomeEventShelfSectionProps {
+  shelf: EventShelf;
+  /** サーバーで解決したリクエスト時刻(ISO)。カウントダウンのSSR/CSR不一致を防ぐ。 */
+  nowIso: string;
+}
+
+/**
+ * ホーム「開催中の企画」棚(1企画ぶん)。
+ * カードは NEW(生成できる) → シルエット(次の1枚) → ✓済み の順で
+ * deriveEventShelves が並べ終えたものをそのまま描画する。
+ */
+export function HomeEventShelfSection({
+  shelf,
+  nowIso,
+}: HomeEventShelfSectionProps) {
+  const router = useRouter();
+  const t = useTranslations("home");
+  const tStyle = useTranslations("style");
+  const locale = useLocale();
+  const { toast } = useToast();
+  const [confirmingPreset, setConfirmingPreset] =
+    useState<StylePresetPublicSummary | null>(null);
+
+  const cardLocale = locale === "en" ? "en" : "ja";
+  const displayName =
+    cardLocale === "en" ? shelf.displayNameEn : shelf.displayNameJa;
+
+  // 残り日数(切り上げ)。当日=1。期間外の棚はサーバー側で除外済みだが防御的に負値は隠す。
+  let countdownLabel: string | null = null;
+  let countdownUrgent = false;
+  if (shelf.endsAt) {
+    const msLeft = new Date(shelf.endsAt).getTime() - new Date(nowIso).getTime();
+    const daysLeft = Math.ceil(msLeft / MS_PER_DAY);
+    if (daysLeft >= 1) {
+      countdownUrgent = daysLeft <= 1;
+      countdownLabel = countdownUrgent
+        ? t("eventShelfCountdownLastDay")
+        : t("eventShelfCountdownDaysLeft", { days: daysLeft });
+    }
+  }
+
+  const handleTeaserTap = () => {
+    toast({ description: t("eventShelfTeaserToast") });
+  };
+
+  const handleConfirm = () => {
+    const preset = confirmingPreset;
+    if (!preset) {
+      return;
+    }
+    setConfirmingPreset(null);
+    router.push(`/style?style=${encodeURIComponent(preset.id)}`);
+  };
+
+  const renderCard = (card: EventShelfCard) => {
+    if (card.kind === "celebration") {
+      return (
+        <button
+          type="button"
+          onClick={() => router.push("/collections")}
+          className="flex-shrink-0 text-left"
+          aria-label={t("eventShelfCelebrationAction")}
+        >
+          <div
+            className="flex flex-col items-center justify-center gap-2 overflow-hidden rounded-xl border border-amber-300 bg-gradient-to-br from-amber-50 to-pink-100 shadow-sm transition hover:ring-2 hover:ring-amber-300"
+            style={{ width: CARD_WIDTH_PX, height: CARD_HEIGHT_PX }}
+          >
+            <PartyPopper className="h-10 w-10 text-amber-500" aria-hidden="true" />
+            <p className="text-sm font-bold text-amber-800">
+              {t("eventShelfCelebrationTitle")}
+            </p>
+            <p className="text-xs text-amber-700 underline">
+              {t("eventShelfCelebrationAction")}
+            </p>
+          </div>
+        </button>
+      );
+    }
+
+    const preset = card.preset;
+    if (!preset) {
+      return null;
+    }
+
+    if (card.kind === "teaser") {
+      // dripLocked カードは内部で非クリック描画になるため、トースト用に外側で拾う。
+      return (
+        <div
+          role="button"
+          tabIndex={0}
+          onClick={handleTeaserTap}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault();
+              handleTeaserTap();
+            }
+          }}
+          className="cursor-pointer"
+          aria-label={tStyle("styleDripLockedLabel")}
+        >
+          <StylePresetPreviewCard
+            preset={preset}
+            alt={tStyle("styleCardAlt", { name: preset.title })}
+            locale={cardLocale}
+            dripLocked
+            dripLockedLabel={tStyle("styleDripLockedLabel")}
+          />
+        </div>
+      );
+    }
+
+    if (card.kind === "done") {
+      return (
+        <div className="relative">
+          <div className="opacity-65">
+            <StylePresetPreviewCard
+              preset={preset}
+              alt={tStyle("styleCardAlt", { name: preset.title })}
+              locale={cardLocale}
+              onClick={() => setConfirmingPreset(preset)}
+            />
+          </div>
+          <span
+            className="pointer-events-none absolute right-2 top-2 z-10 flex h-6 w-6 items-center justify-center rounded-full bg-green-600 text-xs font-bold text-white shadow"
+            aria-label={t("eventShelfDoneBadge")}
+          >
+            ✓
+          </span>
+        </div>
+      );
+    }
+
+    // kind === "new"
+    return (
+      <div className="relative">
+        <StylePresetPreviewCard
+          preset={preset}
+          alt={tStyle("styleCardAlt", { name: preset.title })}
+          locale={cardLocale}
+          onClick={() => setConfirmingPreset(preset)}
+        />
+        <span className="pointer-events-none absolute left-2 top-2 z-10 rounded-full bg-red-500 px-2 py-0.5 text-[10px] font-bold text-white shadow">
+          NEW
+        </span>
+      </div>
+    );
+  };
+
+  return (
+    <section className="mb-8">
+      <div className="mb-3 flex items-center justify-between gap-2 px-4 sm:px-0">
+        <h2 className="min-w-0 truncate text-lg font-semibold text-gray-900">
+          <span aria-hidden="true">🔥 </span>
+          {displayName}
+          {shelf.totalCount !== null && (
+            <span className="ml-2 align-middle text-sm font-semibold tabular-nums text-gray-500">
+              {shelf.collectedCount}/{shelf.totalCount}
+            </span>
+          )}
+        </h2>
+        {countdownLabel && (
+          <span
+            className={`flex-shrink-0 rounded-full px-2.5 py-1 text-xs font-bold ${
+              countdownUrgent
+                ? "bg-red-500 text-white"
+                : "bg-gray-200 text-gray-600"
+            }`}
+          >
+            {countdownLabel}
+          </span>
+        )}
+      </div>
+      <div className="-mx-4 px-4">
+        <Swiper
+          modules={[FreeMode]}
+          slidesPerView="auto"
+          spaceBetween={12}
+          freeMode={{ enabled: true, momentum: true, momentumRatio: 0.4 }}
+          grabCursor
+          allowTouchMove
+          className="!overflow-visible"
+        >
+          {shelf.cards.map((card, index) => (
+            <SwiperSlide
+              key={card.preset ? card.preset.id : `celebration-${index}`}
+              style={{ width: "auto" }}
+            >
+              {renderCard(card)}
+            </SwiperSlide>
+          ))}
+        </Swiper>
+      </div>
+      <AlertDialog
+        open={confirmingPreset !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setConfirmingPreset(null);
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("stylePresetConfirmTitle")}</AlertDialogTitle>
+          </AlertDialogHeader>
+          {confirmingPreset ? (
+            <div className="flex flex-col items-center gap-3 py-2">
+              <div className="relative aspect-[3/4] w-full max-w-[280px] overflow-hidden rounded-lg bg-gray-100">
+                <Image
+                  src={confirmingPreset.thumbnailImageUrl}
+                  alt={tStyle("styleCardAlt", {
+                    name: confirmingPreset.title,
+                  })}
+                  fill
+                  sizes="280px"
+                  className="object-cover object-top"
+                />
+              </div>
+              <p className="text-base font-medium text-slate-900">
+                {confirmingPreset.title}
+              </p>
+            </div>
+          ) : null}
+          <AlertDialogFooter>
+            <AlertDialogCancel>
+              {t("stylePresetConfirmCancel")}
+            </AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirm}>
+              {t("stylePresetConfirmAction")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </section>
+  );
+}

--- a/features/home/lib/derive-event-shelves.ts
+++ b/features/home/lib/derive-event-shelves.ts
@@ -33,14 +33,15 @@ export interface EventShelf {
 
 /**
  * 企画棚の対象カテゴリか。
- * コレクションシリーズ かつ 順次解放 かつ 表示ウィンドウがアクティブ(開始済み・未終了)。
- * starts/ends が null の側は無制限として扱う(/style の表示期間判定と同じ解釈)。
+ * コレクションシリーズ かつ 表示ウィンドウがアクティブ(開始済み・未終了)。
+ * 解放方式(順次/一斉/前提付き)は問わない。starts/ends が null の側は無制限として
+ * 扱う(/style の表示期間判定と同じ解釈)。
  */
 function isActiveEventCategory(
   category: StylePresetPublicSummary["category"],
   now: Date,
 ): boolean {
-  if (!category.isCollectionSeries || !category.sequentialUnlock) {
+  if (!category.isCollectionSeries) {
     return false;
   }
   const startsAt = category.collectionDisplayStartsAt;
@@ -55,22 +56,45 @@ function isActiveEventCategory(
 }
 
 /**
+ * 棚の対象となる「開催中の企画」カテゴリ key 一覧。
+ * 呼び出し側はこの key に対して「生成済みプリセットID集合」を取得してから
+ * deriveEventShelves に渡す(対象が無ければクエリ不要)。
+ */
+export function listActiveEventCategoryKeys(
+  gatedPresets: readonly StylePresetPublicSummary[],
+  now: Date,
+): string[] {
+  const keys: string[] = [];
+  const seen = new Set<string>();
+  for (const preset of gatedPresets) {
+    const category = preset.category;
+    if (seen.has(category.key)) continue;
+    if (!isActiveEventCategory(category, now)) continue;
+    seen.add(category.key);
+    keys.push(category.key);
+  }
+  return keys;
+}
+
+/**
  * gating 適用済みプリセット一覧から「開催中の企画」棚モデルを導出する純関数。
  *
  * 入力の前提(applyCollectionUnlockGating の出力仕様):
- * - sequential カテゴリは「解放済み(昇順) + locked な次の1枚(ティザー)」だけが含まれ、
- *   その先のプリセットは既に除去されている。
+ * - sequential カテゴリは「解放済み(昇順) + locked な次の1枚(ティザー)」のみ含まれる。
+ * - 前提付き(非sequential)カテゴリは未解放も locked 付きで全て残る(ティザー複数)。
+ * - 一斉公開カテゴリは gating no-op で全プリセットが unlocked のまま。
  * - 順序は sort_order 昇順のまま。
  *
- * ✓済み(done)の導出は「解放済みの先頭から distinct 生成数ぶん」。sequential 解放では
- * 順番にしか生成できない(生成が次を解放する)ため、この対応は厳密に成立する。
- * この不変条件が崩れる変更を collection-unlock 側に入れる場合はここも見直すこと。
- *
- * 追加のDBクエリは発行しない(distinct 生成数はホームで解決済みの解放コンテキストを流用)。
+ * ✓済み(done)の判定は「ユーザーが生成済みのプリセットID集合」への所属で行う。
+ * 解放方式(順次/一斉/前提付き)に依存しないため、どのカテゴリでも厳密に成立する。
+ * 未ログイン時は空集合を渡せば全カードが NEW(初日状態)になる。
+ * 進捗カウンターは distinct 生成数(解放コンテキスト)を優先し、無ければID集合の
+ * サイズで代替する(一斉公開カテゴリは解放コンテキストの集計対象外のため)。
  */
 export function deriveEventShelves(
   gatedPresets: readonly StylePresetPublicSummary[],
   distinctGeneratedByCategoryKey: ReadonlyMap<string, number>,
+  generatedPresetIdsByCategoryKey: ReadonlyMap<string, ReadonlySet<string>>,
   now: Date,
 ): EventShelf[] {
   const byCategory = new Map<string, StylePresetPublicSummary[]>();
@@ -93,16 +117,17 @@ export function deriveEventShelves(
   const shelves: EventShelf[] = [];
   for (const [key, presets] of byCategory) {
     const category = categoryByKey.get(key)!;
+    const generatedIds =
+      generatedPresetIdsByCategoryKey.get(key) ?? new Set<string>();
     const distinct = Math.max(
       0,
-      distinctGeneratedByCategoryKey.get(key) ?? 0,
+      distinctGeneratedByCategoryKey.get(key) ?? generatedIds.size,
     );
     const unlocked = presets.filter((p) => !p.locked);
     const teasers = presets.filter((p) => p.locked === true);
 
-    const doneCount = Math.min(distinct, unlocked.length);
-    const done = unlocked.slice(0, doneCount);
-    const news = unlocked.slice(doneCount);
+    const done = unlocked.filter((p) => generatedIds.has(p.id));
+    const news = unlocked.filter((p) => !generatedIds.has(p.id));
 
     const totalCount = category.completionThreshold ?? null;
     const isCompleted = totalCount !== null && distinct >= totalCount;

--- a/features/home/lib/derive-event-shelves.ts
+++ b/features/home/lib/derive-event-shelves.ts
@@ -1,0 +1,163 @@
+import type { StylePresetPublicSummary } from "@/features/style-presets/lib/schema";
+
+/**
+ * ホーム「開催中の企画」棚のカード種別。
+ * - celebration: 全コンプ後の🎉お祝いカード(プリセットを持たない)
+ * - new: 解放済みで未生成(今すぐ生成できる)
+ * - teaser: 次の1枚のシルエット(/style の dripLocked と同じ見せ方)
+ * - done: 生成済み(✓・減光表示)
+ */
+export type EventShelfCardKind = "celebration" | "new" | "teaser" | "done";
+
+export interface EventShelfCard {
+  kind: EventShelfCardKind;
+  /** celebration のみ null */
+  preset: StylePresetPublicSummary | null;
+}
+
+export interface EventShelf {
+  categoryId: string;
+  categoryKey: string;
+  displayNameJa: string;
+  displayNameEn: string;
+  /** 並び順確定済み: celebration → new → teaser → done */
+  cards: EventShelfCard[];
+  /** 進捗カウンター分子(distinct 生成数、分母でクランプ) */
+  collectedCount: number;
+  /** 進捗カウンター分母(completion_threshold)。null なら UI はカウンター非表示 */
+  totalCount: number | null;
+  /** 開催終了日時(カウントダウン用)。null なら無期限(カウントダウン非表示) */
+  endsAt: string | null;
+  isCompleted: boolean;
+}
+
+/**
+ * 企画棚の対象カテゴリか。
+ * コレクションシリーズ かつ 順次解放 かつ 表示ウィンドウがアクティブ(開始済み・未終了)。
+ * starts/ends が null の側は無制限として扱う(/style の表示期間判定と同じ解釈)。
+ */
+function isActiveEventCategory(
+  category: StylePresetPublicSummary["category"],
+  now: Date,
+): boolean {
+  if (!category.isCollectionSeries || !category.sequentialUnlock) {
+    return false;
+  }
+  const startsAt = category.collectionDisplayStartsAt;
+  const endsAt = category.collectionDisplayEndsAt;
+  if (startsAt && new Date(startsAt).getTime() > now.getTime()) {
+    return false;
+  }
+  if (endsAt && new Date(endsAt).getTime() <= now.getTime()) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * gating 適用済みプリセット一覧から「開催中の企画」棚モデルを導出する純関数。
+ *
+ * 入力の前提(applyCollectionUnlockGating の出力仕様):
+ * - sequential カテゴリは「解放済み(昇順) + locked な次の1枚(ティザー)」だけが含まれ、
+ *   その先のプリセットは既に除去されている。
+ * - 順序は sort_order 昇順のまま。
+ *
+ * ✓済み(done)の導出は「解放済みの先頭から distinct 生成数ぶん」。sequential 解放では
+ * 順番にしか生成できない(生成が次を解放する)ため、この対応は厳密に成立する。
+ * この不変条件が崩れる変更を collection-unlock 側に入れる場合はここも見直すこと。
+ *
+ * 追加のDBクエリは発行しない(distinct 生成数はホームで解決済みの解放コンテキストを流用)。
+ */
+export function deriveEventShelves(
+  gatedPresets: readonly StylePresetPublicSummary[],
+  distinctGeneratedByCategoryKey: ReadonlyMap<string, number>,
+  now: Date,
+): EventShelf[] {
+  const byCategory = new Map<string, StylePresetPublicSummary[]>();
+  const categoryByKey = new Map<string, StylePresetPublicSummary["category"]>();
+
+  for (const preset of gatedPresets) {
+    const category = preset.category;
+    if (!isActiveEventCategory(category, now)) {
+      continue;
+    }
+    const list = byCategory.get(category.key);
+    if (list) {
+      list.push(preset);
+    } else {
+      byCategory.set(category.key, [preset]);
+      categoryByKey.set(category.key, category);
+    }
+  }
+
+  const shelves: EventShelf[] = [];
+  for (const [key, presets] of byCategory) {
+    const category = categoryByKey.get(key)!;
+    const distinct = Math.max(
+      0,
+      distinctGeneratedByCategoryKey.get(key) ?? 0,
+    );
+    const unlocked = presets.filter((p) => !p.locked);
+    const teasers = presets.filter((p) => p.locked === true);
+
+    const doneCount = Math.min(distinct, unlocked.length);
+    const done = unlocked.slice(0, doneCount);
+    const news = unlocked.slice(doneCount);
+
+    const totalCount = category.completionThreshold ?? null;
+    const isCompleted = totalCount !== null && distinct >= totalCount;
+    const collectedCount =
+      totalCount !== null ? Math.min(distinct, totalCount) : distinct;
+
+    const cards: EventShelfCard[] = [];
+    if (isCompleted) {
+      cards.push({ kind: "celebration", preset: null });
+    }
+    for (const p of news) cards.push({ kind: "new", preset: p });
+    if (!isCompleted) {
+      for (const p of teasers) cards.push({ kind: "teaser", preset: p });
+    }
+    for (const p of done) cards.push({ kind: "done", preset: p });
+
+    if (cards.length === 0) {
+      continue;
+    }
+
+    shelves.push({
+      categoryId: category.id,
+      categoryKey: key,
+      displayNameJa: category.displayNameJa,
+      displayNameEn: category.displayNameEn,
+      cards,
+      collectedCount,
+      totalCount,
+      endsAt: category.collectionDisplayEndsAt,
+      isCompleted,
+    });
+  }
+
+  // 終了が近い企画を先に(ends null=無期限は最後)。同値は元の並び(sort 安定性)を維持。
+  shelves.sort((a, b) => {
+    const ta = a.endsAt ? new Date(a.endsAt).getTime() : Number.POSITIVE_INFINITY;
+    const tb = b.endsAt ? new Date(b.endsAt).getTime() : Number.POSITIVE_INFINITY;
+    return ta - tb;
+  });
+
+  return shelves;
+}
+
+/**
+ * 棚に含めた企画プリセットの id 集合。
+ * 通常カルーセル側から除外して重複表示を避けるために使う。
+ */
+export function collectShelfPresetIds(shelves: readonly EventShelf[]): Set<string> {
+  const ids = new Set<string>();
+  for (const shelf of shelves) {
+    for (const card of shelf.cards) {
+      if (card.preset) {
+        ids.add(card.preset.id);
+      }
+    }
+  }
+  return ids;
+}

--- a/features/style-presets/lib/schema.ts
+++ b/features/style-presets/lib/schema.ts
@@ -65,6 +65,10 @@ export interface StylePresetCategoryRef {
   /** コレクション表示期間(NULL=無期限)。/style のプリセット一覧公開判定にも使う。 */
   collectionDisplayStartsAt: string | null;
   collectionDisplayEndsAt: string | null;
+  /** コレクションシリーズ(台紙収集の対象カテゴリ)かどうか。ホームの企画棚の対象判定に使う。 */
+  isCollectionSeries: boolean;
+  /** コンプリートに必要な生成体数(コレクションシリーズのみ)。企画棚の進捗カウンター分母に使う。 */
+  completionThreshold: number | null;
   /**
    * 提供者(クリエイター)の profiles.id。コラボ/提供スタイルのクレジット表示に使う。
    * 未設定(従来カテゴリ)なら null/undefined。リポジトリ層では常に値を埋める optional 属性。

--- a/features/style-presets/lib/style-preset-repository.ts
+++ b/features/style-presets/lib/style-preset-repository.ts
@@ -54,6 +54,8 @@ interface StylePresetCategoryRow {
   is_active: boolean;
   collection_display_starts_at?: string | null;
   collection_display_ends_at?: string | null;
+  is_collection_series?: boolean | null;
+  completion_threshold?: number | null;
   unlock_prerequisite_key?: string | null;
   progressive_batch_size?: number | null;
   sequential_unlock?: boolean | null;
@@ -105,7 +107,7 @@ interface StylePresetRow {
 }
 
 const STYLE_PRESET_WITH_CATEGORY_SELECT =
-  "*, provider:profiles!style_presets_provider_user_id_fkey(id, nickname, avatar_url), category:preset_categories!style_presets_category_id_fkey(id, key, display_name_ja, display_name_en, badge_color, badge_text_color, skip_base_prefix, output_aspect_ratio_mode, user_guidance_ja, user_guidance_en, show_source_image_type_control, show_background_change_control, show_generation_model_control, show_user_prompt_input, user_prompt_label, user_prompt_placeholder, user_prompt_max_length, visibility, is_active, collection_display_starts_at, collection_display_ends_at, provider_user_id, provider:profiles!preset_categories_provider_user_id_fkey(id, nickname, avatar_url), unlock_prerequisite_key, progressive_batch_size, sequential_unlock, unlock_announcement_hero_path, unlock_announcement_initial_body, unlock_announcement_drip_body, unlock_announcement_accent_color, unlock_announcement_accent_hover_color, unlock_announcement_title_color, unlock_announcement_soft_color)";
+  "*, provider:profiles!style_presets_provider_user_id_fkey(id, nickname, avatar_url), category:preset_categories!style_presets_category_id_fkey(id, key, display_name_ja, display_name_en, badge_color, badge_text_color, skip_base_prefix, output_aspect_ratio_mode, user_guidance_ja, user_guidance_en, show_source_image_type_control, show_background_change_control, show_generation_model_control, show_user_prompt_input, user_prompt_label, user_prompt_placeholder, user_prompt_max_length, visibility, is_active, collection_display_starts_at, collection_display_ends_at, is_collection_series, completion_threshold, provider_user_id, provider:profiles!preset_categories_provider_user_id_fkey(id, nickname, avatar_url), unlock_prerequisite_key, progressive_batch_size, sequential_unlock, unlock_announcement_hero_path, unlock_announcement_initial_body, unlock_announcement_drip_body, unlock_announcement_accent_color, unlock_announcement_accent_hover_color, unlock_announcement_title_color, unlock_announcement_soft_color)";
 
 function getSupabase(client?: SupabaseClient): SupabaseClient {
   return client ?? createAdminClient();
@@ -189,6 +191,8 @@ function mapCategoryRefStrict(
       isActive: true,
       collectionDisplayStartsAt: null,
       collectionDisplayEndsAt: null,
+      isCollectionSeries: false,
+      completionThreshold: null,
       providerUserId: null,
       providerNickname: null,
       providerAvatarUrl: null,
@@ -229,6 +233,8 @@ function mapCategoryRefStrict(
     isActive: embedded.is_active,
     collectionDisplayStartsAt: embedded.collection_display_starts_at ?? null,
     collectionDisplayEndsAt: embedded.collection_display_ends_at ?? null,
+    isCollectionSeries: embedded.is_collection_series ?? false,
+    completionThreshold: embedded.completion_threshold ?? null,
     providerUserId: embedded.provider_user_id ?? null,
     providerNickname: provider?.nickname ?? null,
     providerAvatarUrl: provider?.avatar_url ?? null,

--- a/messages/ar.ts
+++ b/messages/ar.ts
@@ -1693,6 +1693,12 @@ export const arMessages = {
       "استخدام هذا الأسلوب لتوليد صورتك الخاصة؟",
     userStyleTemplateConfirmCancel: "عرض قوالب أخرى",
     userStyleTemplateConfirmAction: "متابعة",
+    eventShelfTeaserToast: "أنشئ واحدة لفتح التالية!",
+    eventShelfCountdownDaysLeft: "متبقي {days} أيام",
+    eventShelfCountdownLastDay: "ينتهي اليوم",
+    eventShelfCelebrationTitle: "اكتمل!",
+    eventShelfCelebrationAction: "عرض المجموعة",
+    eventShelfDoneBadge: "تم الإنشاء",
   },
   adminStyleTemplates: {
     pageTitle: "إدارة قوالب الأسلوب",

--- a/messages/ar.ts
+++ b/messages/ar.ts
@@ -1699,6 +1699,7 @@ export const arMessages = {
     eventShelfCelebrationTitle: "اكتمل!",
     eventShelfCelebrationAction: "عرض المجموعة",
     eventShelfDoneBadge: "تم الإنشاء",
+    eventShelfNewBadge: "جديد",
   },
   adminStyleTemplates: {
     pageTitle: "إدارة قوالب الأسلوب",

--- a/messages/de.ts
+++ b/messages/de.ts
@@ -1697,6 +1697,12 @@ export const deMessages = {
       "Diesen Stil verwenden, um dein eigenes Bild zu generieren?",
     userStyleTemplateConfirmCancel: "Andere Vorlagen sehen",
     userStyleTemplateConfirmAction: "Weiter",
+    eventShelfTeaserToast: "Erstelle eines, um das nächste freizuschalten!",
+    eventShelfCountdownDaysLeft: "Noch {days} Tage",
+    eventShelfCountdownLastDay: "Endet heute",
+    eventShelfCelebrationTitle: "Komplett!",
+    eventShelfCelebrationAction: "Sammlung ansehen",
+    eventShelfDoneBadge: "Erstellt",
   },
   adminStyleTemplates: {
     pageTitle: "Moderation der Stilvorlagen",

--- a/messages/de.ts
+++ b/messages/de.ts
@@ -1703,6 +1703,7 @@ export const deMessages = {
     eventShelfCelebrationTitle: "Komplett!",
     eventShelfCelebrationAction: "Sammlung ansehen",
     eventShelfDoneBadge: "Erstellt",
+    eventShelfNewBadge: "Neu",
   },
   adminStyleTemplates: {
     pageTitle: "Moderation der Stilvorlagen",

--- a/messages/en.ts
+++ b/messages/en.ts
@@ -1693,6 +1693,12 @@ export const enMessages = {
       "Use this style to generate your own image?",
     userStyleTemplateConfirmCancel: "See other templates",
     userStyleTemplateConfirmAction: "Continue",
+    eventShelfTeaserToast: "Generate one to unlock the next!",
+    eventShelfCountdownDaysLeft: "{days} days left",
+    eventShelfCountdownLastDay: "Ends today",
+    eventShelfCelebrationTitle: "Complete!",
+    eventShelfCelebrationAction: "View collection",
+    eventShelfDoneBadge: "Generated",
   },
   adminStyleTemplates: {
     pageTitle: "Style template moderation",

--- a/messages/en.ts
+++ b/messages/en.ts
@@ -1699,6 +1699,7 @@ export const enMessages = {
     eventShelfCelebrationTitle: "Complete!",
     eventShelfCelebrationAction: "View collection",
     eventShelfDoneBadge: "Generated",
+    eventShelfNewBadge: "NEW",
   },
   adminStyleTemplates: {
     pageTitle: "Style template moderation",

--- a/messages/es.ts
+++ b/messages/es.ts
@@ -1702,6 +1702,7 @@ export const esMessages = {
     eventShelfCelebrationTitle: "¡Completado!",
     eventShelfCelebrationAction: "Ver colección",
     eventShelfDoneBadge: "Generado",
+    eventShelfNewBadge: "Nuevo",
   },
   adminStyleTemplates: {
     pageTitle: "Moderación de plantillas de estilo",

--- a/messages/es.ts
+++ b/messages/es.ts
@@ -1696,6 +1696,12 @@ export const esMessages = {
       "¿Usar este estilo para generar tu propia imagen?",
     userStyleTemplateConfirmCancel: "Ver otras plantillas",
     userStyleTemplateConfirmAction: "Continuar",
+    eventShelfTeaserToast: "¡Genera uno para desbloquear el siguiente!",
+    eventShelfCountdownDaysLeft: "Quedan {days} días",
+    eventShelfCountdownLastDay: "Termina hoy",
+    eventShelfCelebrationTitle: "¡Completado!",
+    eventShelfCelebrationAction: "Ver colección",
+    eventShelfDoneBadge: "Generado",
   },
   adminStyleTemplates: {
     pageTitle: "Moderación de plantillas de estilo",

--- a/messages/fr.ts
+++ b/messages/fr.ts
@@ -1702,6 +1702,7 @@ export const frMessages = {
     eventShelfCelebrationTitle: "Terminé !",
     eventShelfCelebrationAction: "Voir la collection",
     eventShelfDoneBadge: "Généré",
+    eventShelfNewBadge: "Nouveau",
   },
   adminStyleTemplates: {
     pageTitle: "Modération des modèles de style",

--- a/messages/fr.ts
+++ b/messages/fr.ts
@@ -1696,6 +1696,12 @@ export const frMessages = {
       "Utiliser ce style pour générer votre image ?",
     userStyleTemplateConfirmCancel: "Voir d'autres modèles",
     userStyleTemplateConfirmAction: "Continuer",
+    eventShelfTeaserToast: "Générez-en un pour débloquer le suivant !",
+    eventShelfCountdownDaysLeft: "Plus que {days} jours",
+    eventShelfCountdownLastDay: "Se termine aujourd'hui",
+    eventShelfCelebrationTitle: "Terminé !",
+    eventShelfCelebrationAction: "Voir la collection",
+    eventShelfDoneBadge: "Généré",
   },
   adminStyleTemplates: {
     pageTitle: "Modération des modèles de style",

--- a/messages/hi.ts
+++ b/messages/hi.ts
@@ -1700,6 +1700,7 @@ export const hiMessages = {
     eventShelfCelebrationTitle: "पूर्ण!",
     eventShelfCelebrationAction: "संग्रह देखें",
     eventShelfDoneBadge: "जनरेट किया गया",
+    eventShelfNewBadge: "नया",
   },
   adminStyleTemplates: {
     pageTitle: "स्टाइल टेम्पलेट मॉडरेशन",

--- a/messages/hi.ts
+++ b/messages/hi.ts
@@ -1694,6 +1694,12 @@ export const hiMessages = {
       "इस स्टाइल का उपयोग करके अपनी छवि उत्पन्न करें?",
     userStyleTemplateConfirmCancel: "अन्य टेम्पलेट देखें",
     userStyleTemplateConfirmAction: "जारी रखें",
+    eventShelfTeaserToast: "अगला अनलॉक करने के लिए एक जनरेट करें!",
+    eventShelfCountdownDaysLeft: "{days} दिन बाकी",
+    eventShelfCountdownLastDay: "आज समाप्त",
+    eventShelfCelebrationTitle: "पूर्ण!",
+    eventShelfCelebrationAction: "संग्रह देखें",
+    eventShelfDoneBadge: "जनरेट किया गया",
   },
   adminStyleTemplates: {
     pageTitle: "स्टाइल टेम्पलेट मॉडरेशन",

--- a/messages/id.ts
+++ b/messages/id.ts
@@ -1695,6 +1695,12 @@ export const idMessages = {
       "Pakai gaya ini untuk membuat gambarmu?",
     userStyleTemplateConfirmCancel: "Lihat template lainnya",
     userStyleTemplateConfirmAction: "Lanjutkan",
+    eventShelfTeaserToast: "Buat satu untuk membuka berikutnya!",
+    eventShelfCountdownDaysLeft: "{days} hari lagi",
+    eventShelfCountdownLastDay: "Berakhir hari ini",
+    eventShelfCelebrationTitle: "Lengkap!",
+    eventShelfCelebrationAction: "Lihat koleksi",
+    eventShelfDoneBadge: "Sudah dibuat",
   },
   adminStyleTemplates: {
     pageTitle: "Moderasi template gaya",

--- a/messages/id.ts
+++ b/messages/id.ts
@@ -1701,6 +1701,7 @@ export const idMessages = {
     eventShelfCelebrationTitle: "Lengkap!",
     eventShelfCelebrationAction: "Lihat koleksi",
     eventShelfDoneBadge: "Sudah dibuat",
+    eventShelfNewBadge: "Baru",
   },
   adminStyleTemplates: {
     pageTitle: "Moderasi template gaya",

--- a/messages/it.ts
+++ b/messages/it.ts
@@ -1696,6 +1696,12 @@ export const itMessages = {
       "Usare questo stile per generare la tua immagine?",
     userStyleTemplateConfirmCancel: "Vedi altri modelli",
     userStyleTemplateConfirmAction: "Continua",
+    eventShelfTeaserToast: "Generane uno per sbloccare il prossimo!",
+    eventShelfCountdownDaysLeft: "Mancano {days} giorni",
+    eventShelfCountdownLastDay: "Termina oggi",
+    eventShelfCelebrationTitle: "Completato!",
+    eventShelfCelebrationAction: "Vedi la collezione",
+    eventShelfDoneBadge: "Generato",
   },
   adminStyleTemplates: {
     pageTitle: "Moderazione dei modelli di stile",

--- a/messages/it.ts
+++ b/messages/it.ts
@@ -1702,6 +1702,7 @@ export const itMessages = {
     eventShelfCelebrationTitle: "Completato!",
     eventShelfCelebrationAction: "Vedi la collezione",
     eventShelfDoneBadge: "Generato",
+    eventShelfNewBadge: "Nuovo",
   },
   adminStyleTemplates: {
     pageTitle: "Moderazione dei modelli di stile",

--- a/messages/ja.ts
+++ b/messages/ja.ts
@@ -1625,6 +1625,12 @@ export const jaMessages = {
       "このイラストのスタイルを使って生成画面へ移動しますか？",
     userStyleTemplateConfirmCancel: "他のテンプレを見る",
     userStyleTemplateConfirmAction: "移動する",
+    eventShelfTeaserToast: "1つ生成すると解放されます",
+    eventShelfCountdownDaysLeft: "あと{days}日",
+    eventShelfCountdownLastDay: "本日終了",
+    eventShelfCelebrationTitle: "コンプリート！",
+    eventShelfCelebrationAction: "コレクションを見る",
+    eventShelfDoneBadge: "生成済み",
   },
   adminStyleTemplates: {
     pageTitle: "スタイルテンプレート審査",

--- a/messages/ja.ts
+++ b/messages/ja.ts
@@ -1631,6 +1631,7 @@ export const jaMessages = {
     eventShelfCelebrationTitle: "コンプリート！",
     eventShelfCelebrationAction: "コレクションを見る",
     eventShelfDoneBadge: "生成済み",
+    eventShelfNewBadge: "新着",
   },
   adminStyleTemplates: {
     pageTitle: "スタイルテンプレート審査",

--- a/messages/ko.ts
+++ b/messages/ko.ts
@@ -1698,6 +1698,7 @@ export const koMessages = {
     eventShelfCelebrationTitle: "컴플리트!",
     eventShelfCelebrationAction: "컬렉션 보기",
     eventShelfDoneBadge: "생성 완료",
+    eventShelfNewBadge: "신규",
   },
   adminStyleTemplates: {
     pageTitle: "스타일 템플릿 관리",

--- a/messages/ko.ts
+++ b/messages/ko.ts
@@ -1692,6 +1692,12 @@ export const koMessages = {
       "이 스타일로 내 이미지를 생성할까요?",
     userStyleTemplateConfirmCancel: "다른 템플릿 보기",
     userStyleTemplateConfirmAction: "계속",
+    eventShelfTeaserToast: "하나 생성하면 다음이 해금됩니다!",
+    eventShelfCountdownDaysLeft: "{days}일 남음",
+    eventShelfCountdownLastDay: "오늘 종료",
+    eventShelfCelebrationTitle: "컴플리트!",
+    eventShelfCelebrationAction: "컬렉션 보기",
+    eventShelfDoneBadge: "생성 완료",
   },
   adminStyleTemplates: {
     pageTitle: "스타일 템플릿 관리",

--- a/messages/pt.ts
+++ b/messages/pt.ts
@@ -1702,6 +1702,7 @@ export const ptMessages = {
     eventShelfCelebrationTitle: "Completo!",
     eventShelfCelebrationAction: "Ver coleção",
     eventShelfDoneBadge: "Gerado",
+    eventShelfNewBadge: "Novo",
   },
   adminStyleTemplates: {
     pageTitle: "Moderação de modelos de estilo",

--- a/messages/pt.ts
+++ b/messages/pt.ts
@@ -1696,6 +1696,12 @@ export const ptMessages = {
       "Usar este estilo para gerar sua imagem?",
     userStyleTemplateConfirmCancel: "Ver outros modelos",
     userStyleTemplateConfirmAction: "Continuar",
+    eventShelfTeaserToast: "Gere um para desbloquear o próximo!",
+    eventShelfCountdownDaysLeft: "Faltam {days} dias",
+    eventShelfCountdownLastDay: "Termina hoje",
+    eventShelfCelebrationTitle: "Completo!",
+    eventShelfCelebrationAction: "Ver coleção",
+    eventShelfDoneBadge: "Gerado",
   },
   adminStyleTemplates: {
     pageTitle: "Moderação de modelos de estilo",

--- a/messages/th.ts
+++ b/messages/th.ts
@@ -1692,6 +1692,12 @@ export const thMessages = {
       "ใช้สไตล์นี้เพื่อสร้างรูปของคุณเอง?",
     userStyleTemplateConfirmCancel: "ดูเทมเพลตอื่น",
     userStyleTemplateConfirmAction: "ดำเนินการต่อ",
+    eventShelfTeaserToast: "สร้าง 1 ชิ้นเพื่อปลดล็อกชิ้นถัดไป!",
+    eventShelfCountdownDaysLeft: "เหลืออีก {days} วัน",
+    eventShelfCountdownLastDay: "สิ้นสุดวันนี้",
+    eventShelfCelebrationTitle: "ครบแล้ว!",
+    eventShelfCelebrationAction: "ดูคอลเลกชัน",
+    eventShelfDoneBadge: "สร้างแล้ว",
   },
   adminStyleTemplates: {
     pageTitle: "การกลั่นกรองเทมเพลตสไตล์",

--- a/messages/th.ts
+++ b/messages/th.ts
@@ -1698,6 +1698,7 @@ export const thMessages = {
     eventShelfCelebrationTitle: "ครบแล้ว!",
     eventShelfCelebrationAction: "ดูคอลเลกชัน",
     eventShelfDoneBadge: "สร้างแล้ว",
+    eventShelfNewBadge: "ใหม่",
   },
   adminStyleTemplates: {
     pageTitle: "การกลั่นกรองเทมเพลตสไตล์",

--- a/messages/vi.ts
+++ b/messages/vi.ts
@@ -1693,6 +1693,12 @@ export const viMessages = {
       "Dùng phong cách này để tạo hình của bạn?",
     userStyleTemplateConfirmCancel: "Xem mẫu khác",
     userStyleTemplateConfirmAction: "Tiếp tục",
+    eventShelfTeaserToast: "Tạo một cái để mở khóa cái tiếp theo!",
+    eventShelfCountdownDaysLeft: "Còn {days} ngày",
+    eventShelfCountdownLastDay: "Kết thúc hôm nay",
+    eventShelfCelebrationTitle: "Hoàn thành!",
+    eventShelfCelebrationAction: "Xem bộ sưu tập",
+    eventShelfDoneBadge: "Đã tạo",
   },
   adminStyleTemplates: {
     pageTitle: "Kiểm duyệt mẫu phong cách",

--- a/messages/vi.ts
+++ b/messages/vi.ts
@@ -1699,6 +1699,7 @@ export const viMessages = {
     eventShelfCelebrationTitle: "Hoàn thành!",
     eventShelfCelebrationAction: "Xem bộ sưu tập",
     eventShelfDoneBadge: "Đã tạo",
+    eventShelfNewBadge: "Mới",
   },
   adminStyleTemplates: {
     pageTitle: "Kiểm duyệt mẫu phong cách",

--- a/messages/zh-CN.ts
+++ b/messages/zh-CN.ts
@@ -1690,6 +1690,12 @@ export const zhCnMessages = {
       "要用此造型生成你的图片吗?",
     userStyleTemplateConfirmCancel: "看看其他模板",
     userStyleTemplateConfirmAction: "继续",
+    eventShelfTeaserToast: "生成1个即可解锁下一个！",
+    eventShelfCountdownDaysLeft: "还剩{days}天",
+    eventShelfCountdownLastDay: "今日截止",
+    eventShelfCelebrationTitle: "收集完成！",
+    eventShelfCelebrationAction: "查看收藏",
+    eventShelfDoneBadge: "已生成",
   },
   adminStyleTemplates: {
     pageTitle: "造型模板审核",

--- a/messages/zh-CN.ts
+++ b/messages/zh-CN.ts
@@ -1696,6 +1696,7 @@ export const zhCnMessages = {
     eventShelfCelebrationTitle: "收集完成！",
     eventShelfCelebrationAction: "查看收藏",
     eventShelfDoneBadge: "已生成",
+    eventShelfNewBadge: "新着",
   },
   adminStyleTemplates: {
     pageTitle: "造型模板审核",

--- a/messages/zh-TW.ts
+++ b/messages/zh-TW.ts
@@ -1696,6 +1696,7 @@ export const zhTwMessages = {
     eventShelfCelebrationTitle: "收集完成！",
     eventShelfCelebrationAction: "查看收藏",
     eventShelfDoneBadge: "已生成",
+    eventShelfNewBadge: "新著",
   },
   adminStyleTemplates: {
     pageTitle: "造型範本審核",

--- a/messages/zh-TW.ts
+++ b/messages/zh-TW.ts
@@ -1690,6 +1690,12 @@ export const zhTwMessages = {
       "要用此造型生成你的圖片嗎?",
     userStyleTemplateConfirmCancel: "看看其他範本",
     userStyleTemplateConfirmAction: "繼續",
+    eventShelfTeaserToast: "生成1個即可解鎖下一個！",
+    eventShelfCountdownDaysLeft: "還剩{days}天",
+    eventShelfCountdownLastDay: "今日截止",
+    eventShelfCelebrationTitle: "收集完成！",
+    eventShelfCelebrationAction: "查看收藏",
+    eventShelfDoneBadge: "已生成",
   },
   adminStyleTemplates: {
     pageTitle: "造型範本審核",

--- a/tests/unit/features/collections/collection-unlock-announcement.test.ts
+++ b/tests/unit/features/collections/collection-unlock-announcement.test.ts
@@ -30,6 +30,8 @@ function makeCategory(
     isActive: true,
     collectionDisplayStartsAt: null,
     collectionDisplayEndsAt: null,
+    isCollectionSeries: false,
+    completionThreshold: null,
     unlockPrerequisiteKey: null,
     progressiveBatchSize: null,
     sequentialUnlock: false,

--- a/tests/unit/features/collections/collection-unlock-gating.test.ts
+++ b/tests/unit/features/collections/collection-unlock-gating.test.ts
@@ -27,6 +27,8 @@ function makeCategory(
     isActive: true,
     collectionDisplayStartsAt: null,
     collectionDisplayEndsAt: null,
+    isCollectionSeries: false,
+    completionThreshold: null,
     unlockPrerequisiteKey: null,
     progressiveBatchSize: null,
     sequentialUnlock: false,

--- a/tests/unit/features/collections/collection-unlock-server.test.ts
+++ b/tests/unit/features/collections/collection-unlock-server.test.ts
@@ -62,6 +62,8 @@ function categoryRef(
     isActive: true,
     collectionDisplayStartsAt: null,
     collectionDisplayEndsAt: null,
+    isCollectionSeries: false,
+    completionThreshold: null,
     unlockPrerequisiteKey,
     progressiveBatchSize,
     sequentialUnlock,

--- a/tests/unit/features/home/derive-event-shelves.test.ts
+++ b/tests/unit/features/home/derive-event-shelves.test.ts
@@ -1,0 +1,224 @@
+import {
+  deriveEventShelves,
+  collectShelfPresetIds,
+} from "@/features/home/lib/derive-event-shelves";
+import { applyCollectionUnlockGating } from "@/features/collections/lib/collection-unlock-gating";
+import type { StylePresetPublicSummary } from "@/features/style-presets/lib/schema";
+
+function makeCategory(
+  key: string,
+  overrides: Partial<StylePresetPublicSummary["category"]> = {},
+): StylePresetPublicSummary["category"] {
+  return {
+    id: `cat-${key}`,
+    key,
+    displayNameJa: key,
+    displayNameEn: key,
+    badgeColor: "#000000",
+    badgeTextColor: "#ffffff",
+    skipBasePrefix: false,
+    outputAspectRatioMode: "source",
+    userGuidanceJa: null,
+    userGuidanceEn: null,
+    showSourceImageTypeControl: true,
+    showBackgroundChangeControl: true,
+    showGenerationModelControl: true,
+    showUserPromptInput: false,
+    userPromptLabel: null,
+    userPromptPlaceholder: null,
+    userPromptMaxLength: null,
+    visibility: "public",
+    isActive: true,
+    collectionDisplayStartsAt: null,
+    collectionDisplayEndsAt: null,
+    isCollectionSeries: false,
+    completionThreshold: null,
+    unlockPrerequisiteKey: null,
+    progressiveBatchSize: null,
+    sequentialUnlock: false,
+    unlockAnnouncementHeroPath: null,
+    unlockAnnouncementInitialBody: null,
+    unlockAnnouncementDripBody: null,
+    unlockAnnouncementAccentColor: null,
+    unlockAnnouncementAccentHoverColor: null,
+    unlockAnnouncementTitleColor: null,
+    unlockAnnouncementSoftColor: null,
+    ...overrides,
+  };
+}
+
+function makePreset(
+  id: string,
+  category: StylePresetPublicSummary["category"],
+  locked?: boolean,
+): StylePresetPublicSummary {
+  const preset: StylePresetPublicSummary = {
+    id,
+    title: id,
+    thumbnailImageUrl: `https://example.com/${id}.png`,
+    thumbnailWidth: 100,
+    thumbnailHeight: 100,
+    hasBackgroundPrompt: false,
+    category,
+    imageInputMode: "single",
+    dualReferenceSource: "admin",
+  };
+  return locked ? { ...preset, locked: true } : preset;
+}
+
+const NOW = new Date("2026-07-06T00:00:00Z");
+
+/** イタリア旅行相当: sequential・9枠・開催期間 7/3〜7/12 */
+function italyCategory(overrides: Partial<StylePresetPublicSummary["category"]> = {}) {
+  return makeCategory("travel_to_italy", {
+    isCollectionSeries: true,
+    sequentialUnlock: true,
+    completionThreshold: 9,
+    collectionDisplayStartsAt: "2026-07-03T10:00:00Z",
+    collectionDisplayEndsAt: "2026-07-12T13:00:00Z",
+    ...overrides,
+  });
+}
+
+/** 9プリセットを実ゲート(applyCollectionUnlockGating)へ通した出力を作る */
+function gatedItalyPresets(distinct: number) {
+  const cat = italyCategory();
+  const presets = Array.from({ length: 9 }, (_, i) =>
+    makePreset(`italy-${i}`, cat),
+  );
+  return applyCollectionUnlockGating(presets, {
+    prerequisiteCompletedKeys: new Set(),
+    distinctGeneratedByCategoryKey: new Map([["travel_to_italy", distinct]]),
+  });
+}
+
+describe("deriveEventShelves", () => {
+  test("初日(生成0): NEW(表紙) → teaser の2枚。カウンター0/9", () => {
+    const shelves = deriveEventShelves(
+      gatedItalyPresets(0),
+      new Map([["travel_to_italy", 0]]),
+      NOW,
+    );
+    expect(shelves).toHaveLength(1);
+    const shelf = shelves[0];
+    expect(shelf.cards.map((c) => c.kind)).toEqual(["new", "teaser"]);
+    expect(shelf.cards[0].preset?.id).toBe("italy-0");
+    expect(shelf.cards[1].preset?.id).toBe("italy-1");
+    expect(shelf.collectedCount).toBe(0);
+    expect(shelf.totalCount).toBe(9);
+    expect(shelf.isCompleted).toBe(false);
+    expect(shelf.endsAt).toBe("2026-07-12T13:00:00Z");
+  });
+
+  test("中盤(生成2): NEW → teaser → done×2 の並び。doneは昇順のまま", () => {
+    const shelves = deriveEventShelves(
+      gatedItalyPresets(2),
+      new Map([["travel_to_italy", 2]]),
+      NOW,
+    );
+    const shelf = shelves[0];
+    expect(shelf.cards.map((c) => c.kind)).toEqual([
+      "new",
+      "teaser",
+      "done",
+      "done",
+    ]);
+    // 解放済み=italy-0..2、生成済み=先頭2つ、NEW=italy-2、teaser=italy-3
+    expect(shelf.cards[0].preset?.id).toBe("italy-2");
+    expect(shelf.cards[1].preset?.id).toBe("italy-3");
+    expect(shelf.cards[2].preset?.id).toBe("italy-0");
+    expect(shelf.cards[3].preset?.id).toBe("italy-1");
+    expect(shelf.collectedCount).toBe(2);
+  });
+
+  test("全コンプ(生成9): celebration が先頭、teaser は出ない。9/9", () => {
+    const shelves = deriveEventShelves(
+      gatedItalyPresets(9),
+      new Map([["travel_to_italy", 9]]),
+      NOW,
+    );
+    const shelf = shelves[0];
+    expect(shelf.isCompleted).toBe(true);
+    expect(shelf.cards[0]).toEqual({ kind: "celebration", preset: null });
+    expect(shelf.cards.filter((c) => c.kind === "teaser")).toHaveLength(0);
+    expect(shelf.cards.filter((c) => c.kind === "done")).toHaveLength(9);
+    expect(shelf.collectedCount).toBe(9);
+  });
+
+  test("表示期間外(終了後)は棚を出さない", () => {
+    const after = new Date("2026-07-12T13:00:01Z");
+    const shelves = deriveEventShelves(
+      gatedItalyPresets(2),
+      new Map([["travel_to_italy", 2]]),
+      after,
+    );
+    expect(shelves).toHaveLength(0);
+  });
+
+  test("開始前も棚を出さない", () => {
+    const before = new Date("2026-07-03T09:59:59Z");
+    const shelves = deriveEventShelves(
+      gatedItalyPresets(0),
+      new Map(),
+      before,
+    );
+    expect(shelves).toHaveLength(0);
+  });
+
+  test("未ログイン(空コンテキスト)は初日状態になる", () => {
+    const shelves = deriveEventShelves(gatedItalyPresets(0), new Map(), NOW);
+    expect(shelves[0].cards.map((c) => c.kind)).toEqual(["new", "teaser"]);
+    expect(shelves[0].collectedCount).toBe(0);
+  });
+
+  test("コレクションシリーズでない/sequentialでないカテゴリは対象外", () => {
+    const plain = makeCategory("coordinate");
+    const nonSequential = makeCategory("wafer", {
+      isCollectionSeries: true,
+      sequentialUnlock: false,
+    });
+    const shelves = deriveEventShelves(
+      [makePreset("a", plain), makePreset("b", nonSequential)],
+      new Map(),
+      NOW,
+    );
+    expect(shelves).toHaveLength(0);
+  });
+
+  test("複数企画は終了が近い順に並ぶ", () => {
+    const soon = italyCategory();
+    const later = makeCategory("second_event", {
+      isCollectionSeries: true,
+      sequentialUnlock: true,
+      completionThreshold: 6,
+      collectionDisplayStartsAt: "2026-07-01T00:00:00Z",
+      collectionDisplayEndsAt: "2026-07-31T00:00:00Z",
+    });
+    const shelves = deriveEventShelves(
+      [
+        makePreset("later-0", later),
+        makePreset("later-1", later, true),
+        makePreset("italy-0", soon),
+        makePreset("italy-1", soon, true),
+      ],
+      new Map(),
+      NOW,
+    );
+    expect(shelves.map((s) => s.categoryKey)).toEqual([
+      "travel_to_italy",
+      "second_event",
+    ]);
+  });
+
+  test("collectShelfPresetIds は celebration を除く全カードの preset id を返す", () => {
+    const shelves = deriveEventShelves(
+      gatedItalyPresets(9),
+      new Map([["travel_to_italy", 9]]),
+      NOW,
+    );
+    const ids = collectShelfPresetIds(shelves);
+    expect(ids.size).toBe(9);
+    expect(ids.has("italy-0")).toBe(true);
+    expect(ids.has("italy-8")).toBe(true);
+  });
+});

--- a/tests/unit/features/home/derive-event-shelves.test.ts
+++ b/tests/unit/features/home/derive-event-shelves.test.ts
@@ -1,6 +1,7 @@
 import {
   deriveEventShelves,
   collectShelfPresetIds,
+  listActiveEventCategoryKeys,
 } from "@/features/home/lib/derive-event-shelves";
 import { applyCollectionUnlockGating } from "@/features/collections/lib/collection-unlock-gating";
 import type { StylePresetPublicSummary } from "@/features/style-presets/lib/schema";
@@ -80,6 +81,16 @@ function italyCategory(overrides: Partial<StylePresetPublicSummary["category"]> 
   });
 }
 
+/** sequential では先頭から順に生成されるので、生成済みID集合=先頭N個 */
+function italyGeneratedIds(distinct: number): Map<string, ReadonlySet<string>> {
+  return new Map([
+    [
+      "travel_to_italy",
+      new Set(Array.from({ length: distinct }, (_, i) => `italy-${i}`)),
+    ],
+  ]);
+}
+
 /** 9プリセットを実ゲート(applyCollectionUnlockGating)へ通した出力を作る */
 function gatedItalyPresets(distinct: number) {
   const cat = italyCategory();
@@ -97,6 +108,7 @@ describe("deriveEventShelves", () => {
     const shelves = deriveEventShelves(
       gatedItalyPresets(0),
       new Map([["travel_to_italy", 0]]),
+      italyGeneratedIds(0),
       NOW,
     );
     expect(shelves).toHaveLength(1);
@@ -114,6 +126,7 @@ describe("deriveEventShelves", () => {
     const shelves = deriveEventShelves(
       gatedItalyPresets(2),
       new Map([["travel_to_italy", 2]]),
+      italyGeneratedIds(2),
       NOW,
     );
     const shelf = shelves[0];
@@ -135,6 +148,7 @@ describe("deriveEventShelves", () => {
     const shelves = deriveEventShelves(
       gatedItalyPresets(9),
       new Map([["travel_to_italy", 9]]),
+      italyGeneratedIds(9),
       NOW,
     );
     const shelf = shelves[0];
@@ -150,6 +164,7 @@ describe("deriveEventShelves", () => {
     const shelves = deriveEventShelves(
       gatedItalyPresets(2),
       new Map([["travel_to_italy", 2]]),
+      italyGeneratedIds(2),
       after,
     );
     expect(shelves).toHaveLength(0);
@@ -160,25 +175,28 @@ describe("deriveEventShelves", () => {
     const shelves = deriveEventShelves(
       gatedItalyPresets(0),
       new Map(),
+      new Map(),
       before,
     );
     expect(shelves).toHaveLength(0);
   });
 
   test("未ログイン(空コンテキスト)は初日状態になる", () => {
-    const shelves = deriveEventShelves(gatedItalyPresets(0), new Map(), NOW);
+    const shelves = deriveEventShelves(
+      gatedItalyPresets(0),
+      new Map(),
+      new Map(),
+      NOW,
+    );
     expect(shelves[0].cards.map((c) => c.kind)).toEqual(["new", "teaser"]);
     expect(shelves[0].collectedCount).toBe(0);
   });
 
-  test("コレクションシリーズでない/sequentialでないカテゴリは対象外", () => {
+  test("コレクションシリーズでないカテゴリは対象外", () => {
     const plain = makeCategory("coordinate");
-    const nonSequential = makeCategory("wafer", {
-      isCollectionSeries: true,
-      sequentialUnlock: false,
-    });
     const shelves = deriveEventShelves(
-      [makePreset("a", plain), makePreset("b", nonSequential)],
+      [makePreset("a", plain)],
+      new Map(),
       new Map(),
       NOW,
     );
@@ -202,6 +220,7 @@ describe("deriveEventShelves", () => {
         makePreset("italy-1", soon, true),
       ],
       new Map(),
+      new Map(),
       NOW,
     );
     expect(shelves.map((s) => s.categoryKey)).toEqual([
@@ -210,10 +229,92 @@ describe("deriveEventShelves", () => {
     ]);
   });
 
+  test("一斉公開(非sequential)のシリーズも棚に出て、ID集合で✓済みが付く", () => {
+    // 神コレ型: is_collection_series のみ(順次解放なし・前提なし) → gating は no-op
+    const wafer = makeCategory("wafer_like", {
+      isCollectionSeries: true,
+      sequentialUnlock: false,
+      completionThreshold: 6,
+      collectionDisplayStartsAt: "2026-07-03T10:00:00Z",
+      collectionDisplayEndsAt: "2026-07-12T13:00:00Z",
+    });
+    const presets = Array.from({ length: 6 }, (_, i) =>
+      makePreset(`w-${i}`, wafer),
+    );
+    // 生成順は任意(w-1 と w-4 だけ生成済み)。一斉公開は位置ベースでは判定できない
+    const shelves = deriveEventShelves(
+      presets,
+      new Map(),
+      new Map([["wafer_like", new Set(["w-1", "w-4"])]]),
+      NOW,
+    );
+    expect(shelves).toHaveLength(1);
+    const shelf = shelves[0];
+    expect(shelf.cards.map((c) => c.kind)).toEqual([
+      "new",
+      "new",
+      "new",
+      "new",
+      "done",
+      "done",
+    ]);
+    expect(shelf.cards.filter((c) => c.kind === "done").map((c) => c.preset?.id)).toEqual(
+      ["w-1", "w-4"],
+    );
+    // 解放コンテキスト対象外なのでカウンターはID集合サイズで代替
+    expect(shelf.collectedCount).toBe(2);
+    expect(shelf.totalCount).toBe(6);
+  });
+
+  test("一斉公開シリーズの全コンプでも celebration が先頭に付く", () => {
+    const wafer = makeCategory("wafer_like", {
+      isCollectionSeries: true,
+      sequentialUnlock: false,
+      completionThreshold: 3,
+      collectionDisplayEndsAt: "2026-07-12T13:00:00Z",
+    });
+    const presets = Array.from({ length: 3 }, (_, i) =>
+      makePreset(`w-${i}`, wafer),
+    );
+    const shelves = deriveEventShelves(
+      presets,
+      new Map(),
+      new Map([["wafer_like", new Set(["w-0", "w-1", "w-2"])]]),
+      NOW,
+    );
+    expect(shelves[0].isCompleted).toBe(true);
+    expect(shelves[0].cards[0].kind).toBe("celebration");
+  });
+
+  test("listActiveEventCategoryKeys は開催中シリーズの key を重複なしで返す", () => {
+    const italy = italyCategory();
+    const wafer = makeCategory("wafer_like", {
+      isCollectionSeries: true,
+      sequentialUnlock: false,
+      collectionDisplayEndsAt: "2026-07-12T13:00:00Z",
+    });
+    const ended = makeCategory("ended", {
+      isCollectionSeries: true,
+      collectionDisplayEndsAt: "2026-07-01T00:00:00Z",
+    });
+    const keys = listActiveEventCategoryKeys(
+      [
+        makePreset("i-0", italy),
+        makePreset("i-1", italy),
+        makePreset("w-0", wafer),
+        makePreset("e-0", ended),
+        makePreset("c-0", makeCategory("coordinate")),
+      ],
+      NOW,
+    );
+    expect(keys).toEqual(["travel_to_italy", "wafer_like"]);
+  });
+
   test("collectShelfPresetIds は celebration を除く全カードの preset id を返す", () => {
     const shelves = deriveEventShelves(
       gatedItalyPresets(9),
       new Map([["travel_to_italy", 9]]),
+      italyGeneratedIds(9),
       NOW,
     );
     const ids = collectShelfPresetIds(shelves);

--- a/tests/unit/features/style/style-page-client.test.tsx
+++ b/tests/unit/features/style/style-page-client.test.tsx
@@ -410,6 +410,8 @@ const TEST_COORDINATE_CATEGORY = {
   isActive: true,
   collectionDisplayStartsAt: null,
   collectionDisplayEndsAt: null,
+  isCollectionSeries: false,
+  completionThreshold: null,
 } as const;
 
 const presets: readonly StylePresetPublicSummary[] = [

--- a/tests/unit/lib/get-public-style-presets.test.ts
+++ b/tests/unit/lib/get-public-style-presets.test.ts
@@ -55,6 +55,8 @@ describe("get-public-style-presets", () => {
     isActive: true,
     collectionDisplayStartsAt: null,
     collectionDisplayEndsAt: null,
+    isCollectionSeries: false,
+    completionThreshold: null,
   } as const;
 
   test("getPublishedStylePresets_キャッシュタグを付けて公開一覧を返す", async () => {

--- a/tests/unit/lib/style-preset-repository.test.ts
+++ b/tests/unit/lib/style-preset-repository.test.ts
@@ -207,6 +207,8 @@ describe("style-preset repository", () => {
           isActive: true,
           collectionDisplayStartsAt: null,
           collectionDisplayEndsAt: null,
+          isCollectionSeries: false,
+          completionThreshold: null,
           providerUserId: null,
           providerNickname: null,
           providerAvatarUrl: null,


### PR DESCRIPTION
### 概要
ホーム上部のStyleカードが100個超に増え、開催中の企画（イタリア旅行等）のスタイルが埋もれて見つけにくいというUX課題があった。「プロンプトなしでお着替え！」カルーセルの**上**に、開催中のコレクション企画専用の横スクロール棚を追加し、企画スタイルの発見性と参加率を高める。

計画書: `docs/planning/home-event-shelf-implementation-plan.md`（本PRに同梱）

**設計のポイント**
- **DB変更なし・追加クエリなし**: ホームで解決済みの「キャッシュ済プリセット一覧＋ユーザー別解放コンテキスト」だけから棚を導出する（既存の `CachedHomeStylePresetSection` は locked を除外していただけなので、その出力を振り分ける）
- **並び順**: NEW（今生成できる）→ シルエット（次の1枚のみ、`/style` の `dripLocked` 表示を流用）→ ✓済み（減光表示）。全コンプ後は🎉お祝いカード（/collections リンク）が先頭
- **見出し**: 🔥企画名＋進捗カウンター（0/9）＋残り日数バッジ（終了間際は赤、それ以外はグレー）
- **非開催時は棚ごと非表示**（開催中企画クエリが0件なら描画しない）。機能フラグは不要で、admin から `collection_display_ends_at` を過去日時にすれば即オフ可能
- 棚に出した企画プリセットはお着替えカルーセルから除外し重複表示を回避
- シルエットタップで「1つ生成すると解放されます」トースト。✓済み/NEWタップは既存カルーセルと同じ試着確認ダイアログ→ `/style` 遷移
- 未ログインは空コンテキストにより初日状態（表紙NEW＋シルエット）で表示

### 変更内容
- `features/style-presets/lib/{schema,style-preset-repository}.ts`: category summary に `isCollectionSeries` / `completionThreshold` を公開（既存カラムの select/mapping 追加のみ）
- `features/home/lib/derive-event-shelves.ts` 新規: 棚モデル導出の純関数（celebration→new→teaser→done、複数企画は終了が近い順）
- `features/home/components/HomeEventShelfSection.tsx` 新規: 棚UI（Swiper、`StylePresetPreviewCard` 流用）
- `features/home/components/CachedHomeStylePresetSection.tsx`: 棚の導出・描画を統合、カルーセルから企画プリセットを除外
- `messages/*.ts`（全15ロケール）: 棚関連の翻訳キー6件を追加
- `tests/unit/features/home/derive-event-shelves.test.ts` 新規: 実ゲート（`applyCollectionUnlockGating`）を通した9ケース

### 実機テスト
- [x] PC（Chrome/モバイルビューポート390px）でローカルprodサーバにて確認: 棚表示（🔥見出し+0/9+あと2日グレーバッジ）、NEWバッジ、シルエット（黒つぶし+🔒生成すると開放）、シルエットタップのトースト、NEWカードタップの試着確認ダイアログ、お着替えカルーセルからの企画プリセット除外
- [ ] iOS Safari で主要導線を確認
- [ ] Android Chrome で主要導線を確認
- [ ] ログイン済みアカウントで進捗反映（✓済み・カウンター・コンプお祝いカード）を確認

### テスト方法
- `npm run lint`: 変更ファイルはクリーン（全体149件は変更前後で同一＝既存）
- `npm run typecheck`: エラー511件はベースラインと同数・同一箇所（`tests/**` の既知の既存エラーのみ）
- `npm run test`: 236スイート・2349件パス（新規9件含む）
- `npm run build -- --webpack`: 成功
- 実機確認: 上記チェックリストのとおり、本番データ（travel_to_italy・7/12終了）で棚の表示・操作を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwcR7uKsNrx7vB1MeHTx7J