### PR TITLE
feat(campaigns): ことわざ辞典 Xシェア抽選キャンペーン(応募動線＋応募規約)

### DIFF
--- a/app/campaigns/kotowaza-lottery/page.tsx
+++ b/app/campaigns/kotowaza-lottery/page.tsx
@@ -59,7 +59,15 @@ export default async function KotowazaLotteryRulesPage() {
 
       <Section no="01" title="主催者">
         <p>
-          本キャンペーンは、Persta.AI 運営者 土井秀悠（以下「主催者」といいます。）が主催します。
+          本キャンペーンは、Persta.AI 運営者（以下「主催者」といいます。）が主催します。
+          主催者の氏名・連絡先は
+          <Link
+            href="/tokushoho"
+            className="text-amber-600 underline hover:text-amber-700"
+          >
+            特定商取引法に基づく表記
+          </Link>
+          に記載しています。
         </p>
         <p className="text-gray-500">
           ※ 本キャンペーンは、X Corp. および Amazon とは一切関係ありません。

--- a/app/campaigns/kotowaza-lottery/page.tsx
+++ b/app/campaigns/kotowaza-lottery/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import { connection } from "next/server";
 import Link from "next/link";
 
 const PAGE_TITLE = "うちの子のことわざ辞典 Xシェアキャンペーン 応募規約 | Persta.AI";
@@ -38,9 +37,7 @@ function Section({
   );
 }
 
-export default async function KotowazaLotteryRulesPage() {
-  await connection();
-
+export default function KotowazaLotteryRulesPage() {
   return (
     <main className="mx-auto max-w-2xl px-5 pb-16 pt-8">
       <p className="text-xs font-bold tracking-wide text-amber-600">

--- a/app/campaigns/kotowaza-lottery/page.tsx
+++ b/app/campaigns/kotowaza-lottery/page.tsx
@@ -1,0 +1,188 @@
+import type { Metadata } from "next";
+import { connection } from "next/server";
+import Link from "next/link";
+
+const PAGE_TITLE = "うちの子のことわざ辞典 Xシェアキャンペーン 応募規約 | Persta.AI";
+const PAGE_DESCRIPTION =
+  "「うちの子のことわざ辞典」をコンプリートしてXにシェアした方から抽選で1名様にAmazonギフトカード3,000円分をプレゼント。応募規約・注意事項。";
+
+export const metadata: Metadata = {
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
+  robots: { index: false, follow: true },
+};
+
+const MENTION = "@mickey_fuku";
+const HASHTAG = "#うちの子のことわざ辞典";
+const PERIOD = "2026年7月18日(土) 18:00 〜 7月26日(日) 21:59";
+
+function Section({
+  no,
+  title,
+  children,
+}: {
+  no: string;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="mt-8">
+      <h2 className="flex items-baseline gap-2 text-base font-bold text-gray-900">
+        <span className="text-sm text-amber-600">{no}</span>
+        {title}
+      </h2>
+      <div className="mt-2 space-y-2 text-sm leading-relaxed text-gray-700">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+export default async function KotowazaLotteryRulesPage() {
+  await connection();
+
+  return (
+    <main className="mx-auto max-w-2xl px-5 pb-16 pt-8">
+      <p className="text-xs font-bold tracking-wide text-amber-600">
+        CAMPAIGN
+      </p>
+      <h1 className="mt-1 text-2xl font-bold leading-relaxed text-gray-900">
+        うちの子のことわざ辞典
+        <br />
+        Xシェアキャンペーン 応募規約
+      </h1>
+      <p className="mt-3 rounded-xl bg-amber-50 px-4 py-3 text-sm font-medium text-amber-800">
+        「うちの子のことわざ辞典」をコンプリートし、対象のカードをXにシェアした方の中から、
+        抽選で<span className="font-bold">1名様</span>に
+        <span className="font-bold">Amazonギフトカード3,000円分</span>をプレゼントします。
+      </p>
+
+      <Section no="01" title="主催者">
+        <p>
+          本キャンペーンは、Persta.AI 運営者（以下「当社」といいます。）が主催します。
+        </p>
+        <p className="text-gray-500">
+          ※ 本キャンペーンは、X Corp. および Amazon とは一切関係ありません。
+        </p>
+      </Section>
+
+      <Section no="02" title="応募期間">
+        <p>{PERIOD}（日本時間）</p>
+        <p className="text-gray-500">
+          ※ 応募期間中に投稿されたものを対象とします。期間外の投稿は対象外です。
+        </p>
+      </Section>
+
+      <Section no="03" title="参加資格">
+        <p>次のすべてを満たす方が応募できます。</p>
+        <ul className="list-disc space-y-1 pl-5">
+          <li>日本国内にお住まいの方</li>
+          <li>18歳以上の方</li>
+          <li>本規約およびXルールに同意いただける方</li>
+          <li>Xアカウントを公開設定にしている方</li>
+        </ul>
+      </Section>
+
+      <Section no="04" title="応募方法">
+        <ol className="list-decimal space-y-1 pl-5">
+          <li>
+            Persta.AI で「うちの子のことわざ辞典」の対象スタイルを生成し、コンプリート
+            （6種）してコンプリートカードを完成させます。
+          </li>
+          <li>
+            完成カードのページにある「Xで応募する」ボタンから、ハッシュタグ
+            <span className="font-bold">{HASHTAG}</span> と当社指定アカウント
+            <span className="font-bold">{MENTION}</span> を付けてXに投稿します。
+          </li>
+        </ol>
+        <p className="rounded-lg bg-emerald-50 px-3 py-2 text-emerald-800">
+          <span className="font-bold">参加に課金は不要です。</span>
+          有料プランへの加入や課金の有無は、当選確率に一切影響しません。
+        </p>
+      </Section>
+
+      <Section no="05" title="賞品">
+        <p>Amazonギフトカード 3,000円分 を抽選で1名様。</p>
+        <p className="text-gray-500">
+          ※ Amazonギフトカードは Amazon.co.jp でのみご利用いただけます。有効期限・利用条件は
+          Amazon の定めるところによります。
+        </p>
+      </Section>
+
+      <Section no="06" title="抽選・当選発表">
+        <p>
+          応募期間終了後、応募条件を満たした投稿を対象に、当社所定の方法により厳正に抽選のうえ、
+          当選者を決定します。
+        </p>
+        <p>
+          当選者には、当社公式Xアカウントからのご連絡および当社所定フォームへのご入力依頼をもって
+          通知します。指定期限までにご入力がない場合、当選が無効となる場合があります。
+        </p>
+        <p className="text-gray-500">
+          ※ 賞品の発送をもって当選発表に代えさせていただく場合があります。
+        </p>
+      </Section>
+
+      <Section no="07" title="応募上限・無効となる場合">
+        <ul className="list-disc space-y-1 pl-5">
+          <li>応募は、お1人様1回（1アカウント）までとします。</li>
+          <li>
+            複数アカウントの利用、同一・類似内容の繰り返し投稿、非公開・削除された投稿、
+            自動化ツール等による不正応募は無効とします。
+          </li>
+          <li>
+            本規約・Xルール・法令への違反、虚偽情報、第三者の権利を侵害する投稿があった場合は、
+            応募または当選を無効とします。
+          </li>
+        </ul>
+      </Section>
+
+      <Section no="08" title="投稿画像の取扱い">
+        <p>
+          応募者は、応募投稿および画像が第三者の権利を侵害しないことを保証するものとします。
+        </p>
+        <p>
+          応募者は当社に対し、当選発表・広報・SNS・Web掲載のために必要な範囲で、応募投稿および
+          画像を無償・非独占的に利用する権利を許諾するものとします。
+        </p>
+      </Section>
+
+      <Section no="09" title="個人情報の取扱い">
+        <p>
+          当社は、応募確認・重複応募の排除・抽選・当選連絡・賞品送付・不正防止・お問い合わせ対応・
+          法令遵守のために、Xアカウント名・投稿URL・当選連絡に必要なメールアドレス等を利用します。
+        </p>
+        <p>
+          取得した個人情報は、法令に基づく場合を除き、ご本人の同意なく第三者に提供しません。
+          詳細は当社プライバシーポリシーをご確認ください。
+        </p>
+      </Section>
+
+      <Section no="10" title="税金の取扱い">
+        <p>
+          賞品の受領に伴い税務上の取扱いが生じる場合は、当選者ご自身の責任と負担において対応いただきます。
+        </p>
+      </Section>
+
+      <Section no="11" title="変更・中止">
+        <p>
+          当社は、法令またはプラットフォームのルール変更、システム障害その他やむを得ない事情により、
+          本キャンペーンの内容を変更・中断・中止することがあります。
+        </p>
+      </Section>
+
+      <Section no="12" title="準拠法">
+        <p>本規約は日本法に準拠し、日本国内に居住する方を対象とします。</p>
+      </Section>
+
+      <div className="mt-10 flex flex-wrap gap-3 text-sm">
+        <Link
+          href="/collections/kotowaza"
+          className="font-bold text-amber-600 underline hover:text-amber-700"
+        >
+          ← 企画ページへ戻る
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/app/campaigns/kotowaza-lottery/page.tsx
+++ b/app/campaigns/kotowaza-lottery/page.tsx
@@ -59,7 +59,7 @@ export default async function KotowazaLotteryRulesPage() {
 
       <Section no="01" title="主催者">
         <p>
-          本キャンペーンは、Persta.AI 運営者（以下「当社」といいます。）が主催します。
+          本キャンペーンは、Persta.AI 運営者 土井秀悠（以下「主催者」といいます。）が主催します。
         </p>
         <p className="text-gray-500">
           ※ 本キャンペーンは、X Corp. および Amazon とは一切関係ありません。
@@ -91,7 +91,7 @@ export default async function KotowazaLotteryRulesPage() {
           </li>
           <li>
             完成カードのページにある「Xで応募する」ボタンから、ハッシュタグ
-            <span className="font-bold">{HASHTAG}</span> と当社指定アカウント
+            <span className="font-bold">{HASHTAG}</span> と主催者指定アカウント
             <span className="font-bold">{MENTION}</span> を付けてXに投稿します。
           </li>
         </ol>
@@ -111,11 +111,11 @@ export default async function KotowazaLotteryRulesPage() {
 
       <Section no="06" title="抽選・当選発表">
         <p>
-          応募期間終了後、応募条件を満たした投稿を対象に、当社所定の方法により厳正に抽選のうえ、
+          応募期間終了後、応募条件を満たした投稿を対象に、主催者所定の方法により厳正に抽選のうえ、
           当選者を決定します。
         </p>
         <p>
-          当選者には、当社公式Xアカウントからのご連絡および当社所定フォームへのご入力依頼をもって
+          当選者には、主催者公式Xアカウントからのご連絡および主催者所定フォームへのご入力依頼をもって
           通知します。指定期限までにご入力がない場合、当選が無効となる場合があります。
         </p>
         <p className="text-gray-500">
@@ -142,19 +142,19 @@ export default async function KotowazaLotteryRulesPage() {
           応募者は、応募投稿および画像が第三者の権利を侵害しないことを保証するものとします。
         </p>
         <p>
-          応募者は当社に対し、当選発表・広報・SNS・Web掲載のために必要な範囲で、応募投稿および
+          応募者は主催者に対し、当選発表・広報・SNS・Web掲載のために必要な範囲で、応募投稿および
           画像を無償・非独占的に利用する権利を許諾するものとします。
         </p>
       </Section>
 
       <Section no="09" title="個人情報の取扱い">
         <p>
-          当社は、応募確認・重複応募の排除・抽選・当選連絡・賞品送付・不正防止・お問い合わせ対応・
+          主催者は、応募確認・重複応募の排除・抽選・当選連絡・賞品送付・不正防止・お問い合わせ対応・
           法令遵守のために、Xアカウント名・投稿URL・当選連絡に必要なメールアドレス等を利用します。
         </p>
         <p>
           取得した個人情報は、法令に基づく場合を除き、ご本人の同意なく第三者に提供しません。
-          詳細は当社プライバシーポリシーをご確認ください。
+          詳細は主催者プライバシーポリシーをご確認ください。
         </p>
       </Section>
 
@@ -166,7 +166,7 @@ export default async function KotowazaLotteryRulesPage() {
 
       <Section no="11" title="変更・中止">
         <p>
-          当社は、法令またはプラットフォームのルール変更、システム障害その他やむを得ない事情により、
+          主催者は、法令またはプラットフォームのルール変更、システム障害その他やむを得ない事情により、
           本キャンペーンの内容を変更・中断・中止することがあります。
         </p>
       </Section>

--- a/app/m/[token]/page.tsx
+++ b/app/m/[token]/page.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/features/collections/lib/public-mount-server-api";
 import { mountAspectForCategory } from "@/features/collections/lib/mount-aspects";
 import { MountShareButton } from "@/features/collections/components/MountShareButton";
+import { XLotteryEntryButton } from "@/features/campaigns/components/XLotteryEntryButton";
 import { MountCelebrationBackground } from "@/features/collections/components/MountCelebrationBackground";
 import { CompletionFeedPostButton } from "@/features/collections/components/CompletionFeedPostButton";
 
@@ -154,6 +155,11 @@ export default async function PublicMountPage({
 
       {isOwner ? (
         <div className="flex w-full max-w-sm flex-col items-center gap-3">
+          <XLotteryEntryButton
+            categoryKey={mount.categoryKey}
+            completionId={mount.completionId}
+            mountImageUrl={mount.mountImageUrl}
+          />
           <MountShareButton
             completionId={mount.completionId}
             mountImageUrl={mount.mountImageUrl}

--- a/features/campaigns/components/XLotteryEntryButton.tsx
+++ b/features/campaigns/components/XLotteryEntryButton.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import {
+  buildPublicMountUrl,
+  trackMountShareEvent,
+} from "@/features/collections/lib/share-mount";
+import {
+  buildXLotteryIntentUrl,
+  findActiveXLotteryCampaign,
+  type XLotteryCampaign,
+} from "../x-lottery-campaign";
+
+/**
+ * 完走台紙の所有者にだけ表示する「Xで応募する」ボタン(キャンペーン期間中のみ)。
+ *
+ * 既存のシェア(URLのみ / OGP優先)とは別に、応募条件(ハッシュタグ + 主催者メンション)
+ * を満たす X intent を開く。期間・対象カテゴリの判定は x-lottery-campaign に集約。
+ * クライアント時刻で表示可否を判定するため、SSRとの hydration mismatch を避けて
+ * マウント後に描画する(未該当なら何も出さない)。
+ */
+export function XLotteryEntryButton({
+  categoryKey,
+  completionId,
+  mountImageUrl,
+}: {
+  categoryKey: string;
+  completionId: string;
+  mountImageUrl: string;
+}) {
+  // クライアント時刻(new Date)で期間判定するため、マウント後にだけ解決する
+  // (SSRでは常に非表示にして hydration mismatch を避ける。ShareLinkButton と同方式)。
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    // マウント検知の1回だけの setState。SSR/CSR の時刻差による hydration mismatch を
+    // 避けるための正当な用途で、cascading render は起きない。
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setMounted(true);
+  }, []);
+
+  const campaign: XLotteryCampaign | null = mounted
+    ? findActiveXLotteryCampaign(categoryKey, new Date())
+    : null;
+
+  if (!campaign) return null;
+
+  const handleClick = () => {
+    const shareUrl = buildPublicMountUrl(completionId, mountImageUrl);
+    const intentUrl = buildXLotteryIntentUrl(campaign, shareUrl);
+    // 応募=シェアなので既存の共有計測も呼ぶ(best-effort)。
+    trackMountShareEvent(completionId);
+    window.open(intentUrl, "_blank", "noopener,noreferrer");
+  };
+
+  return (
+    <div className="flex w-full flex-col items-center gap-2 rounded-2xl border-2 border-dashed border-amber-300 bg-amber-50 px-5 py-4">
+      <p className="text-sm font-bold text-amber-700">
+        🎁 Xでシェアして応募しよう！
+      </p>
+      <p className="text-xs leading-relaxed text-amber-700/90">
+        抽選で1名様に <span className="font-bold">Amazonギフト3,000円分</span>
+      </p>
+      <button
+        type="button"
+        onClick={handleClick}
+        className="inline-flex items-center gap-2 rounded-full bg-[#1d1d1f] px-6 py-2.5 text-sm font-bold text-white transition-transform hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300"
+      >
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden className="h-4 w-4">
+          <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+        </svg>
+        Xで応募する
+      </button>
+      <Link
+        href={campaign.rulesPath}
+        className="text-[11px] text-amber-700/80 underline hover:text-amber-800"
+      >
+        応募規約・注意事項をみる
+      </Link>
+    </div>
+  );
+}

--- a/features/campaigns/components/XLotteryEntryButton.tsx
+++ b/features/campaigns/components/XLotteryEntryButton.tsx
@@ -66,7 +66,7 @@ export function XLotteryEntryButton({
         onClick={handleClick}
         className="inline-flex items-center gap-2 rounded-full bg-[#1d1d1f] px-6 py-2.5 text-sm font-bold text-white transition-transform hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300"
       >
-        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden className="h-4 w-4">
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" className="h-4 w-4">
           <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
         </svg>
         Xで応募する

--- a/features/campaigns/x-lottery-campaign.ts
+++ b/features/campaigns/x-lottery-campaign.ts
@@ -1,0 +1,81 @@
+/**
+ * Xシェア抽選キャンペーンの定義と、応募用 X intent URL の組み立て。
+ *
+ * 法務方針(オープン懸賞に倒す)に沿った運用の要:
+ * - 参加に課金は不要・課金は当選確率に影響しない(規約に明記=/campaigns/<slug>)
+ * - 応募=公開アカウントから1人1回、指定ハッシュタグ + 主催者メンション付き投稿
+ * - 日本国内居住者・18歳以上限定
+ * この設定はLP/応募規約/ボタン文面の単一の真実源。カテゴリkey・期間・タグ・
+ * メンション先を1箇所で管理する。
+ */
+export interface XLotteryCampaign {
+  /** 内部ID(ログ・分析用)。 */
+  id: string;
+  /** 対象コレクションカテゴリ key(上巻・下巻など)。この完走ページにだけ応募ボタンを出す。 */
+  categoryKeys: readonly string[];
+  /** 応募受付の開始/終了(ISO, UTC)。この期間内だけボタンを表示する。 */
+  entryStartsAt: string;
+  entryEndsAt: string;
+  /** 応募ポストに付けるハッシュタグ(先頭の # は付けない)。 */
+  hashtags: readonly string[];
+  /** 主催者メンション先(先頭の @ は付けない)。応募回収のため必須。 */
+  mention: string;
+  /** 応募ポストの定型メッセージ。 */
+  message: string;
+  /** 応募規約ページのパス。 */
+  rulesPath: string;
+}
+
+export const X_LOTTERY_CAMPAIGNS: readonly XLotteryCampaign[] = [
+  {
+    id: "kotowaza-2026-07",
+    categoryKeys: ["kotowaza_dictionary", "kotowaza_dictionary_2"],
+    // 7/18 (土) 18:00 JST 〜 7/26 (日) 21:59 JST
+    entryStartsAt: "2026-07-18T09:00:00.000Z",
+    entryEndsAt: "2026-07-26T12:59:59.000Z",
+    hashtags: ["うちの子のことわざ辞典"],
+    mention: "mickey_fuku",
+    message: "うちの子のことわざ辞典をコンプリートしました！",
+    rulesPath: "/campaigns/kotowaza-lottery",
+  },
+];
+
+/**
+ * 指定カテゴリで「現在応募受付中」のキャンペーンを返す(無ければ null)。
+ * starts/ends の判定は now を基準に inclusive(開始時刻ちょうどは受付、終了時刻は
+ * entryEndsAt を過ぎたら締切)。
+ */
+export function findActiveXLotteryCampaign(
+  categoryKey: string | null | undefined,
+  now: Date,
+  campaigns: readonly XLotteryCampaign[] = X_LOTTERY_CAMPAIGNS,
+): XLotteryCampaign | null {
+  if (!categoryKey) return null;
+  const t = now.getTime();
+  for (const c of campaigns) {
+    if (!c.categoryKeys.includes(categoryKey)) continue;
+    if (t < new Date(c.entryStartsAt).getTime()) continue;
+    if (t > new Date(c.entryEndsAt).getTime()) continue;
+    return c;
+  }
+  return null;
+}
+
+/**
+ * 応募用の X intent(post) URL を組み立てる。
+ * text にメッセージ + 主催者メンション、hashtags にタグ、url に台紙シェアURLを渡す。
+ * → 投稿には「メッセージ + @メンション + OGPカード + #ハッシュタグ」が入り、
+ *   Xガイドラインの「主催者@ユーザー名を含める」を満たしつつ応募回収できる。
+ */
+export function buildXLotteryIntentUrl(
+  campaign: XLotteryCampaign,
+  shareUrl: string,
+): string {
+  const params = new URLSearchParams();
+  params.set("text", `${campaign.message} @${campaign.mention}`);
+  params.set("url", shareUrl);
+  if (campaign.hashtags.length > 0) {
+    params.set("hashtags", campaign.hashtags.join(","));
+  }
+  return `https://x.com/intent/post?${params.toString()}`;
+}

--- a/tests/unit/features/campaigns/x-lottery-campaign.test.ts
+++ b/tests/unit/features/campaigns/x-lottery-campaign.test.ts
@@ -1,0 +1,103 @@
+import {
+  findActiveXLotteryCampaign,
+  buildXLotteryIntentUrl,
+  type XLotteryCampaign,
+} from "@/features/campaigns/x-lottery-campaign";
+
+const CAMPAIGN: XLotteryCampaign = {
+  id: "test-campaign",
+  categoryKeys: ["kotowaza_dictionary", "kotowaza_dictionary_2"],
+  entryStartsAt: "2026-07-18T09:00:00.000Z",
+  entryEndsAt: "2026-07-26T12:59:59.000Z",
+  hashtags: ["うちの子のことわざ辞典"],
+  mention: "mickey_fuku",
+  message: "うちの子のことわざ辞典をコンプリートしました！",
+  rulesPath: "/campaigns/kotowaza-lottery",
+};
+const CAMPAIGNS = [CAMPAIGN];
+
+describe("findActiveXLotteryCampaign", () => {
+  test("対象カテゴリ・期間内なら該当キャンペーンを返す", () => {
+    const now = new Date("2026-07-20T00:00:00.000Z");
+    expect(
+      findActiveXLotteryCampaign("kotowaza_dictionary", now, CAMPAIGNS),
+    ).toBe(CAMPAIGN);
+    // 下巻カテゴリも同一キャンペーン対象
+    expect(
+      findActiveXLotteryCampaign("kotowaza_dictionary_2", now, CAMPAIGNS),
+    ).toBe(CAMPAIGN);
+  });
+
+  test("対象外カテゴリは null", () => {
+    const now = new Date("2026-07-20T00:00:00.000Z");
+    expect(
+      findActiveXLotteryCampaign("travel_to_italy", now, CAMPAIGNS),
+    ).toBeNull();
+  });
+
+  test("categoryKey が null/undefined は null", () => {
+    const now = new Date("2026-07-20T00:00:00.000Z");
+    expect(findActiveXLotteryCampaign(null, now, CAMPAIGNS)).toBeNull();
+    expect(findActiveXLotteryCampaign(undefined, now, CAMPAIGNS)).toBeNull();
+  });
+
+  test("開始前は null、開始時刻ちょうどは受付", () => {
+    expect(
+      findActiveXLotteryCampaign(
+        "kotowaza_dictionary",
+        new Date("2026-07-18T08:59:59.000Z"),
+        CAMPAIGNS,
+      ),
+    ).toBeNull();
+    expect(
+      findActiveXLotteryCampaign(
+        "kotowaza_dictionary",
+        new Date("2026-07-18T09:00:00.000Z"),
+        CAMPAIGNS,
+      ),
+    ).toBe(CAMPAIGN);
+  });
+
+  test("終了時刻を過ぎたら null", () => {
+    expect(
+      findActiveXLotteryCampaign(
+        "kotowaza_dictionary",
+        new Date("2026-07-26T12:59:59.000Z"),
+        CAMPAIGNS,
+      ),
+    ).toBe(CAMPAIGN);
+    expect(
+      findActiveXLotteryCampaign(
+        "kotowaza_dictionary",
+        new Date("2026-07-26T13:00:00.000Z"),
+        CAMPAIGNS,
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("buildXLotteryIntentUrl", () => {
+  test("text にメッセージ+メンション、hashtags にタグ、url に台紙URLが入る", () => {
+    const url = buildXLotteryIntentUrl(
+      CAMPAIGN,
+      "https://www.persta.ai/m/abc?v=123",
+    );
+    const parsed = new URL(url);
+    expect(parsed.origin + parsed.pathname).toBe("https://x.com/intent/post");
+    expect(parsed.searchParams.get("text")).toBe(
+      "うちの子のことわざ辞典をコンプリートしました！ @mickey_fuku",
+    );
+    expect(parsed.searchParams.get("hashtags")).toBe("うちの子のことわざ辞典");
+    expect(parsed.searchParams.get("url")).toBe(
+      "https://www.persta.ai/m/abc?v=123",
+    );
+  });
+
+  test("複数ハッシュタグはカンマ区切り", () => {
+    const url = buildXLotteryIntentUrl(
+      { ...CAMPAIGN, hashtags: ["タグA", "タグB"] },
+      "https://www.persta.ai/m/abc",
+    );
+    expect(new URL(url).searchParams.get("hashtags")).toBe("タグA,タグB");
+  });
+});


### PR DESCRIPTION
### 概要
「うちの子のことわざ辞典」企画向けの **Xシェア抽選キャンペーン**（コンプリート→Xシェアした方から抽選で1名様にAmazonギフトカード3,000円分）の応募動線と応募規約を実装する。法務ディープリサーチの推奨に沿い、**オープン懸賞に倒す設計**（参加無料・課金は当選確率に非影響・日本国内・18歳以上・1人1回・公開アカウント・公式メンション付き投稿）。

導線は完走台紙ページの所有者にのみ、**キャンペーン期間中だけ**表示。対象カテゴリ未作成・期間外ではボタンは出ないため、マージしても既存への影響はゼロ。

- 応募条件: `#うちの子のことわざ辞典` ＋ `@mickey_fuku` を付けてXに投稿
- 期間: 2026/7/18 18:00 〜 7/26 21:59 JST
- 賞品: Amazonギフトカード 3,000円分 × 1名

### 変更内容
- `features/campaigns/x-lottery-campaign.ts` 新規: キャンペーン定義（対象カテゴリ／期間／ハッシュタグ／メンション先／規約パス）と、応募用 X intent URL 組み立ての純関数。**設定の単一の真実源**
- `features/campaigns/components/XLotteryEntryButton.tsx` 新規: 完走台紙の所有者に期間中のみ表示する「Xで応募する」ボタン。既存シェア（URLのみ／OGP優先）とは別に、ハッシュタグ＋メンション＋OGPカードが載る X intent を開く
- `app/campaigns/kotowaza-lottery/page.tsx` 新規: 応募規約ページ（主催者・期間・参加資格・応募方法・賞品・抽選/当選発表・無効事由・投稿画像の取扱い・個人情報・税金・変更中止・準拠法の全12条）。ボタンからリンク
- `app/m/[token]/page.tsx`: 完走シェア欄に応募ボタンを追加（mount型完走のみ。book型=イタリアは対象外）
- `tests/unit/features/campaigns/x-lottery-campaign.test.ts` 新規: 期間境界・対象カテゴリ・intent URL 組み立ての7ケース

### 実機テスト
- [x] 応募規約ページ `/campaigns/kotowaza-lottery` の表示
- [x] 期間を一時的に広げ、完走台紙（テストユーザーの神コレ mount）で「Xで応募する」ボタンが所有者に表示されることを確認（確認後、設定は元の 7/18〜7/26・kotowaza カテゴリに復元済み）
- [ ] 期間開始後、実際の X intent 投稿画面にハッシュタグ・メンション・OGPカードが入ることを本番/プレビューで確認

### テスト方法
- `npm run lint`: 変更ファイルはクリーン
- `npm run test`: 2358件パス（新規7件）
- `npm run typecheck`: エラーはベースライン（`tests/**` 既知）と同一
- `npm run build -- --webpack`: 成功（`/campaigns/kotowaza-lottery` ルート生成確認）

### 運用メモ（本PRのスコープ外・開催前の残作業）
1. 応募規約の主催者名（現「Persta.AI 運営」）を正式表記に差し替え要否を確認
2. 抽選運用: 応募ポストは `@mickey_fuku` メンション＋ハッシュタグで回収 → 期間終了後に乱数抽選＋**ログ保存**（「厳正な抽選」「1名」表示の証跡）→ 公式アカウント連絡＋自社フォームでメアドのみ取得 → Amazonギフト（Eメール型）送付
3. 上巻カテゴリ `kotowaza_dictionary`／下巻 `kotowaza_dictionary_2` を admin で作成（棚・解放ゲート設定）すると、その完走ページに応募ボタンが自動で出る

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwcR7uKsNrx7vB1MeHTx7J