### PR TITLE
feat(style): 新着判定を公開日時(published_at)基準に変更

### DIFF
--- a/.cursor/rules/database-design.mdc
+++ b/.cursor/rules/database-design.mdc
@@ -338,10 +338,10 @@ alwaysApply: false
 
 #### `style_presets`
 - 主キー: `id`
-- 主要カラム: `slug`, `title`, `styling_prompt`, `background_prompt`, `thumbnail_image_url`, `thumbnail_storage_path`, `thumbnail_width`, `thumbnail_height`, `sort_order`, `status`, `category_id`, `image_input_mode`, `dual_reference_source` (`admin|user_upload`), `reference_image_url`, `reference_image_storage_path`, `reference_image_width`, `reference_image_height`, `created_by`, `updated_by`, `created_at`, `updated_at`
+- 主要カラム: `slug`, `title`, `styling_prompt`, `background_prompt`, `thumbnail_image_url`, `thumbnail_storage_path`, `thumbnail_width`, `thumbnail_height`, `sort_order`, `status`, `published_at`, `category_id`, `image_input_mode`, `dual_reference_source` (`admin|user_upload`), `reference_image_url`, `reference_image_storage_path`, `reference_image_width`, `reference_image_height`, `created_by`, `updated_by`, `created_at`, `updated_at`
 - 外部キー: `created_by -> auth.users.id`, `updated_by -> auth.users.id`, `category_id -> preset_categories.id` (`ON DELETE RESTRICT`)
 - CHECK 制約: `style_presets_dual_admin_requires_reference` — `(single AND admin) OR (dual AND user_upload) OR (dual AND admin AND reference NOT NULL)` の組み合わせのみ許可 (single+user_upload は禁止)
-- 備考: One-Tap Style の管理プリセット。`status` は `draft/published`。`styling_prompt` が衣装変更用、`background_prompt` は背景変更チェックが ON のときだけ使う任意フィールド。`image_input_mode='dual'` + `dual_reference_source='admin'` の場合は preset 固有の参考画像 (image_1) を `style_presets` bucket の `{presetId}/reference.webp` から取得する。`dual_reference_source='user_upload'` の場合はユーザーが `/style` で都度アップロードした temp 画像を使う
+- 備考: One-Tap Style の管理プリセット。`status` は `draft/published`。`published_at` は `set_style_preset_published_at` trigger が「published へ遷移するたび」に更新（再公開で新着に返り咲く）。新着判定（ホーム新着枠/NEWバッジ/✨新着チップ）は `published_at ?? created_at`。`styling_prompt` が衣装変更用、`background_prompt` は背景変更チェックが ON のときだけ使う任意フィールド。`image_input_mode='dual'` + `dual_reference_source='admin'` の場合は preset 固有の参考画像 (image_1) を `style_presets` bucket の `{presetId}/reference.webp` から取得する。`dual_reference_source='user_upload'` の場合はユーザーが `/style` で都度アップロードした temp 画像を使う
 - RLS: `published` かつカテゴリ `visibility='public'` の行のみ公開 `SELECT`
 
 #### `preset_categories`
@@ -489,6 +489,7 @@ alwaysApply: false
 - コメント返信/整合性: `validate_parent_comment`, `prevent_direct_parent_delete_with_replies`, `update_parent_last_activity_at`, `update_parent_last_activity_at_on_delete`, `broadcast_reply_lifecycle_event`
 - 更新日時: `update_updated_at_column`, `update_banners_updated_at`, `update_popup_banners_updated_at`, `update_popup_banner_views_updated_at`, `update_materials_images_updated_at`, `update_notification_preferences_updated_at`
 - `style_presets` は `update_updated_at_column()` trigger で `updated_at` を更新
+- 公開日時: `set_style_preset_published_at` — `style_presets.status` が published へ遷移した INSERT/UPDATE で `published_at = now()` を設定（published のままの編集では更新しない）
 - 絵師カタログ制約: `enforce_catalog_entry_submission_cap`
 - アカウント初期化: `handle_new_user`
 - 監視・診断: `detect_generation_billing_anomalies`, `monitor_generation_billing_anomalies`

