### PR TITLE
feat(generation): 出力比率モードに「登録画像(サムネ)に合わせる」を追加

### DIFF
--- a/app/(app)/style/generate/handler.ts
+++ b/app/(app)/style/generate/handler.ts
@@ -536,6 +536,10 @@ export async function postStyleGenerateRoute(
         openaiMultiInputClient,
         referenceImage,
         outputAspectRatioMode: preset.category.outputAspectRatioMode,
+        presetImageDimensions:
+          preset.thumbnailWidth > 0 && preset.thumbnailHeight > 0
+            ? { width: preset.thumbnailWidth, height: preset.thumbnailHeight }
+            : null,
       });
       lastDispatchResult = dispatchResult;
 

--- a/app/api/admin/preset-categories/[id]/route.ts
+++ b/app/api/admin/preset-categories/[id]/route.ts
@@ -166,7 +166,7 @@ export async function PATCH(
       return NextResponse.json(
         {
           error:
-            "output_aspect_ratio_mode must be 'source' or one of 9:16,4:5,3:4,2:3,1:1,3:2,4:3,5:4,16:9",
+            "output_aspect_ratio_mode must be 'source', 'preset_image' or one of 9:16,4:5,3:4,2:3,1:1,3:2,4:3,5:4,16:9",
         },
         { status: 400 },
       );

--- a/app/api/admin/preset-categories/route.ts
+++ b/app/api/admin/preset-categories/route.ts
@@ -223,7 +223,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         {
           error:
-            "output_aspect_ratio_mode must be 'source' or one of 9:16,4:5,3:4,2:3,1:1,3:2,4:3,5:4,16:9",
+            "output_aspect_ratio_mode must be 'source', 'preset_image' or one of 9:16,4:5,3:4,2:3,1:1,3:2,4:3,5:4,16:9",
         },
         { status: 400 },
       );

