### PR TITLE
fix(collections): 台紙作り直し時にホーム投稿サムネも最新へ貼り替える

### DIFF
--- a/app/api/collections/mount/route.ts
+++ b/app/api/collections/mount/route.ts
@@ -52,6 +52,8 @@ async function refreshCompletionFeedPost(
   revalidateTag("home-posts", "max");
   revalidateTag("home-posts-week", "max");
   revalidateTag("search-posts", "max");
+  // 本人プロフィールの投稿一覧サムネも更新(完走投稿ルートと同じタグ群)。
+  revalidateTag(`user-profile-${userId}`, "max");
   revalidateTag(`post-detail-${postId}`, { expire: 0 });
 }
 

--- a/app/api/collections/mount/route.ts
+++ b/app/api/collections/mount/route.ts
@@ -16,6 +16,7 @@ import {
   parseOgpMountPlacement,
 } from "@/features/collections/lib/compose-mount-ogp";
 import { getRepresentativeImagesForCategory } from "@/features/collections/lib/representative-images";
+import { refreshCompletionFeedPostImage } from "@/features/collections/lib/completion-feed-post";
 import { resolveSelectedImages } from "@/features/collections/lib/resolve-selected-images";
 import { recordStyleUsageEvent } from "@/features/style/lib/style-usage-events";
 import type { ReserveCollectionResultRow } from "@/features/collections/lib/collection-types";
@@ -30,6 +31,28 @@ const CATEGORY_KEY_PATTERN = /^[a-z][a-z0-9_]{1,49}$/;
 
 function jsonError(message: string, code: string, status: number) {
   return NextResponse.json({ error: message, errorCode: code }, { status });
+}
+
+/**
+ * 台紙を作り直したとき、ホームに投稿済みの完走フィード投稿サムネも最新へ貼り替える。
+ * 投稿していなければ何もしない。best-effort(失敗しても作り直しは成功扱い)。
+ * 貼り替えたらフィード/詳細/検索の cache を失効させ、新サムネを反映する。
+ */
+async function refreshCompletionFeedPost(
+  userId: string,
+  completionId: string,
+  mountStoragePath: string,
+): Promise<void> {
+  const { postId } = await refreshCompletionFeedPostImage(
+    createAdminClient(),
+    completionId,
+    mountStoragePath,
+  );
+  if (!postId) return;
+  revalidateTag("home-posts", "max");
+  revalidateTag("home-posts-week", "max");
+  revalidateTag("search-posts", "max");
+  revalidateTag(`post-detail-${postId}`, { expire: 0 });
 }
 
 /**
@@ -380,6 +403,8 @@ export async function POST(request: NextRequest) {
           throw new Error(`book update failed: ${updateError.message}`);
         }
         revalidateTag(`collection-completions:${user.id}`, "max");
+        // 完走をホームに投稿済みなら、そのサムネも新しい表紙へ貼り替える(best-effort)。
+        await refreshCompletionFeedPost(user.id, completionId, bookMountPath);
         if (previousMountPath && previousMountPath !== bookMountPath) {
           // 旧 mount-{ts}.png と そのOGPツイン ogp-{ts}.png を削除(ベストエフォート)。
           const stale = [previousMountPath];
@@ -564,6 +589,8 @@ export async function POST(request: NextRequest) {
       if (updateError) {
         throw new Error(`mount_image_path update failed: ${updateError.message}`);
       }
+      // 完走をホームに投稿済みなら、そのサムネも新しい台紙へ貼り替える(best-effort)。
+      await refreshCompletionFeedPost(user.id, completionId, mountStoragePath);
       // 旧 mount + OGP は削除(残しても問題ないが容量節約)
       if (previousMountPath && previousMountPath !== mountStoragePath) {
         const oldOgpPath = ogpPathFromMountPath(previousMountPath);

--- a/features/collections/lib/completion-feed-post.ts
+++ b/features/collections/lib/completion-feed-post.ts
@@ -62,3 +62,61 @@ export async function postCompletionToFeed(
   if (!postId) throw new Error("post creation returned no id");
   return { postId: postId as string };
 }
+
+/**
+ * 完走の台紙を作り直した(表紙変更含む)ときに、既に作成済みの「完走フィード投稿」行の
+ * サムネ画像を最新の mount_image_path に貼り替える。
+ *
+ * 完走フィード投稿は初回投稿時に画像をスナップショットするため、作り直し後もこの helper を
+ * 呼ばないと古い表紙のサムネが残る(book/mount 共通の不具合)。投稿行(generated_images)は
+ * 完走ごとに最大1行なので、存在すれば画像列を更新する。台紙更新の副作用のため best-effort で
+ * 扱い、失敗しても throw しない(呼び出し側の作り直し自体は成功させる)。
+ *
+ * @returns 更新した投稿行の id(行が無ければ null)。呼び出し側の revalidate 対象に使える。
+ */
+export async function refreshCompletionFeedPostImage(
+  adminSupabase: SupabaseClient,
+  completionId: string,
+  mountStoragePath: string,
+): Promise<{ postId: string | null }> {
+  try {
+    const { data: existing } = await adminSupabase
+      .from("generated_images")
+      .select("id")
+      .eq("completion_id", completionId)
+      .maybeSingle();
+    if (!existing?.id) return { postId: null };
+
+    const imageUrl = buildPublicGeneratedImageUrl(mountStoragePath);
+    if (!imageUrl) return { postId: null };
+
+    const { thumbPath, displayPath } = await uploadWebPVariants(
+      imageUrl,
+      mountStoragePath,
+    );
+
+    const { error: updateError } = await adminSupabase
+      .from("generated_images")
+      .update({
+        image_url: imageUrl,
+        storage_path: mountStoragePath,
+        storage_path_display: displayPath,
+        storage_path_thumb: thumbPath,
+        // 実寸は Post 詳細の lazy compute で取り直されるためクリアする
+        width: null,
+        height: null,
+      })
+      .eq("id", existing.id as string);
+    if (updateError) {
+      console.error(
+        "[refreshCompletionFeedPostImage] update failed:",
+        updateError.message,
+      );
+      return { postId: null };
+    }
+    return { postId: existing.id as string };
+  } catch (e) {
+    console.error("[refreshCompletionFeedPostImage] failed:", e);
+    return { postId: null };
+  }
+}