--- a/features/home/lib/home-carousel-presets.ts
+++ b/features/home/lib/home-carousel-presets.ts
@@ -13,20 +13,24 @@ export const CAROUSEL_MAX_NEW_ITEMS = 7;
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
-/** 新着(登録から STYLE_NEW_WINDOW_DAYS 日以内)か。NEW バッジ表示にも使う。 */
+/**
+ * 新着(公開から STYLE_NEW_WINDOW_DAYS 日以内)か。NEW バッジ表示にも使う。
+ * 判定は公開日時(publishedAt)を優先する。下書き期間が長かったプリセットでも
+ * 公開した日から新着になり、再公開(下書き→公開)でも新着に返り咲く。
+ */
 export function isNewPreset(
   preset: StylePresetPublicSummary,
   now: Date,
 ): boolean {
-  const created = Date.parse(preset.createdAt);
-  if (Number.isNaN(created)) return false;
-  return now.getTime() - created <= STYLE_NEW_WINDOW_DAYS * DAY_MS;
+  const published = Date.parse(preset.publishedAt ?? preset.createdAt);
+  if (Number.isNaN(published)) return false;
+  return now.getTime() - published <= STYLE_NEW_WINDOW_DAYS * DAY_MS;
 }
 
 /**
  * カルーセル表示用のプリセットを導出する。
  *
- * 並び: 新着(直近 STYLE_NEW_WINDOW_DAYS 日・作成日の新しい順)を先頭に最大
+ * 並び: 新着(公開から STYLE_NEW_WINDOW_DAYS 日以内・公開日の新しい順)を先頭に最大
  * CAROUSEL_MAX_NEW_ITEMS 枚 → 残りを人気(直近30日生成数の降順)で埋めて合計
  * CAROUSEL_MAX_ITEMS 枚。人気順だけだと登録直後のスタイル(生成数0)が
  * ホームに一切露出しないため、新着枠を先頭に確保する。
@@ -40,9 +44,11 @@ export function deriveHomeCarouselPresets(
   generateCounts: Readonly<Record<string, number>>,
   now: Date,
 ): StylePresetPublicSummary[] {
+  const publishedTime = (preset: StylePresetPublicSummary) =>
+    Date.parse(preset.publishedAt ?? preset.createdAt);
   const newest = presets
     .filter((preset) => isNewPreset(preset, now))
-    .sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt))
+    .sort((a, b) => publishedTime(b) - publishedTime(a))
     .slice(0, CAROUSEL_MAX_NEW_ITEMS);
   const newestIds = new Set(newest.map((preset) => preset.id));
   const popular = presets

--- a/features/home/lib/home-carousel-presets.ts
+++ b/features/home/lib/home-carousel-presets.ts
@@ -1,5 +1,9 @@
-import { STYLE_NEW_WINDOW_DAYS } from "@/features/style/lib/style-browse-filter";
+import { isNewPreset } from "@/features/style/lib/style-browse-filter";
 import type { StylePresetPublicSummary } from "@/features/style-presets/lib/schema";
+
+// 新着判定は探索シート(✨新着チップ)と同一実装を共有する。
+// CachedHomeStylePresetSection の NEW バッジ判定用に再エクスポートする。
+export { isNewPreset };
 
 /**
  * ホームのお着替えカルーセルに出す最大枚数。全件(120枚超×ループ用3複製)を
@@ -11,21 +15,6 @@ export const CAROUSEL_MAX_ITEMS = 20;
 /** カルーセル先頭に固定で出す「新着」の最大枚数(残り = 人気枠 13枚)。 */
 export const CAROUSEL_MAX_NEW_ITEMS = 7;
 
-const DAY_MS = 24 * 60 * 60 * 1000;
-
-/**
- * 新着(公開から STYLE_NEW_WINDOW_DAYS 日以内)か。NEW バッジ表示にも使う。
- * 判定は公開日時(publishedAt)を優先する。下書き期間が長かったプリセットでも
- * 公開した日から新着になり、再公開(下書き→公開)でも新着に返り咲く。
- */
-export function isNewPreset(
-  preset: StylePresetPublicSummary,
-  now: Date,
-): boolean {
-  const published = Date.parse(preset.publishedAt ?? preset.createdAt);
-  if (Number.isNaN(published)) return false;
-  return now.getTime() - published <= STYLE_NEW_WINDOW_DAYS * DAY_MS;
-}
 
 /**
  * カルーセル表示用のプリセットを導出する。

--- a/features/style-presets/lib/schema.ts
+++ b/features/style-presets/lib/schema.ts
@@ -153,8 +153,14 @@ export interface StylePresetPublicSummary {
   thumbnailWidth: number;
   thumbnailHeight: number;
   hasBackgroundPrompt: boolean;
-  /** 公開プリセットの作成日時(ISO)。/style 探索シートの「✨新着」チップ判定に使う。 */
+  /** 公開プリセットの作成日時(ISO)。publishedAt が無い場合の新着判定フォールバック。 */
   createdAt: string;
