### PR TITLE
fix(collections): ことわざ下巻の遊び方リンクを/collections/kotowazaに

### DIFF
--- a/features/collections/lib/collection-guides.ts
+++ b/features/collections/lib/collection-guides.ts
@@ -9,7 +9,9 @@
  */
 const COLLECTION_GUIDE_PATHS: Record<string, string> = {
   travel_to_italy: "/collections/italy",
+  // ことわざ辞典は上巻/下巻とも同じ遊び方ページを指す。
   kotowaza_dictionary: "/collections/kotowaza",
+  kotowaza_dictionary_2: "/collections/kotowaza",
 };
 
 /** 未登録カテゴリのフォールバック先(神コレの遊び方)。 */

--- a/tests/unit/features/collections/collection-guides.test.ts
+++ b/tests/unit/features/collections/collection-guides.test.ts
@@ -1,0 +1,27 @@
+import {
+  collectionGuidePath,
+  DEFAULT_COLLECTION_GUIDE_PATH,
+} from "@/features/collections/lib/collection-guides";
+
+describe("collectionGuidePath", () => {
+  test("ことわざ辞典 上巻/下巻はどちらも /collections/kotowaza", () => {
+    expect(collectionGuidePath("kotowaza_dictionary")).toBe(
+      "/collections/kotowaza",
+    );
+    expect(collectionGuidePath("kotowaza_dictionary_2")).toBe(
+      "/collections/kotowaza",
+    );
+  });
+
+  test("イタリア旅行は /collections/italy", () => {
+    expect(collectionGuidePath("travel_to_italy")).toBe("/collections/italy");
+  });
+
+  test("未登録カテゴリ・null は神コレのガイドにフォールバック", () => {
+    expect(collectionGuidePath("unknown_category")).toBe(
+      DEFAULT_COLLECTION_GUIDE_PATH,
+    );
+    expect(collectionGuidePath(null)).toBe(DEFAULT_COLLECTION_GUIDE_PATH);
+    expect(collectionGuidePath(undefined)).toBe(DEFAULT_COLLECTION_GUIDE_PATH);
+  });
+});


### PR DESCRIPTION
## 概要

コンプリートモーダルの「遊び方をみる」から、ことわざ辞典**下巻**が神コレの遊び方（`/collections/wafer`）に遷移していた問題を修正します。

## 原因

`collection-guides.ts` の `COLLECTION_GUIDE_PATHS` に **上巻 `kotowaza_dictionary` はあるが、下巻 `kotowaza_dictionary_2` が未登録**だったため、下巻はデフォルト（神コレ）にフォールバックしていました。

## 修正

- `kotowaza_dictionary_2: "/collections/kotowaza"` を追加（上巻/下巻とも同じ遊び方ページ）
- `collectionGuidePath` の分岐テストを追加（上巻/下巻→kotowaza、未登録→フォールバック）

## 検証

- `npm run lint`（対象クリーン）／`npm run test`（追加3ケース pass）／`npm run build -- --webpack`（成功）

マージ方式: **Squash and merge**