### PR TITLE
fix(posts): 【緊急】ログインユーザーのホームがSSRクラッシュする障害を修正

### DIFF
--- a/features/posts/lib/server-api.ts
+++ b/features/posts/lib/server-api.ts
@@ -38,6 +38,22 @@ import {
 
 export type LikeRange = "all" | "day" | "week" | "month";
 
+/**
+ * PostgREST の .in() に一度に渡すID数の上限。URL長・応答サイズを抑えるための単位で、
+ * これを超える入力はチャンクに分割して取得し結果を結合する。
+ * 以前は超過時に throw していたため、ホームの「オススメ」(先週投稿の全件集計)が
+ * 週の投稿数100件超えと同時にSSRごと落ちる障害が起きた(2026-07-12)。
+ */
+const IN_QUERY_CHUNK_SIZE = 100;
+
+function chunkArray<T>(items: readonly T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
 type CommentRow = {
   id: string;
   user_id: string | null;
@@ -905,22 +921,6 @@ export async function getLikeCount(
 }
 
 /**
- * PostgREST の .in() に一度に渡すID数の上限。URL長・応答サイズを抑えるための単位で、
- * これを超える入力はチャンクに分割して取得し結果を結合する。
- * 以前は超過時に throw していたため、ホームの「オススメ」(先週投稿の全件集計)が
- * 週の投稿数100件超えと同時にSSRごと落ちる障害が起きた(2026-07-12)。
- */
-const IN_QUERY_CHUNK_SIZE = 100;
-
-function chunkArray<T>(items: readonly T[], size: number): T[][] {
-  const chunks: T[][] = [];
-  for (let i = 0; i < items.length; i += size) {
-    chunks.push(items.slice(i, i + size));
-  }
-  return chunks;
-}
-
-/**
  * いいね数を一括取得（バッチ。100件を超える入力はチャンク分割して取得）
  * @param supabaseOverride - use cache 用。指定時は cookies を使わない
  */
@@ -1085,6 +1085,24 @@ export async function getLikeCountsByRangeBatch(
 
   const supabase = supabaseOverride ?? (await createClient());
 
+  // JST基準の期間フィルタ（昨日/先週/先月）。チャンクごとに再計算しないよう外で確定する。
+  let gteDate: string | undefined;
+  let lteDate: string | undefined;
+  if (range === "day") {
+    // Daily: 昨日のいいねのみ
+    gteDate = getJSTYesterdayStart().toISOString();
+    lteDate = getJSTYesterdayEnd().toISOString();
+  } else if (range === "week") {
+    // Week: 先週のいいねのみ
+    gteDate = getJSTLastWeekStart().toISOString();
+    lteDate = getJSTLastWeekEnd().toISOString();
+  } else if (range === "month") {
+    // Month: 先月のいいねのみ
+    gteDate = getJSTLastMonthStart().toISOString();
+    lteDate = getJSTLastMonthEnd().toISOString();
+  }
+  // range === "all" の場合は期間制限なし
+
   const chunkResults = await Promise.all(
     chunkArray(imageIds, IN_QUERY_CHUNK_SIZE).map(async (chunk) => {
       let query = supabase
@@ -1092,30 +1110,9 @@ export async function getLikeCountsByRangeBatch(
         .select("image_id")
         .in("image_id", chunk);
 
-      // JST基準で期間フィルタリング（昨日/先週/先月）
-      if (range === "day") {
-        // Daily: 昨日のいいねのみ
-        const jstYesterdayStart = getJSTYesterdayStart();
-        const jstYesterdayEnd = getJSTYesterdayEnd();
-        query = query
-          .gte("created_at", jstYesterdayStart.toISOString())
-          .lte("created_at", jstYesterdayEnd.toISOString());
-      } else if (range === "week") {
-        // Week: 先週のいいねのみ
-        const jstLastWeekStart = getJSTLastWeekStart();
-        const jstLastWeekEnd = getJSTLastWeekEnd();
-        query = query
-          .gte("created_at", jstLastWeekStart.toISOString())
-          .lte("created_at", jstLastWeekEnd.toISOString());
-      } else if (range === "month") {
-        // Month: 先月のいいねのみ
-        const jstLastMonthStart = getJSTLastMonthStart();
-        const jstLastMonthEnd = getJSTLastMonthEnd();
-        query = query
-          .gte("created_at", jstLastMonthStart.toISOString())
-          .lte("created_at", jstLastMonthEnd.toISOString());
+      if (gteDate && lteDate) {
+        query = query.gte("created_at", gteDate).lte("created_at", lteDate);
       }
-      // range === "all" の場合は期間制限なし
 
       const { data, error } = await query;
 

--- a/features/posts/lib/server-api.ts
+++ b/features/posts/lib/server-api.ts
@@ -217,24 +217,28 @@ async function getProfileMap(
   }
 
   const supabase = supabaseOverride ?? (await createClient());
-  const { data: profiles, error: profilesError } = await supabase
-    .from("profiles")
-    .select("user_id,nickname,avatar_url,subscription_plan")
-    .in("user_id", userIds);
+  const chunkResults = await Promise.all(
+    chunkArray(userIds, IN_QUERY_CHUNK_SIZE).map(async (chunk) => {
+      const { data: profiles, error: profilesError } = await supabase
+        .from("profiles")
+        .select("user_id,nickname,avatar_url,subscription_plan")
+        .in("user_id", chunk);
 
-  if (profilesError) {
-    console.error("Profile fetch error:", profilesError);
-    return profileMap;
-  }
+      if (profilesError) {
+        console.error("Profile fetch error:", profilesError);
+        return [];
+      }
 
-  if (profiles) {
-    for (const profile of profiles) {
-      profileMap[profile.user_id] = {
-        nickname: profile.nickname,
-        avatar_url: profile.avatar_url,
-        subscription_plan: profile.subscription_plan ?? "free",
-      };
-    }
+      return profiles ?? [];
+    })
+  );
+
+  for (const profile of chunkResults.flat()) {
+    profileMap[profile.user_id] = {
+      nickname: profile.nickname,
+      avatar_url: profile.avatar_url,
+      subscription_plan: profile.subscription_plan ?? "free",
+    };
   }
 
   return profileMap;
@@ -901,7 +905,23 @@ export async function getLikeCount(
 }
 
 /**
- * いいね数を一括取得（バッチ、最大100件）
+ * PostgREST の .in() に一度に渡すID数の上限。URL長・応答サイズを抑えるための単位で、
+ * これを超える入力はチャンクに分割して取得し結果を結合する。
+ * 以前は超過時に throw していたため、ホームの「オススメ」(先週投稿の全件集計)が
+ * 週の投稿数100件超えと同時にSSRごと落ちる障害が起きた(2026-07-12)。
+ */
+const IN_QUERY_CHUNK_SIZE = 100;
+
+function chunkArray<T>(items: readonly T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
+/**
+ * いいね数を一括取得（バッチ。100件を超える入力はチャンク分割して取得）
  * @param supabaseOverride - use cache 用。指定時は cookies を使わない
  */
 export async function getLikeCountsBatch(
@@ -912,21 +932,23 @@ export async function getLikeCountsBatch(
     return {};
   }
 
-  if (imageIds.length > 100) {
-    throw new Error("バッチサイズは100件までです");
-  }
-
   const supabase = supabaseOverride ?? (await createClient());
 
-  const { data, error } = await supabase
-    .from("likes")
-    .select("image_id")
-    .in("image_id", imageIds);
+  const chunkResults = await Promise.all(
+    chunkArray(imageIds, IN_QUERY_CHUNK_SIZE).map(async (chunk) => {
+      const { data, error } = await supabase
+        .from("likes")
+        .select("image_id")
+        .in("image_id", chunk);
 
-  if (error) {
-    console.error("Database query error:", error);
-    throw new Error(`いいね数の一括取得に失敗しました: ${error.message}`);
-  }
+      if (error) {
+        console.error("Database query error:", error);
+        throw new Error(`いいね数の一括取得に失敗しました: ${error.message}`);
+      }
+
+      return data ?? [];
+    })
+  );
 
   // 集計
   const counts: Record<string, number> = {};
@@ -934,7 +956,7 @@ export async function getLikeCountsBatch(
     counts[id] = 0;
   });
 
-  data?.forEach((like) => {
+  chunkResults.flat().forEach((like) => {
     if (like.image_id) {
       counts[like.image_id] = (counts[like.image_id] || 0) + 1;
     }
@@ -965,7 +987,7 @@ export async function getUserLikeStatus(imageId: string, userId: string): Promis
 }
 
 /**
- * ユーザーのいいね状態を一括取得（バッチ）
+ * ユーザーのいいね状態を一括取得（バッチ。100件を超える入力はチャンク分割して取得）
  */
 export async function getUserLikeStatusesBatch(
   imageIds: string[],
@@ -975,29 +997,31 @@ export async function getUserLikeStatusesBatch(
     return {};
   }
 
-  if (imageIds.length > 100) {
-    throw new Error("バッチサイズは100件までです");
-  }
-
   const supabase = await createClient();
 
-  const { data, error } = await supabase
-    .from("likes")
-    .select("image_id")
-    .in("image_id", imageIds)
-    .eq("user_id", userId);
+  const chunkResults = await Promise.all(
+    chunkArray(imageIds, IN_QUERY_CHUNK_SIZE).map(async (chunk) => {
+      const { data, error } = await supabase
+        .from("likes")
+        .select("image_id")
+        .in("image_id", chunk)
+        .eq("user_id", userId);
 
-  if (error) {
-    console.error("Database query error:", error);
-    throw new Error(`いいね状態の一括取得に失敗しました: ${error.message}`);
-  }
+      if (error) {
+        console.error("Database query error:", error);
+        throw new Error(`いいね状態の一括取得に失敗しました: ${error.message}`);
+      }
+
+      return data ?? [];
+    })
+  );
 
   const statuses: Record<string, boolean> = {};
   imageIds.forEach((id) => {
     statuses[id] = false;
   });
 
-  data?.forEach((like) => {
+  chunkResults.flat().forEach((like) => {
     if (like.image_id) {
       statuses[like.image_id] = true;
     }
@@ -1061,42 +1085,48 @@ export async function getLikeCountsByRangeBatch(
 
   const supabase = supabaseOverride ?? (await createClient());
 
-  let query = supabase
-    .from("likes")
-    .select("image_id")
-    .in("image_id", imageIds);
+  const chunkResults = await Promise.all(
+    chunkArray(imageIds, IN_QUERY_CHUNK_SIZE).map(async (chunk) => {
+      let query = supabase
+        .from("likes")
+        .select("image_id")
+        .in("image_id", chunk);
 
-  // JST基準で期間フィルタリング（昨日/先週/先月）
-  if (range === "day") {
-    // Daily: 昨日のいいねのみ
-    const jstYesterdayStart = getJSTYesterdayStart();
-    const jstYesterdayEnd = getJSTYesterdayEnd();
-    query = query
-      .gte("created_at", jstYesterdayStart.toISOString())
-      .lte("created_at", jstYesterdayEnd.toISOString());
-  } else if (range === "week") {
-    // Week: 先週のいいねのみ
-    const jstLastWeekStart = getJSTLastWeekStart();
-    const jstLastWeekEnd = getJSTLastWeekEnd();
-    query = query
-      .gte("created_at", jstLastWeekStart.toISOString())
-      .lte("created_at", jstLastWeekEnd.toISOString());
-  } else if (range === "month") {
-    // Month: 先月のいいねのみ
-    const jstLastMonthStart = getJSTLastMonthStart();
-    const jstLastMonthEnd = getJSTLastMonthEnd();
-    query = query
-      .gte("created_at", jstLastMonthStart.toISOString())
-      .lte("created_at", jstLastMonthEnd.toISOString());
-  }
-  // range === "all" の場合は期間制限なし
+      // JST基準で期間フィルタリング（昨日/先週/先月）
+      if (range === "day") {
+        // Daily: 昨日のいいねのみ
+        const jstYesterdayStart = getJSTYesterdayStart();
+        const jstYesterdayEnd = getJSTYesterdayEnd();
+        query = query
+          .gte("created_at", jstYesterdayStart.toISOString())
+          .lte("created_at", jstYesterdayEnd.toISOString());
+      } else if (range === "week") {
+        // Week: 先週のいいねのみ
+        const jstLastWeekStart = getJSTLastWeekStart();
+        const jstLastWeekEnd = getJSTLastWeekEnd();
+        query = query
+          .gte("created_at", jstLastWeekStart.toISOString())
+          .lte("created_at", jstLastWeekEnd.toISOString());
+      } else if (range === "month") {
+        // Month: 先月のいいねのみ
+        const jstLastMonthStart = getJSTLastMonthStart();
+        const jstLastMonthEnd = getJSTLastMonthEnd();
+        query = query
+          .gte("created_at", jstLastMonthStart.toISOString())
+          .lte("created_at", jstLastMonthEnd.toISOString());
+      }
+      // range === "all" の場合は期間制限なし
 
-  const { data, error } = await query;
+      const { data, error } = await query;
 
-  if (error) {
-    console.error("Database query error:", error);
-    throw new Error(`いいね数の一括集計に失敗しました: ${error.message}`);
-  }
+      if (error) {
+        console.error("Database query error:", error);
+        throw new Error(`いいね数の一括集計に失敗しました: ${error.message}`);
+      }
+
+      return data ?? [];
+    })
+  );
 
   // image_idごとに集計
   const counts: Record<string, number> = {};
@@ -1105,7 +1135,7 @@ export async function getLikeCountsByRangeBatch(
     counts[id] = 0;
   });
   // いいねがある投稿のカウントを増やす
-  data?.forEach((like) => {
+  chunkResults.flat().forEach((like) => {
     if (like.image_id) {
       counts[like.image_id] = (counts[like.image_id] || 0) + 1;
     }
@@ -1190,7 +1220,7 @@ export async function getCommentCount(
 }
 
 /**
- * コメント数を一括取得（バッチ、最大100件）
+ * コメント数を一括取得（バッチ。100件を超える入力はチャンク分割して取得）
  * @param supabaseOverride - use cache 用。指定時は cookies を使わない
  */
 export async function getCommentCountsBatch(
@@ -1201,23 +1231,25 @@ export async function getCommentCountsBatch(
     return {};
   }
 
-  if (imageIds.length > 100) {
-    throw new Error("バッチサイズは100件までです");
-  }
-
   const supabase = supabaseOverride ?? (await createClient());
 
-  const { data, error } = await supabase
-    .from("comments")
-    .select("image_id")
-    .in("image_id", imageIds)
-    .is("parent_comment_id", null)
-    .is("deleted_at", null);
+  const chunkResults = await Promise.all(
+    chunkArray(imageIds, IN_QUERY_CHUNK_SIZE).map(async (chunk) => {
+      const { data, error } = await supabase
+        .from("comments")
+        .select("image_id")
+        .in("image_id", chunk)
+        .is("parent_comment_id", null)
+        .is("deleted_at", null);
 
-  if (error) {
-    console.error("Database query error:", error);
-    throw new Error(`コメント数の一括取得に失敗しました: ${error.message}`);
-  }
+      if (error) {
+        console.error("Database query error:", error);
+        throw new Error(`コメント数の一括取得に失敗しました: ${error.message}`);
+      }
+
+      return data ?? [];
+    })
+  );
 
   // 集計
   const counts: Record<string, number> = {};
@@ -1225,7 +1257,7 @@ export async function getCommentCountsBatch(
     counts[id] = 0;
   });
 
-  data?.forEach((comment) => {
+  chunkResults.flat().forEach((comment) => {
     if (comment.image_id) {
       counts[comment.image_id] = (counts[comment.image_id] || 0) + 1;
     }
@@ -1259,29 +1291,31 @@ export async function getReplyCountsBatch(
     return {};
   }
 
-  if (parentCommentIds.length > 100) {
-    throw new Error("バッチサイズは100件までです");
-  }
-
   const supabase = supabaseOverride ?? (await createClient());
 
-  const { data, error } = await supabase
-    .from("comments")
-    .select("parent_comment_id")
-    .in("parent_comment_id", parentCommentIds)
-    .is("deleted_at", null);
+  const chunkResults = await Promise.all(
+    chunkArray(parentCommentIds, IN_QUERY_CHUNK_SIZE).map(async (chunk) => {
+      const { data, error } = await supabase
+        .from("comments")
+        .select("parent_comment_id")
+        .in("parent_comment_id", chunk)
+        .is("deleted_at", null);
 
-  if (error) {
-    console.error("Database query error:", error);
-    throw new Error(`返信数の一括取得に失敗しました: ${error.message}`);
-  }
+      if (error) {
+        console.error("Database query error:", error);
+        throw new Error(`返信数の一括取得に失敗しました: ${error.message}`);
+      }
+
+      return data ?? [];
+    })
+  );
 
   const counts: Record<string, number> = {};
   parentCommentIds.forEach((id) => {
     counts[id] = 0;
   });
 
-  data?.forEach((reply) => {
+  chunkResults.flat().forEach((reply) => {
     if (reply.parent_comment_id) {
       counts[reply.parent_comment_id] = (counts[reply.parent_comment_id] || 0) + 1;
     }

--- a/tests/unit/features/posts/batch-helpers.test.ts
+++ b/tests/unit/features/posts/batch-helpers.test.ts
@@ -15,6 +15,7 @@ import {
   getLikeCountsBatch,
   getCommentCountsBatch,
   getLikeCountsByRangeBatch,
+  getReplyCountsBatch,
   getUserLikeStatusesBatch,
 } from "@/features/posts/lib/server-api";
 import { createClient } from "@/lib/supabase/server";
@@ -120,6 +121,39 @@ describe("バッチ取得ヘルパーのチャンク分割", () => {
     expect(statuses["id-0"]).toBe(false);
   });
 
+  test("getReplyCountsBatch_150件入力でthrowせず分割して集計する", async () => {
+    const { client, inCalls } = makeFakeClient(
+      [
+        { parent_comment_id: "id-10" },
+        { parent_comment_id: "id-10" },
+        { parent_comment_id: "id-140" },
+      ],
+      "parent_comment_id",
+    );
+
+    const counts = await getReplyCountsBatch(MANY_IDS, client);
+
+    expect(inCalls.map((c) => c.length)).toEqual([100, 50]);
+    expect(counts["id-10"]).toBe(2);
+    expect(counts["id-140"]).toBe(1);
+    expect(counts["id-0"]).toBe(0);
+  });
+
+  test.each(["day", "month", "all"] as const)(
+    "getLikeCountsByRangeBatch_range=%s でも分割して集計する",
+    async (range) => {
+      const { client, inCalls } = makeFakeClient(
+        [{ image_id: "id-3" }],
+        "image_id",
+      );
+
+      const counts = await getLikeCountsByRangeBatch(MANY_IDS, range, client);
+
+      expect(inCalls.map((c) => c.length)).toEqual([100, 50]);
+      expect(counts["id-3"]).toBe(1);
+    },
+  );
+
   test("100件以下は従来どおり1回のクエリで取得する", async () => {
     const { client, inCalls } = makeFakeClient([{ image_id: "a" }], "image_id");
 
@@ -127,5 +161,41 @@ describe("バッチ取得ヘルパーのチャンク分割", () => {
 
     expect(inCalls).toHaveLength(1);
     expect(counts).toEqual({ a: 1, b: 0 });
+  });
+
+  test("空配列は即空オブジェクトを返しクエリしない", async () => {
+    const { client, inCalls } = makeFakeClient([], "image_id");
+
+    expect(await getLikeCountsBatch([], client)).toEqual({});
+    expect(await getCommentCountsBatch([], client)).toEqual({});
+    expect(await getReplyCountsBatch([], client)).toEqual({});
+    expect(await getLikeCountsByRangeBatch([], "week", client)).toEqual({});
+    expect(inCalls).toHaveLength(0);
+  });
+
+  test("チャンク内のDBエラーはthrowされる", async () => {
+    const chain: Record<string, unknown> = {};
+    for (const method of ["select", "is", "eq", "gte", "lte", "in"]) {
+      chain[method] = jest.fn(() => chain);
+    }
+    chain.then = (
+      resolve: (v: { data: null; error: { message: string } }) => void,
+    ) => resolve({ data: null, error: { message: "boom" } });
+    const failingClient = {
+      from: jest.fn(() => chain),
+    } as unknown as SupabaseClient;
+
+    await expect(getLikeCountsBatch(["a"], failingClient)).rejects.toThrow(
+      "いいね数の一括取得に失敗しました",
+    );
+    await expect(getCommentCountsBatch(["a"], failingClient)).rejects.toThrow(
+      "コメント数の一括取得に失敗しました",
+    );
+    await expect(getReplyCountsBatch(["a"], failingClient)).rejects.toThrow(
+      "返信数の一括取得に失敗しました",
+    );
+    await expect(
+      getLikeCountsByRangeBatch(["a"], "week", failingClient),
+    ).rejects.toThrow("いいね数の一括集計に失敗しました");
   });
 });

--- a/tests/unit/features/posts/batch-helpers.test.ts
+++ b/tests/unit/features/posts/batch-helpers.test.ts
@@ -1,0 +1,131 @@
+/** @jest-environment node */
+
+/**
+ * バッチ取得ヘルパーのチャンク分割の回帰テスト。
+ * かつて「100件超で throw」だったため、ホームの「オススメ」(先週投稿の全件集計)が
+ * 週の投稿数100件超えと同時にSSRごと落ちた(2026-07-12 本番障害)。
+ * 100件超の入力で throw せず、チャンクに分けて取得・結合されることを保証する。
+ */
+
+jest.mock("@/lib/supabase/server", () => ({
+  createClient: jest.fn(),
+}));
+
+import {
+  getLikeCountsBatch,
+  getCommentCountsBatch,
+  getLikeCountsByRangeBatch,
+  getUserLikeStatusesBatch,
+} from "@/features/posts/lib/server-api";
+import { createClient } from "@/lib/supabase/server";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+const mockCreateClient = createClient as jest.MockedFunction<
+  typeof createClient
+>;
+
+/**
+ * .from().select().in().is().eq().gte().lte() をどの順で繋いでも動くフェイククライアント。
+ * in() で受けた ID チャンクを記録し、await 時に該当行だけ返す。
+ */
+function makeFakeClient(rows: Record<string, string>[], idColumn: string) {
+  const inCalls: string[][] = [];
+  function makeChain() {
+    let chunkIds: string[] = [];
+    const chain: Record<string, unknown> = {};
+    for (const method of ["select", "is", "eq", "gte", "lte"]) {
+      chain[method] = jest.fn(() => chain);
+    }
+    chain.in = jest.fn((_col: string, ids: string[]) => {
+      chunkIds = ids;
+      inCalls.push(ids);
+      return chain;
+    });
+    chain.then = (
+      resolve: (v: { data: Record<string, string>[]; error: null }) => void,
+    ) =>
+      resolve({
+        data: rows.filter((r) => chunkIds.includes(r[idColumn])),
+        error: null,
+      });
+    return chain;
+  }
+  const client = { from: jest.fn(() => makeChain()) };
+  return { client: client as unknown as SupabaseClient, inCalls };
+}
+
+const MANY_IDS = Array.from({ length: 150 }, (_, i) => `id-${i}`);
+
+describe("バッチ取得ヘルパーのチャンク分割", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("getLikeCountsBatch_150件入力でthrowせず100+50に分割して集計する", async () => {
+    const { client, inCalls } = makeFakeClient(
+      [
+        { image_id: "id-0" },
+        { image_id: "id-0" },
+        { image_id: "id-120" },
+      ],
+      "image_id",
+    );
+
+    const counts = await getLikeCountsBatch(MANY_IDS, client);
+
+    expect(inCalls.map((c) => c.length)).toEqual([100, 50]);
+    expect(counts["id-0"]).toBe(2);
+    expect(counts["id-120"]).toBe(1);
+    expect(counts["id-5"]).toBe(0);
+    expect(Object.keys(counts)).toHaveLength(150);
+  });
+
+  test("getCommentCountsBatch_150件入力でthrowせず分割して集計する", async () => {
+    const { client, inCalls } = makeFakeClient(
+      [{ image_id: "id-101" }],
+      "image_id",
+    );
+
+    const counts = await getCommentCountsBatch(MANY_IDS, client);
+
+    expect(inCalls.map((c) => c.length)).toEqual([100, 50]);
+    expect(counts["id-101"]).toBe(1);
+    expect(counts["id-1"]).toBe(0);
+  });
+
+  test("getLikeCountsByRangeBatch_150件入力でthrowせず分割して集計する", async () => {
+    const { client, inCalls } = makeFakeClient(
+      [{ image_id: "id-99" }, { image_id: "id-149" }],
+      "image_id",
+    );
+
+    const counts = await getLikeCountsByRangeBatch(MANY_IDS, "week", client);
+
+    expect(inCalls.map((c) => c.length)).toEqual([100, 50]);
+    expect(counts["id-99"]).toBe(1);
+    expect(counts["id-149"]).toBe(1);
+  });
+
+  test("getUserLikeStatusesBatch_150件入力でthrowせず分割して判定する", async () => {
+    const { client, inCalls } = makeFakeClient(
+      [{ image_id: "id-130" }],
+      "image_id",
+    );
+    mockCreateClient.mockResolvedValue(client as never);
+
+    const statuses = await getUserLikeStatusesBatch(MANY_IDS, "user-1");
+
+    expect(inCalls.map((c) => c.length)).toEqual([100, 50]);
+    expect(statuses["id-130"]).toBe(true);
+    expect(statuses["id-0"]).toBe(false);
+  });
+
+  test("100件以下は従来どおり1回のクエリで取得する", async () => {
+    const { client, inCalls } = makeFakeClient([{ image_id: "a" }], "image_id");
+
+    const counts = await getLikeCountsBatch(["a", "b"], client);
+
+    expect(inCalls).toHaveLength(1);
+    expect(counts).toEqual({ a: 1, b: 0 });
+  });
+});


### PR DESCRIPTION
### 概要
**本番障害の緊急修正です。** 2026-07-12(日)より、ログイン済みユーザーが www.persta.ai にアクセスすると「Application error: a server-side exception has occurred」(digest: 265885447)が表示され、ホームが一切見られない状態になっていた。

**原因**: ホームの「オススメ」タブ用の `getPosts(20, 0, "week")` は「先週」に投稿された全件(最大1000件)を取得してから `enrichPosts` でいいね数・コメント数を付与するが、`getLikeCountsBatch` 等のバッチ取得関数が **100件超の入力で `throw new Error("バッチサイズは100件までです")`** するガードを持っていた。日曜になり「先週」窓が 7/5〜7/11 にシフトした結果、対象投稿が **102件**（イタリア旅行企画終盤の投稿増）となり閾値を突破、SSR ごとクラッシュした。前日までの窓（6/28〜7/4）は55件だったため、日付変化で突然発症した。

再現手順・エラー実体はローカル（同一本番DB接続）で確認済み:
```
Error: バッチサイズは100件までです
    at async k (.next/server/app/[locale]/page.js:...)
```

### 変更内容
- `features/posts/lib/server-api.ts`
  - 共通ヘルパー `chunkArray` + `IN_QUERY_CHUNK_SIZE(=100)` を追加
  - 以下6関数を「100件超で throw」から「**100件ずつチャンク並列取得して結合**」に変更（`.in()` のURL長を抑えるという元のガードの意図は維持）
    - `getLikeCountsBatch` / `getCommentCountsBatch` / `getReplyCountsBatch` / `getUserLikeStatusesBatch`（旧: throw ガードあり）
    - `getLikeCountsByRangeBatch` / `getProfileMap`（旧: ガード無しで同経路を通り、件数増で同種の問題になり得たため統一）
- `tests/unit/features/posts/batch-helpers.test.ts` 新規: 150件入力で throw せず 100+50 に分割・正しく集計される回帰テスト（5ケース）

### 実機テスト
- [x] ローカル prod ビルド（本番DB接続）＋ログイン済みアカウントでホームが正常表示されること（修正前は同条件で Application error を再現済み）
- [x] サーバログに「バッチサイズ」エラーが出ないこと
- [ ] 本番デプロイ後、ログイン済みアカウントでホーム表示を確認

### テスト方法
- `npm run lint`: エラー0（警告6件は本ファイルの既存のもの）
- `npm run typecheck`: 511件＝ベースラインと同数（`tests/**` の既知の既存エラーのみ）
- `npm run test`: 2345件パス（新規5件含む）
- `npm run build -- --webpack`: 成功

### 備考
- 匿名アクセスはキャッシュ済みシェルが返るため顕在化せず、「ログイン時のみエラー」という症状だった
- 恒久観点: 「オススメ」の先週全件取得(limit 1000)は投稿数の伸びとともに重くなるため、いずれDB側集計への移行を検討する余地あり（本PRのスコープ外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwcR7uKsNrx7vB1MeHTx7J