### PR TITLE
perf(home): ポップアップバナー画像のサーバー側preloadでLCP改善+二重ダウンロード解消

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,10 +1,13 @@
 import type { Metadata } from "next";
+import { getImageProps } from "next/image";
 import { Suspense } from "react";
+import { preload } from "react-dom";
 import { getSiteUrl } from "@/lib/env";
 import { getUser } from "@/lib/auth";
 import { isCreatorLooksEnabledForUser } from "@/lib/auth/creator-looks";
 import { isAdminViewer as checkIsAdminViewer } from "@/lib/env";
 import { getActivePopupBanners } from "@/features/popup-banners/lib/get-active-popup-banners";
+import { POPUP_BANNER_IMAGE_SIZES } from "@/features/popup-banners/lib/popup-banner-image";
 import { PopupBannerOverlay } from "@/features/popup-banners/components/PopupBannerOverlay";
 import { CachedHomeBannerSection } from "@/features/home/components/CachedHomeBannerSection";
 import { CachedHomePostListSection } from "@/features/home/components/CachedHomePostListSection";
@@ -135,6 +138,29 @@ async function HomePopupBannerSection({
   const popupBanners = e2ePopupBanners
     ? e2ePopupBanners
     : await getActivePopupBanners();
+
+  // ポップアップはクライアントで hydration 後に表示されるため、そのままだと
+  // 画像の取得開始が数秒遅れて LCP を悪化させる(実測で Load Delay 約5.6秒)。
+  // 表示候補の先頭バナーを <link rel="preload"> で先行ダウンロードさせ、
+  // Overlay の <Image> と同じ srcset/sizes を getImageProps で再現して
+  // ブラウザのキャッシュに確実にヒットさせる。
+  // (表示済みで実際には出ないユーザーにも1枚分の DL が発生するが、
+  //  HTTP キャッシュに乗るため再訪時の実コストはほぼ無い)
+  const preloadBanner = popupBanners[0];
+  if (preloadBanner?.imageUrl) {
+    const { props: imgProps } = getImageProps({
+      src: preloadBanner.imageUrl,
+      alt: "",
+      fill: true,
+      sizes: POPUP_BANNER_IMAGE_SIZES,
+    });
+    preload(imgProps.src, {
+      as: "image",
+      imageSrcSet: imgProps.srcSet,
+      imageSizes: imgProps.sizes,
+      fetchPriority: "high",
+    });
+  }
 
   return <PopupBannerOverlay banners={popupBanners} />;
 }

--- a/features/popup-banners/components/PopupBannerOverlay.tsx
+++ b/features/popup-banners/components/PopupBannerOverlay.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import Image from "next/image";
+import Image, { getImageProps } from "next/image";
 import Link from "next/link";
 import { Check, X } from "lucide-react";
 import { useTranslations } from "next-intl";
@@ -13,6 +13,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { usePopupBanner } from "@/features/popup-banners/hooks/usePopupBanner";
+import { POPUP_BANNER_IMAGE_SIZES } from "@/features/popup-banners/lib/popup-banner-image";
 import type { ActivePopupBanner } from "@/features/popup-banners/lib/schema";
 
 interface PopupBannerOverlayProps {
@@ -90,7 +91,21 @@ export function PopupBannerOverlay({ banners }: PopupBannerOverlayProps) {
 
     preloadImage.onload = decodeAndFinalize;
     preloadImage.onerror = finalize;
-    preloadImage.src = currentBanner.imageUrl;
+    // 表示に使う <Image>(next/image) と同じ srcset/sizes を与え、ブラウザに
+    // 同一の最適化 URL を選ばせる。生 URL を読むと表示用と別リソースになり
+    // 二重ダウンロードになるうえ、サーバー側 preload(<link rel="preload">)の
+    // キャッシュにも当たらない。
+    const { props: gateImageProps } = getImageProps({
+      src: currentBanner.imageUrl,
+      alt: "",
+      fill: true,
+      sizes: POPUP_BANNER_IMAGE_SIZES,
+    });
+    preloadImage.sizes = gateImageProps.sizes ?? "";
+    if (gateImageProps.srcSet) {
+      preloadImage.srcset = gateImageProps.srcSet;
+    }
+    preloadImage.src = gateImageProps.src;
 
     if (preloadImage.complete) {
       decodeAndFinalize();
@@ -128,7 +143,7 @@ export function PopupBannerOverlay({ banners }: PopupBannerOverlayProps) {
         alt={visibleBanner.alt || t("imageAltFallback")}
         fill
         className="object-cover"
-        sizes="(max-width: 768px) 80vw, 420px"
+        sizes={POPUP_BANNER_IMAGE_SIZES}
         priority
       />
     </div>

--- a/features/popup-banners/lib/popup-banner-image.ts
+++ b/features/popup-banners/lib/popup-banner-image.ts
@@ -1,0 +1,9 @@
+/**
+ * ポップアップバナー画像の sizes 定義。
+ *
+ * PopupBannerOverlay の <Image>(表示) / 先読みゲート、および home page の
+ * サーバー側 preload(<link rel="preload">)で同じ値を使う。値がずれると
+ * ブラウザが選ぶ srcset 候補が食い違い、同じ画像を2回ダウンロードしてしまう
+ * ため、必ずこの定数を共有すること。
+ */
+export const POPUP_BANNER_IMAGE_SIZES = "(max-width: 768px) 80vw, 420px";

--- a/tests/unit/components/popup-banner-overlay.test.tsx
+++ b/tests/unit/components/popup-banner-overlay.test.tsx
@@ -24,6 +24,11 @@ jest.mock("next/image", () => ({
       <img alt={alt} src={src} {...rest} />
     );
   },
+  // 先読みゲートが表示用と同じ最適化URLを解決するのに使う。テストでは
+  // 変換せず src/sizes をそのまま返す(srcSet 無し = src がそのまま読まれる)。
+  getImageProps: (props: { src: string; sizes?: string }) => ({
+    props: { src: props.src, sizes: props.sizes },
+  }),
 }));
 
 jest.mock("next/link", () => ({


### PR DESCRIPTION
## 概要

ホームの Lighthouse 計測（モバイル）で LCP 7.8 秒の主因が「コラボ企画ポップアップバナー画像」の読み込み開始遅延（Load Delay 約5.6秒）であることが判明したため、バナー画像をサーバー側で preload して読み込みを前倒しします。あわせて、調査中に見つかった同画像の二重ダウンロード問題を解消します。

## 背景（計測結果）

本番ホーム（モバイル設定）の Lighthouse で Performance 59、LCP 7.8s。LCP 要素はポップアップバナー画像で、内訳は TTFB 842ms / **Load Delay 5,614ms** / Load 185ms / Render Delay 1,177ms。ポップアップはクライアントで hydration 後に `useEffect` 内の JS 先読みを経て表示されるため、画像リクエストの開始自体が数秒遅れていました。バナー URL はサーバーで確定しているため、`<link rel="preload">` で JS を待たずにダウンロードを開始できます。

## 変更内容

- `app/[locale]/page.tsx`: 表示候補の先頭バナーを `getImageProps` + `ReactDOM.preload`（`fetchPriority: "high"`）で `<link rel="preload" as="image">` として出力。表示用 `<Image>` と同一の srcset/sizes を再現し、キャッシュに確実にヒットさせる
- `PopupBannerOverlay.tsx`: JS 先読みゲートが生の Supabase URL を読んでおり、表示用の最適化 URL（`/_next/image`）と**毎回二重ダウンロード**になっていた既存問題を修正。ゲートにも同一の srcset/sizes を付与し、preload・ゲート・表示の3者が同一リソースを共有
- `features/popup-banners/lib/popup-banner-image.ts`（新規）: sizes 定義を `POPUP_BANNER_IMAGE_SIZES` として共有化（値のズレによる二重ダウンロード再発を防止）
- テスト: `next/image` モックに `getImageProps` を追加（既存6テストの追従。挙動アサーションは変更なし）

## トレードオフ

閉じた履歴がありポップアップが表示されないユーザーにも preload 1枚分のダウンロードが発生します。ただし画像は HTTP キャッシュに乗るため再訪時の実コストはほぼゼロで、二重ダウンロード解消による削減の方が大きいと判断しました。

## 検証

- 実ブラウザ（dev）で `<link rel="preload" fetchpriority="high">` の出力を確認
- ポップアップ表示時の画像リクエストが最適化 URL（w=1080）1本のみになることを確認（preload キャッシュにヒット、転送300B）
- 閉じた履歴があるユーザーには従来どおり非表示のままであることを確認
- `npm run lint` / `npm run typecheck` / `npm run test`（2459件パス）/ `npm run build -- --webpack` 成功

## マージ方式

短命の feature ブランチのため **Squash and merge** を指定してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
