### PR TITLE
fix(collections): 紙吹雪をready後に発火＋ことわざ台紙の各画像を角丸化

### DIFF
--- a/app/api/collections/mount/route.ts
+++ b/app/api/collections/mount/route.ts
@@ -29,6 +29,14 @@ const GENERATED_IMAGES_BUCKET = "generated-images";
 const TEMPLATE_BUCKET = "collection-mount-templates";
 const CATEGORY_KEY_PATTERN = /^[a-z][a-z0-9_]{1,49}$/;
 
+// 台紙に貼る各画像を角丸にするコレクション(ことわざ辞典 上巻/下巻)。
+// 他シリーズ(神コレ等)は従来どおり四角のまま貼る。値は短辺に対する角丸半径比。
+const ROUNDED_MOUNT_CATEGORY_KEYS = new Set<string>([
+  "kotowaza_dictionary",
+  "kotowaza_dictionary_2",
+]);
+const ROUNDED_MOUNT_CORNER_RATIO = 0.08;
+
 function jsonError(message: string, code: string, status: number) {
   return NextResponse.json({ error: message, errorCode: code }, { status });
 }
@@ -471,7 +479,16 @@ export async function POST(request: NextRequest) {
       reps.map((r) => downloadBuffer(admin, GENERATED_IMAGES_BUCKET, r.storagePath)),
     );
 
-    const mountPng = await composeMount({ templatePng, stickers, slots });
+    // ことわざ辞典のみ、各画像を角丸で貼る(他シリーズは 0 = 従来の四角貼り)。
+    const cornerRadiusRatio = ROUNDED_MOUNT_CATEGORY_KEYS.has(categoryKey)
+      ? ROUNDED_MOUNT_CORNER_RATIO
+      : 0;
+    const mountPng = await composeMount({
+      templatePng,
+      stickers,
+      slots,
+      cornerRadiusRatio,
+    });
 
     // パスにタイムスタンプが含まれるため毎回新規パス。事前 remove は不要。
     const { error: uploadError } = await admin.storage

