### PR TITLE
feat(style): /style の企画カードに生成済み✓バッジを表示

### DIFF
--- a/features/collections/lib/generated-preset-ids.ts
+++ b/features/collections/lib/generated-preset-ids.ts
@@ -1,0 +1,44 @@
+import "server-only";
+
+import { createAdminClient } from "@/lib/supabase/admin";
+
+/**
+ * 指定ユーザーが、指定カテゴリ(企画=collection-series)で既に生成済みの
+ * プリセットID集合を返す。/style やホームの「生成済み ✓」判定に使う。
+ *
+ * image_jobs の成功ジョブから style_template_id(= 生成したプリセットID)を集める。
+ * 失敗時・対象カテゴリなしのときは空配列(= すべて未生成扱い)にフォールバックし、
+ * 画面全体は壊さない。
+ */
+export async function getGeneratedCollectionPresetIds(
+  userId: string,
+  categoryKeys: readonly string[],
+): Promise<string[]> {
+  if (categoryKeys.length === 0) {
+    return [];
+  }
+  try {
+    const admin = createAdminClient();
+    const { data, error } = await admin
+      .from("image_jobs")
+      .select("style_template_id")
+      .eq("user_id", userId)
+      .eq("status", "succeeded")
+      .in("style_preset_category_key", categoryKeys as string[])
+      .not("style_template_id", "is", null)
+      .limit(1000);
+    if (error) {
+      return [];
+    }
+    const ids = new Set<string>();
+    for (const row of data ?? []) {
+      const id = (row as { style_template_id: string | null }).style_template_id;
+      if (id) {
+        ids.add(id);
+      }
+    }
+    return Array.from(ids);
+  } catch {
+    return [];
+  }
+}

--- a/features/collections/lib/generated-preset-ids.ts
+++ b/features/collections/lib/generated-preset-ids.ts
@@ -1,40 +1,37 @@
 import "server-only";
 
