### PR TITLE
fix(collections): 段階解放モーダルの見出しを汎用化(「新たに解放！」)

### DIFF
--- a/features/collections/components/UnlockModals.tsx
+++ b/features/collections/components/UnlockModals.tsx
@@ -179,13 +179,17 @@ export function UnlockDripModal({
   body?: string | null;
   /** 配色(未指定なら標準の紫基調)。 */
   colors?: UnlockAnnouncementColors;
-  /** 見出し「新たに N◯ 解放！」の単位(既定「体」。sequential は「日」など)。 */
+  /**
+   * 見出しの単位ラベル。指定時は「新たに N{unitLabel} 解放！」(例: "体")。
+   * null/未指定は件数・単位を出さず汎用の「新たに解放！」を表示する。
+   */
   unitLabel?: string | null;
 }) {
   const { cssVars, titleColor } = resolveColors(colors);
   const count = newlyUnlocked.length;
-  const unit = unitLabel ?? "体";
   const bodyText = body ?? `${title}の続きが登場しました。`;
+  // 単位ラベルがあれば「新たにN{unit} 解放！」、無ければ企画非依存の汎用見出し。
+  const heading = unitLabel ? `新たに${count}${unitLabel} 解放！` : "新たに解放！";
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4"
@@ -201,8 +205,7 @@ export function UnlockDripModal({
         <CloseButton onClose={onClose} />
         <NewPill />
         <h2 className="mt-2 text-lg font-bold" style={{ color: titleColor }}>
-          新たに{count}
-          {unit} 解放！
+          {heading}
         </h2>
         <p className="mt-1 text-sm text-[#7A5A93]">{bodyText}</p>
 

--- a/features/collections/lib/collection-unlock-announcement.ts
+++ b/features/collections/lib/collection-unlock-announcement.ts
@@ -38,7 +38,10 @@ export interface CollectionUnlockAnnouncement {
    */
   baselineUnlockedCount: number;
   /**
-   * 「新たに N◯ 解放！」の単位ラベル。sequential は "日"(Day)、前提型は null(=「体」)。
+   * 解放モーダル見出しの単位ラベル。
+   * - 前提型(ぷち神など)は "体" → 「新たに N体 解放！」。
+   * - sequential(travel / ことわざ辞典など)は null → 単位・件数を出さず汎用の「新たに解放！」。
+   *   企画ごとに「日」等の固有単位に依存しないための汎用表示。
    */
   unitLabel: string | null;
   /**
@@ -128,7 +131,7 @@ export function buildCollectionUnlockAnnouncements(
       prerequisiteKey,
       prerequisiteAckCount,
       baselineUnlockedCount,
-      unitLabel: sequential ? "日" : null,
+      unitLabel: sequential ? null : "体",
       heroImagePath: category.unlockAnnouncementHeroPath,
       initialBody: category.unlockAnnouncementInitialBody,
       dripBody: category.unlockAnnouncementDripBody,

--- a/tests/unit/features/collections/collection-unlock-announcement.test.ts
+++ b/tests/unit/features/collections/collection-unlock-announcement.test.ts
@@ -248,7 +248,7 @@ describe("buildCollectionUnlockAnnouncements", () => {
       );
     }
 
-    test("前提なしでも告知対象になり、昇順・baseline=1・単位=日", () => {
+    test("前提なしでも告知対象になり、昇順・baseline=1・単位ラベルなし(汎用)", () => {
       const result = buildCollectionUnlockAnnouncements(seqPresets(), {
         prerequisiteCompletedKeys: new Set(),
         distinctGeneratedByCategoryKey: new Map([[SEQ_KEY, 1]]), // はじまり生成済 → Day1解放
@@ -257,7 +257,7 @@ describe("buildCollectionUnlockAnnouncements", () => {
       const a = result[0];
       expect(a.unlockedCount).toBe(2); // はじまり + Day1
       expect(a.baselineUnlockedCount).toBe(1); // 表紙は常時解放
-      expect(a.unitLabel).toBe("日");
+      expect(a.unitLabel).toBeNull(); // sequential は汎用見出し(「新たに解放！」)
       expect(a.prerequisiteAckCount).toBe(0); // 前提ackゲートなし
       // 昇順(先頭=はじまり, 次=Day1)
       expect(a.unlockedPresets.map((p) => p.title)).toEqual(["はじまり", "Day1"]);

--- a/tests/unit/features/collections/collection-unlock-drip-listener.test.tsx
+++ b/tests/unit/features/collections/collection-unlock-drip-listener.test.tsx
@@ -44,7 +44,7 @@ function makeAnnouncement(
     prerequisiteAckCount: 0,
     // sequential: baseline=1(表紙は常時解放) → 初回生成から drip 対象になる。
     baselineUnlockedCount: 1,
-    unitLabel: "日",
+    unitLabel: null, // sequential は汎用見出し(「新たに解放！」)
     heroImagePath: null,
     initialBody: null,
     dripBody: null,

--- a/tests/unit/features/collections/unlock-modals.test.tsx
+++ b/tests/unit/features/collections/unlock-modals.test.tsx
@@ -123,7 +123,7 @@ describe("UnlockDripModal", () => {
     { id: "p2", title: "スタイルB", thumbnailUrl: "https://example.com/b.png" },
   ];
 
-  test("未設定: 解放数の見出しと標準文、サムネを表示", () => {
+  test("unitLabel未設定: 汎用見出し「新たに解放！」と標準文、サムネを表示", () => {
     render(
       <UnlockDripModal
         title="ぷち神"
@@ -131,13 +131,26 @@ describe("UnlockDripModal", () => {
         onClose={() => {}}
       />,
     );
-    expect(screen.getByText("新たに2体 解放！")).toBeInTheDocument();
+    // 件数・単位を出さない企画非依存の汎用見出し。
+    expect(screen.getByText("新たに解放！")).toBeInTheDocument();
     expect(screen.getByText("ぷち神の続きが登場しました。")).toBeInTheDocument();
     expect(screen.getByAltText("スタイルA")).toHaveAttribute(
       "src",
       "https://example.com/a.png",
     );
     expect(screen.getByAltText("スタイルB")).toBeInTheDocument();
+  });
+
+  test("unitLabel=体: 件数付き見出し「新たに2体 解放！」を表示", () => {
+    render(
+      <UnlockDripModal
+        title="ぷち神"
+        newlyUnlocked={newlyUnlocked}
+        onClose={() => {}}
+        unitLabel="体"
+      />,
+    );
+    expect(screen.getByText("新たに2体 解放！")).toBeInTheDocument();
   });
 
   test("設定あり: 本文と配色が props で反映される", () => {


### PR DESCRIPTION
## 概要

sequential 系コレクション（ことわざ辞典・イタリア旅行など）で1枚生成したときに出る **段階解放モーダルの見出し** が「新たに**1日** 解放！」と、イタリア旅行の「Day（日）」由来の固有単位になっていました。企画非依存の汎用文言 **「新たに解放！」** に変更します。

## 変更内容

- `collection-unlock-announcement.ts`：`unitLabel` を `sequential ? "日" : null` → **`sequential ? null : "体"`** に変更
  - sequential（travel / ことわざ辞典）→ `null`（件数・単位を出さない汎用見出し）
  - 前提型（ぷち神など）→ `"体"` を明示（従来の「新たに N体 解放！」を維持）
- `UnlockModals.tsx`（`UnlockDripModal`）：見出しを
  - `unitLabel` あり → 「新たに N{unitLabel} 解放！」
  - `unitLabel` なし → 「**新たに解放！**」
- 関連ユニットテストを新仕様へ更新（汎用見出し／"体" 見出しの両ケースを網羅）

## 影響範囲

- ことわざ辞典 上巻・下巻（sequential）の drip モーダル → 「新たに解放！」
- ぷち神など前提型 → 変更なし（「新たに N体 解放！」のまま）
- イタリア旅行は企画終了済みのため実害なし

## 検証

- `npm run lint`（対象クリーン）／`npm run typecheck`（非testで新規エラー無し）
- `npm run test`（2393 passed）／`npm run build -- --webpack`（成功）

マージ方式: **Squash and merge**