### PR TITLE
fix(collections): ことわざLPの注記を実態に合わせ、クリエイター相談リンクを追加

### DIFF
--- a/features/collections/components/KotowazaGuide.tsx
+++ b/features/collections/components/KotowazaGuide.tsx
@@ -567,8 +567,7 @@ export function KotowazaGuide({
       <div className="px-6 pb-10 text-center">
         <Link
           href="/creators"
-          className="text-xs underline underline-offset-2 transition-colors"
-          style={{ color: "#b3a794" }}
+          className="text-xs text-[#b3a794] underline underline-offset-2 transition-colors hover:text-[#8a7c66]"
         >
           コラボご希望の方・プロンプト掲載のご相談はこちら ›
         </Link>

--- a/features/collections/components/KotowazaGuide.tsx
+++ b/features/collections/components/KotowazaGuide.tsx
@@ -558,10 +558,21 @@ export function KotowazaGuide({
         </Reveal>
         <Reveal delay={100}>
           <p className="mx-auto mt-6 max-w-sm text-xs leading-relaxed" style={{ color: "#9c9184" }}>
-            ※ あつめる・カードの保存にはログインが必要です（未ログインでも一枚お試し生成できます）。
+            ※ あつめる・カードの保存にはログインが必要です。
           </p>
         </Reveal>
       </section>
+
+      {/* ===== クリエイター相談(控えめなフッターリンク) ===== */}
+      <div className="px-6 pb-10 text-center">
+        <Link
+          href="/creators"
+          className="text-xs underline underline-offset-2 transition-colors"
+          style={{ color: "#b3a794" }}
+        >
+          コラボご希望の方・プロンプト掲載のご相談はこちら ›
+        </Link>
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
### 概要
ことわざLP `/collections/kotowaza` 末尾の注記が実態と食い違っていたため、イタリア旅行LP（`ItalyTravelGuide`）に合わせて修正する。

- **誤**: 「※ あつめる・カードの保存にはログインが必要です（未ログインでも一枚お試し生成できます）。」
  → 未ログインでは生成できないため、この括弧書きは事実と異なる
- **正**: 「※ あつめる・カードの保存にはログインが必要です。」（イタリアLPと同一文言）
- あわせて、イタリアLPと同様に末尾へ「コラボご希望の方・プロンプト掲載のご相談はこちら ›」（`/creators`）リンクを追加

### 変更内容
- `features/collections/components/KotowazaGuide.tsx`: 注記文言の修正＋クリエイター相談フッターリンクの追加

### 実機テスト
- [x] ローカルprodサーバで、注記が「※ あつめる・カードの保存にはログインが必要です。」になり、末尾にコラボ相談リンクが表示されることを確認（スクリーンショット取得済み）

### テスト方法
- `npm run lint` / `npm run test`（2362件）/ `npm run build -- --webpack`：すべて緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwcR7uKsNrx7vB1MeHTx7J