### PR TITLE
docs(collections): ことわざLPの完成カード文言を「完成は自分の目で！」に変更

### DIFF
--- a/features/collections/components/KotowazaGuide.tsx
+++ b/features/collections/components/KotowazaGuide.tsx
@@ -512,12 +512,12 @@ export function KotowazaGuide({
                     className="rounded-full px-4 py-1.5 text-xs font-bold text-white shadow"
                     style={{ backgroundColor: SHU, fontFamily: HEADING_FONT }}
                   >
-                    企画スタートでお披露目！
+                    完成は自分の目で！
                   </span>
                 </div>
               </div>
               <p className="mt-3 text-xs" style={{ color: "#9c9184" }}>
-                ＼ 完成イメージはシークレット ／<br />※ 画像はイメージです。実際のカードとはデザイン・収録語が異なります。
+                ＼ 完成はコンプしてのお楽しみ ／<br />※ 画像はイメージです。実際のカードとはデザイン・収録語が異なります。
               </p>
             </div>
           </Reveal>


### PR DESCRIPTION
## 概要

ことわざ辞典LP「そろえたら、特別なカードをGET！」セクションの完成カード（シークレット表示）の文言を、**お披露目しない方針**に合わせて変更します。

## 変更内容

- バッジ：「企画スタートでお披露目！」→ **「完成は自分の目で！」**
- キャプション：「＼ 完成イメージはシークレット ／」→ **「＼ 完成はコンプしてのお楽しみ ／」**
- 「※ 画像はイメージです…」の注記は据え置き

## 検証

- `npm run lint`（対象クリーン）／`npm run build -- --webpack`（成功）

マージ方式: **Squash and merge**