### PR TITLE
fix(admin): 生成promptの許容文字数を10000→100000に緩和

### DIFF
--- a/app/api/admin/generation-prompts/[key]/route.ts
+++ b/app/api/admin/generation-prompts/[key]/route.ts
@@ -16,7 +16,7 @@ import {
 import { extractTemplateVariables } from "@/shared/generation/prompt-template";
 
 // DB の prompt_overrides_content_check と同値に保つこと (defense in depth)
-const MAX_CONTENT_LENGTH = 20000;
+const MAX_CONTENT_LENGTH = 100000;
 
 /**
  * 編集後に変更を即時反映させるための共通リバリデーション。

--- a/app/api/admin/generation-prompts/[key]/route.ts
+++ b/app/api/admin/generation-prompts/[key]/route.ts
@@ -16,7 +16,7 @@ import {
 import { extractTemplateVariables } from "@/shared/generation/prompt-template";
 
 // DB の prompt_overrides_content_check と同値に保つこと (defense in depth)
-const MAX_CONTENT_LENGTH = 10000;
+const MAX_CONTENT_LENGTH = 20000;
 
 /**
  * 編集後に変更を即時反映させるための共通リバリデーション。

--- a/features/generation-prompts/components/AdminPromptEditClient.tsx
+++ b/features/generation-prompts/components/AdminPromptEditClient.tsx
@@ -6,7 +6,7 @@ import { applyTemplate } from "@/shared/generation/prompt-template";
 import { extractTemplateVariables } from "@/shared/generation/prompt-template";
 
 // API (route.ts) / DB (prompt_overrides_content_check) の上限と同値に保つこと
-const MAX_CONTENT_LENGTH = 20000;
+const MAX_CONTENT_LENGTH = 100000;
 const SIGNIFICANT_CHANGE_RATIO = 0.3; // ±30% で大幅変更とみなす
 
 interface Props {

--- a/features/generation-prompts/components/AdminPromptEditClient.tsx
+++ b/features/generation-prompts/components/AdminPromptEditClient.tsx
@@ -6,7 +6,7 @@ import { applyTemplate } from "@/shared/generation/prompt-template";
 import { extractTemplateVariables } from "@/shared/generation/prompt-template";
 
 // API (route.ts) / DB (prompt_overrides_content_check) の上限と同値に保つこと
-const MAX_CONTENT_LENGTH = 10000;
+const MAX_CONTENT_LENGTH = 20000;
 const SIGNIFICANT_CHANGE_RATIO = 0.3; // ±30% で大幅変更とみなす
 
 interface Props {

--- a/supabase/migrations/20260722114900_relax_prompt_overrides_content_length_100k.sql
+++ b/supabase/migrations/20260722114900_relax_prompt_overrides_content_length_100k.sql
@@ -1,17 +1,17 @@
 -- ===============================================
--- prompt_overrides.content の最大文字数を 10000 → 20000 に緩和
+-- prompt_overrides.content の最大文字数を 10000 → 100000 に緩和
 -- ===============================================
 -- 背景:
 --   admin の生成 prompt エディタ (/admin/generation-prompts/[key]) で、
 --   creator_looks.meta_extractor の meta-prompt が 10000 字上限に
---   達して保存できなくなったため、上限を 20000 字に引き上げる。
+--   達して保存できなくなったため、上限を 100000 字に引き上げる。
 --
 -- 設計判断:
 --   - 前回の緩和 (20260603101100, 4000 -> 10000) と同じ方針。
 --     文字数上限は「暴走入力 (監査ログ肥大・PII 肥大) を防ぐ安全ガード」であり、
 --     特定 key 専用ではなく全 prompt_key 共通のグローバル上限のまま緩和する。
 --   - API (route.ts) / client (AdminPromptEditClient) / DB の 3 層で同じ上限を持つ
---     defense in depth 設計を維持 (各層の MAX_CONTENT_LENGTH も 20000 に更新済み)。
+--     defense in depth 設計を維持 (各層の MAX_CONTENT_LENGTH も 100000 に更新済み)。
 --   - 上限の緩和のみで、既存 row は全て length<=10000 のため制約違反は発生しない。
 
 BEGIN;
@@ -21,10 +21,10 @@ ALTER TABLE public.prompt_overrides
 
 ALTER TABLE public.prompt_overrides
   ADD CONSTRAINT prompt_overrides_content_check
-  CHECK (length(content) <= 20000 AND length(trim(content)) > 0);
+  CHECK (length(content) <= 100000 AND length(trim(content)) > 0);
 
 COMMENT ON COLUMN public.prompt_overrides.content IS
-  '{{varname}} プレースホルダー記法でテンプレ変数を含む prompt テキスト。max 20000 文字';
+  '{{varname}} プレースホルダー記法でテンプレ変数を含む prompt テキスト。max 100000 文字';
 
 COMMIT;
 

--- a/supabase/migrations/20260722114900_relax_prompt_overrides_content_length_20k.sql
+++ b/supabase/migrations/20260722114900_relax_prompt_overrides_content_length_20k.sql
@@ -1,0 +1,40 @@
+-- ===============================================
+-- prompt_overrides.content の最大文字数を 10000 → 20000 に緩和
+-- ===============================================
+-- 背景:
+--   admin の生成 prompt エディタ (/admin/generation-prompts/[key]) で、
+--   creator_looks.meta_extractor の meta-prompt が 10000 字上限に
+--   達して保存できなくなったため、上限を 20000 字に引き上げる。
+--
+-- 設計判断:
+--   - 前回の緩和 (20260603101100, 4000 -> 10000) と同じ方針。
+--     文字数上限は「暴走入力 (監査ログ肥大・PII 肥大) を防ぐ安全ガード」であり、
+--     特定 key 専用ではなく全 prompt_key 共通のグローバル上限のまま緩和する。
+--   - API (route.ts) / client (AdminPromptEditClient) / DB の 3 層で同じ上限を持つ
+--     defense in depth 設計を維持 (各層の MAX_CONTENT_LENGTH も 20000 に更新済み)。
+--   - 上限の緩和のみで、既存 row は全て length<=10000 のため制約違反は発生しない。
+
+BEGIN;
+
+ALTER TABLE public.prompt_overrides
+  DROP CONSTRAINT IF EXISTS prompt_overrides_content_check;
+
+ALTER TABLE public.prompt_overrides
+  ADD CONSTRAINT prompt_overrides_content_check
+  CHECK (length(content) <= 20000 AND length(trim(content)) > 0);
+
+COMMENT ON COLUMN public.prompt_overrides.content IS
+  '{{varname}} プレースホルダー記法でテンプレ変数を含む prompt テキスト。max 20000 文字';
+
+COMMIT;
+
+-- ===============================================
+-- DOWN: 上限を 10000 に戻す (= length>10000 の row が無い前提)
+-- BEGIN;
+-- ALTER TABLE public.prompt_overrides
+--   DROP CONSTRAINT IF EXISTS prompt_overrides_content_check;
+-- ALTER TABLE public.prompt_overrides
+--   ADD CONSTRAINT prompt_overrides_content_check
+--   CHECK (length(content) <= 10000 AND length(trim(content)) > 0);
+-- COMMIT;
+-- ===============================================

--- a/tests/integration/api/admin-generation-prompts-routes.test.ts
+++ b/tests/integration/api/admin-generation-prompts-routes.test.ts
@@ -169,18 +169,18 @@ describe("PUT /api/admin/generation-prompts/[key]", () => {
     expect(res.status).toBe(400);
   });
 
-  test("10000 文字超過は 400", async () => {
+  test("20000 文字超過は 400", async () => {
     mockRequireAdmin.mockResolvedValue(FAKE_ADMIN);
-    const res = await PUT(makePutRequest({ content: "x".repeat(10001) }), {
+    const res = await PUT(makePutRequest({ content: "x".repeat(20001) }), {
       params: Promise.resolve({ key: "style.base_prefix" }),
     });
     expect(res.status).toBe(400);
   });
 
-  test("4000 超〜10000 以内は許可 (上限緩和後)", async () => {
+  test("10000 超〜20000 以内は許可 (上限緩和後)", async () => {
     mockRequireAdmin.mockResolvedValue(FAKE_ADMIN);
     mockUpsert.mockResolvedValue({ previousContent: null });
-    const res = await PUT(makePutRequest({ content: "x".repeat(8000) }), {
+    const res = await PUT(makePutRequest({ content: "x".repeat(15000) }), {
       params: Promise.resolve({ key: "style.base_prefix" }),
     });
     expect(res.status).toBe(200);

--- a/tests/integration/api/admin-generation-prompts-routes.test.ts
+++ b/tests/integration/api/admin-generation-prompts-routes.test.ts
@@ -169,18 +169,18 @@ describe("PUT /api/admin/generation-prompts/[key]", () => {
     expect(res.status).toBe(400);
   });
 
-  test("20000 文字超過は 400", async () => {
+  test("100000 文字超過は 400", async () => {
     mockRequireAdmin.mockResolvedValue(FAKE_ADMIN);
-    const res = await PUT(makePutRequest({ content: "x".repeat(20001) }), {
+    const res = await PUT(makePutRequest({ content: "x".repeat(100001) }), {
       params: Promise.resolve({ key: "style.base_prefix" }),
     });
     expect(res.status).toBe(400);
   });
 
-  test("10000 超〜20000 以内は許可 (上限緩和後)", async () => {
+  test("10000 超〜100000 以内は許可 (上限緩和後)", async () => {
     mockRequireAdmin.mockResolvedValue(FAKE_ADMIN);
     mockUpsert.mockResolvedValue({ previousContent: null });
-    const res = await PUT(makePutRequest({ content: "x".repeat(15000) }), {
+    const res = await PUT(makePutRequest({ content: "x".repeat(50000) }), {
       params: Promise.resolve({ key: "style.base_prefix" }),
     });
     expect(res.status).toBe(200);


### PR DESCRIPTION
## 概要

admin の生成 prompt エディタ（`/admin/generation-prompts/[key]`）で、`creator_looks.meta_extractor` の meta-prompt が現行の 10,000 字上限に達して保存できなくなったため、許容文字数を **100,000 字** に引き上げます。

## 変更内容

前回の緩和（4,000 → 10,000、`20260603101100_relax_prompt_overrides_content_length.sql`）と同じ方針で、3層（defense in depth）の上限を揃えて更新します。

| 層 | ファイル | 変更 |
|---|---|---|
| DB | `supabase/migrations/20260722114900_relax_prompt_overrides_content_length_100k.sql`（新規） | `prompt_overrides_content_check` を `length(content) <= 100000` に再作成 |
| API | `app/api/admin/generation-prompts/[key]/route.ts` | `MAX_CONTENT_LENGTH` 10000 → 100000 |
| クライアント | `features/generation-prompts/components/AdminPromptEditClient.tsx` | `MAX_CONTENT_LENGTH` 10000 → 100000（文字数カウンタ表示も追従） |

## 設計メモ

- 文字数上限は「暴走入力（監査ログ肥大・PII 肥大）を防ぐ安全ガード」であり、特定 key 専用ではなく全 prompt_key 共通のグローバル上限のまま緩和（前回の設計判断を踏襲）
- 緩和のみのため既存 row への影響なし（全 row が length <= 10000）
- マイグレーションファイルに DOWN 手順をコメントで記載

## 検証

- 統合テスト更新: 「100000 文字超過は 400」「10000 超〜100000 以内は許可」（18件パス）
- `npm run lint` / `npm run test`（2,527件パス）/ `npm run build -- --webpack` 成功

## マイグレーション適用

未適用です。マージ前後に `supabase db push` で適用します（緩和のみのため適用タイミングによる利用者影響はありません）。

## マージ方式

短命の fix ブランチのため **Squash and merge** を指定してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
