### PR TITLE
fix(collections): admin_only前提カテゴリの完走をadminプレビューで認識する

### DIFF
--- a/app/api/collections/unlock-announcements/route.ts
+++ b/app/api/collections/unlock-announcements/route.ts
@@ -43,6 +43,7 @@ export async function GET() {
       presets,
       user.id,
       supabase,
+      { includeAdminOnly: isAdmin },
     );
     const announcements = buildCollectionUnlockAnnouncements(presets, context);
     return NextResponse.json({ announcements });

--- a/features/collections/lib/collection-progress-repository.ts
+++ b/features/collections/lib/collection-progress-repository.ts
@@ -57,6 +57,41 @@ export async function getCollectionProgressForUser(
   return filterLockedCategories(withCompletion, supabase);
 }
 
+/** 解放ゲートの前提判定に必要な最小フラグ(重い画像/completion付与を伴わない)。 */
+export interface CollectionCompletionFlag {
+  categoryKey: string;
+  isCompleted: boolean;
+  uniqueOutfitCount: number;
+}
+
+/**
+ * 解放ゲートの前提判定に必要な最小情報(完走フラグ・ユニーク生成数)だけを、
+ * admin対応RPC get_collection_progress_for_user で取得する軽量版。
+ *
+ * getCollectionProgressForUser と違い、集めた画像(attachCollectedImages の N+1)や
+ * completion_id・キャラ画像などの付与を一切行わない。admin プレビューの解放判定
+ * (resolveCollectionUnlockContext)は is_completed / unique_outfit_count しか使わないため、
+ * 重い関連データ取得を避けてレンダリングの低速化を防ぐ。
+ */
+export async function getCollectionCompletionFlagsForUser(
+  userId: string,
+  includeAdminOnly: boolean,
+): Promise<CollectionCompletionFlag[]> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase.rpc("get_collection_progress_for_user", {
+    p_user_id: userId,
+    p_include_admin_only: includeAdminOnly,
+  });
+  if (error) {
+    throw error;
+  }
+  return ((data ?? []) as CollectionProgressRow[]).map((row) => ({
+    categoryKey: row.category_key,
+    isCompleted: row.is_completed,
+    uniqueOutfitCount: row.unique_outfit_count,
+  }));
+}
+
 /**
  * 解放ゲート(unlock_prerequisite_key)をマイページの進捗一覧にも適用する。
  *

--- a/features/collections/lib/collection-unlock-server.ts
+++ b/features/collections/lib/collection-unlock-server.ts
@@ -4,7 +4,10 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { createAdminClient } from "@/lib/supabase/admin";
 import type { StylePresetPublicSummary } from "@/features/style-presets/lib/schema";
 import { listPublishedStylePresets } from "@/features/style-presets/lib/style-preset-repository";
-import { getCollectionProgress } from "./collection-progress-repository";
+import {
+  getCollectionProgress,
+  getCollectionProgressForUser,
+} from "./collection-progress-repository";
 import {
   computeUnlockedCount,
   sequentialBatchSize,
@@ -37,6 +40,7 @@ export async function resolveCollectionUnlockContext(
   presets: readonly StylePresetPublicSummary[],
   userId: string,
   authedClient: SupabaseClient,
+  options: { includeAdminOnly?: boolean } = {},
 ): Promise<CollectionUnlockContext> {
   // 解放ゲートを持つカテゴリ(前提付き)＋ sequential(前提なしで単独順次解放)を対象にする。
   // sequential も distinct 集計が必要なため gatedCategoryKeys に含める。
@@ -62,7 +66,11 @@ export async function resolveCollectionUnlockContext(
 
   const [prerequisiteProgress, distinctGeneratedByCategoryKey] =
     await Promise.all([
-      resolveCompletedPrerequisiteKeys(prerequisiteKeys, authedClient),
+      resolveCompletedPrerequisiteKeys(
+        prerequisiteKeys,
+        authedClient,
+        options.includeAdminOnly ? { userId } : null,
+      ),
       resolveDistinctGeneratedCounts(gatedCategoryKeys, userId),
     ]);
 
@@ -74,19 +82,27 @@ export async function resolveCollectionUnlockContext(
 }
 
 /**
- * get_collection_progress RPC から「完走済み(mount完成)の前提条件カテゴリ key」と、
- * その「ユニーク生成数」(コンプリート演出が ack する値)を抽出する。
- * RPC は auth.uid() を使うため、必ず cookie 認証済みクライアントを渡すこと。
+ * 「完走済み(mount完成)の前提条件カテゴリ key」と、その「ユニーク生成数」
+ * (コンプリート演出が ack する値)を抽出する。
+ *
+ * 既定は public 限定の get_collection_progress(auth.uid() 使用)で判定するため、
+ * 必ず cookie 認証済みクライアントを渡すこと。ただし admin プレビュー時
+ * (adminContext 指定)は、前提が admin_only シリーズでも認識できるよう
+ * admin対応の get_collection_progress_for_user(include_admin_only=true)で判定する。
+ * これがないと、公開前(admin_only)の上巻を完走しても下巻が解放されない。
  * 取得失敗時は「未完走」として安全側に倒す(解放対象を出さない)。
  */
 async function resolveCompletedPrerequisiteKeys(
   prerequisiteKeys: ReadonlySet<string>,
   authedClient: SupabaseClient,
+  adminContext?: { userId: string } | null,
 ): Promise<{ completedKeys: Set<string>; uniqueCountByKey: Map<string, number> }> {
   const completedKeys = new Set<string>();
   const uniqueCountByKey = new Map<string, number>();
   try {
-    const progress = await getCollectionProgress(authedClient);
+    const progress = adminContext
+      ? await getCollectionProgressForUser(adminContext.userId, true)
+      : await getCollectionProgress(authedClient);
     for (const row of progress) {
       if (row.isCompleted && prerequisiteKeys.has(row.categoryKey)) {
         completedKeys.add(row.categoryKey);
@@ -198,10 +214,13 @@ export async function authorizeStylePresetUnlock(
   }
 
   // 1) 前提条件カテゴリの完走チェック(前提付きのときのみ)。
+  //    admin プレビュー(includeAdminOnly)時は admin_only の前提も認識できるよう
+  //    admin対応RPCで判定する(表示ゲートと同一ポリシー)。
   if (hasPrereq) {
     const { completedKeys } = await resolveCompletedPrerequisiteKeys(
       new Set([category.unlockPrerequisiteKey!]),
       authedClient,
+      options.includeAdminOnly ? { userId } : null,
     );
     if (!completedKeys.has(category.unlockPrerequisiteKey!)) {
       return { allowed: false, reason: "prerequisite_incomplete" };

--- a/features/collections/lib/collection-unlock-server.ts
+++ b/features/collections/lib/collection-unlock-server.ts
@@ -6,7 +6,7 @@ import type { StylePresetPublicSummary } from "@/features/style-presets/lib/sche
 import { listPublishedStylePresets } from "@/features/style-presets/lib/style-preset-repository";
 import {
   getCollectionProgress,
-  getCollectionProgressForUser,
+  getCollectionCompletionFlagsForUser,
 } from "./collection-progress-repository";
 import {
   computeUnlockedCount,
@@ -101,7 +101,7 @@ async function resolveCompletedPrerequisiteKeys(
   const uniqueCountByKey = new Map<string, number>();
   try {
     const progress = adminContext
-      ? await getCollectionProgressForUser(adminContext.userId, true)
+      ? await getCollectionCompletionFlagsForUser(adminContext.userId, true)
       : await getCollectionProgress(authedClient);
     for (const row of progress) {
       if (row.isCompleted && prerequisiteKeys.has(row.categoryKey)) {

--- a/features/home/components/CachedHomeStylePresetSection.tsx
+++ b/features/home/components/CachedHomeStylePresetSection.tsx
@@ -56,6 +56,7 @@ export async function CachedHomeStylePresetSection({
       cachedPresets,
       userId,
       await createClient(),
+      { includeAdminOnly: isAdminViewer },
     );
   }
   const gated = applyCollectionUnlockGating(cachedPresets, unlockContext);

--- a/features/style/components/StylePageBody.tsx
+++ b/features/style/components/StylePageBody.tsx
@@ -68,6 +68,7 @@ export async function StylePageBody({ searchParams }: StylePageBodyProps) {
             cachedPresets,
             user.id,
             await createClient(),
+            { includeAdminOnly: isAdminViewerFlag },
           ),
         )
       : applyCollectionUnlockGating(cachedPresets, EMPTY_UNLOCK_CONTEXT);

--- a/tests/unit/features/collections/collection-progress-repository.test.ts
+++ b/tests/unit/features/collections/collection-progress-repository.test.ts
@@ -35,7 +35,10 @@ jest.mock("@/features/collections/lib/representative-images", () => ({
     getRepresentativeImagesForCategoryMock(...args),
 }));
 
-import { getCollectionProgressForUser } from "@/features/collections/lib/collection-progress-repository";
+import {
+  getCollectionProgressForUser,
+  getCollectionCompletionFlagsForUser,
+} from "@/features/collections/lib/collection-progress-repository";
 
 const PROGRESS_ROW = {
   category_id: "cat-1",
@@ -102,6 +105,43 @@ function buildAdminClient() {
 beforeEach(() => {
   jest.clearAllMocks();
   getRepresentativeImagesForCategoryMock.mockResolvedValue([]);
+});
+
+describe("getCollectionCompletionFlagsForUser: 前提判定用の軽量取得", () => {
+  test("RPCを直接叩き、is_completed/unique_outfit_count のみを map して返す(重い付与なし)", async () => {
+    const rpc = jest.fn().mockResolvedValue({
+      data: [{ ...PROGRESS_ROW, is_completed: true, unique_outfit_count: 6 }],
+      error: null,
+    });
+    const from = jest.fn(); // 軽量版は from() を一切呼ばない想定。
+    createAdminClientMock.mockImplementation(() => ({ rpc, from }));
+
+    const result = await getCollectionCompletionFlagsForUser("user-9", true);
+
+    expect(rpc).toHaveBeenCalledWith("get_collection_progress_for_user", {
+      p_user_id: "user-9",
+      p_include_admin_only: true,
+    });
+    expect(from).not.toHaveBeenCalled();
+    expect(result).toEqual([
+      {
+        categoryKey: "db_driven_category",
+        isCompleted: true,
+        uniqueOutfitCount: 6,
+      },
+    ]);
+  });
+
+  test("RPCエラー時は throw する", async () => {
+    const rpc = jest
+      .fn()
+      .mockResolvedValue({ data: null, error: { message: "boom" } });
+    createAdminClientMock.mockImplementation(() => ({ rpc, from: jest.fn() }));
+
+    await expect(
+      getCollectionCompletionFlagsForUser("user-9", false),
+    ).rejects.toBeTruthy();
+  });
 });
 
 describe("getCollectionProgressForUser: progress-modal フィールド結合", () => {

--- a/tests/unit/features/collections/collection-unlock-server.test.ts
+++ b/tests/unit/features/collections/collection-unlock-server.test.ts
@@ -5,6 +5,7 @@ jest.mock("@/lib/supabase/admin", () => ({
 }));
 jest.mock("@/features/collections/lib/collection-progress-repository", () => ({
   getCollectionProgress: jest.fn(),
+  getCollectionProgressForUser: jest.fn(),
 }));
 jest.mock("@/features/style-presets/lib/style-preset-repository", () => ({
   listPublishedStylePresets: jest.fn(),
@@ -15,7 +16,10 @@ import {
   authorizeStylePresetUnlock,
 } from "@/features/collections/lib/collection-unlock-server";
 import { createAdminClient } from "@/lib/supabase/admin";
-import { getCollectionProgress } from "@/features/collections/lib/collection-progress-repository";
+import {
+  getCollectionProgress,
+  getCollectionProgressForUser,
+} from "@/features/collections/lib/collection-progress-repository";
 import { listPublishedStylePresets } from "@/features/style-presets/lib/style-preset-repository";
 import type { StylePresetPublicSummary } from "@/features/style-presets/lib/schema";
 
@@ -23,6 +27,10 @@ const mockCreateAdminClient =
   createAdminClient as jest.MockedFunction<typeof createAdminClient>;
 const mockGetCollectionProgress =
   getCollectionProgress as jest.MockedFunction<typeof getCollectionProgress>;
+const mockGetCollectionProgressForUser =
+  getCollectionProgressForUser as jest.MockedFunction<
+    typeof getCollectionProgressForUser
+  >;
 const mockListPublished =
   listPublishedStylePresets as jest.MockedFunction<
     typeof listPublishedStylePresets
@@ -181,6 +189,44 @@ describe("resolveCollectionUnlockContext", () => {
     // 前提なしでも sequential は distinct を解決する(= ゲート対象)。
     expect(ctx.distinctGeneratedByCategoryKey.get(SEQ)).toBe(3);
     expect(mockCreateAdminClient).toHaveBeenCalled();
+  });
+
+  it("既定(非admin)は public 限定 RPC で前提を判定する", async () => {
+    setProgress([{ categoryKey: PREREQ, isCompleted: true }]);
+    setDistinctRpc([{ category_key: PETIT, unique_count: 0 }]);
+    const presets = [presetSummary("p1", categoryRef(PETIT, PREREQ, 2))];
+
+    await resolveCollectionUnlockContext(presets, "user-1", dummyClient);
+
+    expect(mockGetCollectionProgress).toHaveBeenCalled();
+    expect(mockGetCollectionProgressForUser).not.toHaveBeenCalled();
+  });
+
+  it("includeAdminOnly=true は admin対応RPC(admin_only含む)で前提を判定する", async () => {
+    // public 限定 RPC は admin_only の上巻を返さない(空)が、admin対応RPCは返す想定。
+    setProgress([]);
+    mockGetCollectionProgressForUser.mockResolvedValue([
+      { categoryKey: "kotowaza_dictionary", isCompleted: true, uniqueOutfitCount: 6 },
+    ] as unknown as Awaited<ReturnType<typeof getCollectionProgressForUser>>);
+    setDistinctRpc([{ category_key: "kotowaza_dictionary_2", unique_count: 0 }]);
+    const presets = [
+      presetSummary(
+        "p1",
+        categoryRef("kotowaza_dictionary_2", "kotowaza_dictionary", 2, true),
+      ),
+    ];
+
+    const ctx = await resolveCollectionUnlockContext(
+      presets,
+      "user-1",
+      dummyClient,
+      { includeAdminOnly: true },
+    );
+
+    expect(mockGetCollectionProgressForUser).toHaveBeenCalledWith("user-1", true);
+    expect(mockGetCollectionProgress).not.toHaveBeenCalled();
+    // admin対応RPCが上巻の完走を返すので、前提クリアと判定される。
+    expect(ctx.prerequisiteCompletedKeys.has("kotowaza_dictionary")).toBe(true);
   });
 });
 

--- a/tests/unit/features/collections/collection-unlock-server.test.ts
+++ b/tests/unit/features/collections/collection-unlock-server.test.ts
@@ -5,7 +5,7 @@ jest.mock("@/lib/supabase/admin", () => ({
 }));
 jest.mock("@/features/collections/lib/collection-progress-repository", () => ({
   getCollectionProgress: jest.fn(),
-  getCollectionProgressForUser: jest.fn(),
+  getCollectionCompletionFlagsForUser: jest.fn(),
 }));
 jest.mock("@/features/style-presets/lib/style-preset-repository", () => ({
   listPublishedStylePresets: jest.fn(),
@@ -18,7 +18,7 @@ import {
 import { createAdminClient } from "@/lib/supabase/admin";
 import {
   getCollectionProgress,
-  getCollectionProgressForUser,
+  getCollectionCompletionFlagsForUser,
 } from "@/features/collections/lib/collection-progress-repository";
 import { listPublishedStylePresets } from "@/features/style-presets/lib/style-preset-repository";
 import type { StylePresetPublicSummary } from "@/features/style-presets/lib/schema";
@@ -27,9 +27,9 @@ const mockCreateAdminClient =
   createAdminClient as jest.MockedFunction<typeof createAdminClient>;
 const mockGetCollectionProgress =
   getCollectionProgress as jest.MockedFunction<typeof getCollectionProgress>;
-const mockGetCollectionProgressForUser =
-  getCollectionProgressForUser as jest.MockedFunction<
-    typeof getCollectionProgressForUser
+const mockGetCollectionFlagsForUser =
+  getCollectionCompletionFlagsForUser as jest.MockedFunction<
+    typeof getCollectionCompletionFlagsForUser
   >;
 const mockListPublished =
   listPublishedStylePresets as jest.MockedFunction<
@@ -199,15 +199,15 @@ describe("resolveCollectionUnlockContext", () => {
     await resolveCollectionUnlockContext(presets, "user-1", dummyClient);
 
     expect(mockGetCollectionProgress).toHaveBeenCalled();
-    expect(mockGetCollectionProgressForUser).not.toHaveBeenCalled();
+    expect(mockGetCollectionFlagsForUser).not.toHaveBeenCalled();
   });
 
-  it("includeAdminOnly=true は admin対応RPC(admin_only含む)で前提を判定する", async () => {
-    // public 限定 RPC は admin_only の上巻を返さない(空)が、admin対応RPCは返す想定。
+  it("includeAdminOnly=true は admin対応の軽量RPC(admin_only含む)で前提を判定する", async () => {
+    // public 限定 RPC は admin_only の上巻を返さない(空)が、admin対応の軽量関数は返す想定。
     setProgress([]);
-    mockGetCollectionProgressForUser.mockResolvedValue([
+    mockGetCollectionFlagsForUser.mockResolvedValue([
       { categoryKey: "kotowaza_dictionary", isCompleted: true, uniqueOutfitCount: 6 },
-    ] as unknown as Awaited<ReturnType<typeof getCollectionProgressForUser>>);
+    ]);
     setDistinctRpc([{ category_key: "kotowaza_dictionary_2", unique_count: 0 }]);
     const presets = [
       presetSummary(
@@ -223,7 +223,7 @@ describe("resolveCollectionUnlockContext", () => {
       { includeAdminOnly: true },
     );
 
-    expect(mockGetCollectionProgressForUser).toHaveBeenCalledWith("user-1", true);
+    expect(mockGetCollectionFlagsForUser).toHaveBeenCalledWith("user-1", true);
     expect(mockGetCollectionProgress).not.toHaveBeenCalled();
     // admin対応RPCが上巻の完走を返すので、前提クリアと判定される。
     expect(ctx.prerequisiteCompletedKeys.has("kotowaza_dictionary")).toBe(true);


### PR DESCRIPTION
## 概要

コレクションの解放ゲートで、**前提カテゴリが `admin_only`（公開前）だと、admin が完走しても解放されない**問題を修正します。

例：ことわざ辞典 **上巻**（`admin_only`）を完走しても、**下巻が解放されず・解放通知も出ない**。

## 原因

前提の完走判定に使う `get_collection_progress()` RPC は `visibility='public'` のカテゴリしか返しません。一方、presets 一覧側は admin に対して `admin_only` も含めて出しています。この**配線の非対称**により、admin_only の前提（上巻）の完走が解放判定に反映されませんでした。

## 修正

`resolveCollectionUnlockContext` と `authorizeStylePresetUnlock` に `includeAdminOnly` を通し、**admin のときは admin対応RPC `get_collection_progress_for_user(include_admin_only=true)`** で前提完走を判定します（この RPC は admin プレビュー用に既存）。

- 反映経路（すべて既に admin フラグを保持）：
  - 表示ゲート：`StylePageBody`（/style）・`CachedHomeStylePresetSection`（ホーム）
  - 解放通知：`app/api/collections/unlock-announcements`
  - 生成認可：`authorizeStylePresetUnlock`（generate-async は既に `includeAdminOnly` を渡済み）
- **一般ユーザーの挙動は完全に不変**（デフォルト = public 限定のまま）。admin（env の ADMIN_USER_IDS）だけが admin_only の前提を認識
- 本番公開（`public`）時も従来どおり動作

## 効果

admin_only のまま、上巻完走 → **下巻の解放・解放通知・下巻の生成**をプレビュー検証できるようになります。

## 検証

- `npm run lint`（対象クリーン）／`npm run typecheck`（非testで新規エラー無し）
- `npm run test`（2397 passed／unlock-server テストに admin経路の2ケース追加）
- `npm run build -- --webpack`（成功）

マージ方式: **Squash and merge**