### PR TITLE
perf(home): 上部バナーのpreloadとCLS対策(0.32→0.03)

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -9,6 +9,12 @@ import { isAdminViewer as checkIsAdminViewer } from "@/lib/env";
 import { getActivePopupBanners } from "@/features/popup-banners/lib/get-active-popup-banners";
 import { POPUP_BANNER_IMAGE_SIZES } from "@/features/popup-banners/lib/popup-banner-image";
 import { PopupBannerOverlay } from "@/features/popup-banners/components/PopupBannerOverlay";
+import { getPublicBanners } from "@/features/banners/lib/get-banners";
+import {
+  HOME_BANNER_IMAGE_HEIGHT,
+  HOME_BANNER_IMAGE_SIZES,
+  HOME_BANNER_IMAGE_WIDTH,
+} from "@/features/home/lib/home-banner-image";
 import { CachedHomeBannerSection } from "@/features/home/components/CachedHomeBannerSection";
 import { CachedHomePostListSection } from "@/features/home/components/CachedHomePostListSection";
 import { CachedHomeStylePresetSection } from "@/features/home/components/CachedHomeStylePresetSection";
@@ -165,6 +171,107 @@ async function HomePopupBannerSection({
   return <PopupBannerOverlay banners={popupBanners} />;
 }
 
+/**
+ * ホーム上部バナー(現在の LCP 要素)の先頭1枚を先行ダウンロードさせる。
+ * バナーは Suspense ストリーミング + クライアントカルーセル経由で表示される
+ * ため、そのままだと画像取得の開始が RSC 到着後になり LCP を悪化させる
+ * (実測で Load Delay 2〜7秒)。HomeBannerCard の <Image> と同じ
+ * srcset/sizes を getImageProps で再現し、キャッシュに確実にヒットさせる。
+ */
+async function HomeBannerPreload() {
+  const banners = await getPublicBanners();
+  const first = banners[0];
+  if (!first?.imageUrl) {
+    return null;
+  }
+
+  const { props: imgProps } = getImageProps({
+    src: first.imageUrl,
+    alt: "",
+    width: HOME_BANNER_IMAGE_WIDTH,
+    height: HOME_BANNER_IMAGE_HEIGHT,
+    sizes: HOME_BANNER_IMAGE_SIZES,
+  });
+  preload(imgProps.src, {
+    as: "image",
+    imageSrcSet: imgProps.srcSet,
+    imageSizes: imgProps.sizes,
+    fetchPriority: "high",
+  });
+
+  return null;
+}
+
+/**
+ * ホーム投稿一覧のフォールバック。実体(PostList)は SortTabs(mb-4) 付きで
+ * レンダーされるため、同じ高さのプレースホルダーを置いて差し替え時に
+ * 下のコンテンツが押し下げられるシフトを防ぐ。
+ */
+function HomePostListFallback() {
+  return (
+    <>
+      <div className="mb-4 border-b">
+        <div className="my-2 h-6 w-40 animate-pulse rounded bg-gray-200" />
+      </div>
+      <PostListSkeleton />
+    </>
+  );
+}
+
+/**
+ * スタイルカルーセル用ローダー。cookies 依存の getUser() をページ本体から
+ * 切り離し、Suspense 内で解決する(ページシェルを静的に保つため)。
+ */
+async function HomeStylePresetSectionLoader() {
+  const currentUser = await getUser();
+  // 公開前カテゴリ(admin_only)を admin / プレビュー admin にだけ表示する
+  const isAdminViewer = checkIsAdminViewer(currentUser?.id ?? null);
+
+  return (
+    <CachedHomeStylePresetSection
+      isAdminViewer={isAdminViewer}
+      userId={currentUser?.id ?? null}
+    />
+  );
+}
+
+/**
+ * Inspire ホームカルーセル用ローダー。
+ * Creator Looks: admin / allowlist 該当ユーザーのみカルーセルに含める (= Stage 1 厳密化)
+ * 非該当ユーザーには Creator Looks 投稿を完全非表示にし、既存 Inspire 投稿のみ表示する
+ */
+async function HomeUserStyleTemplateSectionLoader() {
+  const currentUser = await getUser();
+  const includeCreatorLooks = await isCreatorLooksEnabledForUser(currentUser);
+
+  return (
+    <CachedHomeUserStyleTemplateSection
+      includeCreatorLooks={includeCreatorLooks}
+    />
+  );
+}
+
+/** 解放お知らせのプレビュー(開発/E2E のみ)。?petitUnlockPreview=initial|drip で強制表示。 */
+async function HomePetitUnlockPreviewSection({
+  searchParams,
+}: {
+  searchParams: Promise<{ petitUnlockPreview?: string }>;
+}) {
+  const previewParam = (await searchParams).petitUnlockPreview;
+  const petitUnlockPreview =
+    (previewParam === "initial" || previewParam === "drip") &&
+    (process.env.NODE_ENV !== "production" ||
+      process.env.PLAYWRIGHT_E2E === "1")
+      ? previewParam
+      : null;
+
+  if (!petitUnlockPreview) {
+    return null;
+  }
+
+  return <HomePetitUnlockPreview mode={petitUnlockPreview} />;
+}
+
 export default async function LocaleHome({
   params,
   searchParams,
@@ -175,42 +282,31 @@ export default async function LocaleHome({
   const { locale: localeParam } = await params;
   const locale = isLocale(localeParam) ? localeParam : DEFAULT_LOCALE;
 
-  // Creator Looks: admin / allowlist 該当ユーザーのみカルーセルに含める (= Stage 1 厳密化)
-  // 非該当ユーザーには Creator Looks 投稿を完全非表示にし、既存 Inspire 投稿のみ表示する
-  const currentUser = await getUser();
-  const includeCreatorLooks = await isCreatorLooksEnabledForUser(currentUser);
-  // 公開前カテゴリ(admin_only)を admin / プレビュー admin にだけ表示する
-  const isAdminViewer = checkIsAdminViewer(currentUser?.id ?? null);
-
-  // 解放お知らせのプレビュー(開発/E2E のみ)。?petitUnlockPreview=initial|drip で強制表示。
-  const previewParam = (await searchParams).petitUnlockPreview;
-  const petitUnlockPreview =
-    (previewParam === "initial" || previewParam === "drip") &&
-    (process.env.NODE_ENV !== "production" ||
-      process.env.PLAYWRIGHT_E2E === "1")
-      ? previewParam
-      : null;
+  // cookies / searchParams に依存する処理はページ本体で await せず、
+  // 各 Suspense 内のローダーへ寄せる。ページ本体で await するとページ全体が
+  // 動的になり、初期表示が「ヘッダー + フッターのみ」になってフッターが
+  // 一瞬ビューポート内に見え、コンテンツ到着時に大きな CLS が発生する
+  // (実測 0.15)。シェル(見出し + スケルトン)を先に描画してフッターを
+  // 最初から画面外に置く。
 
   return (
     <div className="mx-auto max-w-6xl px-1 pb-8 pt-6 sm:px-4 md:pt-8">
       <HomeStructuredData locale={locale} />
       <Suspense fallback={null}>
+        <HomeBannerPreload />
+      </Suspense>
+      <Suspense fallback={null}>
         <HomePopupBannerSection searchParams={searchParams} />
       </Suspense>
-      {petitUnlockPreview && (
-        <Suspense fallback={null}>
-          <HomePetitUnlockPreview mode={petitUnlockPreview} />
-        </Suspense>
-      )}
+      <Suspense fallback={null}>
+        <HomePetitUnlockPreviewSection searchParams={searchParams} />
+      </Suspense>
       <HomeHeading />
       <Suspense fallback={<HomeBannerSkeleton />}>
         <CachedHomeBannerSection />
       </Suspense>
       <Suspense fallback={<HomeStylePresetCarouselSkeleton />}>
-        <CachedHomeStylePresetSection
-          isAdminViewer={isAdminViewer}
-          userId={currentUser?.id ?? null}
-        />
+        <HomeStylePresetSectionLoader />
       </Suspense>
       {/*
         Inspire ホームカルーセル（ADR-013）。
@@ -220,12 +316,10 @@ export default async function LocaleHome({
       */}
       {process.env.NEXT_PUBLIC_INSPIRE_HOME_CAROUSEL_ENABLED === "true" && (
         <Suspense fallback={<HomeUserStyleTemplateCarouselSkeleton />}>
-          <CachedHomeUserStyleTemplateSection
-            includeCreatorLooks={includeCreatorLooks}
-          />
+          <HomeUserStyleTemplateSectionLoader />
         </Suspense>
       )}
-      <Suspense fallback={<PostListSkeleton />}>
+      <Suspense fallback={<HomePostListFallback />}>
         <CachedHomePostListSection />
       </Suspense>
     </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -300,6 +300,17 @@ html[lang="en"]:not(.ppr-locale-ready) .main-content {
     will-change: opacity;
   }
 
+  /* ホーム上部バナーのカルーセル。
+     Swiper 初期化前(SSR直後)は swiper/css の .swiper-slide { width: 100% } で
+     スライドが全幅になり、初期化時に 1.5 枚表示へ縮んでレイアウトシフトが
+     起きる(実測 CLS 0.09 相当)。初期化後と同じ幅(spaceBetween 16 /
+     slidesPerView 1.5 の計算式)を事前に与えてシフトを防ぐ。
+     初期化後は Swiper が設定する inline style が優先されるため副作用はない。 */
+  .home-banner-swiper .swiper-slide {
+    width: calc((100% - 8px) / 1.5);
+    margin-right: 16px;
+  }
+
   @keyframes commentComposerSheetSlideIn {
     from {
       transform: translate3d(0, 100%, 0);

--- a/features/home/components/HomeBannerCard.tsx
+++ b/features/home/components/HomeBannerCard.tsx
@@ -3,6 +3,11 @@
 import Link from "next/link";
 import Image from "next/image";
 import { Card } from "@/components/ui/card";
+import {
+  HOME_BANNER_IMAGE_HEIGHT,
+  HOME_BANNER_IMAGE_SIZES,
+  HOME_BANNER_IMAGE_WIDTH,
+} from "../lib/home-banner-image";
 import type { HomeBanner } from "@/constants/homeBanners";
 
 function isExternalUrl(url: string): boolean {
@@ -39,10 +44,10 @@ export function HomeBannerCard({
         <Image
           src={banner.imageUrl}
           alt={banner.alt}
-          width={1200}
-          height={400}
+          width={HOME_BANNER_IMAGE_WIDTH}
+          height={HOME_BANNER_IMAGE_HEIGHT}
           className="w-full h-auto object-cover aspect-[3/1]"
-          sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
+          sizes={HOME_BANNER_IMAGE_SIZES}
           priority={prioritizeImage}
           loading={prioritizeImage ? "eager" : undefined}
         />

--- a/features/home/components/HomeBannerList.tsx
+++ b/features/home/components/HomeBannerList.tsx
@@ -36,6 +36,11 @@ export function HomeBannerList({ banners }: HomeBannerListProps) {
     <div className="mb-8 overflow-x-hidden">
       <div className="-mx-4 px-4">
         <Swiper
+          // Swiper 初期化前(SSR直後)はスライド幅が全幅になり、初期化時に
+          // 1.5枚表示へ縮んでレイアウトシフト(実測CLS 0.09相当)が起きる。
+          // 初期化後と同じ幅を globals.css の .home-banner-swiper で事前に
+          // 与えておく(初期化後は Swiper の inline style が優先される)。
+          className="home-banner-swiper"
           modules={[Autoplay]}
           onSwiper={setSwiper}
           onSlideChange={(swiper) => setActiveIndex(swiper.realIndex)}

--- a/features/home/components/HomeBannerSkeleton.tsx
+++ b/features/home/components/HomeBannerSkeleton.tsx
@@ -1,11 +1,19 @@
 /**
  * ホームバナー用スケルトン（カルーセル形式）
+ *
+ * 実カルーセル(Swiper: slidesPerView 1.5, spaceBetween 16)と同じ高さに
+ * なるよう、2/3幅のカード + 次スライドの一部を再現する。
+ * 高さが実体とずれると差し替え時に下のセクションが動き CLS になる
+ * (旧実装の全幅1枚では実体より約40px高く、CLS 0.09 相当のシフトが出ていた)。
  */
 export function HomeBannerSkeleton() {
   return (
     <div className="mb-8 overflow-x-hidden">
       <div className="-mx-4 px-4">
-        <div className="aspect-[3/1] w-full animate-pulse rounded-lg bg-gray-200" />
+        <div className="flex gap-4">
+          <div className="aspect-[3/1] w-[calc((100%_-_16px)/1.5)] flex-shrink-0 animate-pulse rounded-lg bg-gray-200" />
+          <div className="aspect-[3/1] w-[calc((100%_-_16px)/1.5)] flex-shrink-0 animate-pulse rounded-lg bg-gray-200" />
+        </div>
       </div>
       <div className="mt-4 flex justify-center gap-2">
         <div className="h-2 w-2 animate-pulse rounded-full bg-gray-200" />

--- a/features/home/lib/home-banner-image.ts
+++ b/features/home/lib/home-banner-image.ts
@@ -1,0 +1,11 @@
+/**
+ * ホーム上部バナー画像の sizes 定義。
+ * HomeBannerCard の <Image> と、page.tsx の preload(先行ダウンロード)で
+ * 同じ値を使い、srcset の解決結果を一致させてキャッシュに確実にヒットさせる。
+ */
+export const HOME_BANNER_IMAGE_SIZES =
+  "(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw";
+
+/** HomeBannerCard の <Image> と同じ intrinsic サイズ (aspect 3:1)。 */
+export const HOME_BANNER_IMAGE_WIDTH = 1200;
+export const HOME_BANNER_IMAGE_HEIGHT = 400;


### PR DESCRIPTION
## 概要

ホーム画面のパフォーマンス対応です。(1) 現在の LCP 要素であるホーム上部バナー画像の preload、(2) CLS 0.32 の原因調査と修正を行います。DB 変更なし。

## 現状の計測(本番・モバイル設定の Lighthouse 3回)

| 指標 | run1 | run2 | run3 |
|---|---|---|---|
| Performance | 55 | 66 | 53 |
| LCP | 5.5s | 6.8s | 8.8s |
| うち Load Delay | 2.1s | 5.1s | 7.6s |
| CLS | 0.179 | 0.095 | 0.242 |

LCP 要素は毎回ホーム上部バナー(コラボ企画)で、**画像取得開始の遅れ(Load Delay)が支配的**でした。CLS は PerformanceObserver での実測(0.317)で発生源を3つ特定しました。

## 変更内容

### 1. LCP: 上部バナー先頭1枚の preload

バナーは Suspense ストリーミング + クライアントカルーセル(Swiper)経由で表示されるため、`priority` 指定済みでも画像取得開始が RSC 到着・hydration 後になっていました。ポップアップバナー(PR #437)と同じ方式で、`page.tsx` から `<link rel="preload" fetchPriority="high">` を初期 HTML に発行します。

- `HomeBannerCard` の `<Image>` と同じ srcset/sizes を `getImageProps` で再現(共有定数 `features/home/lib/home-banner-image.ts` を新設)
- 初期 HTML に preload リンクが入ることをローカル prod ビルドで確認済み

### 2. CLS: 実測 0.317 → **0.031**

| 発生源(実測) | シフト量 | 対策 |
|---|---|---|
| ページ全体が動的(本体で `getUser()` 等を await)なため初期表示が「ヘッダー+フッターのみ」になり、コンテンツ到着でフッターが押し出される | 0.149 | cookies/searchParams 依存の await を各 Suspense 内のローダー(`HomeStylePresetSectionLoader` 等)へ移動し、シェル(見出し+スケルトン)を先に描画 |
| Swiper 初期化前はスライドが全幅(swiper/css の `width:100%`)で、初期化時に 1.5 枚表示へ縮む | 0.086 | 初期化後と同じスライド幅を CSS で事前指定(`.home-banner-swiper`)。初期化後は Swiper の inline style が優先されるため副作用なし |
| 投稿一覧スケルトンに SortTabs 相当が無く、実体到着時に下へ押し下げ | 0.079 | フォールバックに同じ高さのプレースホルダーを追加 |
| バナースケルトンが全幅1枚で実体(1.5枚)より約40px高い | (上と複合) | スケルトンを 1.5 枚レイアウトに変更 |

### 検証

- ローカル prod ビルド(webpack)で PerformanceObserver 実測: **CLS 0.317 → 0.031**(2回連続で安定、Core Web Vitals「良好」基準 <0.1 をクリア)
- ローカル prod への Lighthouse(モバイル設定): CLS 0.077 / LCP 要素は引き続きバナー(ネットワーク条件がローカルのため LCP 絶対値はデプロイ後に本番で再計測します)
- `npm run lint` / `npm run test`(2,527件パス) / `npm run build -- --webpack` 成功
- ホーム表示(バナー・カルーセル・投稿一覧・ポップアップ)が正常であることをブラウザで確認

## スコープ外

- スタイルカルーセル画像の最適化(run3 で LCP がカルーセル側になるケースがあったが、バナー高速化で LCP はバナーに安定する想定。デプロイ後の計測で必要なら別対応)

## マージ方式

短命の perf ブランチのため **Squash and merge** を指定してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