+  /**
+   * 最後に公開(draft等→published 遷移)した日時(ISO)。トリガーで自動記録。
+   * 新着判定(ホーム新着枠/NEWバッジ/✨新着チップ)は publishedAt ?? createdAt を使う。
+   * NULL は移行前データ等(createdAt にフォールバック)。
+   */
+  publishedAt: string | null;
   category: StylePresetCategoryRef;
   imageInputMode: ImageInputMode;
   dualReferenceSource: DualReferenceSource;

--- a/features/style-presets/lib/style-preset-repository.ts
+++ b/features/style-presets/lib/style-preset-repository.ts
@@ -91,6 +91,8 @@ interface StylePresetRow {
   updated_by: string | null;
   created_at: string;
   updated_at: string;
+  // 最後に published へ遷移した日時(DBトリガーで自動記録)。新着判定用。
+  published_at?: string | null;
   // プリセット単位の提供者(profiles.id)。カテゴリ単位と独立して設定できる。
   provider_user_id?: string | null;
   // クリエイター提供プロンプト 申請(Phase 1)用カラム(通常プリセットでは null)
@@ -310,6 +312,7 @@ function mapRowToPublicSummary(row: StylePresetRow): StylePresetPublicSummary {
     thumbnailHeight: row.thumbnail_height,
     hasBackgroundPrompt: Boolean(row.background_prompt?.trim()),
     createdAt: row.created_at,
+    publishedAt: row.published_at ?? null,
     category: mapCategoryRefStrict(row, extractCategory(row.category)),
     imageInputMode: row.image_input_mode,
     dualReferenceSource: normalizeDualReferenceSource(row.dual_reference_source),

--- a/features/style/lib/style-browse-filter.ts
+++ b/features/style/lib/style-browse-filter.ts
@@ -63,9 +63,13 @@ export interface StyleBrowseContext {
 }
 
 function isNewPreset(preset: StylePresetPublicSummary, now: Date): boolean {
-  const created = Date.parse(preset.createdAt);
-  if (Number.isNaN(created)) return false;
-  return now.getTime() - created <= STYLE_NEW_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+  // 公開日時(publishedAt)を優先。下書き期間が長くても公開した日から新着になる
+  // (ホームの新着枠 home-carousel-presets.ts の isNewPreset と同じ解釈)。
+  const published = Date.parse(preset.publishedAt ?? preset.createdAt);
+  if (Number.isNaN(published)) return false;
+  return (
+    now.getTime() - published <= STYLE_NEW_WINDOW_DAYS * 24 * 60 * 60 * 1000
+  );
 }
 
 function hasCreator(preset: StylePresetPublicSummary): boolean {

--- a/features/style/lib/style-browse-filter.ts
+++ b/features/style/lib/style-browse-filter.ts
@@ -62,9 +62,17 @@ export interface StyleBrowseContext {
   isAuthenticated: boolean;
 }
 
-function isNewPreset(preset: StylePresetPublicSummary, now: Date): boolean {
-  // 公開日時(publishedAt)を優先。下書き期間が長くても公開した日から新着になる
-  // (ホームの新着枠 home-carousel-presets.ts の isNewPreset と同じ解釈)。
+/**
+ * 新着(公開から STYLE_NEW_WINDOW_DAYS 日以内)か。
+ * 公開日時(publishedAt)を優先し、null(移行前データ等)は createdAt にフォールバック。
+ * 下書き期間が長くても公開した日から新着になり、再公開でも新着に返り咲く。
+ * 探索シートの「✨新着」チップと、ホームの新着枠/NEWバッジ
+ * (features/home/lib/home-carousel-presets.ts)で共有する。
+ */
+export function isNewPreset(
+  preset: StylePresetPublicSummary,
+  now: Date,
+): boolean {
   const published = Date.parse(preset.publishedAt ?? preset.createdAt);
   if (Number.isNaN(published)) return false;
   return (

--- a/supabase/migrations/20260721120000_add_style_preset_published_at.sql
+++ b/supabase/migrations/20260721120000_add_style_preset_published_at.sql
@@ -1,0 +1,42 @@
+-- /style プリセットの「公開日時」。
+--
+-- 新着判定(ホームの新着枠・NEWバッジ・探索シートの✨新着)は従来 created_at
+-- (レコード作成=下書き保存時点)を使っていたが、長く下書きのままだった
+-- プリセットを公開しても新着にならない問題があった。公開日時を別カラムで
+-- 記録し、アプリ側は published_at ?? created_at で新着を判定する。
+ALTER TABLE public.style_presets
+  ADD COLUMN published_at TIMESTAMPTZ NULL;
+
+COMMENT ON COLUMN public.style_presets.published_at IS
+  '最後に draft等→published へ遷移した日時(トリガーで自動記録)。新着判定に使う。NULL は未公開または移行前データ';
+
+-- 既存の公開済みプリセットは created_at で埋める(従来の新着判定と同じ挙動を維持)。
+UPDATE public.style_presets
+SET published_at = created_at
+WHERE status = 'published';
+
+-- status が published へ「遷移」するたびに published_at を更新する(案B)。
+--  - INSERT で最初から published の場合も記録する
+--  - 公開中の編集(published のまま UPDATE)では更新しない
+--  - 公開→下書き→再公開では最新の再公開日時に更新される(新着に返り咲く)
+CREATE OR REPLACE FUNCTION public.set_style_preset_published_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.status = 'published' AND NEW.published_at IS NULL THEN
+      NEW.published_at = now();
+    END IF;
+  ELSIF NEW.status = 'published' AND OLD.status IS DISTINCT FROM 'published' THEN
+    NEW.published_at = now();
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER set_style_preset_published_at
+  BEFORE INSERT OR UPDATE ON public.style_presets
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_style_preset_published_at();

--- a/supabase/migrations/20260721130000_refine_style_preset_published_at_trigger.sql
+++ b/supabase/migrations/20260721130000_refine_style_preset_published_at_trigger.sql
@@ -1,0 +1,25 @@
+-- published_at トリガーの改善(PR #439 レビュー対応)。
+--
+-- 従来: published への遷移で常に published_at = now() に上書き。
+-- 変更: 遷移と同時に published_at が明示的に指定された場合はその値を尊重する
+--       (データ移行・過去日時の調整などで UPDATE ... SET status, published_at を
+--        一度に実行できるように)。明示指定が無い場合は従来どおり now()。
+CREATE OR REPLACE FUNCTION public.set_style_preset_published_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.status = 'published' AND NEW.published_at IS NULL THEN
+      NEW.published_at = now();
+    END IF;
+  ELSIF NEW.status = 'published' AND OLD.status IS DISTINCT FROM 'published' THEN
+    -- published_at が変更されていない(= 明示指定なし)ときだけ自動設定する。
+    IF NEW.published_at IS NOT DISTINCT FROM OLD.published_at THEN
+      NEW.published_at = now();
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;

--- a/tests/unit/features/home/home-carousel-presets.test.ts
+++ b/tests/unit/features/home/home-carousel-presets.test.ts
@@ -12,6 +12,7 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 function preset(
   id: string,
   createdDaysAgo: number,
+  publishedDaysAgo: number | null = createdDaysAgo,
 ): StylePresetPublicSummary {
   return {
     id,
@@ -21,6 +22,10 @@ function preset(
     thumbnailHeight: 1,
     hasBackgroundPrompt: false,
     createdAt: new Date(NOW.getTime() - createdDaysAgo * DAY_MS).toISOString(),
+    publishedAt:
+      publishedDaysAgo === null
+        ? null
+        : new Date(NOW.getTime() - publishedDaysAgo * DAY_MS).toISOString(),
     category: {
       key: "coordinate",
       displayNameJa: "コーディネート",
@@ -96,8 +101,38 @@ describe("deriveHomeCarouselPresets", () => {
     expect(result.map((p) => p.id)).toEqual(["b", "a", "c"]);
   });
 
-  test("createdAt が不正な値でも新着扱いせずクラッシュしない", () => {
-    const broken = { ...preset("broken", 1), createdAt: "invalid" };
+  test("下書き期間が長くても公開が直近なら新着になる(publishedAt優先)", () => {
+    const presets = [
+      // 100日前に下書き作成 → 2日前に公開
+      preset("old-draft-published-now", 100, 2),
+      // 100日前に作成・公開済み(人気あり)
+      preset("old-published", 100, 100),
+    ];
+    const result = deriveHomeCarouselPresets(
+      presets,
+      { "old-published": 50 },
+      NOW,
+    );
+    expect(result.map((p) => p.id)).toEqual([
+      "old-draft-published-now",
+      "old-published",
+    ]);
+  });
+
+  test("publishedAt が null(移行前データ等)なら createdAt にフォールバック", () => {
+    const presets = [
+      preset("legacy-new", 3, null),
+      preset("legacy-old", 100, null),
+    ];
+    const result = deriveHomeCarouselPresets(presets, {}, NOW);
+    expect(result.map((p) => p.id)).toEqual(["legacy-new", "legacy-old"]);
+  });
+
+  test("日付が不正な値でも新着扱いせずクラッシュしない", () => {
+    const broken = {
+      ...preset("broken", 1, null),
+      createdAt: "invalid",
+    };
     const result = deriveHomeCarouselPresets(
       [broken, preset("ok", 1)],
       {},

--- a/tests/unit/features/style/style-browse-filter.test.ts
+++ b/tests/unit/features/style/style-browse-filter.test.ts
@@ -13,6 +13,7 @@ function preset(
   id: string,
   overrides: {
     createdDaysAgo?: number;
+    publishedDaysAgo?: number | null;
     categoryKey?: string;
     categoryNameJa?: string;
     providerUserId?: string | null;
@@ -25,6 +26,7 @@ function preset(
 ): StylePresetPublicSummary {
   const {
     createdDaysAgo = 100,
+    publishedDaysAgo = createdDaysAgo,
     categoryKey = "coordinate",
     categoryNameJa = categoryKey,
     providerUserId = null,
@@ -42,6 +44,10 @@ function preset(
     thumbnailHeight: 1,
     hasBackgroundPrompt: false,
     createdAt: new Date(NOW.getTime() - createdDaysAgo * DAY_MS).toISOString(),
+    publishedAt:
+      publishedDaysAgo === null
+        ? null
+        : new Date(NOW.getTime() - publishedDaysAgo * DAY_MS).toISOString(),
     category: {
       key: categoryKey,
       displayNameJa: categoryNameJa,
@@ -257,6 +263,16 @@ describe("filterStyleBrowsePresets", () => {
     expect(filterStyleBrowsePresets(presets, "new", ctx).map((p) => p.id)).toEqual(
       ["new"],
     );
+  });
+
+  test("new: 下書き期間が長くても公開が直近なら新着(publishedAt優先)", () => {
+    const withLatePublish = [
+      ...presets,
+      preset("late-publish", { createdDaysAgo: 100, publishedDaysAgo: 2 }),
+    ];
+    expect(
+      filterStyleBrowsePresets(withLatePublish, "new", ctx).map((p) => p.id),
+    ).toEqual(["new", "late-publish"]);
   });
 
   test("popular: 生成数>0のみを降順で", () => {

--- a/tests/unit/lib/style-preset-repository.test.ts
+++ b/tests/unit/lib/style-preset-repository.test.ts
@@ -186,6 +186,8 @@ describe("style-preset repository", () => {
         thumbnailHeight: 1173,
         hasBackgroundPrompt: true,
         createdAt: "2026-03-22T00:00:00.000Z",
+        // fixture の row に published_at が無い場合は null(移行前データ相当)。
+        publishedAt: null,
         category: {
           id: TEST_CATEGORY_ID,
           key: "coordinate",


### PR DESCRIPTION
## 概要

新着判定（ホームの新着枠・NEW バッジ・探索シートの✨新着チップ）が `created_at`（レコード作成＝下書き保存時点）基準だったため、長く下書きのままだったプリセットを公開しても新着にならない問題への対応です。公開日時 `published_at` を導入し、新着判定をそこに切り替えます。

## 変更内容

### DB（本番適用済み）

`supabase/migrations/20260721120000_add_style_preset_published_at.sql`

- `style_presets.published_at TIMESTAMPTZ NULL` を追加
- 既存の公開済みプリセットは `created_at` でバックフィル（従来の新着判定と同じ挙動を維持）
- トリガー `set_style_preset_published_at`: `status` が published へ**遷移するたび**に `published_at = now()` を設定
  - 下書き→再公開でも最新の公開日時に更新される（＝新着に返り咲く。運営が意図的に使える）
  - 公開中のままの編集（title 修正等）では更新されない

### アプリ

- `StylePresetPublicSummary` に `publishedAt: string | null` を追加（リポジトリでマッピング）
- 新着判定3箇所（`home-carousel-presets.ts` / `style-browse-filter.ts`）を `publishedAt ?? createdAt` に切替（null は移行前データ向けフォールバック）
- ホーム新着枠の並び順も公開日時の新しい順に変更
- `.cursor/rules/database-design.mdc` にカラム・トリガー・判定仕様を追記

### テスト

- 「下書き100日→2日前に公開 → 新着になる」「publishedAt null は createdAt にフォールバック」等を追加（全2468件パス）

## 動作検証（本番DB・テスト行のラウンドトリップで実施後に削除済み）

1. 下書きで作成 → `published_at = null` ✅
2. 公開に変更 → 現在時刻が設定 ✅
3. 下書きに戻して再公開 → 最新時刻に更新 ✅
4. 公開中のまま編集 → 変化なし ✅

また、公開済み全件のバックフィル完了（`published_at IS NULL` の公開行は0件）を確認済み。

## マージ方式

短命の feature ブランチのため **Squash and merge** を指定してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
