### PR TITLE
fix(home): 企画棚の生成済みカードの減光をやめ✓バッジのみにする

### DIFF
--- a/features/home/components/HomeEventShelfSection.tsx
+++ b/features/home/components/HomeEventShelfSection.tsx
@@ -318,16 +318,14 @@ export function HomeEventShelfSection({
     if (card.kind === "done") {
       return (
         <div className="relative">
-          <div className="opacity-65">
-            <StylePresetPreviewCard
-              preset={preset}
-              // ステータス(生成済み)を alt に前置し、視覚バッジは aria-hidden にして
-              // スクリーンリーダーへ二重読み上げにならないようにする。
-              alt={`${t("eventShelfDoneBadge")} - ${tStyle("styleCardAlt", { name: preset.title })}`}
-              locale={cardLocale}
-              onClick={() => setConfirmingPreset(preset)}
-            />
-          </div>
+          <StylePresetPreviewCard
+            preset={preset}
+            // ステータス(生成済み)を alt に前置し、視覚バッジは aria-hidden にして
+            // スクリーンリーダーへ二重読み上げにならないようにする。
+            alt={`${t("eventShelfDoneBadge")} - ${tStyle("styleCardAlt", { name: preset.title })}`}
+            locale={cardLocale}
+            onClick={() => setConfirmingPreset(preset)}
+          />
           <span
             className="pointer-events-none absolute right-2 top-2 z-10 flex h-6 w-6 items-center justify-center rounded-full bg-green-600 text-xs font-bold text-white shadow"
             aria-hidden="true"


### PR DESCRIPTION
## 概要

ホームの企画棚で、生成済み(done)カードのサムネイルが薄く(`opacity-65`)なっていたのを**やめ**、✓バッジのみで「生成済み」を表現します（/style のカードと同じ見え方に統一）。

## 変更内容

- `HomeEventShelfSection`：done カードの `opacity-65` ラッパを除去（✓バッジは維持）

## 検証

- `npm run lint` / `npm run typecheck`（対象クリーン・新規エラー無し）
- `npm run build -- --webpack`（成功）

マージ方式: **Squash and merge**