### PR TITLE
feat(home): お着替えカルーセルを人気順Top20に絞り込み+基準キャプション追加

### DIFF
--- a/features/home/components/CachedHomeStylePresetSection.tsx
+++ b/features/home/components/CachedHomeStylePresetSection.tsx
@@ -30,6 +30,11 @@ const EMPTY_UNLOCK_CONTEXT: CollectionUnlockContext = {
   distinctGeneratedByCategoryKey: new Map(),
 };
 
+// カルーセルに出す最大枚数。全件(120枚超×ループ用3複製)を並べると
+// ホーム初回表示の DOM/ハイドレーションが重くなるため、人気上位のみに絞る。
+// 全件の探索は「すべて見る」(探索シート)が担う。
+const CAROUSEL_MAX_ITEMS = 20;
+
 /**
  * ホームの Style プリセットセクション。
  * admin は admin_only カテゴリも(公開前プレビュー用に)併せて表示する。
@@ -179,6 +184,14 @@ export async function CachedHomeStylePresetSection({
       .filter(Boolean);
   }
 
+  // カルーセルは直近30日の人気順(生成数降順)で上位のみ表示する。
+  // sort は安定なので同数(未生成含む)は管理画面の並び順(sort_order)を維持する。
+  const carouselPresets = [...presets]
+    .sort(
+      (a, b) => (generateCounts[b.id] ?? 0) - (generateCounts[a.id] ?? 0),
+    )
+    .slice(0, CAROUSEL_MAX_ITEMS);
+
   return (
     <>
       {unlockAnnouncements.length > 0 && (
@@ -193,7 +206,7 @@ export async function CachedHomeStylePresetSection({
         />
       ))}
       <HomeStylePresetCarousel
-        presets={presets}
+        presets={carouselPresets}
         // 探索シートには /style と同じ「解放ゲート適用済みの全プリセット」を渡す
         // (カルーセルと違い locked=シルエットや棚振り分け分も含めて一覧できる)。
         browsePresets={gated}

--- a/features/home/components/HomeStylePresetCarousel.tsx
+++ b/features/home/components/HomeStylePresetCarousel.tsx
@@ -273,9 +273,15 @@ export function HomeStylePresetCarousel({
   return (
     <div ref={containerRef} className="mb-8 overflow-x-hidden">
       <div className="mb-3 flex items-center justify-between gap-3 px-4 sm:px-0">
-        <h2 className="text-lg font-semibold text-gray-900">
-          {tHome("stylePresetCarouselTitle")}
-        </h2>
+        <div>
+          <h2 className="text-lg font-semibold text-gray-900">
+            {tHome("stylePresetCarouselTitle")}
+          </h2>
+          {/* カルーセルは人気順上位のみ表示するため、その基準を薄く添える。 */}
+          <p className="mt-0.5 text-xs text-slate-500">
+            {tHome("stylePresetCarouselCaption")}
+          </p>
+        </div>
         {/* /style の「すべて見る」と同じ見た目。ホームに留まったまま探索シートを開く。 */}
         <button
           type="button"

