### PR TITLE
fix(collections): 共有ページの「遊び方をみる」をコレクション別に出し分け

### DIFF
--- a/app/m/[token]/page.tsx
+++ b/app/m/[token]/page.tsx
@@ -10,6 +10,7 @@ import {
   withOgpVersion,
 } from "@/features/collections/lib/public-mount-server-api";
 import { mountAspectForCategory } from "@/features/collections/lib/mount-aspects";
+import { collectionGuidePath } from "@/features/collections/lib/collection-guides";
 import { MountShareButton } from "@/features/collections/components/MountShareButton";
 import { XLotteryEntryButton } from "@/features/campaigns/components/XLotteryEntryButton";
 import { MountCelebrationBackground } from "@/features/collections/components/MountCelebrationBackground";
@@ -182,7 +183,7 @@ export default async function PublicMountPage({
         </p>
         <div className="mt-3">
           <Link
-            href="/collections/wafer"
+            href={collectionGuidePath(mount.categoryKey)}
             className="text-xs text-gray-500 underline hover:text-gray-700"
           >
             遊び方をみる


### PR DESCRIPTION
## 概要

コレクション完走の共有ページ `/m/[token]` の「遊び方をみる」リンクが `/collections/wafer`(神コレクション)にハードコードされており、**ことわざ辞典やイタリア旅行を完走しても神コレの遊び方ページへ遷移していた**不具合を修正します。

## 原因

`app/m/[token]/page.tsx` の「遊び方をみる」`<Link>` の `href` が `/collections/wafer` 固定でした。

## 修正

既存のヘルパー `collectionGuidePath(categoryKey)`(`features/collections/lib/collection-guides.ts`)を使い、完走したコレクションのカテゴリキーに応じて遊び方ページを出し分けます。

- `kotowaza_dictionary` / `kotowaza_dictionary_2` → `/collections/kotowaza`
- `travel_to_italy` → `/collections/italy`
- 神コレ等・未登録 → `/collections/wafer`(従来どおりフォールバック)

このヘルパーは既に `CollectionProgressModal` の遊び方リンクでも使われており、同じ出し分けロジックに揃えます。

## 検証

- 実データの共有 URL(`/m/85b1ae63-...` = ことわざ辞典 上巻・`category_key: kotowaza_dictionary`)を dev サーバーで開き、「遊び方をみる」の `href` が `/collections/kotowaza` になることを確認
- `npm run lint`(変更ファイル)/ `npm run build -- --webpack` 成功

## マージ方式

短命の fix ブランチのため **Squash and merge** を指定してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