--- a/features/generation/lib/guest-generate.ts
+++ b/features/generation/lib/guest-generate.ts
@@ -176,6 +176,11 @@ export interface DispatchGuestImageGenerationInput {
   uploadImage: File;
   referenceImage?: File | null;
   outputAspectRatioMode?: StyleOutputAspectRatioMode;
+  /**
+   * preset の登録画像(サムネ)の実寸。outputAspectRatioMode="preset_image" のとき、
+   * この寸法から出力アスペクトを決める(DB保存済みの整数のため画像処理は不要)。
+   */
+  presetImageDimensions?: { width: number; height: number } | null;
   geminiApiKey: string;
   openaiApiKey?: string;
   geminiTimeoutMs?: number;
@@ -287,18 +292,25 @@ async function dispatchOpenAI(
     };
   }
   try {
-    // 明示比率なら、その比率の寸法から OpenAI 出力サイズを決める(GPT Image 2 も非正方形可)。
-    // source は undefined にして入力画像ベース(従来挙動)に委ねる。
+    // 明示比率(や登録画像=preset_image)なら、その比率の寸法から OpenAI 出力サイズを決める
+    // (GPT Image 2 も非正方形可)。source は undefined にして入力画像ベース(従来挙動)に委ねる。
     const aspectMode = normalizeStyleOutputAspectRatioMode(
       input.outputAspectRatioMode,
     );
-    const targetSize =
+    const targetLabel =
       aspectMode === "source"
-        ? undefined
-        : getGptImage2TargetSize(
-            gptImage2.sizeTier,
-            aspectLabelToDimensions(aspectMode),
+        ? null
+        : resolveOutputAspectRatio(
+            aspectMode,
+            null,
+            input.presetImageDimensions,
           );
+    const targetSize = targetLabel
+      ? getGptImage2TargetSize(
+          gptImage2.sizeTier,
+          aspectLabelToDimensions(targetLabel),
+        )
+      : undefined;
     let result: OpenAIImageEditResult;
     if (input.referenceImage) {
       const referenceArrayBuffer = await input.referenceImage.arrayBuffer();
@@ -371,10 +383,12 @@ async function dispatchGemini(
   const imageSize = extractImageSize(input.model as GeminiOnlyModel);
   const { part: imagePart, dimensions: inputDimensions } =
     await fileToInlineDataPartWithDimensions(input.uploadImage);
-  // モード="source" は入力比率を自動スナップ、明示比率はその比率で出力する。
+  // モード="source" は入力比率を自動スナップ、"preset_image" は登録画像(サムネ)比率、
+  // 明示比率はその比率で出力する。
   const aspectRatio = resolveOutputAspectRatio(
     input.outputAspectRatioMode,
     inputDimensions,
+    input.presetImageDimensions,
   );
   const parts: GeminiContentPart[] = [
     { text: input.promptText },

--- a/features/generation/lib/guest-generate.ts
+++ b/features/generation/lib/guest-generate.ts
@@ -297,8 +297,11 @@ async function dispatchOpenAI(
     const aspectMode = normalizeStyleOutputAspectRatioMode(
       input.outputAspectRatioMode,
     );
+    // source、および preset_image でサムネ寸法が無い場合は入力ベース(undefined)に委ねる
+    // (寸法無しで resolve すると 1:1 に落ちて正方形強制になるのを防ぐ)。
     const targetLabel =
-      aspectMode === "source"
+      aspectMode === "source" ||
+      (aspectMode === "preset_image" && !input.presetImageDimensions)
         ? null
         : resolveOutputAspectRatio(
             aspectMode,

--- a/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
+++ b/features/preset-categories/components/AdminPresetCategoryFormClient.tsx
@@ -975,6 +975,7 @@ export function AdminPresetCategoryFormClient({
             className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm"
           >
             <option value="source">アップロード画像に合わせる(自動)</option>
+            <option value="preset_image">登録画像(サムネ)に合わせる</option>
             {EXPLICIT_OUTPUT_ASPECT_RATIOS.map((ratio) => {
               const [w, h] = ratio.split(":").map(Number);
               const orientation =
@@ -987,7 +988,7 @@ export function AdminPresetCategoryFormClient({
             })}
           </select>
           <span className="mt-1 block text-xs text-slate-500">
-            「自動」はアップロード画像の比率に合わせて9段階(9:16〜16:9)の最も近い比率で出力します。比率を明示指定すると、このカテゴリの生成は常にその比率で出力します(Gemini)。OpenAI は 1:1 のみ固定に対応。
+            「自動」はアップロード画像の比率に合わせて9段階(9:16〜16:9)の最も近い比率で出力します。「登録画像(サムネ)に合わせる」は preset ごとのサムネ画像の比率で出力するため、イラストごとに縦横比を変えられます(サムネ寸法はDB保存済みのため生成時間に影響しません)。比率を明示指定すると常にその比率で出力します(Gemini)。OpenAI は 1:1 のみ固定に対応。
           </span>
         </label>
 

--- a/shared/generation/style-output-aspect-ratio.ts
+++ b/shared/generation/style-output-aspect-ratio.ts
@@ -18,9 +18,10 @@ import {
 export const EXPLICIT_OUTPUT_ASPECT_RATIOS: readonly GeminiAspectRatio[] =
   GEMINI_SUPPORTED_ASPECT_RATIOS.map((entry) => entry.label);
 
-/** admin で選択できる出力比率モード。"source"(自動) + 明示9比率。 */
+/** admin で選択できる出力比率モード。"source"(自動) + "preset_image"(登録画像) + 明示9比率。 */
 export const STYLE_OUTPUT_ASPECT_RATIO_MODES = [
   "source",
+  "preset_image",
   "9:16",
   "4:5",
   "3:4",
@@ -41,7 +42,9 @@ export function isStyleOutputAspectRatioMode(
   value: unknown,
 ): value is StyleOutputAspectRatioMode {
   return (
-    value === "source" || (typeof value === "string" && EXPLICIT_SET.has(value))
+    value === "source" ||
+    value === "preset_image" ||
+    (typeof value === "string" && EXPLICIT_SET.has(value))
   );
 }
 
@@ -54,17 +57,24 @@ export function normalizeStyleOutputAspectRatioMode(
 }
 
 /**
- * モード + 入力画像寸法から、最終的な Gemini 出力アスペクト比を解決する。
- * - "source" … 入力寸法を9段階の最近傍にスナップ(自動選択)
- * - 明示比率 … その比率をそのまま使う
+ * モード + 入力画像寸法(+ 登録画像寸法)から、最終的な Gemini 出力アスペクト比を解決する。
+ * - "source"       … 入力寸法を9段階の最近傍にスナップ(自動選択)
+ * - "preset_image" … preset のサムネ(登録画像)寸法を9段階の最近傍にスナップ。
+ *                     寸法が無いときは入力寸法にフォールバック(= source と同挙動)。
+ *                     ※ サムネ寸法はDB保存済みの整数のみ使うため、画像処理は発生しない。
+ * - 明示比率        … その比率をそのまま使う
  */
 export function resolveOutputAspectRatio(
   mode: unknown,
   inputDimensions: { width: number; height: number } | null | undefined,
+  presetImageDimensions?: { width: number; height: number } | null | undefined,
 ): GeminiAspectRatio {
   const normalized = normalizeStyleOutputAspectRatioMode(mode);
   if (normalized === "source") {
     return resolveGeminiAspectRatio(inputDimensions);
+  }
+  if (normalized === "preset_image") {
+    return resolveGeminiAspectRatio(presetImageDimensions ?? inputDimensions);
   }
   return normalized;
 }

--- a/supabase/functions/image-gen-worker/index.ts
+++ b/supabase/functions/image-gen-worker/index.ts
@@ -2252,9 +2252,12 @@ Deno.serve(async () => {
                         height: oneTapStyleMetadata.thumbnailHeight,
                       }
                     : null;
-                // source は入力ベース(undefined)。それ以外(明示/preset_image)は具体ラベルへ解決。
+                // source、および preset_image でサムネ寸法が無い場合は入力ベース(undefined)に委ねる
+                // (寸法無しで resolve すると 1:1 に落ちて正方形強制になるのを防ぐ)。
+                // それ以外(明示/寸法ありのpreset_image)は具体ラベルへ解決。
                 const targetLabel =
-                  oneTapAspectMode === "source"
+                  oneTapAspectMode === "source" ||
+                  (oneTapAspectMode === "preset_image" && !oneTapPresetImageDims)
                     ? null
                     : resolveOutputAspectRatio(
                         oneTapAspectMode,

--- a/supabase/functions/image-gen-worker/index.ts
+++ b/supabase/functions/image-gen-worker/index.ts
@@ -2162,13 +2162,24 @@ Deno.serve(async () => {
                       )
                     : null;
                   // one_tap_style は preset カテゴリの出力比率モードを尊重する
-                  // (source=入力比率に自動スナップ / 明示比率=その比率で出力)。
+                  // (source=入力比率 / preset_image=登録画像(サムネ)比率 / 明示比率=その比率)。
+                  // preset サムネ寸法は metadata に保存済みの整数のため追加I/Oは無い。
                   // それ以外(coordinate / inspire 等)は従来どおり入力比率に自動スナップ。
+                  const presetImageDims =
+                    oneTapStyleMetadata &&
+                    oneTapStyleMetadata.thumbnailWidth > 0 &&
+                    oneTapStyleMetadata.thumbnailHeight > 0
+                      ? {
+                          width: oneTapStyleMetadata.thumbnailWidth,
+                          height: oneTapStyleMetadata.thumbnailHeight,
+                        }
+                      : null;
                   const aspectRatio: GeminiAspectRatio =
                     job.generation_type === "one_tap_style"
                       ? resolveOutputAspectRatio(
                           oneTapStyleMetadata?.outputAspectRatioMode,
                           aspectDims,
+                          presetImageDims,
                         )
                       : resolveGeminiAspectRatio(aspectDims);
 
@@ -2223,22 +2234,39 @@ Deno.serve(async () => {
                 }
                 const openAIRequestTimeoutMs =
                   resolveOpenAIRequestTimeoutMs(gptImage2);
-                // 出力比率: one_tap_style で明示比率なら、その比率の寸法から OpenAI 出力サイズを決める
-                // (GPT Image 2 も 9:16〜16:9 を出力可能)。source / 非one_tap は undefined にして
-                // 呼び出し側の入力画像ベース(従来挙動)に委ねる。
+                // 出力比率: one_tap_style で明示比率/登録画像(preset_image)なら、その比率の寸法から
+                // OpenAI 出力サイズを決める(GPT Image 2 も 9:16〜16:9 を出力可能)。source / 非one_tap は
+                // undefined にして呼び出し側の入力画像ベース(従来挙動)に委ねる。
                 const oneTapAspectMode =
                   job.generation_type === "one_tap_style"
                     ? normalizeStyleOutputAspectRatioMode(
                         oneTapStyleMetadata?.outputAspectRatioMode,
                       )
                     : "source";
-                const targetSize =
+                const oneTapPresetImageDims =
+                  oneTapStyleMetadata &&
+                  oneTapStyleMetadata.thumbnailWidth > 0 &&
+                  oneTapStyleMetadata.thumbnailHeight > 0
+                    ? {
+                        width: oneTapStyleMetadata.thumbnailWidth,
+                        height: oneTapStyleMetadata.thumbnailHeight,
+                      }
+                    : null;
+                // source は入力ベース(undefined)。それ以外(明示/preset_image)は具体ラベルへ解決。
+                const targetLabel =
                   oneTapAspectMode === "source"
-                    ? undefined
-                    : getGptImage2TargetSize(
-                        gptImage2.sizeTier,
-                        aspectLabelToDimensions(oneTapAspectMode),
+                    ? null
+                    : resolveOutputAspectRatio(
+                        oneTapAspectMode,
+                        null,
+                        oneTapPresetImageDims,
                       );
+                const targetSize = targetLabel
+                  ? getGptImage2TargetSize(
+                      gptImage2.sizeTier,
+                      aspectLabelToDimensions(targetLabel),
+                    )
+                  : undefined;
                 const attemptStartedAtMs = Date.now();
                 let attemptHttpStatus: number | null = null;
                 let attemptHttpOk = false;

--- a/tests/unit/features/generation/guest-generate.test.ts
+++ b/tests/unit/features/generation/guest-generate.test.ts
@@ -600,6 +600,46 @@ describe("guest-generate", () => {
       );
     });
 
+    test("preset_image + サムネ横長 なら OpenAI targetSize が横長になる", async () => {
+      const openaiClient = jest.fn().mockResolvedValue({
+        data: "OPENAI_BASE64",
+        mimeType: "image/png",
+      });
+      await dispatchGuestImageGeneration({
+        model: "gpt-image-2-low-1k",
+        promptText: "x",
+        uploadImage: createPngFile(),
+        geminiApiKey: "(unused)",
+        openaiApiKey: "openai-key",
+        openaiClient,
+        outputAspectRatioMode: "preset_image",
+        presetImageDimensions: { width: 1600, height: 900 },
+      });
+      const call = openaiClient.mock.calls[0][0] as { targetSize: string };
+      // 横長サムネ → 出力サイズも横長(width > height)。targetSize は "WxH" 文字列。
+      expect(call.targetSize).toBeDefined();
+      const [w, h] = call.targetSize.split("x").map(Number);
+      expect(w).toBeGreaterThan(h);
+    });
+
+    test("preset_image + サムネ寸法なし は targetSize 未指定(source同等=入力ベースに委ねる)", async () => {
+      const openaiClient = jest.fn().mockResolvedValue({
+        data: "OPENAI_BASE64",
+        mimeType: "image/png",
+      });
+      await dispatchGuestImageGeneration({
+        model: "gpt-image-2-low-1k",
+        promptText: "x",
+        uploadImage: createPngFile(),
+        geminiApiKey: "(unused)",
+        openaiApiKey: "openai-key",
+        openaiClient,
+        outputAspectRatioMode: "preset_image",
+        presetImageDimensions: null,
+      });
+      expect(openaiClient.mock.calls[0][0].targetSize).toBeUndefined();
+    });
+
     test("referenceImage 指定時は OpenAI multi-input に image_0 と image_1 を送る", async () => {
       const openaiClient = jest.fn();
       const openaiMultiInputClient = jest.fn().mockResolvedValue([

--- a/tests/unit/shared/generation/style-output-aspect-ratio.test.ts
+++ b/tests/unit/shared/generation/style-output-aspect-ratio.test.ts
@@ -22,9 +22,46 @@ describe("style-output-aspect-ratio", () => {
       "5:4",
       "16:9",
     ]);
-    // モード一覧 = source + 9比率
-    expect(STYLE_OUTPUT_ASPECT_RATIO_MODES.length).toBe(10);
+    // モード一覧 = source + preset_image + 9比率
+    expect(STYLE_OUTPUT_ASPECT_RATIO_MODES.length).toBe(11);
     expect(STYLE_OUTPUT_ASPECT_RATIO_MODES[0]).toBe("source");
+    expect(STYLE_OUTPUT_ASPECT_RATIO_MODES[1]).toBe("preset_image");
+  });
+
+  describe("preset_image モード(登録画像に合わせる)", () => {
+    test("isStyleOutputAspectRatioMode で有効", () => {
+      expect(isStyleOutputAspectRatioMode("preset_image")).toBe(true);
+    });
+    test("normalize でそのまま維持", () => {
+      expect(normalizeStyleOutputAspectRatioMode("preset_image")).toBe(
+        "preset_image",
+      );
+    });
+    test("preset サムネ寸法から比率を解決する(入力寸法は無視)", () => {
+      // 横長サムネ → 横長比率。入力は縦長でも preset 側が優先される。
+      expect(
+        resolveOutputAspectRatio(
+          "preset_image",
+          { width: 900, height: 1600 }, // 入力=縦長(無視される)
+          { width: 1600, height: 900 }, // サムネ=横長
+        ),
+      ).toBe("16:9");
+    });
+    test("preset サムネ寸法が無ければ入力寸法にフォールバック(source同等)", () => {
+      const withInput = resolveOutputAspectRatio(
+        "preset_image",
+        { width: 1600, height: 900 },
+        null,
+      );
+      const asSource = resolveOutputAspectRatio(
+        "source",
+        { width: 1600, height: 900 },
+      );
+      expect(withInput).toBe(asSource);
+    });
+    test("shouldForceSquareStyleOutput は preset_image では false", () => {
+      expect(shouldForceSquareStyleOutput("preset_image")).toBe(false);
+    });
   });
 
   describe("isStyleOutputAspectRatioMode", () => {


### PR DESCRIPTION
### 概要
出力比率モードに **「登録画像(サムネ)に合わせる」(`preset_image`)** を追加する。カテゴリ設定は1つでも、**preset(イラスト)ごとにそのサムネ画像の比率で出力**できるようになり、「カテゴリ固定なのでイラストごとに縦横比を変えられない」という課題を解決する（例：character_remix で横長サムネの preset は横長出力）。

**パフォーマンス影響なし**: サムネ寸法は既にDBに整数で保存済み（`thumbnail_width/height`、非同期は one_tap_style メタデータにも保存済み）。生成時に画像をダウンロード/デコードする処理は発生せず、比率決定は保存済み整数の四則演算（9段階スナップ）のみ。むしろ `source`（アップロード画像のヘッダをパース）より軽い。

### 変更内容
- `shared/generation/style-output-aspect-ratio.ts`: モードに `preset_image` を追加。`resolveOutputAspectRatio(mode, inputDims, presetImageDims?)` に第3引数を追加し、`preset_image` は preset サムネ寸法で解決（無ければ入力寸法へフォールバック=source同等）
- 同期経路: `features/generation/lib/guest-generate.ts`（Gemini/OpenAI targetSize 両方）＋ `app/(app)/style/generate/handler.ts`（preset サムネ寸法を渡す）
- 非同期worker: `supabase/functions/image-gen-worker/index.ts`（metadata の `thumbnailWidth/Height` を Gemini/OpenAI 両経路で渡す。**追加I/Oなし**）
- admin: カテゴリ編集フォームの出力比率ドロップダウンに「登録画像(サムネ)に合わせる」を追加＋説明文
- API 検証のエラーメッセージに `preset_image` を追記
- `tests/unit/shared/generation/style-output-aspect-ratio.test.ts`: preset_image の解決/フォールバック/正規化のケースを追加

### 実機テスト
- [ ] admin で character_remix 等のカテゴリを「登録画像(サムネ)に合わせる」に設定し、横長サムネの preset で横長出力・縦長サムネで縦長出力を確認（デプロイ後）
  - ※ 非同期生成に反映するには **image-gen-worker の再デプロイが必要**

### テスト方法
- `npm run lint` / `npm run test`（2372件・aspect 14件）/ `npm run typecheck`（ベースライン同一 511）/ `npm run build -- --webpack`：すべて緑
- `deno check`（worker）: 29件は既存ベースライン、本変更による新規エラーは0

### デプロイ/運用メモ
1. マージ後、**`supabase functions deploy image-gen-worker`** を実行（非同期生成の比率反映に必須）
2. admin で対象カテゴリの出力比率を「登録画像(サムネ)に合わせる」に変更すると、以降その挙動に

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwcR7uKsNrx7vB1MeHTx7J