### PR TITLE
fix(collections): 完走モーダルの「シェアページへ」でモーダルを閉じる

### DIFF
--- a/features/collections/components/CollectionProgressModal.tsx
+++ b/features/collections/components/CollectionProgressModal.tsx
@@ -614,6 +614,7 @@ export function CollectionProgressModal({
             {celebration.sharePath ? (
               <Link
                 href={celebration.sharePath}
+                onClick={onClose}
                 className="block w-full rounded-full bg-gradient-to-r from-amber-400 to-orange-500 px-6 py-3 text-center text-base font-bold text-white shadow-[0_4px_0_rgba(234,88,12,0.4)] transition-transform hover:-translate-y-0.5"
               >
                 シェアページへ

--- a/tests/unit/features/collections/collection-progress-modal.test.tsx
+++ b/tests/unit/features/collections/collection-progress-modal.test.tsx
@@ -107,12 +107,15 @@ const completedCelebration: CollectionCelebration = {
   collectedImageUrls: [],
 };
 
-function renderModal(celebration: CollectionCelebration) {
+function renderModal(
+  celebration: CollectionCelebration,
+  onClose: () => void = jest.fn(),
+) {
   return render(
     <CollectionProgressModal
       open
       celebration={celebration}
-      onClose={jest.fn()}
+      onClose={onClose}
     />,
   );
 }
@@ -167,6 +170,14 @@ describe("CollectionProgressModal: 完了ビューのシェア (PC)", () => {
 
     const link = screen.getByRole("link", { name: "シェアページへ" });
     expect(link).toHaveAttribute("href", "/m/completion-1");
+  });
+
+  test("「シェアページへ」クリックで onClose が呼ばれモーダルを閉じる", () => {
+    const onClose = jest.fn();
+    renderModal(completedCelebration, onClose);
+
+    fireEvent.click(screen.getByRole("link", { name: "シェアページへ" }));
+    expect(onClose).toHaveBeenCalled();
   });
 
   test("completionId が null ならシェアメニューを出さない", () => {


### PR DESCRIPTION
## 概要

コンプリートカードの完走モーダルで「**シェアページへ**」を押すと、シェアページへ遷移してもモーダルが残ったままになっていた問題を修正します。

## 原因・修正

- 「シェアページへ」の `Link` に `onClick={onClose}` が無かった（同モーダル内の「遊び方をみる」等には付いている）
- `onClick={onClose}` を追加し、遷移時にモーダルを閉じる
- クリックで `onClose` が呼ばれることを検証するテストを追加

## 検証

- `npm run lint`（対象クリーン）／`npm run typecheck`（非testで新規エラー無し）
- `npm run test`（モーダルテスト 20 passed）／`npm run build -- --webpack`（成功）

マージ方式: **Squash and merge**