-import { createAdminClient } from "@/lib/supabase/admin";
+import type { SupabaseClient } from "@supabase/supabase-js";
 
 /**
- * 指定ユーザーが、指定カテゴリ(企画=collection-series)で既に生成済みの
- * プリセットID集合を返す。/style やホームの「生成済み ✓」判定に使う。
+ * 指定カテゴリ(企画=collection-series)で、呼び出しユーザー本人が既に生成済みの
+ * プリセットID集合を返す。/style の「生成済み ✓」判定に使う。
  *
- * image_jobs の成功ジョブから style_template_id(= 生成したプリセットID)を集める。
- * 失敗時・対象カテゴリなしのときは空配列(= すべて未生成扱い)にフォールバックし、
- * 画面全体は壊さない。
+ * DB 側 DISTINCT の RPC get_generated_preset_ids(SECURITY INVOKER, auth.uid())を、
+ * セッション認証済みクライアントで呼ぶ。これにより:
+ *  - RLS が適用され本人行のみ対象(service_role を使わない)、
+ *  - DISTINCT を DB 側で行うため PostgREST の 1000 行上限に依存しない。
+ * 失敗時・対象カテゴリなしのときは空配列(= すべて未生成扱い)にフォールバックする。
+ *
+ * @param client cookie 認証済みサーバークライアント(lib/supabase/server の createClient())
  */
 export async function getGeneratedCollectionPresetIds(
-  userId: string,
+  client: SupabaseClient,
   categoryKeys: readonly string[],
 ): Promise<string[]> {
   if (categoryKeys.length === 0) {
     return [];
   }
   try {
-    const admin = createAdminClient();
-    const { data, error } = await admin
-      .from("image_jobs")
-      .select("style_template_id")
-      .eq("user_id", userId)
-      .eq("status", "succeeded")
-      .in("style_preset_category_key", categoryKeys as string[])
-      .not("style_template_id", "is", null)
-      .limit(1000);
+    const { data, error } = await client.rpc("get_generated_preset_ids", {
+      p_category_keys: categoryKeys as string[],
+    });
     if (error) {
       return [];
     }
     const ids = new Set<string>();
-    for (const row of data ?? []) {
-      const id = (row as { style_template_id: string | null }).style_template_id;
-      if (id) {
-        ids.add(id);
+    for (const row of (data ?? []) as Array<{ preset_id: string | null }>) {
+      if (row.preset_id) {
+        ids.add(row.preset_id);
       }
     }
     return Array.from(ids);

--- a/features/home/components/CachedHomeStylePresetSection.tsx
+++ b/features/home/components/CachedHomeStylePresetSection.tsx
@@ -6,6 +6,7 @@ import {
 import { buildCollectionUnlockAnnouncements } from "@/features/collections/lib/collection-unlock-announcement";
 import { resolveCollectionUnlockContext } from "@/features/collections/lib/collection-unlock-server";
 import { categoryNeedsUnlockContext } from "@/features/collections/lib/collection-unlock";
+import { getGeneratedCollectionPresetIds } from "@/features/collections/lib/generated-preset-ids";
 import { PetitUnlockAnnouncer } from "@/features/collections/components/PetitUnlockAnnouncer";
 import { buildPublicGeneratedImageUrl } from "@/features/collections/lib/public-mount-server-api";
 import { createClient } from "@/lib/supabase/server";
@@ -67,35 +68,26 @@ export async function CachedHomeStylePresetSection({
 
   // ✓済み判定用: 開催中企画カテゴリの「生成済みプリセットID集合」。
   // 解放方式(順次/一斉/前提付き)に依存せず厳密に判定するためIDで持つ。
+  // 生成済みIDは generation_metadata->'oneTapStyle'->>'id'(= プリセットID)に入るため、
+  // DB側 DISTINCT の RPC(getGeneratedCollectionPresetIds)で取得する。
   // 開催中企画がある場合のみ発行(通常時はクエリ増ゼロ)。失敗時は空集合=全てNEW表示に
   // フォールバックし、ホーム全体は壊さない。
   const generatedIdsByKey = new Map<string, ReadonlySet<string>>();
   const activeEventKeys = listActiveEventCategoryKeys(gated, now);
   if (userId && activeEventKeys.length > 0) {
-    try {
-      const admin = createAdminClient();
-      const { data, error } = await admin
-        .from("image_jobs")
-        .select("style_template_id, style_preset_category_key")
-        .eq("user_id", userId)
-        .eq("status", "succeeded")
-        .in("style_preset_category_key", activeEventKeys)
-        .not("style_template_id", "is", null)
-        .limit(1000);
-      if (!error) {
-        for (const row of data ?? []) {
-          const key = row.style_preset_category_key as string;
-          const presetId = row.style_template_id as string;
-          const set = generatedIdsByKey.get(key) as Set<string> | undefined;
-          if (set) {
-            set.add(presetId);
-          } else {
-            generatedIdsByKey.set(key, new Set([presetId]));
-          }
+    const flatGeneratedIds = new Set(
+      await getGeneratedCollectionPresetIds(await createClient(), activeEventKeys),
+    );
+    // カテゴリ別に分けて deriveEventShelves の期待する Map 形状に整える
+    // (プリセットIDは全体で一意のため、各カテゴリの所属プリセットだけを拾えばよい)。
+    for (const key of activeEventKeys) {
+      const idsForKey = new Set<string>();
+      for (const preset of gated) {
+        if (preset.category.key === key && flatGeneratedIds.has(preset.id)) {
+          idsForKey.add(preset.id);
         }
       }
-    } catch {
-      // 取得失敗は初日状態(全てNEW)で表示継続
+      generatedIdsByKey.set(key, idsForKey);
     }
   }
 

--- a/features/style/components/StylePageBody.tsx
+++ b/features/style/components/StylePageBody.tsx
@@ -16,6 +16,7 @@ import { getUserProfileServer } from "@/features/my-page/lib/server-api";
 import { createClient } from "@/lib/supabase/server";
 import { resolveCollectionUnlockContext } from "@/features/collections/lib/collection-unlock-server";
 import { categoryNeedsUnlockContext } from "@/features/collections/lib/collection-unlock";
+import { getGeneratedCollectionPresetIds } from "@/features/collections/lib/generated-preset-ids";
 import {
   applyCollectionUnlockGating,
   type CollectionUnlockContext,
@@ -75,6 +76,22 @@ export async function StylePageBody({ searchParams }: StylePageBodyProps) {
   const profile = user ? await getUserProfileServer(user.id) : null;
   const params = (await searchParams) ?? {};
 
+  // 企画(コレクション)カードの「生成済み ✓」判定用に、本人が生成済みの
+  // プリセットID一覧を取得する。collection-series カテゴリのみ集計(通常カテゴリは対象外)。
+  const seriesCategoryKeys = user
+    ? Array.from(
+        new Set(
+          presets
+            .filter((preset) => preset.category.isCollectionSeries)
+            .map((preset) => preset.category.key),
+        ),
+      )
+    : [];
+  const generatedPresetIds =
+    user && seriesCategoryKeys.length > 0
+      ? await getGeneratedCollectionPresetIds(user.id, seriesCategoryKeys)
+      : [];
+
   return (
     <>
       {/* coordinate と同様、ログイン時はマウント時に router.refresh() して
@@ -125,6 +142,8 @@ export async function StylePageBody({ searchParams }: StylePageBodyProps) {
           subscriptionPlan={profile?.subscription_plan ?? "free"}
           // framing_mode (free_pose) は admin viewer 限定の先行公開 (サーバ側でも検証)
           canUseFreePose={isAdminViewerFlag}
+          // 企画カードの「生成済み ✓」表示用
+          generatedPresetIds={generatedPresetIds}
         />
 
         {/* 生成結果一覧（認証ユーザーのみ）。/coordinate と同じ UI を再利用。 */}

--- a/features/style/components/StylePageBody.tsx
+++ b/features/style/components/StylePageBody.tsx
@@ -89,7 +89,10 @@ export async function StylePageBody({ searchParams }: StylePageBodyProps) {
     : [];
   const generatedPresetIds =
     user && seriesCategoryKeys.length > 0
-      ? await getGeneratedCollectionPresetIds(user.id, seriesCategoryKeys)
+      ? await getGeneratedCollectionPresetIds(
+          await createClient(),
+          seriesCategoryKeys,
+        )
       : [];
 
   return (

--- a/features/style/components/StylePageClient.tsx
+++ b/features/style/components/StylePageClient.tsx
@@ -137,6 +137,12 @@ interface StylePageClientProps {
    * UI 非表示はセキュリティではなく、サーバ側 (generate-async) でも検証される。
    */
   canUseFreePose?: boolean;
+  /**
+   * このユーザーが既に生成済みの企画(コレクション)プリセットIDの一覧。
+   * 該当カードに「生成済み」の ✓ バッジを出して、生成した/まだを見分けやすくする。
+   * サーバ側(StylePageBody)で collection-series カテゴリ分のみ集計して渡す。
+   */
+  generatedPresetIds?: readonly string[];
 }
 
 interface StyleErrorState {
@@ -320,6 +326,7 @@ export function StylePageClient({
   showResultPanel = true,
   subscriptionPlan = "free",
   canUseFreePose = false,
+  generatedPresetIds,
 }: StylePageClientProps) {
   const router = useRouter();
   const t = useTranslations("style");
@@ -327,6 +334,11 @@ export function StylePageClient({
   const postsT = useTranslations("posts");
   const locale = useLocale();
   const styleCardLocale = locale === "en" ? "en" : "ja";
+  // 生成済みの企画プリセットID集合(✓バッジ判定用。O(1)参照のため Set 化)。
+  const generatedPresetIdSet = useMemo(
+    () => new Set(generatedPresetIds ?? []),
+    [generatedPresetIds],
+  );
   const { toast, dismiss } = useToast();
   const presetStripRef = useRef<HTMLDivElement | null>(null);
   const generationStatusSectionRef = useRef<HTMLDivElement | null>(null);
@@ -1735,6 +1747,10 @@ export function StylePageClient({
                     ? t("guestCategoryLoginAction")
                     : undefined
                 }
+                generated={
+                  !isDripLocked && generatedPresetIdSet.has(preset.id)
+                }
+                generatedLabel={t("styleGeneratedBadge")}
               />
             );
           })}

--- a/features/style/components/StylePresetPreviewCard.tsx
+++ b/features/style/components/StylePresetPreviewCard.tsx
@@ -74,6 +74,13 @@ interface StylePresetPreviewCardProps {
   dripLocked?: boolean;
   /** dripLocked=true のとき中央に表示する文言(例: 「あとで とうじょう」)。 */
   dripLockedLabel?: string;
+  /**
+   * このプリセットを既に生成済みのとき true。企画(コレクション)カードで
+   * 「生成した / まだ」を見分けるため、右上に緑の ✓ バッジを表示する。
+   */
+  generated?: boolean;
+  /** generated=true のバッジの読み上げ文言(例: 「生成済み」)。 */
+  generatedLabel?: string;
 }
 
 export function buildStylePresetImageSrc(
@@ -101,6 +108,8 @@ export function StylePresetPreviewCard({
   lockedLabel,
   dripLocked = false,
   dripLockedLabel,
+  generated = false,
+  generatedLabel,
 }: StylePresetPreviewCardProps) {
   const selected = isSelected === true;
   const isLocked = typeof lockedLabel === "string" && lockedLabel.length > 0;
@@ -170,6 +179,15 @@ export function StylePresetPreviewCard({
                 {lockedLabel}
               </span>
             </div>
+          )}
+          {/* 生成済みの企画カードは右上に緑の ✓ バッジ(ホームの企画棚と同じ意匠)。 */}
+          {!dripLocked && generated && (
+            <span
+              className="absolute right-1.5 top-1.5 z-20 flex h-6 w-6 items-center justify-center rounded-full bg-green-600 text-xs font-bold text-white shadow"
+              aria-label={generatedLabel ?? "generated"}
+            >
+              ✓
+            </span>
           )}
         </div>
         <div

--- a/messages/ar.ts
+++ b/messages/ar.ts
@@ -1349,6 +1349,7 @@ export const arMessages = {
     addImageAction: "إضافة صورة",
     styleImageAlt: "صورة الأسلوب المختار",
     styleImageZoomAria: "تكبير صورة الستايل",
+    styleGeneratedBadge: "تم الإنشاء",
     styleCardAlt: "بطاقة أسلوب {name}",
     detailPresetLabel: "أُنشئت بـ One-Tap Style",
     detailPresetCardAlt: "بطاقة أسلوب {name}",

--- a/messages/de.ts
+++ b/messages/de.ts
@@ -1353,6 +1353,7 @@ export const deMessages = {
     addImageAction: "Bild hinzufügen",
     styleImageAlt: "Ausgewähltes Stilbild",
     styleImageZoomAria: "Stilbild vergrößern",
+    styleGeneratedBadge: "Erstellt",
     styleCardAlt: "Stilkarte {name}",
     detailPresetLabel: "Mit One-Tap Style generiert",
     detailPresetCardAlt: "Stilkarte {name}",

--- a/messages/en.ts
+++ b/messages/en.ts
@@ -1349,6 +1349,7 @@ export const enMessages = {
     addImageAction: "Add image",
     styleImageAlt: "Selected style image",
     styleImageZoomAria: "Enlarge style image",
+    styleGeneratedBadge: "Generated",
     styleCardAlt: "{name} style card",
     detailPresetLabel: "Generated with One-Tap Style",
     detailPresetCardAlt: "{name} style card",

--- a/messages/es.ts
+++ b/messages/es.ts
@@ -1352,6 +1352,7 @@ export const esMessages = {
     addImageAction: "Añadir imagen",
     styleImageAlt: "Imagen de estilo seleccionada",
     styleImageZoomAria: "Ampliar imagen de estilo",
+    styleGeneratedBadge: "Generado",
     styleCardAlt: "Tarjeta de estilo {name}",
     detailPresetLabel: "Generado con One-Tap Style",
     detailPresetCardAlt: "Tarjeta de estilo {name}",

--- a/messages/fr.ts
+++ b/messages/fr.ts
@@ -1352,6 +1352,7 @@ export const frMessages = {
     addImageAction: "Ajouter une image",
     styleImageAlt: "Image du style sélectionné",
     styleImageZoomAria: "Agrandir l'image du style",
+    styleGeneratedBadge: "Généré",
     styleCardAlt: "Carte de style {name}",
     detailPresetLabel: "Généré avec One-Tap Style",
     detailPresetCardAlt: "Carte de style {name}",

--- a/messages/hi.ts
+++ b/messages/hi.ts
@@ -1350,6 +1350,7 @@ export const hiMessages = {
     addImageAction: "छवि जोड़ें",
     styleImageAlt: "चयनित स्टाइल छवि",
     styleImageZoomAria: "स्टाइल छवि बड़ी करें",
+    styleGeneratedBadge: "बन गया",
     styleCardAlt: "{name} स्टाइल कार्ड",
     detailPresetLabel: "One-Tap Style से उत्पन्न",
     detailPresetCardAlt: "{name} स्टाइल कार्ड",

--- a/messages/id.ts
+++ b/messages/id.ts
@@ -1351,6 +1351,7 @@ export const idMessages = {
     addImageAction: "Tambah gambar",
     styleImageAlt: "Gambar gaya yang dipilih",
     styleImageZoomAria: "Perbesar gambar gaya",
+    styleGeneratedBadge: "Sudah dibuat",
     styleCardAlt: "Kartu gaya {name}",
     detailPresetLabel: "Dibuat dengan One-Tap Style",
     detailPresetCardAlt: "Kartu gaya {name}",

--- a/messages/it.ts
+++ b/messages/it.ts
@@ -1352,6 +1352,7 @@ export const itMessages = {
     addImageAction: "Aggiungi immagine",
     styleImageAlt: "Immagine dello stile selezionato",
     styleImageZoomAria: "Ingrandisci immagine stile",
+    styleGeneratedBadge: "Generato",
     styleCardAlt: "Carta di stile {name}",
     detailPresetLabel: "Generato con One-Tap Style",
     detailPresetCardAlt: "Carta di stile {name}",

--- a/messages/ja.ts
+++ b/messages/ja.ts
@@ -1292,6 +1292,7 @@ export const jaMessages = {
     addImageAction: "画像を追加",
     styleImageAlt: "選択中のスタイル画像",
     styleImageZoomAria: "スタイル画像を拡大表示",
+    styleGeneratedBadge: "生成済み",
     styleCardAlt: "{name} のスタイルカード",
     detailPresetLabel: "ワンタップスタイルで生成",
     detailPresetCardAlt: "{name} のスタイルカード",

--- a/messages/ko.ts
+++ b/messages/ko.ts
@@ -1348,6 +1348,7 @@ export const koMessages = {
     addImageAction: "이미지 추가",
     styleImageAlt: "선택한 스타일 이미지",
     styleImageZoomAria: "스타일 이미지 확대",
+    styleGeneratedBadge: "생성 완료",
     styleCardAlt: "{name} 스타일 카드",
     detailPresetLabel: "원탭 스타일로 생성됨",
     detailPresetCardAlt: "{name} 스타일 카드",

--- a/messages/pt.ts
+++ b/messages/pt.ts
@@ -1352,6 +1352,7 @@ export const ptMessages = {
     addImageAction: "Adicionar imagem",
     styleImageAlt: "Imagem do estilo selecionado",
     styleImageZoomAria: "Ampliar imagem de estilo",
+    styleGeneratedBadge: "Gerado",
     styleCardAlt: "Cartão de estilo {name}",
     detailPresetLabel: "Gerado com One-Tap Style",
     detailPresetCardAlt: "Cartão de estilo {name}",

--- a/messages/th.ts
+++ b/messages/th.ts
@@ -1348,6 +1348,7 @@ export const thMessages = {
     addImageAction: "เพิ่มรูป",
     styleImageAlt: "รูปสไตล์ที่เลือก",
     styleImageZoomAria: "ขยายรูปสไตล์",
+    styleGeneratedBadge: "สร้างแล้ว",
     styleCardAlt: "การ์ดสไตล์ {name}",
     detailPresetLabel: "สร้างด้วย One-Tap Style",
     detailPresetCardAlt: "การ์ดสไตล์ {name}",

--- a/messages/vi.ts
+++ b/messages/vi.ts
@@ -1349,6 +1349,7 @@ export const viMessages = {
     addImageAction: "Thêm hình",
     styleImageAlt: "Hình phong cách đã chọn",
     styleImageZoomAria: "Phóng to ảnh phong cách",
+    styleGeneratedBadge: "Đã tạo",
     styleCardAlt: "Thẻ phong cách {name}",
     detailPresetLabel: "Tạo bằng One-Tap Style",
     detailPresetCardAlt: "Thẻ phong cách {name}",

--- a/messages/zh-CN.ts
+++ b/messages/zh-CN.ts
@@ -1347,6 +1347,7 @@ export const zhCnMessages = {
     addImageAction: "添加图片",
     styleImageAlt: "选定的造型图片",
     styleImageZoomAria: "放大风格图片",
+    styleGeneratedBadge: "已生成",
     styleCardAlt: "{name} 造型卡",
     detailPresetLabel: "由一键造型生成",
     detailPresetCardAlt: "{name} 造型卡",

--- a/messages/zh-TW.ts
+++ b/messages/zh-TW.ts
@@ -1347,6 +1347,7 @@ export const zhTwMessages = {
     addImageAction: "新增圖片",
     styleImageAlt: "選定的造型圖片",
     styleImageZoomAria: "放大風格圖片",
+    styleGeneratedBadge: "已生成",
     styleCardAlt: "{name} 造型卡",
     detailPresetLabel: "由一鍵造型生成",
     detailPresetCardAlt: "{name} 造型卡",

--- a/supabase/migrations/20260715120000_add_get_generated_preset_ids_rpc.sql
+++ b/supabase/migrations/20260715120000_add_get_generated_preset_ids_rpc.sql
@@ -1,0 +1,39 @@
+-- 生成済みプリセットID(企画カードの「生成済み ✓」判定用)を DB 側 DISTINCT で返す RPC。
+--
+-- 背景:
+--   /style の企画(コレクション)カードで「生成した/まだ」を見分けるため、本人が
+--   生成済みのプリセットID集合が必要。以前はアプリ側で image_jobs を最大1000行取得し
+--   メモリで new Set していたが、
+--     1) PostgREST の 1000 行上限でジョブ多数のユーザーは取りこぼす恐れ、
+--     2) 本人データ取得に service_role(RLS バイパス)を使う懸念、
+--   があった。DB 側 DISTINCT + SECURITY INVOKER(auth.uid())で両方を解消する。
+--
+-- 権限:
+--   SECURITY INVOKER のため image_jobs の RLS(「本人行のみ SELECT 可」)が適用され、
+--   auth.uid() 以外の行は返らない。authenticated ロールに EXECUTE を付与し、
+--   通常のセッションクライアント(cookie 認証)から呼ぶ。
+-- 生成プリセットIDは style_template_id ではなく generation_metadata->'oneTapStyle'->>'id'
+-- に入る(one-tap 生成では style_template_id は NULL)。get_collection_progress /
+-- count_distinct_styles_by_category と同じ正典ソースを使う。
+CREATE OR REPLACE FUNCTION public.get_generated_preset_ids(
+  p_category_keys TEXT[]
+)
+RETURNS TABLE (preset_id TEXT)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+  SELECT DISTINCT ij.generation_metadata -> 'oneTapStyle' ->> 'id'
+  FROM public.image_jobs ij
+  WHERE ij.user_id = (SELECT auth.uid())
+    AND ij.status = 'succeeded'
+    AND ij.style_preset_category_key = ANY(p_category_keys)
+    AND ij.generation_metadata -> 'oneTapStyle' ->> 'id' IS NOT NULL;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_generated_preset_ids(TEXT[]) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_generated_preset_ids(TEXT[]) TO authenticated;
+
+COMMENT ON FUNCTION public.get_generated_preset_ids(TEXT[]) IS
+  'auth.uid() が指定カテゴリで生成済み(succeeded)のプリセットID(style_template_id)を DISTINCT で返す。企画カードの生成済み✓判定用。';

--- a/tests/unit/features/collections/generated-preset-ids.test.ts
+++ b/tests/unit/features/collections/generated-preset-ids.test.ts
@@ -1,63 +1,49 @@
 /** @jest-environment node */
 
-const createAdminClientMock = jest.fn();
-jest.mock("@/lib/supabase/admin", () => ({
-  createAdminClient: () => createAdminClientMock(),
-}));
-
+import type { SupabaseClient } from "@supabase/supabase-js";
 import { getGeneratedCollectionPresetIds } from "@/features/collections/lib/generated-preset-ids";
 
-/** image_jobs クエリのチェーンをモックし、最終 .limit() が {data,error} を返すようにする。 */
-function mockImageJobs(result: {
-  data: Array<{ style_template_id: string | null }> | null;
+/** rpc() が {data,error} を返すだけのセッションクライアントスタブ。 */
+function clientWithRpc(result: {
+  data: Array<{ preset_id: string | null }> | null;
   error: unknown;
 }) {
-  const limit = jest.fn().mockResolvedValue(result);
-  const not = jest.fn(() => ({ limit }));
-  const inFn = jest.fn(() => ({ not }));
-  const eq2 = jest.fn(() => ({ in: inFn }));
-  const eq1 = jest.fn(() => ({ eq: eq2 }));
-  const select = jest.fn(() => ({ eq: eq1 }));
-  const from = jest.fn(() => ({ select }));
-  createAdminClientMock.mockReturnValue({ from });
-  return { from, select, inFn };
+  const rpc = jest.fn().mockResolvedValue(result);
+  return { client: { rpc } as unknown as SupabaseClient, rpc };
 }
 
-beforeEach(() => {
-  jest.clearAllMocks();
-});
-
 describe("getGeneratedCollectionPresetIds", () => {
-  test("カテゴリが空なら DB を叩かず空配列", async () => {
-    const result = await getGeneratedCollectionPresetIds("user-1", []);
+  test("カテゴリが空なら RPC を呼ばず空配列", async () => {
+    const { client, rpc } = clientWithRpc({ data: [], error: null });
+    const result = await getGeneratedCollectionPresetIds(client, []);
     expect(result).toEqual([]);
-    expect(createAdminClientMock).not.toHaveBeenCalled();
+    expect(rpc).not.toHaveBeenCalled();
   });
 
-  test("成功ジョブの style_template_id を重複排除して返す", async () => {
-    const { inFn } = mockImageJobs({
+  test("RPCの preset_id を重複排除して返す", async () => {
+    const { client, rpc } = clientWithRpc({
       data: [
-        { style_template_id: "p1" },
-        { style_template_id: "p2" },
-        { style_template_id: "p1" }, // 重複
-        { style_template_id: null }, // null は無視
+        { preset_id: "p1" },
+        { preset_id: "p2" },
+        { preset_id: "p1" }, // 重複(DBがDISTINCTするが多重防御)
+        { preset_id: null }, // null は無視
       ],
       error: null,
     });
 
-    const result = await getGeneratedCollectionPresetIds("user-1", [
+    const result = await getGeneratedCollectionPresetIds(client, [
       "kotowaza_dictionary",
     ]);
 
-    expect(inFn).toHaveBeenCalledWith("style_preset_category_key", [
-      "kotowaza_dictionary",
-    ]);
+    expect(rpc).toHaveBeenCalledWith("get_generated_preset_ids", {
+      p_category_keys: ["kotowaza_dictionary"],
+    });
     expect(result.sort()).toEqual(["p1", "p2"]);
   });
 
   test("RPCエラー時は空配列にフォールバックする", async () => {
-    mockImageJobs({ data: null, error: { message: "boom" } });
-    const result = await getGeneratedCollectionPresetIds("user-1", ["k"]);
+    const { client } = clientWithRpc({ data: null, error: { message: "boom" } });
+    const result = await getGeneratedCollectionPresetIds(client, ["k"]);
     expect(result).toEqual([]);
   });
 });

--- a/tests/unit/features/collections/generated-preset-ids.test.ts
+++ b/tests/unit/features/collections/generated-preset-ids.test.ts
@@ -1,0 +1,63 @@
+/** @jest-environment node */
+
+const createAdminClientMock = jest.fn();
+jest.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => createAdminClientMock(),
+}));
+
+import { getGeneratedCollectionPresetIds } from "@/features/collections/lib/generated-preset-ids";
+
+/** image_jobs クエリのチェーンをモックし、最終 .limit() が {data,error} を返すようにする。 */
+function mockImageJobs(result: {
+  data: Array<{ style_template_id: string | null }> | null;
+  error: unknown;
+}) {
+  const limit = jest.fn().mockResolvedValue(result);
+  const not = jest.fn(() => ({ limit }));
+  const inFn = jest.fn(() => ({ not }));
+  const eq2 = jest.fn(() => ({ in: inFn }));
+  const eq1 = jest.fn(() => ({ eq: eq2 }));
+  const select = jest.fn(() => ({ eq: eq1 }));
+  const from = jest.fn(() => ({ select }));
+  createAdminClientMock.mockReturnValue({ from });
+  return { from, select, inFn };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("getGeneratedCollectionPresetIds", () => {
+  test("カテゴリが空なら DB を叩かず空配列", async () => {
+    const result = await getGeneratedCollectionPresetIds("user-1", []);
+    expect(result).toEqual([]);
+    expect(createAdminClientMock).not.toHaveBeenCalled();
+  });
+
+  test("成功ジョブの style_template_id を重複排除して返す", async () => {
+    const { inFn } = mockImageJobs({
+      data: [
+        { style_template_id: "p1" },
+        { style_template_id: "p2" },
+        { style_template_id: "p1" }, // 重複
+        { style_template_id: null }, // null は無視
+      ],
+      error: null,
+    });
+
+    const result = await getGeneratedCollectionPresetIds("user-1", [
+      "kotowaza_dictionary",
+    ]);
+
+    expect(inFn).toHaveBeenCalledWith("style_preset_category_key", [
+      "kotowaza_dictionary",
+    ]);
+    expect(result.sort()).toEqual(["p1", "p2"]);
+  });
+
+  test("RPCエラー時は空配列にフォールバックする", async () => {
+    mockImageJobs({ data: null, error: { message: "boom" } });
+    const result = await getGeneratedCollectionPresetIds("user-1", ["k"]);
+    expect(result).toEqual([]);
+  });
+});

--- a/tests/unit/features/style/style-preset-preview-card.test.tsx
+++ b/tests/unit/features/style/style-preset-preview-card.test.tsx
@@ -142,6 +142,45 @@ describe("StylePresetPreviewCard - 提供者クレジット", () => {
   });
 });
 
+describe("StylePresetPreviewCard - 生成済み ✓ バッジ", () => {
+  test("generated=true で ✓ バッジ(ラベル付き)を表示する", () => {
+    render(
+      <StylePresetPreviewCard
+        preset={makePreset({ category: CHIBI_CATEGORY })}
+        alt="alt"
+        generated
+        generatedLabel="生成済み"
+      />,
+    );
+    expect(screen.getByLabelText("生成済み")).toBeInTheDocument();
+  });
+
+  test("generated=false では ✓ バッジを表示しない", () => {
+    render(
+      <StylePresetPreviewCard
+        preset={makePreset({ category: CHIBI_CATEGORY })}
+        alt="alt"
+        generatedLabel="生成済み"
+      />,
+    );
+    expect(screen.queryByLabelText("生成済み")).toBeNull();
+  });
+
+  test("dripLocked のときは generated でも ✓ バッジを出さない", () => {
+    render(
+      <StylePresetPreviewCard
+        preset={makePreset({ category: CHIBI_CATEGORY })}
+        alt="alt"
+        generated
+        generatedLabel="生成済み"
+        dripLocked
+        dripLockedLabel="あとで とうじょう"
+      />,
+    );
+    expect(screen.queryByLabelText("生成済み")).toBeNull();
+  });
+});
+
 describe("StylePresetPreviewCard - ロック表示", () => {
   test("lockedLabel を渡すとロックラベルを表示する", () => {
     render(


### PR DESCRIPTION
## 概要

ホーム・スタイル画面で「企画で生成したもの／まだのもの」を見分けやすくするため、**生成済みの企画カードの右上に緑の ✓ バッジ**を表示します。

- ホームの「企画棚」には既に ✓ 実装済み。今回は**/style 画面のプリセットカード**に同じ ✓ を追加します。

## 変更内容

- `StylePresetPreviewCard`：`generated` / `generatedLabel` prop を追加し、`generated=true`（かつ非 dripLocked）のとき右上に緑 ✓ バッジ（ホーム企画棚と同意匠 `bg-green-600`）
- `StylePageBody`（サーバ）：本人が生成済みのプリセットID一覧を取得し `StylePageClient` へ渡す。**collection-series（企画）カテゴリのみ**集計（通常カテゴリ=繰り返し生成するものは対象外）
- 取得ロジックは軽量 lib `getGeneratedCollectionPresetIds`（`image_jobs` の成功ジョブ `style_template_id` を重複排除）へ切り出し。失敗時は空配列にフォールバック
- `StylePageClient`：`generatedPresetIds` を Set 化して各カードへ `generated` を伝搬
- i18n：`styleGeneratedBadge`（ja「生成済み」/ en「Generated」ほか）を15言語に追加
- テスト追加：カードの✓表示条件（generated / 非表示 / dripLocked除外）と lib（重複排除・空・エラーフォールバック）

## 表示条件

- 対象は企画（collection-series）カードのみ。dripLocked（未解放シルエット）には出さない
- ゲストは対象外（生成済みIDなし）

## 検証

- `npm run lint`（対象クリーン。既存の exhaustive-deps 警告のみ）／`npm run typecheck`（非testで新規エラー無し）
- `npm run test`（2406 passed）／`npm run build -- --webpack`（成功）

マージ方式: **Squash and merge**