### PR TITLE
feat(style): Style別共有URLのOGPをそのStyleのサムネイルにする

### DIFF
--- a/app/(app)/style/page.tsx
+++ b/app/(app)/style/page.tsx
@@ -6,6 +6,7 @@ import { StylePageBody } from "@/features/style/components/StylePageBody";
 import { StyleTotalGenerationCount } from "@/features/style/components/StyleTotalGenerationCount";
 import { DEFAULT_LOCALE, isLocale } from "@/i18n/config";
 import { createMarketingPageMetadata } from "@/lib/metadata";
+import { getPublishedStylePreset } from "@/features/style-presets/lib/get-public-style-presets";
 
 interface StylePageProps {
   searchParams?: Promise<{
@@ -13,7 +14,9 @@ interface StylePageProps {
   }>;
 }
 
-export async function generateMetadata(): Promise<Metadata> {
+export async function generateMetadata({
+  searchParams,
+}: StylePageProps): Promise<Metadata> {
   const localeValue = await getLocale();
   const locale = isLocale(localeValue) ? localeValue : DEFAULT_LOCALE;
   const t = await getTranslations("style");
@@ -23,6 +26,37 @@ export async function generateMetadata(): Promise<Metadata> {
     path: "/style",
     locale,
   });
+
+  // ?style=<id> が付いている共有URLでは、そのStyleのサムネイルを OGP 画像にする。
+  // getPublishedStylePreset は published かつ非admin_only のみ返すため、下書き/管理限定
+  // Style は自動的に既定OGへフォールバックする(非公開の漏れなし)。
+  const styleId = (await searchParams)?.style;
+  const preset = styleId ? await getPublishedStylePreset(styleId) : null;
+
+  if (preset) {
+    const alt = `${preset.title} | Persta.AI`;
+    return {
+      ...metadata,
+      title: preset.title,
+      openGraph: {
+        ...metadata.openGraph,
+        title: alt,
+        images: [
+          {
+            url: preset.thumbnailImageUrl,
+            width: preset.thumbnailWidth,
+            height: preset.thumbnailHeight,
+            alt,
+          },
+        ],
+      },
+      twitter: {
+        ...metadata.twitter,
+        title: alt,
+        images: [preset.thumbnailImageUrl],
+      },
+    };
+  }
 
   return {
     ...metadata,

--- a/tests/unit/app/style/generate-metadata.test.ts
+++ b/tests/unit/app/style/generate-metadata.test.ts
@@ -1,5 +1,6 @@
 import { generateMetadata } from "@/app/(app)/style/page";
 import { getPublishedStylePreset } from "@/features/style-presets/lib/get-public-style-presets";
+import type { StylePresetPublicSummary } from "@/features/style-presets/lib/schema";
 
 // generateMetadata だけを検証するため、default export が引き込む重いクライアント
 // コンポーネント群はスタブ化する(メタデータ生成には無関係)。
@@ -57,7 +58,9 @@ describe("style page generateMetadata", () => {
       thumbnailImageUrl: "https://cdn.example.com/thumb.webp",
       thumbnailWidth: 1280,
       thumbnailHeight: 853,
-    } as never);
+      // generateMetadata が参照するのは上記5フィールドのみ。他必須フィールドは
+      // 検証に不要なため、部分モックを公開サマリ型へアサートする。
+    } as unknown as StylePresetPublicSummary);
 
     const meta = await generateMetadata({
       searchParams: Promise.resolve({ style: "abc" }),

--- a/tests/unit/app/style/generate-metadata.test.ts
+++ b/tests/unit/app/style/generate-metadata.test.ts
@@ -1,0 +1,91 @@
+import { generateMetadata } from "@/app/(app)/style/page";
+import { getPublishedStylePreset } from "@/features/style-presets/lib/get-public-style-presets";
+
+// generateMetadata だけを検証するため、default export が引き込む重いクライアント
+// コンポーネント群はスタブ化する(メタデータ生成には無関係)。
+jest.mock("@/features/style/components/StyleTourButton", () => ({
+  StyleTourButton: () => null,
+}));
+jest.mock("@/features/style/components/StylePageBody", () => ({
+  StylePageBody: () => null,
+}));
+jest.mock("@/features/style/components/StyleTotalGenerationCount", () => ({
+  StyleTotalGenerationCount: () => null,
+}));
+
+jest.mock("next-intl/server", () => ({
+  getLocale: jest.fn(async () => "ja"),
+  getTranslations: jest.fn(async () => (key: string) => key),
+}));
+
+jest.mock("@/lib/metadata", () => ({
+  createMarketingPageMetadata: jest.fn(() => ({
+    title: "pageTitle",
+    description: "pageDescription",
+    openGraph: { type: "website" },
+    twitter: { card: "summary_large_image" },
+  })),
+}));
+
+jest.mock("@/features/style-presets/lib/get-public-style-presets", () => ({
+  getPublishedStylePreset: jest.fn(),
+}));
+
+const mockGetPreset = getPublishedStylePreset as jest.MockedFunction<
+  typeof getPublishedStylePreset
+>;
+
+const DEFAULT_OG = "/og/one-tap-style.png";
+
+function firstOgImageUrl(meta: Awaited<ReturnType<typeof generateMetadata>>) {
+  const images = meta.openGraph?.images;
+  const first = Array.isArray(images) ? images[0] : images;
+  return first && typeof first === "object" && "url" in first
+    ? String(first.url)
+    : String(first);
+}
+
+describe("style page generateMetadata", () => {
+  beforeEach(() => {
+    mockGetPreset.mockReset();
+  });
+
+  it("?style=<id> が公開Styleに解決するとサムネイルをOGP画像にする", async () => {
+    mockGetPreset.mockResolvedValue({
+      id: "abc",
+      title: "オリジナル戦車を作ろう",
+      thumbnailImageUrl: "https://cdn.example.com/thumb.webp",
+      thumbnailWidth: 1280,
+      thumbnailHeight: 853,
+    } as never);
+
+    const meta = await generateMetadata({
+      searchParams: Promise.resolve({ style: "abc" }),
+    });
+
+    expect(mockGetPreset).toHaveBeenCalledWith("abc");
+    expect(firstOgImageUrl(meta)).toBe("https://cdn.example.com/thumb.webp");
+    expect(meta.twitter?.images).toEqual(["https://cdn.example.com/thumb.webp"]);
+    expect(meta.title).toBe("オリジナル戦車を作ろう");
+  });
+
+  it("style が非公開/存在しない場合は既定OGへフォールバックする", async () => {
+    mockGetPreset.mockResolvedValue(null);
+
+    const meta = await generateMetadata({
+      searchParams: Promise.resolve({ style: "missing" }),
+    });
+
+    expect(firstOgImageUrl(meta)).toBe(DEFAULT_OG);
+    expect(meta.twitter?.images).toEqual([DEFAULT_OG]);
+  });
+
+  it("style パラメータが無い場合は既定OGで、preset取得を呼ばない", async () => {
+    const meta = await generateMetadata({
+      searchParams: Promise.resolve({}),
+    });
+
+    expect(mockGetPreset).not.toHaveBeenCalled();
+    expect(firstOgImageUrl(meta)).toBe(DEFAULT_OG);
+  });
+});


### PR DESCRIPTION
## 概要

`/style?style=<id>` の共有URLをX等でシェアした際、OGPのカード画像を **そのStyleのサムネイル** にする。これまでは全Style共通の固定画像（`/og/one-tap-style.png`)だった。Style単位でどんな変身ができるかがカードで伝わり、シェア経由の訴求力を高める。

## 変更内容

- `app/(app)/style/page.tsx` の `generateMetadata` で `searchParams.style` を読み、既存の `getPublishedStylePreset(id)` でStyleを解決
- 解決できたら `og:image` / `twitter:image` にサムネイル（`thumbnailImageUrl` / 幅・高さ）を、`og:title` にStyleタイトルを差し込む（カードは `summary_large_image`）
- 未指定・非公開・存在しない場合は従来の既定OGへフォールバック
- `getPublishedStylePreset` は **published かつ非admin_only のみ** を返すため、下書き・管理限定Styleは自動的に既定OGになり **非公開の漏れが無い**
- `generateMetadata` の単体テストを追加（サムネ差し込み／フォールバック2系統）

## 補足・既知の制約

- サムネはStyleごとに縦長/横長/正方が混在。大カード(`summary_large_image`)は約1.91:1で中央クロップされるため、**縦長サムネは上下が切れる**（今回は「サムネそのまま・大カード」の最小実装方針を採用）。将来 1200×630 台紙合成へ拡張する余地あり
- X はOGPを強くキャッシュするため、既存シェア済みURLの反映にはCard Validatorでの再取得が必要な場合あり

## 検証

- `npm run lint`（変更2ファイルはクリーン。既存ベースラインのerror数は変更前後で同一）
- `npm run typecheck`（非testで新規エラー無し）
- `npm run test`（追加3ケース含めパス）
- `npm run build -- --webpack`（成功）

マージ方式: **Squash and merge**