--- a/features/collections/components/CollectionProgressModal.tsx
+++ b/features/collections/components/CollectionProgressModal.tsx
@@ -175,9 +175,10 @@ interface ModalLayout {
 // ready(全画像ロード完了)の保険タイムアウト。これを過ぎたら強制表示する。
 const READY_TIMEOUT_MS = 3500;
 
-// 紙吹雪(confetti)の発火フォールバック。台紙画像のロード(ready)を待たずに、
-// モーダルが開いたらこの時間以内に必ず発火させる(初回コンプリートの取りこぼし対策)。
-const CONFETTI_FALLBACK_MS = 600;
+// 紙吹雪(confetti)は「準備中」が終わり画像が表示された(ready)後に発火する。
+// フェードイン(220ms)後にポンッと出るよう軽く遅延させる。ready は onLoad 完了 or
+// READY_TIMEOUT_MS の保険で必ず true になるため、発火を取りこぼさない。
+const CONFETTI_AFTER_READY_MS = 250;
 
 const MODAL_LAYOUTS: Record<string, ModalLayout> = {
   // ウエハース(4スロット)
@@ -354,22 +355,25 @@ export function CollectionProgressModal({
     return () => window.clearTimeout(timer);
   }, [open, celebration, ready]);
 
-  // 紙吹雪の発火: 完了かつ confetti 演出のとき、台紙画像のロード(ready)を待たず、
-  // ready なら即・未ロードでも CONFETTI_FALLBACK_MS 以内に必ず armed にする。
-  // これで初回コンプリート(台紙画像が未キャッシュで ready が遅い)でも取りこぼさない。
+  // 紙吹雪の発火: 完了かつ confetti 演出で、かつ「準備中」が終わり画像が表示された
+  // (ready) 後にだけ armed にする。準備中スピナー表示のまま先に紙吹雪が飛ぶのを防ぐ。
+  // ready は onLoad 完了 or READY_TIMEOUT_MS の保険で必ず true になるため取りこぼさない。
   useEffect(() => {
     if (
       !open ||
       !celebration ||
       cEffect !== "confetti" ||
-      !(cIsCompleted || cReached)
+      !(cIsCompleted || cReached) ||
+      !ready
     ) {
       return;
     }
-    // ready なら即(次tick)・未ロードでも fallback 以内に発火。
+    // フェードイン(220ms)後にポンッと出るよう軽く遅延させる。
     // 同期 setState(cascading render)を避けるためタイマー経由にする。
-    const delay = ready ? 0 : CONFETTI_FALLBACK_MS;
-    const timer = window.setTimeout(() => setConfettiArmed(true), delay);
+    const timer = window.setTimeout(
+      () => setConfettiArmed(true),
+      CONFETTI_AFTER_READY_MS,
+    );
     return () => window.clearTimeout(timer);
   }, [open, celebration, cEffect, cIsCompleted, cReached, ready]);
 
@@ -502,8 +506,8 @@ export function CollectionProgressModal({
                 Dialog の overflow には影響されない。
               - sparkle: ダイヤのきらめき(完了台紙の見返し等)。モーダル枠内を彩る。 */}
         {/* confetti(クラッカー)は「初コンプの祝い」専用(完了 + confetti 演出)。
-            台紙画像のロード(ready)を待たず confettiArmed で発火するため、初回
-            コンプリートでも確実に飛ぶ(armed の条件に完了/演出種別を含む)。 */}
+            「準備中」が終わり画像が表示された(ready)後に confettiArmed で発火するため、
+            準備中スピナー表示のまま先に紙吹雪が飛ぶことはない。 */}
         <CollectionConfetti show={confettiArmed} />
         <CollectionSparkle show={ready && effect === "sparkle"} />
 

--- a/features/collections/lib/compose-mount.ts
+++ b/features/collections/lib/compose-mount.ts
@@ -15,8 +15,14 @@ export async function composeMount(params: {
   stickers: Buffer[];
   /** 配置スロット(正規化矩形)。呼び出し側で mount_slots ?? プリセットを解決して渡す */
   slots: NormalizedSlotRect[];
+  /**
+   * 各画像を角丸マスクする半径(スロット短辺に対する比率, 0..0.5)。
+   * 0/未指定は角丸なし(従来の四角貼り)。ことわざ辞典など一部シリーズでのみ使う。
+   * 角は透過し、背後の台紙テンプレが覗く(＝角丸で貼ったように見える)。
+   */
+  cornerRadiusRatio?: number;
 }): Promise<Buffer> {
-  const { templatePng, stickers, slots } = params;
+  const { templatePng, stickers, slots, cornerRadiusRatio = 0 } = params;
 
   const base = sharp(templatePng);
   const meta = await base.metadata();
@@ -27,6 +33,7 @@ export async function composeMount(params: {
   }
 
   const count = Math.min(stickers.length, slots.length);
+  const clampedRatio = Math.max(0, Math.min(0.5, cornerRadiusRatio));
 
   const composites = [];
   for (let i = 0; i < count; i++) {
@@ -34,10 +41,24 @@ export async function composeMount(params: {
     if (px.width <= 0 || px.height <= 0) {
       continue;
     }
-    const resized = await sharp(stickers[i])
-      .resize(px.width, px.height, { fit: "cover" })
-      .png()
-      .toBuffer();
+    let pipeline = sharp(stickers[i]).resize(px.width, px.height, {
+      fit: "cover",
+    });
+    if (clampedRatio > 0) {
+      const radius = Math.round(Math.min(px.width, px.height) * clampedRatio);
+      if (radius > 0) {
+        // SVG の角丸矩形を dest-in で合成し、四隅を透過させる(角丸マスク)。
+        const mask = Buffer.from(
+          `<svg width="${px.width}" height="${px.height}">` +
+            `<rect x="0" y="0" width="${px.width}" height="${px.height}" ` +
+            `rx="${radius}" ry="${radius}"/></svg>`,
+        );
+        pipeline = pipeline
+          .ensureAlpha()
+          .composite([{ input: mask, blend: "dest-in" }]);
+      }
+    }
+    const resized = await pipeline.png().toBuffer();
     composites.push({ input: resized, left: px.left, top: px.top });
   }
 

--- a/features/collections/lib/compose-mount.ts
+++ b/features/collections/lib/compose-mount.ts
@@ -35,32 +35,39 @@ export async function composeMount(params: {
   const count = Math.min(stickers.length, slots.length);
   const clampedRatio = Math.max(0, Math.min(0.5, cornerRadiusRatio));
 
-  const composites = [];
-  for (let i = 0; i < count; i++) {
-    const px = toPixelRect(slots[i], width, height);
-    if (px.width <= 0 || px.height <= 0) {
-      continue;
-    }
-    let pipeline = sharp(stickers[i]).resize(px.width, px.height, {
-      fit: "cover",
-    });
-    if (clampedRatio > 0) {
-      const radius = Math.round(Math.min(px.width, px.height) * clampedRatio);
-      if (radius > 0) {
-        // SVG の角丸矩形を dest-in で合成し、四隅を透過させる(角丸マスク)。
-        const mask = Buffer.from(
-          `<svg width="${px.width}" height="${px.height}">` +
-            `<rect x="0" y="0" width="${px.width}" height="${px.height}" ` +
-            `rx="${radius}" ry="${radius}"/></svg>`,
-        );
-        pipeline = pipeline
-          .ensureAlpha()
-          .composite([{ input: mask, blend: "dest-in" }]);
-      }
-    }
-    const resized = await pipeline.png().toBuffer();
-    composites.push({ input: resized, left: px.left, top: px.top });
-  }
+  // 各シールのリサイズ+角丸マスクは互いに独立なので並列実行する(libuv スレッド
+  // プールを活用して応答を短縮)。index マップ+filter でスロット順は維持する。
+  const composites = (
+    await Promise.all(
+      Array.from({ length: count }, async (_, i) => {
+        const px = toPixelRect(slots[i], width, height);
+        if (px.width <= 0 || px.height <= 0) {
+          return null;
+        }
+        let pipeline = sharp(stickers[i]).resize(px.width, px.height, {
+          fit: "cover",
+        });
+        if (clampedRatio > 0) {
+          const radius = Math.round(
+            Math.min(px.width, px.height) * clampedRatio,
+          );
+          if (radius > 0) {
+            // SVG の角丸矩形を dest-in で合成し、四隅を透過させる(角丸マスク)。
+            const mask = Buffer.from(
+              `<svg width="${px.width}" height="${px.height}">` +
+                `<rect x="0" y="0" width="${px.width}" height="${px.height}" ` +
+                `rx="${radius}" ry="${radius}"/></svg>`,
+            );
+            pipeline = pipeline
+              .ensureAlpha()
+              .composite([{ input: mask, blend: "dest-in" }]);
+          }
+        }
+        const resized = await pipeline.png().toBuffer();
+        return { input: resized, left: px.left, top: px.top };
+      }),
+    )
+  ).filter((c): c is { input: Buffer; left: number; top: number } => c !== null);
 
   return base.composite(composites).png().toBuffer();
 }

--- a/tests/unit/features/collections/collection-progress-modal.test.tsx
+++ b/tests/unit/features/collections/collection-progress-modal.test.tsx
@@ -340,7 +340,7 @@ describe("CollectionProgressModal: ready ゲートのデッドロック防止", 
   });
 });
 
-describe("CollectionProgressModal: 完了時の紙吹雪は画像ロードを待たない", () => {
+describe("CollectionProgressModal: 完了時の紙吹雪は表示(ready)後に飛ぶ", () => {
   // 完了モーダル(台紙画像あり)。画像 onLoad を発火させず ready=false のまま。
   const completedConfetti: CollectionCelebration = {
     categoryKey: "collectible_wafer_sticker_god_6p",
@@ -356,23 +356,31 @@ describe("CollectionProgressModal: 完了時の紙吹雪は画像ロードを待
     collectedImageUrls: [],
   };
 
-  test("台紙画像がロードされず ready=false でも、フォールバックで紙吹雪が飛ぶ", () => {
+  test("準備中(ready=false)の間は紙吹雪を出さず、ready保険の到達後に飛ぶ", () => {
     jest.useFakeTimers();
     try {
       renderModal(completedConfetti);
 
       // 台紙画像 onLoad を発火させない → ready=false（準備中スピナー表示）。
       expect(screen.getByLabelText("読み込み中")).toBeInTheDocument();
-      // この時点ではまだ armed 前。
+
+      // 準備中の間は発火しない(600ms 経過してもまだ)。
+      act(() => {
+        jest.advanceTimersByTime(600);
+      });
       expect(
         screen.queryByTestId("collection-confetti"),
       ).not.toBeInTheDocument();
 
-      // CONFETTI_FALLBACK_MS(600ms) 経過で、ready を待たず発火する。
+      // READY_TIMEOUT_MS(3500ms) の保険で forceReady→ready になる。
+      // (この時点で ready 後の紙吹雪タイマーが仕込まれる)
       act(() => {
-        jest.advanceTimersByTime(600);
+        jest.advanceTimersByTime(3500);
       });
-
+      // ready 後の遅延(CONFETTI_AFTER_READY_MS=250ms)経過で発火する。
+      act(() => {
+        jest.advanceTimersByTime(300);
+      });
       expect(
         screen.getByTestId("collection-confetti"),
       ).toBeInTheDocument();

--- a/tests/unit/features/collections/compose-mount.test.ts
+++ b/tests/unit/features/collections/compose-mount.test.ts
@@ -1,0 +1,70 @@
+import sharp from "sharp";
+import { composeMount } from "@/features/collections/lib/compose-mount";
+import type { NormalizedSlotRect } from "@/features/collections/lib/mount-layouts";
+
+// 透明な台紙(100x100)と、全面を覆う不透明な赤いシールを1枚だけ配置する構成。
+// スロットは台紙全面(0,0,1,1)。角丸の有無を四隅/中心の alpha で検証する。
+const SIZE = 100;
+const SLOTS: NormalizedSlotRect[] = [{ x: 0, y: 0, w: 1, h: 1 }];
+
+async function transparentTemplate(): Promise<Buffer> {
+  return sharp({
+    create: {
+      width: SIZE,
+      height: SIZE,
+      channels: 4,
+      background: { r: 0, g: 0, b: 0, alpha: 0 },
+    },
+  })
+    .png()
+    .toBuffer();
+}
+
+async function redSticker(): Promise<Buffer> {
+  return sharp({
+    create: {
+      width: SIZE,
+      height: SIZE,
+      channels: 4,
+      background: { r: 255, g: 0, b: 0, alpha: 1 },
+    },
+  })
+    .png()
+    .toBuffer();
+}
+
+/** 出力 PNG の指定ピクセルの alpha(0..255)を返す。 */
+async function alphaAt(png: Buffer, x: number, y: number): Promise<number> {
+  const { data, info } = await sharp(png)
+    .ensureAlpha()
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+  const idx = (y * info.width + x) * info.channels;
+  return data[idx + info.channels - 1];
+}
+
+describe("composeMount 角丸マスク", () => {
+  it("cornerRadiusRatio 未指定なら四隅まで不透明(従来の四角貼り)", async () => {
+    const out = await composeMount({
+      templatePng: await transparentTemplate(),
+      stickers: [await redSticker()],
+      slots: SLOTS,
+    });
+    expect(await alphaAt(out, 0, 0)).toBe(255); // 左上隅も不透明
+    expect(await alphaAt(out, SIZE - 1, SIZE - 1)).toBe(255); // 右下隅も不透明
+    expect(await alphaAt(out, SIZE / 2, SIZE / 2)).toBe(255); // 中心
+  });
+
+  it("cornerRadiusRatio>0 なら四隅が透過し、中心は不透明", async () => {
+    const out = await composeMount({
+      templatePng: await transparentTemplate(),
+      stickers: [await redSticker()],
+      slots: SLOTS,
+      cornerRadiusRatio: 0.3,
+    });
+    // 四隅(0,0)は角丸で切り取られ透過(背後の透明台紙が覗く)。
+    expect(await alphaAt(out, 0, 0)).toBe(0);
+    // 中心は不透明のまま。
+    expect(await alphaAt(out, SIZE / 2, SIZE / 2)).toBe(255);
+  });
+});


### PR DESCRIPTION
コレクション演出の気になる2点を修正します。

## ① 紙吹雪(クラッカー)のタイミング

進捗モーダル／完走台紙で、**「準備中…」スピナー表示のまま先に紙吹雪が飛んでいた**問題を修正。台紙・進捗画像のロードを待たず 600ms のフォールバックで発火していたのが原因でした。

- `CollectionProgressModal`：紙吹雪の発火条件に **`ready`（画像表示完了）を追加**。準備中の間は発火しない
- フェードイン(220ms)後にポンッと出るよう ready 後に軽く遅延(250ms)して発火
- `ready` は画像 onLoad 完了 or `READY_TIMEOUT_MS`(3500ms)の保険で必ず true になるため、**紙吹雪を取りこぼさない**
- 該当ユニットテストを新仕様に更新（準備中は出さず、ready 到達後に発火）

## ② ことわざ辞典の台紙を角丸貼りに

コンプリート台紙が「画像をそのまま貼っただけ」に見える点を改善。**ことわざ辞典（上巻/下巻）のみ**、各画像を角丸マスクして貼ります。

- `composeMount` に `cornerRadiusRatio`（短辺比・0=角丸なし）を追加。SVG 角丸矩形を `dest-in` でマスクし四隅を透過（＝角丸で貼ったように見える）
- `app/api/collections/mount/route.ts`：対象 key（`kotowaza_dictionary` / `kotowaza_dictionary_2`）のときのみ有効化。**神コレ等 他シリーズは従来どおり四角のまま**（既定 0）
- 角丸を実ピクセル（四隅の alpha=透過／中心=不透明）で検証するユニットテストを追加

※ スコープ「ことわざのみ」・スタイル「角丸のみ（枠・影なし）」はユーザー確認済み。

## 検証

- `npm run lint`（対象クリーン）／`npm run typecheck`（非testで新規エラー無し）
- `npm run test`（2395 passed）／`npm run build -- --webpack`（成功）

## 反映について

- 角丸は**新規に作成/更新した台紙**から適用されます（既存の完走台紙は「カードを更新する」で再合成すると角丸になります）

マージ方式: **Squash and merge**