--- a/features/collections/lib/completion-feed-post.ts
+++ b/features/collections/lib/completion-feed-post.ts
@@ -80,11 +80,18 @@ export async function refreshCompletionFeedPostImage(
   mountStoragePath: string,
 ): Promise<{ postId: string | null }> {
   try {
-    const { data: existing } = await adminSupabase
+    const { data: existing, error: fetchError } = await adminSupabase
       .from("generated_images")
       .select("id")
       .eq("completion_id", completionId)
       .maybeSingle();
+    if (fetchError) {
+      console.error(
+        "[refreshCompletionFeedPostImage] fetch failed:",
+        fetchError.message,
+      );
+      return { postId: null };
+    }
     if (!existing?.id) return { postId: null };
 
     const imageUrl = buildPublicGeneratedImageUrl(mountStoragePath);

--- a/tests/unit/features/collections/completion-feed-post.test.ts
+++ b/tests/unit/features/collections/completion-feed-post.test.ts
@@ -18,16 +18,24 @@ import { refreshCompletionFeedPostImage } from "@/features/collections/lib/compl
 import type { SupabaseClient } from "@supabase/supabase-js";
 
 /** generated_images に対する select().eq().maybeSingle() と update().eq() を記録するフェイク。 */
-function makeClient(existingRow: { id: string } | null) {
+function makeClient(
+  existingRow: { id: string } | null,
+  opts: { fetchError?: { message: string }; updateError?: { message: string } } = {},
+) {
   const update = jest.fn();
-  const updateEq = jest.fn().mockResolvedValue({ error: null });
+  const updateEq = jest
+    .fn()
+    .mockResolvedValue({ error: opts.updateError ?? null });
   update.mockReturnValue({ eq: updateEq });
 
   const client = {
     from: jest.fn(() => ({
       select: jest.fn(() => ({
         eq: jest.fn(() => ({
-          maybeSingle: jest.fn().mockResolvedValue({ data: existingRow }),
+          maybeSingle: jest.fn().mockResolvedValue({
+            data: existingRow,
+            error: opts.fetchError ?? null,
+          }),
         })),
       })),
       update,
@@ -86,6 +94,36 @@ describe("refreshCompletionFeedPostImage", () => {
     expect(r.postId).toBeNull();
     expect(uploadWebPVariantsMock).not.toHaveBeenCalled();
     expect(update).not.toHaveBeenCalled();
+  });
+
+  test("取得クエリが error を返したら WebP生成せず null", async () => {
+    const { client, update } = makeClient(null, {
+      fetchError: { message: "db down" },
+    });
+
+    const r = await refreshCompletionFeedPostImage(
+      client,
+      "completion-1",
+      "path/mount-2.png",
+    );
+
+    expect(r.postId).toBeNull();
+    expect(uploadWebPVariantsMock).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  test("update が error を返したら null(サムネは古いままだが作り直しは成功)", async () => {
+    const { client } = makeClient({ id: "post-1" }, {
+      updateError: { message: "update failed" },
+    });
+
+    const r = await refreshCompletionFeedPostImage(
+      client,
+      "completion-1",
+      "path/mount-2.png",
+    );
+
+    expect(r.postId).toBeNull();
   });
 
   test("WebP生成が失敗しても throw せず null(作り直し自体は成功させる)", async () => {

--- a/tests/unit/features/collections/completion-feed-post.test.ts
+++ b/tests/unit/features/collections/completion-feed-post.test.ts
@@ -1,0 +1,103 @@
+/** @jest-environment node */
+
+// 台紙作り直し時にフィード投稿サムネを貼り替える refreshCompletionFeedPostImage の回帰テスト。
+// 従来は投稿行の画像が初回スナップショットのまま固定で、表紙変更後も古いサムネが残っていた
+// (book/mount 共通の不具合)。
+
+jest.mock("@/lib/supabase/admin", () => ({ createAdminClient: jest.fn() }));
+
+const uploadWebPVariantsMock = jest.fn();
+jest.mock("@/features/generation/lib/webp-storage", () => ({
+  uploadWebPVariants: (...args: unknown[]) => uploadWebPVariantsMock(...args),
+}));
+
+// buildPublicGeneratedImageUrl は URL 組み立てだけなので実物を使う(env に依存)。
+process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+
+import { refreshCompletionFeedPostImage } from "@/features/collections/lib/completion-feed-post";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+/** generated_images に対する select().eq().maybeSingle() と update().eq() を記録するフェイク。 */
+function makeClient(existingRow: { id: string } | null) {
+  const update = jest.fn();
+  const updateEq = jest.fn().mockResolvedValue({ error: null });
+  update.mockReturnValue({ eq: updateEq });
+
+  const client = {
+    from: jest.fn(() => ({
+      select: jest.fn(() => ({
+        eq: jest.fn(() => ({
+          maybeSingle: jest.fn().mockResolvedValue({ data: existingRow }),
+        })),
+      })),
+      update,
+    })),
+  } as unknown as SupabaseClient;
+  return { client, update, updateEq };
+}
+
+describe("refreshCompletionFeedPostImage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    uploadWebPVariantsMock.mockResolvedValue({
+      thumbPath: "path/mount-2.thumb.webp",
+      displayPath: "path/mount-2.display.webp",
+    });
+  });
+
+  test("投稿行があれば新しい画像パスへ貼り替え、id を返す", async () => {
+    const { client, update, updateEq } = makeClient({ id: "post-1" });
+
+    const r = await refreshCompletionFeedPostImage(
+      client,
+      "completion-1",
+      "path/mount-2.png",
+    );
+
+    expect(r.postId).toBe("post-1");
+    expect(uploadWebPVariantsMock).toHaveBeenCalledWith(
+      "https://example.supabase.co/storage/v1/object/public/generated-images/path/mount-2.png",
+      "path/mount-2.png",
+    );
+    // 画像4列を最新へ + width/height をクリア
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        image_url:
+          "https://example.supabase.co/storage/v1/object/public/generated-images/path/mount-2.png",
+        storage_path: "path/mount-2.png",
+        storage_path_display: "path/mount-2.display.webp",
+        storage_path_thumb: "path/mount-2.thumb.webp",
+        width: null,
+        height: null,
+      }),
+    );
+    expect(updateEq).toHaveBeenCalledWith("id", "post-1");
+  });
+
+  test("投稿行が無ければ何もせず null(WebP生成もしない)", async () => {
+    const { client, update } = makeClient(null);
+
+    const r = await refreshCompletionFeedPostImage(
+      client,
+      "completion-1",
+      "path/mount-2.png",
+    );
+
+    expect(r.postId).toBeNull();
+    expect(uploadWebPVariantsMock).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  test("WebP生成が失敗しても throw せず null(作り直し自体は成功させる)", async () => {
+    const { client } = makeClient({ id: "post-1" });
+    uploadWebPVariantsMock.mockRejectedValue(new Error("boom"));
+
+    const r = await refreshCompletionFeedPostImage(
+      client,
+      "completion-1",
+      "path/mount-2.png",
+    );
+
+    expect(r.postId).toBeNull();
+  });
+});


### PR DESCRIPTION
### 概要
**バグ修正。** 完走を「ホームに投稿する」でフィード投稿した後に「カードを更新する」で台紙/表紙を変更しても、ホームの投稿サムネが**旧画像のまま**になっていた（イタリア=book型で報告。神コレ=mount型でも同じ）。

**原因**: 完走フィード投稿は初回投稿時に `collection_completions.mount_image_path` から WebP サムネを生成して `generated_images` の1行にスナップショットする。以降その画像は固定で、
- 台紙作り直し（recompose）API は `collection_completions` 側だけ更新し、投稿行には触れない
- 再投稿時の RPC(`create_collection_completion_post`)も再活性化 UPDATE で画像列を更新しない

ため、表紙を変えてもサムネが追従しなかった。

**修正（A案）**: 台紙作り直しAPIの両分岐（book/mount）で、投稿済みなら投稿行の画像列を新 `mount_image_path` へ貼り替え、WebP variants を再生成し、フィード/詳細/検索の cache を失効させる。これでユーザー操作なしに表紙とサムネが一致する。台紙更新の副作用のため **best-effort**（貼り替えに失敗しても作り直し自体は成功）。

### 変更内容
- `features/collections/lib/completion-feed-post.ts`: `refreshCompletionFeedPostImage(admin, completionId, mountStoragePath)` を追加。投稿行があれば `image_url`/`storage_path`/`storage_path_display`/`storage_path_thumb` を最新へ更新し `width/height` をクリア（Post詳細の lazy compute で取り直し）。行が無ければ・失敗時は no-op で throw しない
- `app/api/collections/mount/route.ts`: book/mount 両方の作り直し分岐で上記を呼ぶローカルヘルパー `refreshCompletionFeedPost`（cache 失効込み）を追加
- `tests/unit/features/collections/completion-feed-post.test.ts` 新規: 貼り替え/行なしno-op/失敗時no-op の3ケース

### 実機テスト
- [ ] （プレビューで）`NEXT_PUBLIC_COLLECTION_FEED_POST_ENABLED=true` の環境で、完走→ホーム投稿→カードを更新（表紙変更）→ ホームフィードのサムネが新表紙になることを確認
  - ※ ローカルは当該フラグOFF・テストユーザーに投稿済み完走が無く、ライブ確認は未実施。ロジックはユニットテストで担保

### テスト方法
- `npm run lint` / `npm run test`（2365件・新規3件）/ `npm run typecheck`（ベースライン同一）/ `npm run build -- --webpack`：すべて緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwcR7uKsNrx7vB1MeHTx7J