--- a/messages/ar.ts
+++ b/messages/ar.ts
@@ -1713,6 +1713,7 @@ export const arMessages = {
     subtitle:
       "منصة تنسيق إطلالات بالذكاء الاصطناعي للإطلالات والشخصيات التي تريد إنشاءها.",
     stylePresetCarouselTitle: "غيّر الإطلالات بسهولة!",
+    stylePresetCarouselCaption: "نعرض الستايلات الرائجة أولًا",
     stylePresetConfirmTitle: "هل تريد تجربة هذه؟",
     stylePresetConfirmCancel: "عرض إطلالات أخرى",
     stylePresetConfirmAction: "تجربة",

--- a/messages/de.ts
+++ b/messages/de.ts
@@ -1717,6 +1717,7 @@ export const deMessages = {
     subtitle:
       "Eine KI-Styling-Plattform für die Looks und Charaktere, die du erschaffen willst.",
     stylePresetCarouselTitle: "Outfits wechseln — ganz einfach!",
+    stylePresetCarouselCaption: "Beliebte Stile werden zuerst angezeigt",
     stylePresetConfirmTitle: "Anprobieren?",
     stylePresetConfirmCancel: "Andere Outfits sehen",
     stylePresetConfirmAction: "Anprobieren",

--- a/messages/en.ts
+++ b/messages/en.ts
@@ -1713,6 +1713,7 @@ export const enMessages = {
     subtitle:
       "An AI styling platform for the looks and characters you want to create.",
     stylePresetCarouselTitle: "Easy outfit change!",
+    stylePresetCarouselCaption: "Showing popular styles first",
     stylePresetConfirmTitle: "Try this on?",
     stylePresetConfirmCancel: "See other outfits",
     stylePresetConfirmAction: "Try on",

--- a/messages/es.ts
+++ b/messages/es.ts
@@ -1716,6 +1716,7 @@ export const esMessages = {
     subtitle:
       "Una plataforma de styling con IA para los looks y personajes que quieres crear.",
     stylePresetCarouselTitle: "¡Cambio de conjunto fácil!",
+    stylePresetCarouselCaption: "Mostrando primero los estilos populares",
     stylePresetConfirmTitle: "¿Quieres probar este conjunto?",
     stylePresetConfirmCancel: "Ver otros conjuntos",
     stylePresetConfirmAction: "Probarlo",

--- a/messages/fr.ts
+++ b/messages/fr.ts
@@ -1716,6 +1716,7 @@ export const frMessages = {
     subtitle:
       "Une plateforme de styling avec IA pour les looks et personnages que vous voulez créer.",
     stylePresetCarouselTitle: "Changez de tenue en toute simplicité !",
+    stylePresetCarouselCaption: "Les styles populaires s’affichent en premier",
     stylePresetConfirmTitle: "Essayer cette tenue ?",
     stylePresetConfirmCancel: "Voir d'autres tenues",
     stylePresetConfirmAction: "Essayer",

--- a/messages/hi.ts
+++ b/messages/hi.ts
@@ -1714,6 +1714,7 @@ export const hiMessages = {
     subtitle:
       "उन लुक्स और कैरेक्टरों के लिए AI स्टाइलिंग प्लेटफ़ॉर्म जिन्हें आप बनाना चाहते हैं।",
     stylePresetCarouselTitle: "आसानी से आउटफ़िट बदलें!",
+    stylePresetCarouselCaption: "लोकप्रिय स्टाइलें पहले दिखाई जा रही हैं",
     stylePresetConfirmTitle: "इसे आज़माएँ?",
     stylePresetConfirmCancel: "अन्य आउटफ़िट देखें",
     stylePresetConfirmAction: "ट्राय करें",

--- a/messages/id.ts
+++ b/messages/id.ts
@@ -1715,6 +1715,7 @@ export const idMessages = {
     subtitle:
       "Platform styling AI untuk tampilan dan karakter yang ingin kamu ciptakan.",
     stylePresetCarouselTitle: "Ganti outfit dengan mudah!",
+    stylePresetCarouselCaption: "Menampilkan gaya populer terlebih dahulu",
     stylePresetConfirmTitle: "Coba ini?",
     stylePresetConfirmCancel: "Lihat outfit lainnya",
     stylePresetConfirmAction: "Coba",

--- a/messages/it.ts
+++ b/messages/it.ts
@@ -1716,6 +1716,7 @@ export const itMessages = {
     subtitle:
       "Una piattaforma di styling con IA per i look e i personaggi che vuoi creare.",
     stylePresetCarouselTitle: "Cambio outfit facile!",
+    stylePresetCarouselCaption: "Mostriamo prima gli stili più popolari",
     stylePresetConfirmTitle: "Provarlo?",
     stylePresetConfirmCancel: "Vedi altri outfit",
     stylePresetConfirmAction: "Provalo",

--- a/messages/ja.ts
+++ b/messages/ja.ts
@@ -1645,6 +1645,7 @@ export const jaMessages = {
     heading: "Persta | ペルスタ",
     subtitle: "着てみたいも、なりたいも。AIスタイリングプラットフォーム",
     stylePresetCarouselTitle: "簡単お着替え！",
+    stylePresetCarouselCaption: "人気のスタイルから表示中",
     stylePresetConfirmTitle: "こちらを試着しますか？",
     stylePresetConfirmCancel: "他のコーデをみる",
     stylePresetConfirmAction: "試着する",

--- a/messages/ko.ts
+++ b/messages/ko.ts
@@ -1712,6 +1712,7 @@ export const koMessages = {
     subtitle:
       "만들고 싶은 룩과 캐릭터를 위한 AI 스타일링 플랫폼.",
     stylePresetCarouselTitle: "간편 코디 변경!",
+    stylePresetCarouselCaption: "인기 스타일부터 표시 중",
     stylePresetConfirmTitle: "이 룩을 입혀볼까요?",
     stylePresetConfirmCancel: "다른 코디 보기",
     stylePresetConfirmAction: "입어보기",

--- a/messages/pt.ts
+++ b/messages/pt.ts
@@ -1716,6 +1716,7 @@ export const ptMessages = {
     subtitle:
       "Uma plataforma de styling com IA para os looks e personagens que você quer criar.",
     stylePresetCarouselTitle: "Troca de roupa fácil!",
+    stylePresetCarouselCaption: "Mostrando primeiro os estilos populares",
     stylePresetConfirmTitle: "Quer experimentar este look?",
     stylePresetConfirmCancel: "Ver outros looks",
     stylePresetConfirmAction: "Experimentar",

--- a/messages/th.ts
+++ b/messages/th.ts
@@ -1712,6 +1712,7 @@ export const thMessages = {
     subtitle:
       "แพลตฟอร์มจัดสไตล์ด้วย AI สำหรับลุคและตัวละครที่คุณอยากสร้าง",
     stylePresetCarouselTitle: "เปลี่ยนชุดง่าย ๆ!",
+    stylePresetCarouselCaption: "แสดงสไตล์ยอดนิยมก่อน",
     stylePresetConfirmTitle: "ลองชุดนี้?",
     stylePresetConfirmCancel: "ดูชุดอื่น",
     stylePresetConfirmAction: "ลอง",

--- a/messages/vi.ts
+++ b/messages/vi.ts
@@ -1713,6 +1713,7 @@ export const viMessages = {
     subtitle:
       "Nền tảng styling AI cho những diện mạo và nhân vật bạn muốn tạo nên.",
     stylePresetCarouselTitle: "Đổi đồ thật dễ dàng!",
+    stylePresetCarouselCaption: "Đang hiển thị các phong cách phổ biến trước",
     stylePresetConfirmTitle: "Thử bộ này?",
     stylePresetConfirmCancel: "Xem các bộ khác",
     stylePresetConfirmAction: "Thử",

--- a/messages/zh-CN.ts
+++ b/messages/zh-CN.ts
@@ -1710,6 +1710,7 @@ export const zhCnMessages = {
     subtitle:
       "想呈现的造型与角色，皆可由这里开始的 AI 造型平台。",
     stylePresetCarouselTitle: "轻松换装!",
+    stylePresetCarouselCaption: "优先展示热门风格",
     stylePresetConfirmTitle: "要试穿这套吗?",
     stylePresetConfirmCancel: "看看其他搭配",
     stylePresetConfirmAction: "试穿",

--- a/messages/zh-TW.ts
+++ b/messages/zh-TW.ts
@@ -1710,6 +1710,7 @@ export const zhTwMessages = {
     subtitle:
       "想呈現的造型與角色，皆可從這裡開始的 AI 造型平台。",
     stylePresetCarouselTitle: "輕鬆換裝!",
+    stylePresetCarouselCaption: "優先顯示熱門風格",
     stylePresetConfirmTitle: "要試穿這套嗎?",
     stylePresetConfirmCancel: "看看其他穿搭",
     stylePresetConfirmAction: "試穿",


### PR DESCRIPTION
## 概要

ホーム画面「簡単お着替え！」カルーセルの初回表示コストを削減するため、表示プリセットを直近30日の人気順上位20件に絞り込みます。あわせて、並び基準をユーザーに伝える薄いキャプションをタイトル下に追加します。

## 背景

公開プリセットが約150件に増え、カルーセルは無限ループ用の3複製により約380個のスライドをホーム初回表示時に DOM 生成・ハイドレーションしていました。網羅的な探索は PR #435 の探索シート（すべて見る）が担うようになったため、カルーセルは「人気スタイルで目を引いて /style へ誘導する」役割に絞ります。

## 変更内容

- `CachedHomeStylePresetSection`: カルーセルへ渡すプリセットを直近30日の生成数（人気）降順で上位20件に絞り込み（`CAROUSEL_MAX_ITEMS = 20`）
  - 人気集計は取得済みの `getStyleGenerateCounts()` を再利用（追加クエリなし）
  - 同数は安定ソートで管理画面の並び順（sort_order）を維持。集計取得失敗時は先頭20件にフォールバック
  - 探索シート（すべて見る）には従来どおり全件を渡す（シートは開くまで DOM 化されないため初期表示コストに影響なし）
- `HomeStylePresetCarousel`: タイトル下にキャプション「人気のスタイルから表示中」を追加（`text-xs text-slate-500`）
- `messages/*`: `stylePresetCarouselCaption` を15言語に追加

## 効果

- スライド数: 約380 → 60（カード数 130 → 20 × ループ用3複製）
- ホーム初回表示の DOM 生成・ハイドレーション・Swiper 計測コストを削減

## 検証

- `npm run lint` / `npm run typecheck`（変更ファイルにエラーなし）
- `npm run test`（2459件パス）
- `npm run build -- --webpack`（成功）

## マージ方式

短命の feature ブランチのため **Squash and merge** を指定してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
