### PR TITLE
fix(db): output_aspect_ratio_mode の CHECK 制約に preset_image を追加

### DIFF
--- a/supabase/migrations/20260712140000_add_preset_image_aspect_mode.sql
+++ b/supabase/migrations/20260712140000_add_preset_image_aspect_mode.sql
@@ -1,0 +1,37 @@
+-- 出力比率モードに 'preset_image'(登録画像=preset サムネに合わせる) を許可する。
+-- PR #421 で追加したモードだが CHECK 制約の更新が漏れており、admin 保存が
+-- 制約違反で 500 になっていた不具合の修正。既存 CHECK を張り替える。
+DO $$
+DECLARE
+  conname_var text;
+BEGIN
+  -- output_aspect_ratio_mode を参照する既存 CHECK を全て削除。
+  FOR conname_var IN
+    SELECT con.conname
+    FROM pg_constraint con
+    JOIN pg_class rel ON rel.oid = con.conrelid
+    JOIN pg_namespace ns ON ns.oid = rel.relnamespace
+    WHERE ns.nspname = 'public'
+      AND rel.relname = 'preset_categories'
+      AND con.contype = 'c'
+      AND pg_get_constraintdef(con.oid) ILIKE '%output_aspect_ratio_mode%'
+  LOOP
+    EXECUTE format(
+      'ALTER TABLE public.preset_categories DROP CONSTRAINT %I',
+      conname_var
+    );
+  END LOOP;
+
+  -- 新しい CHECK: source + preset_image + 明示9比率。
+  ALTER TABLE public.preset_categories
+    ADD CONSTRAINT preset_categories_output_aspect_ratio_mode_check
+    CHECK (
+      output_aspect_ratio_mode IN (
+        'source', 'preset_image',
+        '9:16', '4:5', '3:4', '2:3', '1:1', '3:2', '4:3', '5:4', '16:9'
+      )
+    );
+END $$;
+
+COMMENT ON COLUMN public.preset_categories.output_aspect_ratio_mode IS
+  'source = アップロード比率に合わせて自動選択(9段階の最近傍) / preset_image = preset のサムネ(登録画像)比率に合わせる / 9:16〜16:9 = 明示比率固定';


### PR DESCRIPTION
### 概要
**本番障害の修正。** PR #421 で出力比率モードに `preset_image`(登録画像=サムネに合わせる) を追加したが、`preset_categories.output_aspect_ratio_mode` の DB CHECK 制約(`source` + 明示9比率のみ)の更新が漏れていた。そのため admin でカテゴリを「登録画像(サムネ)に合わせる」に変更して保存すると、制約違反で **500 Internal server error** になっていた。

CHECK 制約を張り替えて `preset_image` を許可する。

### 変更内容
- `supabase/migrations/20260712140000_add_preset_image_aspect_mode.sql` 新規: 既存の output_aspect_ratio_mode 参照 CHECK を全て削除し、`source` + `preset_image` + 明示9比率を許可する CHECK を再作成（**本番へ適用済み**）

### 実機テスト
- [x] 本番DBで character_remix を preset_image に更新できることを確認（検証後、元の 3:4 に戻済み）
- [ ] admin UI でカテゴリを「登録画像(サムネ)に合わせる」に保存できること（500 が出ないこと）

### テスト方法
- `npm run test`（2374件）緑
- 本番 db push 適用成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwcR7uKsNrx7vB1MeHTx7J