### PR TITLE
feat(collections): ことわざLPにXシェア抽選プレゼントの告知を追加

### DIFF
--- a/features/collections/components/KotowazaGuide.tsx
+++ b/features/collections/components/KotowazaGuide.tsx
@@ -277,6 +277,27 @@ export function KotowazaGuide({
           </p>
         </Reveal>
 
+        {/* Xシェア抽選プレゼントの告知(詳細・規約は応募規約ページを単一の真実源に) */}
+        <Reveal delay={280}>
+          <div className="mx-auto mt-5 max-w-sm rounded-2xl border-2 border-amber-300 bg-gradient-to-b from-amber-50 to-white px-5 py-4 text-center shadow-sm">
+            <p className="text-sm font-bold text-amber-700" style={{ fontFamily: HEADING_FONT }}>
+              🎁 Xシェアで抽選プレゼント
+            </p>
+            <p className="mt-1.5 text-xs leading-relaxed text-amber-800">
+              コンプリートしてXにシェアした方から、抽選で
+              <span className="font-bold">1名様</span>に
+              <br />
+              <span className="font-bold">Amazonギフトカード3,000円分</span>をプレゼント！
+            </p>
+            <Link
+              href="/campaigns/kotowaza-lottery"
+              className="mt-2 inline-block text-[11px] font-bold text-amber-700 underline hover:text-amber-800"
+            >
+              応募規約・注意事項をみる
+            </Link>
+          </div>
+        </Reveal>
+
         {/* ことわざ勢ぞろい(6コマ) */}
         <Reveal delay={300}>
           <div className="mx-auto mt-8 grid max-w-md grid-cols-3 gap-2 sm:grid-cols-6 sm:gap-3">


### PR DESCRIPTION
### 概要
企画LP `/collections/kotowaza` を見た段階では、Xシェア抽選（Amazonギフト3,000円1名）の存在に気づけなかった（抽選の告知は完走台紙ページのボタンと応募規約ページにしか無かった）。参加動機を高めるため、LPのヒーローに抽選プレゼントの告知ボックスを追加する。

詳細・応募規約は応募規約ページ `/campaigns/kotowaza-lottery` を単一の真実源としてリンクする（LP側には賞品・人数の要点のみ記載）。

### 変更内容
- `features/collections/components/KotowazaGuide.tsx`: ヒーローの企画期間ラベル直後に「🎁 Xシェアで抽選プレゼント」告知ボックス（Amazonギフト3,000円・1名・規約リンク）を追加

### 実機テスト
- [x] ローカルprodサーバで `/collections/kotowaza` に告知ボックスが表示されることを確認（スクリーンショット取得済み）

### テスト方法
- `npm run lint` / `npm run test`（2358件）/ `npm run build -- --webpack`：すべて緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwcR7uKsNrx7vB1MeHTx7J