### PR TITLE
feat(seo): 検索インデックスを阻害していたcanonical・sitemapを修正し、スタイル紹介ページ(/styles)を新設

### DIFF
--- a/app/[locale]/(app)/coordinate/page.tsx
+++ b/app/[locale]/(app)/coordinate/page.tsx
@@ -1,0 +1,1 @@
+export { default, generateMetadata } from "../../../(app)/coordinate/page";

--- a/app/[locale]/(app)/layout.tsx
+++ b/app/[locale]/(app)/layout.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../(app)/layout";

--- a/app/[locale]/(app)/loading.tsx
+++ b/app/[locale]/(app)/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../(app)/loading";

--- a/app/[locale]/(app)/style/page.tsx
+++ b/app/[locale]/(app)/style/page.tsx
@@ -1,0 +1,1 @@
+export { default, generateMetadata } from "../../../(app)/style/page";

--- a/app/[locale]/catalog/page.tsx
+++ b/app/[locale]/catalog/page.tsx
@@ -1,1 +1,1 @@
-export { default, metadata } from "../../catalog/page";
+export { default, generateMetadata } from "../../catalog/page";

--- a/app/[locale]/catalog/submit/page.tsx
+++ b/app/[locale]/catalog/submit/page.tsx
@@ -1,1 +1,1 @@
-export { default, metadata } from "../../../catalog/submit/page";
+export { default, generateMetadata } from "../../../catalog/submit/page";

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -110,6 +110,15 @@ function HomeStructuredData({ locale }: { locale: Locale }) {
     "alternateName": ["Persta", "ペルスタ"],
     "url": siteUrl,
     "description": copy.organizationDescription,
+    // サイト内検索(/search?q=)の存在を検索エンジンに伝える(サイトリンク検索ボックス)
+    "potentialAction": {
+      "@type": "SearchAction",
+      "target": {
+        "@type": "EntryPoint",
+        "urlTemplate": `${siteUrl}${localizePublicPath("/search", locale)}?q={search_term_string}`,
+      },
+      "query-input": "required name=search_term_string",
+    },
   };
 
   return (

--- a/app/[locale]/styles/[slug]/page.tsx
+++ b/app/[locale]/styles/[slug]/page.tsx
@@ -1,0 +1,1 @@
+export { default, generateMetadata } from "../../../styles/[slug]/page";

--- a/app/[locale]/styles/page.tsx
+++ b/app/[locale]/styles/page.tsx
@@ -1,0 +1,1 @@
+export { default, generateMetadata } from "../../styles/page";

--- a/app/catalog/[slug]/p/[entryId]/page.tsx
+++ b/app/catalog/[slug]/p/[entryId]/page.tsx
@@ -1,7 +1,10 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { connection } from "next/server";
+import { getLocale } from "next-intl/server";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { DEFAULT_LOCALE, isLocale } from "@/i18n/config";
+import { createLocaleAlternates } from "@/lib/metadata";
 import {
   getCachedCampaignBySlug,
   getCachedPublicEntriesByCampaign,
@@ -42,9 +45,16 @@ export async function generateMetadata({
     SIGNED_URL_TTL_SECONDS,
   );
 
+  const localeValue = await getLocale();
+  const locale = isLocale(localeValue) ? localeValue : DEFAULT_LOCALE;
+
   return {
     title,
     description,
+    alternates: createLocaleAlternates(
+      `/catalog/${slug}/p/${entryId}`,
+      locale
+    ),
     openGraph: {
       title,
       description,

--- a/app/catalog/[slug]/page.tsx
+++ b/app/catalog/[slug]/page.tsx
@@ -2,7 +2,10 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { connection } from "next/server";
 import Link from "next/link";
+import { getLocale } from "next-intl/server";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { DEFAULT_LOCALE, isLocale } from "@/i18n/config";
+import { createLocaleAlternates } from "@/lib/metadata";
 import {
   getCachedCampaignBySlug,
   getCachedPublicEntriesByCampaign,
@@ -39,11 +42,15 @@ export async function generateMetadata({
     coverImageUrl = url;
   }
 
+  const localeValue = await getLocale();
+  const locale = isLocale(localeValue) ? localeValue : DEFAULT_LOCALE;
+
   return {
     title: `${campaign.title} | 絵師カタログ | Persta.AI`,
     description:
       campaign.description ??
       `${campaign.title} - 絵師さんの作品をまとめた本です。`,
+    alternates: createLocaleAlternates(`/catalog/${slug}`, locale),
     openGraph: {
       title: campaign.title,
       description: campaign.description ?? undefined,

--- a/app/catalog/page.tsx
+++ b/app/catalog/page.tsx
@@ -1,23 +1,29 @@
 import type { Metadata } from "next";
 import { connection } from "next/server";
+import { getLocale } from "next-intl/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getCachedPublishedCampaigns } from "@/features/catalog/lib/get-public-catalog";
 import { createCatalogSignedUrls } from "@/features/catalog/lib/repository";
 import { CampaignCard } from "@/features/catalog/components/CampaignCard";
+import { DEFAULT_LOCALE, isLocale } from "@/i18n/config";
+import { createMarketingPageMetadata } from "@/lib/metadata";
 
 const SIGNED_URL_TTL_SECONDS = 60 * 30;
 
-export const metadata: Metadata = {
-  title: "絵師カタログ | Persta.AI",
-  description:
-    "X で活動するクリエイターさんの作品を、企画ごとの本としてまとめて楽しめるカタログです。",
-  openGraph: {
-    title: "絵師カタログ | Persta.AI",
+export async function generateMetadata(): Promise<Metadata> {
+  const localeValue = await getLocale();
+  const locale = isLocale(localeValue) ? localeValue : DEFAULT_LOCALE;
+
+  return createMarketingPageMetadata({
+    title: locale === "ja" ? "絵師カタログ" : "Artist Catalog",
     description:
-      "X で活動するクリエイターさんの作品を、企画ごとの本としてまとめて楽しめるカタログです。",
-    type: "website",
-  },
-};
+      locale === "ja"
+        ? "X で活動するクリエイターさんの作品を、企画ごとの本としてまとめて楽しめるカタログです。"
+        : "A catalog of works by artists on X, collected into books by project.",
+    path: "/catalog",
+    locale,
+  });
+}
 
 export default async function CatalogIndexPage() {
   await connection();

--- a/app/catalog/submit/page.tsx
+++ b/app/catalog/submit/page.tsx
@@ -2,15 +2,25 @@ import type { Metadata } from "next";
 import { connection } from "next/server";
 import { notFound } from "next/navigation";
 import Link from "next/link";
+import { getLocale } from "next-intl/server";
 import { env, isCatalogFeatureEnabled } from "@/lib/env";
 import { getCachedCampaignBySlug } from "@/features/catalog/lib/get-public-catalog";
 import { CatalogSubmissionForm } from "@/features/catalog/components/CatalogSubmissionForm";
+import { DEFAULT_LOCALE, isLocale } from "@/i18n/config";
+import { createLocaleAlternates } from "@/lib/metadata";
 
-export const metadata: Metadata = {
-  title: "作品を申請する | 絵師カタログ | Persta.AI",
-  description:
-    "X で活動するクリエイターさん向けの、絵師カタログ申請フォームです。未ログインでも申請できます。",
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const localeValue = await getLocale();
+  const locale = isLocale(localeValue) ? localeValue : DEFAULT_LOCALE;
+
+  return {
+    title: "作品を申請する | 絵師カタログ | Persta.AI",
+    description:
+      "X で活動するクリエイターさん向けの、絵師カタログ申請フォームです。未ログインでも申請できます。",
+    // ?campaign=<slug> のクエリ違い URL はクエリ無しの /catalog/submit に正規化する
+    alternates: createLocaleAlternates("/catalog/submit", locale),
+  };
+}
 
 interface PageProps {
   searchParams: Promise<{ campaign?: string }>;

--- a/app/catalog/submit/thanks/page.tsx
+++ b/app/catalog/submit/thanks/page.tsx
@@ -4,6 +4,8 @@ import Link from "next/link";
 
 export const metadata: Metadata = {
   title: "申請ありがとうございます | 絵師カタログ | Persta.AI",
+  // フォーム送信後の確認ページは検索結果に出す価値がないため noindex
+  robots: { index: false, follow: true },
 };
 
 export default async function CatalogSubmitThanksPage() {

--- a/app/collab/page.tsx
+++ b/app/collab/page.tsx
@@ -5,6 +5,7 @@ import {
   type PastCollab,
 } from "@/features/collab/components/CollabRecruitGuide";
 import { listPublishedStylePresets } from "@/features/style-presets/lib/style-preset-repository";
+import { createCanonicalAlternates } from "@/lib/metadata";
 
 const OGP_IMAGE = "/collections/wafer/god-share.webp";
 const PAGE_TITLE =
@@ -18,6 +19,7 @@ const ITALY_CATEGORY_KEY = "travel_to_italy";
 export const metadata: Metadata = {
   title: PAGE_TITLE,
   description: PAGE_DESCRIPTION,
+  alternates: createCanonicalAlternates("/collab"),
   openGraph: {
     title: "一緒にコラボしませんか？｜コラボ企画パートナー募集",
     description:

--- a/app/collections/italy/page.tsx
+++ b/app/collections/italy/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { connection } from "next/server";
+import { createCanonicalAlternates } from "@/lib/metadata";
 import { getPresetCategoryByKey } from "@/features/style-presets/lib/preset-category-repository";
 import { listPublishedStylePresets } from "@/features/style-presets/lib/style-preset-repository";
 import { ItalyTravelGuide } from "@/features/collections/components/ItalyTravelGuide";
@@ -15,6 +16,7 @@ const PAGE_DESCRIPTION =
 export const metadata: Metadata = {
   title: PAGE_TITLE,
   description: PAGE_DESCRIPTION,
+  alternates: createCanonicalAlternates("/collections/italy"),
   openGraph: {
     title: "うちの子のイタリア旅行日記｜めくれる旅行日記をつくろう",
     description:

--- a/app/collections/kotowaza/page.tsx
+++ b/app/collections/kotowaza/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { connection } from "next/server";
+import { createCanonicalAlternates } from "@/lib/metadata";
 import { getPresetCategoryByKey } from "@/features/style-presets/lib/preset-category-repository";
 import { KotowazaGuide } from "@/features/collections/components/KotowazaGuide";
 
@@ -14,6 +15,7 @@ const PAGE_DESCRIPTION =
 export const metadata: Metadata = {
   title: PAGE_TITLE,
   description: PAGE_DESCRIPTION,
+  alternates: createCanonicalAlternates("/collections/kotowaza"),
   openGraph: {
     title: "うちの子のことわざ辞典｜6語そろえてコンプリート",
     description:

--- a/app/collections/page.tsx
+++ b/app/collections/page.tsx
@@ -7,6 +7,7 @@ import { getPublicCollectionSeriesCatalog } from "@/features/collections/lib/col
 import { getCollectionProgressForUser } from "@/features/collections/lib/collection-progress-repository";
 import { buildCollectionCatalogView } from "@/features/collections/lib/collection-catalog-view";
 import { CollectionCatalogGrid } from "@/features/collections/components/CollectionCatalogGrid";
+import { createCanonicalAlternates } from "@/lib/metadata";
 
 const OGP_IMAGE = "/og/wafer-god.jpg";
 const PAGE_TITLE = "コレクション図鑑｜うちの子で集めよう | Persta.AI";
@@ -16,6 +17,7 @@ const PAGE_DESCRIPTION =
 export const metadata: Metadata = {
   title: PAGE_TITLE,
   description: PAGE_DESCRIPTION,
+  alternates: createCanonicalAlternates("/collections"),
   openGraph: {
     title: "コレクション図鑑｜うちの子で集めよう",
     description: "うちの子で楽しめるコレクション一覧。集めてコンプリートしよう。",

--- a/app/collections/wafer/page.tsx
+++ b/app/collections/wafer/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { connection } from "next/server";
+import { createCanonicalAlternates } from "@/lib/metadata";
 import { getPresetCategoryByKey } from "@/features/style-presets/lib/preset-category-repository";
 import { WaferGuide } from "@/features/collections/components/WaferGuide";
 
@@ -14,6 +15,7 @@ const PAGE_DESCRIPTION =
 export const metadata: Metadata = {
   title: PAGE_TITLE,
   description: PAGE_DESCRIPTION,
+  alternates: createCanonicalAlternates("/collections/wafer"),
   openGraph: {
     title: "うちの子の神コレクション｜6柱そろえてコンプリート",
     description:

--- a/app/creators/page.tsx
+++ b/app/creators/page.tsx
@@ -5,6 +5,7 @@ import {
   type GalleryImage,
 } from "@/features/creators/components/CreatorsRecruitGuide";
 import { listPublishedStylePresets } from "@/features/style-presets/lib/style-preset-repository";
+import { createCanonicalAlternates } from "@/lib/metadata";
 
 const OGP_IMAGE = "/og/one-tap-style.png";
 const PAGE_TITLE =
@@ -15,6 +16,7 @@ const PAGE_DESCRIPTION =
 export const metadata: Metadata = {
   title: PAGE_TITLE,
   description: PAGE_DESCRIPTION,
+  alternates: createCanonicalAlternates("/creators"),
   openGraph: {
     title: "あなたのプロンプトを掲載しませんか？｜One-Tap Style クリエイター募集",
     description:

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,7 +8,7 @@ import "./globals.css";
 //   2 回目のオープン時にアイコンが描画されない不具合が出ることがある。）
 import "yet-another-react-lightbox/styles.css";
 import { LocaleShell } from "@/components/LocaleShell";
-import { getSiteUrl } from "@/lib/env";
+import { env, getSiteUrl } from "@/lib/env";
 import { DEFAULT_LOCALE, getLocaleDir, locales } from "@/i18n/config";
 import { getSiteCopy } from "@/i18n/page-copy";
 
@@ -25,6 +25,7 @@ const geistMono = localFont({
 });
 
 const siteUrl = getSiteUrl() || "https://persta.ai";
+const googleSiteVerification = env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION;
 const defaultSiteCopy = getSiteCopy(DEFAULT_LOCALE);
 const localeCookiePattern = locales.join("|");
 const rtlLocales = locales.filter((locale) => getLocaleDir(locale) === "rtl");
@@ -42,18 +43,19 @@ export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),
   title: defaultSiteCopy.title,
   description: defaultSiteCopy.description,
-  alternates: {
-    canonical: siteUrl,
-    languages: {
-      ja: `${siteUrl}/ja`,
-      en: `${siteUrl}/en`,
-      "x-default": `${siteUrl}/ja`,
-    },
-  },
+  // 注意: ここに alternates(canonical)を置いてはならない。
+  // root layout の alternates は「自分で alternates を定義しないすべてのページ」に
+  // 継承され、全ページの canonical がトップページを指してしまう(= 検索エンジンに
+  // 各ページを「トップの複製」と誤認させ、インデックスから除外させる)。
+  // canonical/hreflang は各ページが createLocaleAlternates / createCanonicalAlternates
+  // (lib/metadata.ts)で自己参照を宣言する。
   robots: {
     index: true,
     follow: true,
   },
+  ...(googleSiteVerification
+    ? { verification: { google: googleSiteVerification } }
+    : {}),
 };
 
 export const viewport = {

--- a/app/posts/[id]/page.tsx
+++ b/app/posts/[id]/page.tsx
@@ -149,8 +149,10 @@ export default async function PostDetailPage({ params }: PostDetailPageProps) {
   // - 既存のキャッシュ済み getPost を再利用し、余分なDB往復を避ける(MUST-ADDRESS-006)
   // - redirect() は内部で例外を投げるため try/catch の外で呼ぶ
   let completionRedirect: string | null = null;
+  let postForJsonLd: Awaited<ReturnType<typeof getPost>> = null;
   try {
     const post = await getPost(id, currentUserId, true);
+    postForJsonLd = post;
     if (post?.completion_id && post.is_posted) {
       completionRedirect =
         post.completion_view_mode === "book"
@@ -165,8 +167,58 @@ export default async function PostDetailPage({ params }: PostDetailPageProps) {
     redirect(completionRedirect);
   }
 
+  // 画像検索での発見性を高める ImageObject 構造化データ。
+  // getPost はキャッシュ済みのため追加の DB 往復は発生しない。
+  let imageJsonLd: Record<string, unknown> | null = null;
+  if (postForJsonLd) {
+    const localeValue = await getLocale();
+    const locale = isLocale(localeValue) ? localeValue : DEFAULT_LOCALE;
+    const copy = getPostPageCopy(locale);
+    const siteUrl = getSiteUrl();
+    const rawImageUrl = getPostDisplayUrl(postForJsonLd);
+    const absoluteImageUrl =
+      rawImageUrl && rawImageUrl.startsWith("http")
+        ? rawImageUrl
+        : siteUrl && rawImageUrl
+          ? `${siteUrl}${rawImageUrl}`
+          : null;
+
+    if (absoluteImageUrl) {
+      imageJsonLd = {
+        "@context": "https://schema.org",
+        "@type": "ImageObject",
+        contentUrl: absoluteImageUrl,
+        name: buildSanitizedText(postForJsonLd.caption, copy.fallbackAlt, 80),
+        description: buildSanitizedText(
+          postForJsonLd.caption,
+          copy.fallbackDescription,
+          120
+        ),
+        ...(postForJsonLd.posted_at
+          ? { datePublished: postForJsonLd.posted_at }
+          : {}),
+        ...(postForJsonLd.user?.nickname
+          ? {
+              creator: {
+                "@type": "Person",
+                name: postForJsonLd.user.nickname,
+              },
+            }
+          : {}),
+      };
+    }
+  }
+
   // use cache でキャッシュして即時表示を優先（閲覧数はキャッシュ時スキップ）
   return (
-    <CachedPostDetail postId={id} currentUserId={currentUserId} />
+    <>
+      <CachedPostDetail postId={id} currentUserId={currentUserId} />
+      {imageJsonLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(imageJsonLd) }}
+        />
+      )}
+    </>
   );
 }

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -7,6 +7,7 @@ import { PostListSkeleton } from "@/features/posts/components/PostListSkeleton";
 import { getSiteUrl } from "@/lib/env";
 import { getUser } from "@/lib/auth";
 import { DEFAULT_LOCALE, isLocale, localizePublicPath } from "@/i18n/config";
+import { createLocaleAlternates } from "@/lib/metadata";
 import { getSearchCopy } from "@/i18n/page-copy";
 
 interface SearchPageProps {
@@ -39,6 +40,9 @@ export async function generateMetadata({
   return {
     title,
     description,
+    // ?q= 付きの検索結果 URL はクエリ無しの /search に正規化する
+    // (クエリごとの薄い重複ページがインデックスされるのを防ぐ)
+    alternates: createLocaleAlternates("/search", locale),
     openGraph: {
       title,
       description,

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -30,7 +30,7 @@ const LOCALIZED_PUBLIC_PATHS = [
 ] as const;
 
 // ロケール分割していない公開ページ(単一 URL で公開)
-const UNLOCALIZED_PUBLIC_PATHS = ["/collections", "/creators"] as const;
+const UNLOCALIZED_PUBLIC_PATHS = ["/collections", "/creators", "/collab"] as const;
 
 type LocalizedPath = (typeof LOCALIZED_PUBLIC_PATHS)[number];
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -7,7 +7,7 @@ import {
   locales,
   localizePublicPath,
 } from "@/i18n/config";
-import { getPublishedStylePresets } from "@/features/style-presets/lib/get-public-style-presets";
+import { listPublishedStylePresets } from "@/features/style-presets/lib/style-preset-repository";
 
 // ロケール展開する公開ページ(PUBLIC_PATH_PATTERNS に含まれるパス)
 const LOCALIZED_PUBLIC_PATHS = [
@@ -65,6 +65,23 @@ function priorityFor(path: LocalizedPath): number {
 }
 
 /**
+ * ビルド時プリレンダの "use cache" 充填には時間制限があり、超過すると
+ * USE_CACHE_TIMEOUT でビルド自体が失敗する。DB の一時的な遅延・ハングで
+ * デプロイが落ちないよう、動的データの取得は個別にタイムボックスし、
+ * 間に合わなかった分は諦めて残りのエントリだけで sitemap を生成する。
+ */
+const SITEMAP_QUERY_TIMEOUT_MS = 10_000;
+
+function withTimeout<T>(promise: Promise<T>, fallback: T): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((resolve) => {
+      setTimeout(() => resolve(fallback), SITEMAP_QUERY_TIMEOUT_MS);
+    }),
+  ]);
+}
+
+/**
  * hreflang アノテーション(sitemap の xhtml:link)。
  * 動的コンテンツはロケールごとに 15 エントリへ複製する代わりに、
  * デフォルトロケール URL 1 エントリ + 言語別 alternates で表現し、
@@ -119,9 +136,28 @@ async function getSitemapEntries(): Promise<MetadataRoute.Sitemap> {
     })
   );
 
-  // 投稿詳細ページ（最大1000件まで）
-  // デフォルトロケール URL 1 エントリ + hreflang alternates で全ロケールを表現する
-  let postPages: MetadataRoute.Sitemap = [];
+  // 動的コンテンツ(投稿・カタログ・スタイル)は並列で取得し、
+  // どれかが遅延・失敗しても他のエントリと静的ページで sitemap を成立させる。
+  const [postPages, catalogPages, stylePages] = await Promise.all([
+    fetchPostPages(baseUrl),
+    fetchCatalogPages(baseUrl),
+    fetchStylePages(baseUrl),
+  ]);
+
+  return [
+    ...staticPages,
+    ...unlocalizedPages,
+    ...stylePages,
+    ...postPages,
+    ...catalogPages,
+  ];
+}
+
+/**
+ * 投稿詳細ページ（最大1000件まで）。
+ * デフォルトロケール URL 1 エントリ + hreflang alternates で全ロケールを表現する。
+ */
+async function fetchPostPages(baseUrl: string): Promise<MetadataRoute.Sitemap> {
   try {
     const supabase = createAdminClient();
     // 注意: generated_images に updated_at カラムは存在しない(select すると
@@ -131,70 +167,83 @@ async function getSitemapEntries(): Promise<MetadataRoute.Sitemap> {
       .select("id, posted_at")
       .eq("is_posted", true)
       .order("posted_at", { ascending: false })
-      .limit(1000); // 1 sitemapあたり50,000 URL制限を考慮して1000件に制限
+      .limit(1000) // 1 sitemapあたり50,000 URL制限を考慮して1000件に制限
+      .abortSignal(AbortSignal.timeout(SITEMAP_QUERY_TIMEOUT_MS));
 
-    if (!error && posts) {
-      postPages = posts
-        .filter((post) => post.id)
-        .map((post) => {
-          const path = `/posts/${post.id}`;
-          return {
-            url: `${baseUrl}${localizePublicPath(path, DEFAULT_LOCALE)}`,
-            ...(post.posted_at
-              ? { lastModified: new Date(post.posted_at) }
-              : {}),
-            changeFrequency: "weekly" as const,
-            priority: 0.6,
-            alternates: buildLanguageAlternates(path, baseUrl),
-          };
-        });
-    } else if (error) {
+    if (error) {
       console.error("Failed to fetch posts for sitemap:", error);
+      return [];
     }
-  } catch (error) {
-    // エラーが発生した場合は、静的ページのみを返す
-    console.error("Failed to fetch posts for sitemap:", error);
-  }
 
-  // 公開中の catalog 企画
-  let catalogPages: MetadataRoute.Sitemap = [];
+    return (posts ?? [])
+      .filter((post) => post.id)
+      .map((post) => {
+        const path = `/posts/${post.id}`;
+        return {
+          url: `${baseUrl}${localizePublicPath(path, DEFAULT_LOCALE)}`,
+          ...(post.posted_at ? { lastModified: new Date(post.posted_at) } : {}),
+          changeFrequency: "weekly" as const,
+          priority: 0.6,
+          alternates: buildLanguageAlternates(path, baseUrl),
+        };
+      });
+  } catch (error) {
+    console.error("Failed to fetch posts for sitemap:", error);
+    return [];
+  }
+}
+
+/** 公開中の catalog 企画。 */
+async function fetchCatalogPages(
+  baseUrl: string
+): Promise<MetadataRoute.Sitemap> {
   try {
     const supabase = createAdminClient();
-    const { data: campaigns, error: campaignError } = await supabase
+    const { data: campaigns, error } = await supabase
       .from("catalog_campaigns")
       .select("slug, updated_at")
       .eq("status", "published")
       .order("display_order", { ascending: true })
-      .limit(500);
+      .limit(500)
+      .abortSignal(AbortSignal.timeout(SITEMAP_QUERY_TIMEOUT_MS));
 
-    if (!campaignError && campaigns) {
-      catalogPages = campaigns
-        .filter((c) => c.slug)
-        .map((c) => {
-          const path = `/catalog/${c.slug}`;
-          return {
-            url: `${baseUrl}${localizePublicPath(path, DEFAULT_LOCALE)}`,
-            lastModified: c.updated_at ? new Date(c.updated_at) : new Date(),
-            changeFrequency: "weekly" as const,
-            priority: 0.7,
-            alternates: buildLanguageAlternates(path, baseUrl),
-          };
-        });
-    } else if (campaignError) {
-      console.error(
-        "Failed to fetch catalog campaigns for sitemap:",
-        campaignError
-      );
+    if (error) {
+      console.error("Failed to fetch catalog campaigns for sitemap:", error);
+      return [];
     }
+
+    return (campaigns ?? [])
+      .filter((c) => c.slug)
+      .map((c) => {
+        const path = `/catalog/${c.slug}`;
+        return {
+          url: `${baseUrl}${localizePublicPath(path, DEFAULT_LOCALE)}`,
+          lastModified: c.updated_at ? new Date(c.updated_at) : new Date(),
+          changeFrequency: "weekly" as const,
+          priority: 0.7,
+          alternates: buildLanguageAlternates(path, baseUrl),
+        };
+      });
   } catch (error) {
     console.error("Failed to fetch catalog campaigns for sitemap:", error);
+    return [];
   }
+}
 
-  // 公開スタイル紹介ページ(/styles/[slug])
-  let stylePages: MetadataRoute.Sitemap = [];
+/**
+ * 公開スタイル紹介ページ(/styles/[slug])。
+ * repository を直接呼ぶ(get-public-style-presets の "use cache" ラッパーを経由すると
+ * sitemap 自身の "use cache" 充填の中で入れ子のキャッシュ充填が発生し、
+ * ビルド時プリレンダのタイムアウト要因になり得るため)。
+ */
+async function fetchStylePages(
+  baseUrl: string
+): Promise<MetadataRoute.Sitemap> {
   try {
-    const presets = await getPublishedStylePresets();
-    stylePages = presets
+    // listPublishedStylePresets は内部でエラー時に [] を返す。
+    // repository に abortSignal を注入できないため withTimeout で打ち切る。
+    const presets = await withTimeout(listPublishedStylePresets(), []);
+    return presets
       .filter((preset) => preset.slug)
       .map((preset) => {
         const path = `/styles/${preset.slug}`;
@@ -208,15 +257,8 @@ async function getSitemapEntries(): Promise<MetadataRoute.Sitemap> {
       });
   } catch (error) {
     console.error("Failed to fetch style presets for sitemap:", error);
+    return [];
   }
-
-  return [
-    ...staticPages,
-    ...unlocalizedPages,
-    ...stylePages,
-    ...postPages,
-    ...catalogPages,
-  ];
 }
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,89 +1,165 @@
 import { MetadataRoute } from "next";
+import { cacheLife, cacheTag } from "next/cache";
 import { getSiteUrl } from "@/lib/env";
-import { createClient } from "@/lib/supabase/server";
-import { locales, localizePublicPath } from "@/i18n/config";
+import { createAdminClient } from "@/lib/supabase/admin";
+import {
+  DEFAULT_LOCALE,
+  locales,
+  localizePublicPath,
+} from "@/i18n/config";
+import { getPublishedStylePresets } from "@/features/style-presets/lib/get-public-style-presets";
 
-export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+// ロケール展開する公開ページ(PUBLIC_PATH_PATTERNS に含まれるパス)
+const LOCALIZED_PUBLIC_PATHS = [
+  "/",
+  "/style",
+  "/coordinate",
+  "/styles",
+  "/search",
+  "/about",
+  "/pricing",
+  "/terms",
+  "/privacy",
+  "/community-guidelines",
+  "/credits/purchase",
+  "/tokushoho",
+  "/payment-services-act",
+  "/thanks-sample",
+  "/free-materials",
+  "/catalog",
+] as const;
+
+// ロケール分割していない公開ページ(単一 URL で公開)
+const UNLOCALIZED_PUBLIC_PATHS = ["/collections", "/creators"] as const;
+
+type LocalizedPath = (typeof LOCALIZED_PUBLIC_PATHS)[number];
+
+function changeFrequencyFor(
+  path: LocalizedPath
+): NonNullable<MetadataRoute.Sitemap[number]["changeFrequency"]> {
+  if (path === "/" || path === "/search") return "daily";
+  if (
+    path === "/style" ||
+    path === "/coordinate" ||
+    path === "/styles" ||
+    path === "/catalog"
+  ) {
+    return "daily";
+  }
+  if (path === "/credits/purchase" || path === "/free-materials") {
+    return "weekly";
+  }
+  return "monthly";
+}
+
+function priorityFor(path: LocalizedPath): number {
+  if (path === "/") return 1;
+  if (path === "/style" || path === "/coordinate") return 0.9;
+  if (path === "/styles" || path === "/search" || path === "/catalog") {
+    return 0.8;
+  }
+  if (path === "/about" || path === "/credits/purchase") return 0.7;
+  if (path === "/free-materials") return 0.6;
+  if (path === "/terms" || path === "/privacy") return 0.5;
+  return 0.4;
+}
+
+/**
+ * hreflang アノテーション(sitemap の xhtml:link)。
+ * 動的コンテンツはロケールごとに 15 エントリへ複製する代わりに、
+ * デフォルトロケール URL 1 エントリ + 言語別 alternates で表現し、
+ * sitemap の肥大(URL 数 × 15)を防ぐ。
+ */
+function buildLanguageAlternates(path: string, baseUrl: string) {
+  return {
+    languages: Object.fromEntries([
+      ...locales.map((locale) => [
+        locale,
+        `${baseUrl}${localizePublicPath(path, locale)}`,
+      ]),
+      ["x-default", `${baseUrl}${localizePublicPath(path, DEFAULT_LOCALE)}`],
+    ]),
+  };
+}
+
+/**
+ * sitemap のエントリを生成する。
+ *
+ * 重要: ここでは cookie ベースの `createClient()`(lib/supabase/server.ts)を
+ * 使ってはならない。sitemap はリクエスト外(ビルド時プリレンダ)でも評価される
+ * ため、`cookies()` に依存すると例外 → catch → 「静的ページのみの sitemap」に
+ * 静かに縮退する(実際に本番でこの縮退が起きていた)。
+ * リポジトリ層と同じ cookie 非依存の admin クライアントで公開データのみを
+ * 明示条件(is_posted / published)付きで取得する。
+ */
+async function getSitemapEntries(): Promise<MetadataRoute.Sitemap> {
+  "use cache";
+  cacheTag("sitemap");
+  // デプロイ後もビルド時スナップショットに固定されないよう、定期的に再検証する
+  cacheLife("hours");
+
   const siteUrl = getSiteUrl() || "https://persta.ai";
   const baseUrl = siteUrl;
-  const publicPaths = [
-    "/",
-    "/search",
-    "/about",
-    "/terms",
-    "/privacy",
-    "/credits/purchase",
-    "/tokushoho",
-    "/payment-services-act",
-    "/thanks-sample",
-    "/free-materials",
-    "/catalog",
-  ] as const;
 
-  // 主要な静的ページ
+  // 主要な静的ページ(ロケール展開)
   // lastModified は省略（正確な更新日が不明なため。new Date() は生成のたびに変わり changeFrequency と矛盾する）
   const staticPages: MetadataRoute.Sitemap = locales.flatMap((locale) =>
-    publicPaths.map((path) => ({
+    LOCALIZED_PUBLIC_PATHS.map((path) => ({
       url: `${baseUrl}${localizePublicPath(path, locale)}`,
-      changeFrequency:
-        path === "/" || path === "/search"
-          ? ("daily" as const)
-          : path === "/credits/purchase" || path === "/free-materials"
-            ? ("weekly" as const)
-            : ("monthly" as const),
-      priority:
-        path === "/"
-          ? 1
-          : path === "/search"
-            ? 0.8
-            : path === "/about" || path === "/credits/purchase"
-              ? 0.7
-              : path === "/free-materials"
-                ? 0.6
-                : path === "/terms" || path === "/privacy"
-                  ? 0.5
-                  : 0.4,
+      changeFrequency: changeFrequencyFor(path),
+      priority: priorityFor(path),
     }))
   );
 
-  // 投稿詳細ページを取得（最大1000件まで）
-  // 注意: 投稿数が非常に多い場合は、sitemapの分割を検討
+  const unlocalizedPages: MetadataRoute.Sitemap = UNLOCALIZED_PUBLIC_PATHS.map(
+    (path) => ({
+      url: `${baseUrl}${path}`,
+      changeFrequency: "weekly" as const,
+      priority: 0.6,
+    })
+  );
+
+  // 投稿詳細ページ（最大1000件まで）
+  // デフォルトロケール URL 1 エントリ + hreflang alternates で全ロケールを表現する
   let postPages: MetadataRoute.Sitemap = [];
-  
   try {
-    const supabase = await createClient();
+    const supabase = createAdminClient();
+    // 注意: generated_images に updated_at カラムは存在しない(select すると
+    // 42703 でクエリ全体が失敗し、投稿が 1 件も sitemap に載らなくなる)。
     const { data: posts, error } = await supabase
       .from("generated_images")
-      .select("id, posted_at, updated_at")
+      .select("id, posted_at")
       .eq("is_posted", true)
       .order("posted_at", { ascending: false })
       .limit(1000); // 1 sitemapあたり50,000 URL制限を考慮して1000件に制限
 
     if (!error && posts) {
-      postPages = locales.flatMap((locale) =>
-        posts
-          .filter((post) => post.id)
-          .map((post) => ({
-            url: `${baseUrl}${localizePublicPath(`/posts/${post.id}`, locale)}`,
-            lastModified: post.updated_at
-              ? new Date(post.updated_at)
-              : post.posted_at
-                ? new Date(post.posted_at)
-                : new Date(),
+      postPages = posts
+        .filter((post) => post.id)
+        .map((post) => {
+          const path = `/posts/${post.id}`;
+          return {
+            url: `${baseUrl}${localizePublicPath(path, DEFAULT_LOCALE)}`,
+            ...(post.posted_at
+              ? { lastModified: new Date(post.posted_at) }
+              : {}),
             changeFrequency: "weekly" as const,
             priority: 0.6,
-          }))
-      );
+            alternates: buildLanguageAlternates(path, baseUrl),
+          };
+        });
+    } else if (error) {
+      console.error("Failed to fetch posts for sitemap:", error);
     }
   } catch (error) {
     // エラーが発生した場合は、静的ページのみを返す
     console.error("Failed to fetch posts for sitemap:", error);
   }
 
-  // 公開中の catalog 企画を追加
+  // 公開中の catalog 企画
   let catalogPages: MetadataRoute.Sitemap = [];
   try {
-    const supabase = await createClient();
+    const supabase = createAdminClient();
     const { data: campaigns, error: campaignError } = await supabase
       .from("catalog_campaigns")
       .select("slug, updated_at")
@@ -92,20 +168,57 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       .limit(500);
 
     if (!campaignError && campaigns) {
-      catalogPages = locales.flatMap((locale) =>
-        campaigns
-          .filter((c) => c.slug)
-          .map((c) => ({
-            url: `${baseUrl}${localizePublicPath(`/catalog/${c.slug}`, locale)}`,
+      catalogPages = campaigns
+        .filter((c) => c.slug)
+        .map((c) => {
+          const path = `/catalog/${c.slug}`;
+          return {
+            url: `${baseUrl}${localizePublicPath(path, DEFAULT_LOCALE)}`,
             lastModified: c.updated_at ? new Date(c.updated_at) : new Date(),
             changeFrequency: "weekly" as const,
             priority: 0.7,
-          })),
+            alternates: buildLanguageAlternates(path, baseUrl),
+          };
+        });
+    } else if (campaignError) {
+      console.error(
+        "Failed to fetch catalog campaigns for sitemap:",
+        campaignError
       );
     }
   } catch (error) {
     console.error("Failed to fetch catalog campaigns for sitemap:", error);
   }
 
-  return [...staticPages, ...postPages, ...catalogPages];
+  // 公開スタイル紹介ページ(/styles/[slug])
+  let stylePages: MetadataRoute.Sitemap = [];
+  try {
+    const presets = await getPublishedStylePresets();
+    stylePages = presets
+      .filter((preset) => preset.slug)
+      .map((preset) => {
+        const path = `/styles/${preset.slug}`;
+        return {
+          url: `${baseUrl}${localizePublicPath(path, DEFAULT_LOCALE)}`,
+          lastModified: new Date(preset.publishedAt ?? preset.createdAt),
+          changeFrequency: "weekly" as const,
+          priority: 0.7,
+          alternates: buildLanguageAlternates(path, baseUrl),
+        };
+      });
+  } catch (error) {
+    console.error("Failed to fetch style presets for sitemap:", error);
+  }
+
+  return [
+    ...staticPages,
+    ...unlocalizedPages,
+    ...stylePages,
+    ...postPages,
+    ...catalogPages,
+  ];
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  return getSitemapEntries();
 }

--- a/app/styles/[slug]/page.tsx
+++ b/app/styles/[slug]/page.tsx
@@ -1,0 +1,254 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import Image from "next/image";
+import { notFound } from "next/navigation";
+import { ChevronRight, Wand2 } from "lucide-react";
+import {
+  getPublishedStylePresets,
+  getPublishedStylePresetBySlugPublic,
+} from "@/features/style-presets/lib/get-public-style-presets";
+import { PublicStyleCard } from "@/features/style-presets/components/PublicStyleCard";
+import { DEFAULT_LOCALE, isLocale, localizePublicPath } from "@/i18n/config";
+import {
+  createLocaleAlternates,
+  getDefaultTwitterImages,
+} from "@/lib/metadata";
+import { getStylesCopy } from "@/i18n/page-copy";
+import { getSiteUrl } from "@/lib/env";
+
+// locale は cookie 依存の getLocale() ではなく URL パラメータから解決する。
+// これによりページ全体が静的プリレンダ可能になり、JSON-LD が初期 HTML に含まれる
+// (getLocale はリクエスト依存の動的 API のため PPR の静的シェルから外れてしまう)。
+// ロケール無しの /styles/[slug] 直アクセスは proxy が /{locale}/... へリダイレクトする。
+interface PageProps {
+  params: Promise<{ slug: string; locale?: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { slug, locale: localeParam } = await params;
+  const locale = isLocale(localeParam) ? localeParam : DEFAULT_LOCALE;
+  const copy = getStylesCopy(locale);
+
+  const preset = await getPublishedStylePresetBySlugPublic(slug);
+  if (!preset) {
+    return { title: copy.indexTitle };
+  }
+
+  const siteUrl = getSiteUrl();
+  const title = `${preset.title} | ${copy.detailTitleSuffix}`;
+  const description = copy.detailDescription.replaceAll(
+    "{title}",
+    preset.title
+  );
+  const localizedPath = localizePublicPath(`/styles/${slug}`, locale);
+  const url = siteUrl ? `${siteUrl}${localizedPath}` : undefined;
+  const ogTitle = `${preset.title} | Persta.AI`;
+
+  return {
+    title,
+    description,
+    alternates: createLocaleAlternates(`/styles/${slug}`, locale),
+    openGraph: {
+      title: ogTitle,
+      description,
+      url,
+      siteName: "Persta.AI",
+      type: "website",
+      images: [
+        {
+          url: preset.thumbnailImageUrl,
+          width: preset.thumbnailWidth,
+          height: preset.thumbnailHeight,
+          alt: ogTitle,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: ogTitle,
+      description,
+      images: preset.thumbnailImageUrl
+        ? [preset.thumbnailImageUrl]
+        : getDefaultTwitterImages(siteUrl),
+    },
+  };
+}
+
+export default async function StyleDetailPage({ params }: PageProps) {
+  const { slug, locale: localeParam } = await params;
+  const locale = isLocale(localeParam) ? localeParam : DEFAULT_LOCALE;
+  const copy = getStylesCopy(locale);
+
+  const preset = await getPublishedStylePresetBySlugPublic(slug);
+  if (!preset) {
+    notFound();
+  }
+
+  const categoryName =
+    locale === "ja"
+      ? preset.category.displayNameJa
+      : preset.category.displayNameEn;
+  const providerName = preset.providerNickname ?? preset.category.providerNickname;
+  const description = copy.detailDescription.replaceAll(
+    "{title}",
+    preset.title
+  );
+  const stylesIndexPath = localizePublicPath("/styles", locale);
+  const generatePath = `${localizePublicPath("/style", locale)}?style=${preset.id}`;
+
+  const allPresets = await getPublishedStylePresets();
+  const relatedPresets = allPresets
+    .filter(
+      (candidate) =>
+        candidate.category.key === preset.category.key &&
+        candidate.id !== preset.id
+    )
+    .slice(0, 8);
+
+  // HomeStructuredData と同じ方針: 環境変数未設定時も既定ドメインで JSON-LD を出す
+  const siteUrl = getSiteUrl() || "https://persta.ai";
+  const jsonLd = [
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        {
+          "@type": "ListItem",
+          position: 1,
+          name: "Persta.AI",
+          item: `${siteUrl}${localizePublicPath("/", locale)}`,
+        },
+        {
+          "@type": "ListItem",
+          position: 2,
+          name: copy.indexHeading,
+          item: `${siteUrl}${stylesIndexPath}`,
+        },
+        {
+          "@type": "ListItem",
+          position: 3,
+          name: preset.title,
+          item: `${siteUrl}${localizePublicPath(`/styles/${slug}`, locale)}`,
+        },
+      ],
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "ImageObject",
+      contentUrl: preset.thumbnailImageUrl,
+      name: preset.title,
+      description,
+      ...(providerName
+        ? { creator: { "@type": "Person", name: providerName } }
+        : {}),
+    },
+  ];
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      <div className="mx-auto max-w-5xl px-4 pb-12 pt-6 md:pt-8">
+        {/* パンくず: 内部リンクとして Home / styles 一覧への導線を明示する */}
+        <nav
+          aria-label="Breadcrumb"
+          className="mb-5 flex flex-wrap items-center gap-1 text-xs text-gray-500 md:text-sm"
+        >
+          <Link
+            href={localizePublicPath("/", locale)}
+            className="hover:text-gray-800 hover:underline"
+          >
+            Persta.AI
+          </Link>
+          <ChevronRight className="h-3.5 w-3.5 shrink-0 rtl:rotate-180" aria-hidden />
+          <Link
+            href={stylesIndexPath}
+            className="hover:text-gray-800 hover:underline"
+          >
+            {copy.indexHeading}
+          </Link>
+          <ChevronRight className="h-3.5 w-3.5 shrink-0 rtl:rotate-180" aria-hidden />
+          <span className="text-gray-800">{preset.title}</span>
+        </nav>
+
+        <div className="grid gap-6 md:grid-cols-2 md:gap-10">
+          <div className="relative mx-auto aspect-[3/4] w-full max-w-md overflow-hidden rounded-2xl border border-gray-200 bg-gray-100 shadow-sm">
+            <Image
+              src={preset.thumbnailImageUrl}
+              alt={preset.title}
+              fill
+              priority
+              sizes="(max-width: 768px) 100vw, 448px"
+              className="object-cover object-top"
+            />
+          </div>
+
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <span
+                className="inline-block rounded-full px-3 py-1 text-xs font-semibold"
+                style={{
+                  backgroundColor: preset.category.badgeColor,
+                  color: preset.category.badgeTextColor,
+                }}
+              >
+                {categoryName}
+              </span>
+              <h1 className="text-2xl font-bold text-gray-900 md:text-3xl">
+                {preset.title}
+              </h1>
+              {providerName && (
+                <p className="text-sm text-gray-500">
+                  {copy.providerLabel.replace("{name}", providerName)}
+                </p>
+              )}
+            </div>
+
+            <p className="text-sm leading-relaxed text-gray-600 md:text-base">
+              {description}
+            </p>
+
+            <Link
+              href={generatePath}
+              className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-pink-500 to-orange-400 px-6 py-3 text-sm font-semibold text-white shadow-[0_4px_14px_rgba(236,72,153,0.35)] transition-transform hover:scale-[1.02] motion-reduce:transition-none"
+            >
+              <Wand2 className="h-4 w-4" aria-hidden />
+              {copy.cta}
+            </Link>
+          </div>
+        </div>
+
+        {relatedPresets.length > 0 && (
+          <section className="mt-12">
+            <h2 className="mb-4 text-lg font-bold text-gray-900 md:text-xl">
+              {copy.related}
+            </h2>
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:gap-4 lg:grid-cols-4">
+              {relatedPresets.map((related) => (
+                <PublicStyleCard
+                  key={related.id}
+                  preset={related}
+                  locale={locale}
+                />
+              ))}
+            </div>
+          </section>
+        )}
+
+        <div className="mt-10">
+          <Link
+            href={stylesIndexPath}
+            className="text-sm text-gray-600 underline underline-offset-2 hover:text-gray-900"
+          >
+            {copy.allStyles}
+          </Link>
+        </div>
+      </div>
+
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+    </main>
+  );
+}

--- a/app/styles/page.tsx
+++ b/app/styles/page.tsx
@@ -1,0 +1,83 @@
+import type { Metadata } from "next";
+import { getPublishedStylePresets } from "@/features/style-presets/lib/get-public-style-presets";
+import { PublicStyleCard } from "@/features/style-presets/components/PublicStyleCard";
+import { DEFAULT_LOCALE, isLocale, localizePublicPath } from "@/i18n/config";
+import { createMarketingPageMetadata } from "@/lib/metadata";
+import { getStylesCopy } from "@/i18n/page-copy";
+import { getSiteUrl } from "@/lib/env";
+
+// locale は cookie 依存の getLocale() ではなく URL パラメータから解決する。
+// これによりページ全体が静的プリレンダ可能になり、JSON-LD が初期 HTML に含まれる
+// (getLocale はリクエスト依存の動的 API のため PPR の静的シェルから外れてしまう)。
+// ロケール無しの /styles 直アクセスは proxy が /{locale}/styles へリダイレクトする。
+interface StylesIndexPageProps {
+  params: Promise<{ locale?: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: StylesIndexPageProps): Promise<Metadata> {
+  const { locale: localeParam } = await params;
+  const locale = isLocale(localeParam) ? localeParam : DEFAULT_LOCALE;
+  const copy = getStylesCopy(locale);
+
+  return createMarketingPageMetadata({
+    title: copy.indexTitle,
+    description: copy.indexDescription,
+    path: "/styles",
+    locale,
+    // indexTitle にはブランド名が含まれるため、OG 側は見出しをベースにする
+    // (createMarketingPageMetadata が "| Persta.AI" を付与する)
+    ogTitle: copy.indexHeading,
+  });
+}
+
+export default async function StylesIndexPage({
+  params,
+}: StylesIndexPageProps) {
+  const { locale: localeParam } = await params;
+  const locale = isLocale(localeParam) ? localeParam : DEFAULT_LOCALE;
+  const copy = getStylesCopy(locale);
+  const presets = await getPublishedStylePresets();
+  // HomeStructuredData と同じ方針: 環境変数未設定時も既定ドメインで JSON-LD を出す
+  const siteUrl = getSiteUrl() || "https://persta.ai";
+
+  // ItemList: 検索エンジンに一覧とスタイル紹介ページの関係を伝える
+  const itemListJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: copy.indexHeading,
+    itemListElement: presets.slice(0, 50).map((preset, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: preset.title,
+      url: `${siteUrl}${localizePublicPath(`/styles/${preset.slug}`, locale)}`,
+    })),
+  };
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      <div className="mx-auto max-w-6xl px-4 pb-12 pt-6 md:pt-8">
+        <header className="mb-6 space-y-2 md:mb-8">
+          <h1 className="text-2xl font-bold text-gray-900 md:text-3xl">
+            {copy.indexHeading}
+          </h1>
+          <p className="max-w-3xl text-sm text-gray-600 md:text-base">
+            {copy.indexIntro}
+          </p>
+        </header>
+
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:gap-4 lg:grid-cols-4">
+          {presets.map((preset) => (
+            <PublicStyleCard key={preset.id} preset={preset} locale={locale} />
+          ))}
+        </div>
+      </div>
+
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListJsonLd) }}
+      />
+    </main>
+  );
+}

--- a/app/styles/page.tsx
+++ b/app/styles/page.tsx
@@ -2,7 +2,10 @@ import type { Metadata } from "next";
 import { cacheLife, cacheTag } from "next/cache";
 import { getPublishedStylePresets } from "@/features/style-presets/lib/get-public-style-presets";
 import { StylesGalleryClient } from "@/features/style-presets/components/StylesGalleryClient";
-import { getStyleGenerateCounts } from "@/features/style/lib/style-popularity";
+import {
+  getStyleGenerateCounts,
+  getStyleGenerateTotalCounts,
+} from "@/features/style/lib/style-popularity";
 import { DEFAULT_LOCALE, isLocale, localizePublicPath } from "@/i18n/config";
 import { createMarketingPageMetadata } from "@/lib/metadata";
 import { getStylesCopy } from "@/i18n/page-copy";
@@ -53,9 +56,10 @@ export default async function StylesIndexPage({
   const { locale: localeParam } = await params;
   const locale = isLocale(localeParam) ? localeParam : DEFAULT_LOCALE;
   const copy = getStylesCopy(locale);
-  const [presets, generateCounts, nowIso] = await Promise.all([
+  const [presets, generateCounts, generateTotals, nowIso] = await Promise.all([
     getPublishedStylePresets(),
     getStyleGenerateCounts(),
+    getStyleGenerateTotalCounts(),
     getStylesGalleryNowIso(),
   ]);
   // HomeStructuredData と同じ方針: 環境変数未設定時も既定ドメインで JSON-LD を出す
@@ -89,6 +93,7 @@ export default async function StylesIndexPage({
         <StylesGalleryClient
           presets={presets}
           generateCounts={generateCounts}
+          generateTotals={generateTotals}
           nowIso={nowIso}
           locale={locale}
         />

--- a/app/styles/page.tsx
+++ b/app/styles/page.tsx
@@ -1,10 +1,25 @@
 import type { Metadata } from "next";
+import { cacheLife, cacheTag } from "next/cache";
 import { getPublishedStylePresets } from "@/features/style-presets/lib/get-public-style-presets";
-import { PublicStyleCard } from "@/features/style-presets/components/PublicStyleCard";
+import { StylesGalleryClient } from "@/features/style-presets/components/StylesGalleryClient";
+import { getStyleGenerateCounts } from "@/features/style/lib/style-popularity";
 import { DEFAULT_LOCALE, isLocale, localizePublicPath } from "@/i18n/config";
 import { createMarketingPageMetadata } from "@/lib/metadata";
 import { getStylesCopy } from "@/i18n/page-copy";
 import { getSiteUrl } from "@/lib/env";
+
+/**
+ * 「✨新着」「🎉イベント」チップ判定の基準時刻。
+ * 静的プリレンダ中は Date を直接使えないため "use cache" スコープで確定させる。
+ * cacheLife はプリセット一覧のキャッシュ(minutes)と揃え、数分単位で追従する
+ * (判定窓は 14 日なのでこの粒度で十分)。
+ */
+async function getStylesGalleryNowIso(): Promise<string> {
+  "use cache";
+  cacheTag("style-presets");
+  cacheLife("minutes");
+  return new Date().toISOString();
+}
 
 // locale は cookie 依存の getLocale() ではなく URL パラメータから解決する。
 // これによりページ全体が静的プリレンダ可能になり、JSON-LD が初期 HTML に含まれる
@@ -38,7 +53,11 @@ export default async function StylesIndexPage({
   const { locale: localeParam } = await params;
   const locale = isLocale(localeParam) ? localeParam : DEFAULT_LOCALE;
   const copy = getStylesCopy(locale);
-  const presets = await getPublishedStylePresets();
+  const [presets, generateCounts, nowIso] = await Promise.all([
+    getPublishedStylePresets(),
+    getStyleGenerateCounts(),
+    getStylesGalleryNowIso(),
+  ]);
   // HomeStructuredData と同じ方針: 環境変数未設定時も既定ドメインで JSON-LD を出す
   const siteUrl = getSiteUrl() || "https://persta.ai";
 
@@ -67,11 +86,12 @@ export default async function StylesIndexPage({
           </p>
         </header>
 
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:gap-4 lg:grid-cols-4">
-          {presets.map((preset) => (
-            <PublicStyleCard key={preset.id} preset={preset} locale={locale} />
-          ))}
-        </div>
+        <StylesGalleryClient
+          presets={presets}
+          generateCounts={generateCounts}
+          nowIso={nowIso}
+          locale={locale}
+        />
       </div>
 
       <script

--- a/components/AppSidebar.tsx
+++ b/components/AppSidebar.tsx
@@ -99,15 +99,15 @@ export function AppSidebar() {
   useEffect(() => {
     if (user && !hasPrefetched.current) {
       router.prefetch(localizedHomePath);
-      router.prefetch("/coordinate");
-      router.prefetch("/style");
+      router.prefetch(localizePublicPath("/coordinate", locale));
+      router.prefetch(localizePublicPath("/style", locale));
       router.prefetch("/challenge");
       router.prefetch("/notifications");
       router.prefetch("/my-page");
       router.prefetch("/my-page/contact");
       hasPrefetched.current = true;
     }
-  }, [localizedHomePath, user, router]);
+  }, [localizedHomePath, locale, user, router]);
 
   useEffect(() => {
     return subscribeCoordinateSourceStockSavePromptDot(
@@ -184,7 +184,9 @@ export function AppSidebar() {
         markMissionTabSnoozed();
       }
 
-      router.push(resolvedPath);
+      // 公開パス(/coordinate, /style 等)はロケール付き URL へ直接遷移し、
+      // proxy の 307 リダイレクトを介さない(1 ホップ分速くする)。
+      router.push(localizePublicPath(resolvedPath, locale));
     });
   };
 

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -9,7 +9,20 @@ export function Footer() {
 	const locale = isLocale(localeValue) ? localeValue : DEFAULT_LOCALE;
 	const t = useTranslations("footer");
 
-	const links = [
+	// 公開コンテンツへの導線。クローラーの回遊経路と各ページへの内部リンク評価を
+	// 確保する SEO 上の役割も持つ(これらのページはナビからも辿れる必要がある)。
+	const contentLinks = [
+		{ href: localizePublicPath("/styles", locale), label: t("styles") },
+		{ href: localizePublicPath("/catalog", locale), label: t("catalog") },
+		{ href: "/collections", label: t("collections") },
+		{
+			href: localizePublicPath("/free-materials", locale),
+			label: t("freeMaterials"),
+		},
+		{ href: "/creators", label: t("creators") },
+	];
+
+	const legalLinks = [
 		{ href: localizePublicPath("/about", locale), label: t("about") },
 		// { href: "/pricing", label: "料金" },
 		{ href: localizePublicPath("/terms", locale), label: t("terms") },
@@ -22,37 +35,43 @@ export function Footer() {
 		// { href: "/payment-services-act", label: "資金決済法に基づく表示" },
 	];
 
+	const linkRows = [contentLinks, legalLinks];
+
 	return (
 		<footer className="mt-8 border-t bg-white/80">
-			<div className="mx-auto max-w-7xl px-4 py-6">
-				{/* モバイル: 2x2グリッド */}
-				<div className="grid grid-cols-2 gap-3 text-center text-xs text-gray-600 md:hidden">
-					{links.map((link) => (
-						<Link
-							key={link.href}
-							href={link.href}
-							className="text-gray-700 underline underline-offset-2 hover:text-gray-900 transition-colors"
-						>
-							{link.label}
-						</Link>
-					))}
-				</div>
-				{/* PC: 横並び（|区切り） */}
-				<div className="hidden items-center justify-center gap-2 text-center text-sm text-gray-600 md:flex">
-					{links.map((link, index) => (
-						<span key={link.href} className="flex items-center">
-							<Link
-								href={link.href}
-								className="text-gray-700 underline underline-offset-2 hover:text-gray-900 transition-colors"
-							>
-								{link.label}
-							</Link>
-							{index < links.length - 1 && (
-								<span className="mx-2 text-gray-400">|</span>
-							)}
-						</span>
-					))}
-				</div>
+			<div className="mx-auto max-w-7xl space-y-4 px-4 py-6">
+				{linkRows.map((links, rowIndex) => (
+					<div key={rowIndex}>
+						{/* モバイル: 2xNグリッド */}
+						<div className="grid grid-cols-2 gap-3 text-center text-xs text-gray-600 md:hidden">
+							{links.map((link) => (
+								<Link
+									key={link.href}
+									href={link.href}
+									className="text-gray-700 underline underline-offset-2 hover:text-gray-900 transition-colors"
+								>
+									{link.label}
+								</Link>
+							))}
+						</div>
+						{/* PC: 横並び（|区切り） */}
+						<div className="hidden items-center justify-center gap-2 text-center text-sm text-gray-600 md:flex">
+							{links.map((link, index) => (
+								<span key={link.href} className="flex items-center">
+									<Link
+										href={link.href}
+										className="text-gray-700 underline underline-offset-2 hover:text-gray-900 transition-colors"
+									>
+										{link.label}
+									</Link>
+									{index < links.length - 1 && (
+										<span className="mx-2 text-gray-400">|</span>
+									)}
+								</span>
+							))}
+						</div>
+					</div>
+				))}
 			</div>
 		</footer>
 	);

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -13,13 +13,13 @@ export function Footer() {
 	// 確保する SEO 上の役割も持つ(これらのページはナビからも辿れる必要がある)。
 	const contentLinks = [
 		{ href: localizePublicPath("/styles", locale), label: t("styles") },
-		{ href: localizePublicPath("/catalog", locale), label: t("catalog") },
-		{ href: "/collections", label: t("collections") },
+		// { href: localizePublicPath("/catalog", locale), label: t("catalog") },
+		// { href: "/collections", label: t("collections") },
 		{
 			href: localizePublicPath("/free-materials", locale),
 			label: t("freeMaterials"),
 		},
-		{ href: "/creators", label: t("creators") },
+		// { href: "/creators", label: t("creators") },
 	];
 
 	const legalLinks = [

--- a/components/NavigationBar.tsx
+++ b/components/NavigationBar.tsx
@@ -82,14 +82,14 @@ export function NavigationBar() {
   useEffect(() => {
     if (user && !hasPrefetched.current) {
       router.prefetch(localizedHomePath);
-      router.prefetch("/coordinate");
-      router.prefetch("/style");
+      router.prefetch(localizePublicPath("/coordinate", locale));
+      router.prefetch(localizePublicPath("/style", locale));
       router.prefetch("/challenge");
       router.prefetch("/notifications");
       router.prefetch("/my-page");
       hasPrefetched.current = true;
     }
-  }, [localizedHomePath, user, router]);
+  }, [localizedHomePath, locale, user, router]);
 
   useEffect(() => {
     if (!pendingPathname) {
@@ -146,7 +146,9 @@ export function NavigationBar() {
       return;
     }
 
-    let destinationPath = resolvedPath;
+    // 公開パス(/coordinate, /style 等)はロケール付き URL へ直接遷移し、
+    // proxy の 307 リダイレクトを介さない(1 ホップ分速くする)。
+    let destinationPath = localizePublicPath(resolvedPath, locale);
     let pendingTargetPath = normalizedTargetPath;
 
     if (requiresAuthForGuestNavigation(normalizedTargetPath) && !user) {

--- a/features/home/components/CachedHomeStylePresetSection.tsx
+++ b/features/home/components/CachedHomeStylePresetSection.tsx
@@ -17,10 +17,7 @@ import {
   listActiveEventCategoryKeys,
 } from "@/features/home/lib/derive-event-shelves";
 import type { CompletedMountView } from "@/features/my-page/components/MyPageCollections";
-import {
-  getStyleGenerateCounts,
-  getStyleGenerateTotalCounts,
-} from "@/features/style/lib/style-popularity";
+import { getStyleGenerateCounts } from "@/features/style/lib/style-popularity";
 import {
   deriveHomeCarouselPresets,
   isNewPreset,
@@ -165,23 +162,10 @@ export async function CachedHomeStylePresetSection({
     unlockContext,
   );
 
-  // ホームの「すべて見る」から開く探索シート用データ(/style の StylePageBody と同方針)。
-  //  - 人気/累計は全ユーザー共通の "use cache" 済み集計
-  //  - お気に入りは本人のみ(RLS適用)。未ログイン時はクエリ自体を発行しない
-  const [generateCounts, generateTotals] = await Promise.all([
-    getStyleGenerateCounts(),
-    getStyleGenerateTotalCounts(),
-  ]);
-  let favoritePresetIds: string[] = [];
-  if (userId) {
-    const supabase = await createClient();
-    const { data } = await supabase
-      .from("style_preset_favorites")
-      .select("preset_id");
-    favoritePresetIds = (data ?? [])
-      .map((row) => row.preset_id as string)
-      .filter(Boolean);
-  }
+  // カルーセルの並び順(人気)に使う全ユーザー共通の "use cache" 済み集計。
+  // かつてはホーム上の探索シート用に累計集計・お気に入りも取得していたが、
+  // 「すべて見る」を /styles ページへのリンクに統一したため不要になった。
+  const generateCounts = await getStyleGenerateCounts();
 
   // カルーセルは「新着(先頭・最大 CAROUSEL_MAX_NEW_ITEMS 枚) + 人気順」の
   // 上位 CAROUSEL_MAX_ITEMS 枚のみ表示する。人気順だけだと登録直後の
@@ -212,14 +196,6 @@ export async function CachedHomeStylePresetSection({
       <HomeStylePresetCarousel
         presets={carouselPresets}
         newPresetIds={newPresetIds}
-        // 探索シートには /style と同じ「解放ゲート適用済みの全プリセット」を渡す
-        // (カルーセルと違い locked=シルエットや棚振り分け分も含めて一覧できる)。
-        browsePresets={gated}
-        generateCounts={generateCounts}
-        generateTotals={generateTotals}
-        initialFavoritePresetIds={favoritePresetIds}
-        isAuthenticated={Boolean(userId)}
-        generatedPresetIds={Array.from(flatGeneratedIds)}
       />
     </>
   );

--- a/features/home/components/CachedHomeStylePresetSection.tsx
+++ b/features/home/components/CachedHomeStylePresetSection.tsx
@@ -17,7 +17,10 @@ import {
   listActiveEventCategoryKeys,
 } from "@/features/home/lib/derive-event-shelves";
 import type { CompletedMountView } from "@/features/my-page/components/MyPageCollections";
-import { getStyleGenerateCounts } from "@/features/style/lib/style-popularity";
+import {
+  getStyleGenerateCounts,
+  getStyleGenerateTotalCounts,
+} from "@/features/style/lib/style-popularity";
 import {
   deriveHomeCarouselPresets,
   isNewPreset,
@@ -162,10 +165,13 @@ export async function CachedHomeStylePresetSection({
     unlockContext,
   );
 
-  // カルーセルの並び順(人気)に使う全ユーザー共通の "use cache" 済み集計。
-  // かつてはホーム上の探索シート用に累計集計・お気に入りも取得していたが、
-  // 「すべて見る」を /styles ページへのリンクに統一したため不要になった。
-  const generateCounts = await getStyleGenerateCounts();
+  // 全ユーザー共通の "use cache" 済み集計。
+  // 人気(直近30日)はカルーセルの並び順、累計は試着確認モーダルの
+  // 「これまでに◯回つくられました」表示に使う。
+  const [generateCounts, generateTotals] = await Promise.all([
+    getStyleGenerateCounts(),
+    getStyleGenerateTotalCounts(),
+  ]);
 
   // カルーセルは「新着(先頭・最大 CAROUSEL_MAX_NEW_ITEMS 枚) + 人気順」の
   // 上位 CAROUSEL_MAX_ITEMS 枚のみ表示する。人気順だけだと登録直後の
@@ -191,11 +197,13 @@ export async function CachedHomeStylePresetSection({
           shelf={shelf}
           nowIso={now.toISOString()}
           completedMount={completedMountByKey.get(shelf.categoryKey) ?? null}
+          generateTotals={generateTotals}
         />
       ))}
       <HomeStylePresetCarousel
         presets={carouselPresets}
         newPresetIds={newPresetIds}
+        generateTotals={generateTotals}
       />
     </>
   );

--- a/features/home/components/HomeEventShelfSection.tsx
+++ b/features/home/components/HomeEventShelfSection.tsx
@@ -7,15 +7,6 @@ import { useLocale, useTranslations } from "next-intl";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { FreeMode } from "swiper/modules";
 import { PartyPopper } from "lucide-react";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import { useToast } from "@/components/ui/use-toast";
 import {
   CollectionProgressModal,
@@ -27,6 +18,12 @@ import {
 } from "@/features/collections/components/CollectionMountComposer";
 import { mountAspectForCategory } from "@/features/collections/lib/mount-aspects";
 import { StylePresetPreviewCard } from "@/features/style/components/StylePresetPreviewCard";
+import { StyleTryOnConfirmDialog } from "@/features/style-presets/components/StyleTryOnConfirmDialog";
+import {
+  DEFAULT_LOCALE,
+  isLocale,
+  localizePublicPath,
+} from "@/i18n/config";
 import type { StylePresetPublicSummary } from "@/features/style-presets/lib/schema";
 import type { CompletedMountView } from "@/features/my-page/components/MyPageCollections";
 import type {
@@ -224,7 +221,11 @@ export function HomeEventShelfSection({
       return;
     }
     setConfirmingPreset(null);
-    router.push(`/style?style=${encodeURIComponent(preset.id)}`);
+    // 公開パスはロケール付き URL へ直接遷移し、proxy の 307 リダイレクトを介さない。
+    const pathLocale = isLocale(locale) ? locale : DEFAULT_LOCALE;
+    router.push(
+      `${localizePublicPath("/style", pathLocale)}?style=${encodeURIComponent(preset.id)}`
+    );
   };
 
   const renderCard = (card: EventShelfCard) => {
@@ -403,46 +404,17 @@ export function HomeEventShelfSection({
           ))}
         </Swiper>
       </div>
-      <AlertDialog
-        open={confirmingPreset !== null}
+      {/* ホームのカルーセル・/styles と共通の試着確認モーダル
+          (サムネイルの実アスペクト比で表示)。 */}
+      <StyleTryOnConfirmDialog
+        preset={confirmingPreset}
         onOpenChange={(open) => {
           if (!open) {
             setConfirmingPreset(null);
           }
         }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{t("stylePresetConfirmTitle")}</AlertDialogTitle>
-          </AlertDialogHeader>
-          {confirmingPreset ? (
-            <div className="flex flex-col items-center gap-3 py-2">
-              <div className="relative aspect-[3/4] w-full max-w-[280px] overflow-hidden rounded-lg bg-gray-100">
-                <Image
-                  src={confirmingPreset.thumbnailImageUrl}
-                  alt={tStyle("styleCardAlt", {
-                    name: confirmingPreset.title,
-                  })}
-                  fill
-                  sizes="280px"
-                  className="object-cover object-top"
-                />
-              </div>
-              <p className="text-base font-medium text-slate-900">
-                {confirmingPreset.title}
-              </p>
-            </div>
-          ) : null}
-          <AlertDialogFooter>
-            <AlertDialogCancel>
-              {t("stylePresetConfirmCancel")}
-            </AlertDialogCancel>
-            <AlertDialogAction onClick={handleConfirm}>
-              {t("stylePresetConfirmAction")}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        onConfirm={handleConfirm}
+      />
       <CollectionProgressModal
         key={
           mountCelebration

--- a/features/home/components/HomeEventShelfSection.tsx
+++ b/features/home/components/HomeEventShelfSection.tsx
@@ -50,6 +50,8 @@ interface HomeEventShelfSectionProps {
    * null(未作成/未ログイン)なら /collections リンクのお祝いカードにフォールバック。
    */
   completedMount?: CompletedMountView | null;
+  /** プリセットID -> 累計生成数(試着確認モーダルの「これまでに◯回」表示)。 */
+  generateTotals?: Readonly<Record<string, number>>;
 }
 
 /**
@@ -61,6 +63,7 @@ export function HomeEventShelfSection({
   shelf,
   nowIso,
   completedMount = null,
+  generateTotals,
 }: HomeEventShelfSectionProps) {
   const router = useRouter();
   const t = useTranslations("home");
@@ -414,6 +417,8 @@ export function HomeEventShelfSection({
           }
         }}
         onConfirm={handleConfirm}
+        locale={cardLocale}
+        generateTotals={generateTotals}
       />
       <CollectionProgressModal
         key={

--- a/features/home/components/HomeStylePresetCarousel.tsx
+++ b/features/home/components/HomeStylePresetCarousel.tsx
@@ -24,6 +24,8 @@ interface HomeStylePresetCarouselProps {
   presets: StylePresetPublicSummary[];
   /** NEW バッジを付ける新着プリセットID(登録14日以内)。 */
   newPresetIds?: readonly string[];
+  /** プリセットID -> 累計生成数(試着確認モーダルの「これまでに◯回」表示)。 */
+  generateTotals?: Readonly<Record<string, number>>;
 }
 
 const SCROLL_VELOCITY_PX_PER_SEC = 32;
@@ -78,6 +80,7 @@ function saveCurrentTranslate(swiper: SwiperType | null) {
 export function HomeStylePresetCarousel({
   presets,
   newPresetIds,
+  generateTotals,
 }: HomeStylePresetCarouselProps) {
   const router = useRouter();
   const t = useTranslations("style");
@@ -328,6 +331,8 @@ export function HomeStylePresetCarousel({
         preset={confirmingPreset}
         onOpenChange={handleDialogOpenChange}
         onConfirm={handleConfirm}
+        locale={locale === "ja" ? "ja" : "en"}
+        generateTotals={generateTotals}
       />
     </div>
   );

--- a/features/home/components/HomeStylePresetCarousel.tsx
+++ b/features/home/components/HomeStylePresetCarousel.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
@@ -9,16 +8,8 @@ import { LayoutGrid } from "lucide-react";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { FreeMode } from "swiper/modules";
 import type { Swiper as SwiperType } from "swiper";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import { StylePresetPreviewCard } from "@/features/style/components/StylePresetPreviewCard";
+import { StyleTryOnConfirmDialog } from "@/features/style-presets/components/StyleTryOnConfirmDialog";
 import {
   DEFAULT_LOCALE,
   isLocale,
@@ -332,42 +323,12 @@ export function HomeStylePresetCarousel({
           })}
         </Swiper>
       </div>
-      <AlertDialog
-        open={confirmingPreset !== null}
+      {/* /styles と共通の試着確認モーダル(サムネイルの実アスペクト比で表示)。 */}
+      <StyleTryOnConfirmDialog
+        preset={confirmingPreset}
         onOpenChange={handleDialogOpenChange}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              {tHome("stylePresetConfirmTitle")}
-            </AlertDialogTitle>
-          </AlertDialogHeader>
-          {confirmingPreset ? (
-            <div className="flex flex-col items-center gap-3 py-2">
-              <div className="relative aspect-[3/4] w-full max-w-[280px] overflow-hidden rounded-lg bg-gray-100">
-                <Image
-                  src={confirmingPreset.thumbnailImageUrl}
-                  alt={t("styleCardAlt", { name: confirmingPreset.title })}
-                  fill
-                  sizes="280px"
-                  className="object-cover object-top"
-                />
-              </div>
-              <p className="text-base font-medium text-slate-900">
-                {confirmingPreset.title}
-              </p>
-            </div>
-          ) : null}
-          <AlertDialogFooter>
-            <AlertDialogCancel>
-              {tHome("stylePresetConfirmCancel")}
-            </AlertDialogCancel>
-            <AlertDialogAction onClick={handleConfirm}>
-              {tHome("stylePresetConfirmAction")}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        onConfirm={handleConfirm}
+      />
     </div>
   );
 }

--- a/features/home/components/HomeStylePresetCarousel.tsx
+++ b/features/home/components/HomeStylePresetCarousel.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import Image from "next/image";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
 import { LayoutGrid } from "lucide-react";
@@ -18,8 +19,11 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { StylePresetPreviewCard } from "@/features/style/components/StylePresetPreviewCard";
-import { StyleBrowseSheet } from "@/features/style/components/StyleBrowseSheet";
-import { useStyleFavorites } from "@/features/style/hooks/useStyleFavorites";
+import {
+  DEFAULT_LOCALE,
+  isLocale,
+  localizePublicPath,
+} from "@/i18n/config";
 import type { StylePresetPublicSummary } from "@/features/style-presets/lib/schema";
 
 import "swiper/css";
@@ -27,20 +31,6 @@ import "swiper/css/free-mode";
 
 interface HomeStylePresetCarouselProps {
   presets: StylePresetPublicSummary[];
-  /**
-   * 「すべて見る」の探索シートに出すプリセット。/style と同じ
-   * 解放ゲート適用済みの全件(locked や企画棚ぶんも含む)を受け取る。
-   */
-  browsePresets: readonly StylePresetPublicSummary[];
-  /** 探索シート用: プリセットID -> 直近生成数(👑人気チップ)。 */
-  generateCounts: Readonly<Record<string, number>>;
-  /** 探索シート用: プリセットID -> 累計生成数(拡大プレビューの利用回数)。 */
-  generateTotals: Readonly<Record<string, number>>;
-  /** 探索シート用: 本人のお気に入り初期集合(以後は楽観更新)。 */
-  initialFavoritePresetIds: readonly string[];
-  isAuthenticated: boolean;
-  /** 企画カードの「生成済み ✓」用。 */
-  generatedPresetIds: readonly string[];
   /** NEW バッジを付ける新着プリセットID(登録14日以内)。 */
   newPresetIds?: readonly string[];
 }
@@ -96,32 +86,19 @@ function saveCurrentTranslate(swiper: SwiperType | null) {
 
 export function HomeStylePresetCarousel({
   presets,
-  browsePresets,
-  generateCounts,
-  generateTotals,
-  initialFavoritePresetIds,
-  isAuthenticated,
-  generatedPresetIds,
   newPresetIds,
 }: HomeStylePresetCarouselProps) {
   const router = useRouter();
   const t = useTranslations("style");
   const tHome = useTranslations("home");
-  const locale = useLocale();
-  const styleCardLocale = locale === "en" ? "en" : "ja";
+  const localeValue = useLocale();
+  const locale = isLocale(localeValue) ? localeValue : DEFAULT_LOCALE;
   const swiperRef = useRef<SwiperType | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const isUserActiveRef = useRef(false);
   const isDialogOpenRef = useRef(false);
   const [confirmingPreset, setConfirmingPreset] =
     useState<StylePresetPublicSummary | null>(null);
-  // 探索シート(チップ+グリッド)の開閉と、お気に入り(しおり)集合(/style と共通フック)。
-  const [isBrowseSheetOpen, setIsBrowseSheetOpen] = useState(false);
-  const { favoritePresetIds, toggleFavorite } = useStyleFavorites({
-    initialFavoritePresetIds,
-    isAuthenticated,
-  });
-  const generatedPresetIdSet = new Set(generatedPresetIds);
   const newPresetIdSet = new Set(newPresetIds ?? []);
 
   useEffect(() => {
@@ -254,25 +231,10 @@ export function HomeStylePresetCarousel({
     }
     isDialogOpenRef.current = false;
     setConfirmingPreset(null);
-    router.push(`/style?style=${encodeURIComponent(preset.id)}`);
+    router.push(
+      `${localizePublicPath("/style", locale)}?style=${encodeURIComponent(preset.id)}`
+    );
   };
-
-  // 探索シートの開閉。開いている間はカルーセルの自動スクロールを止める。
-  const handleBrowseSheetOpenChange = (open: boolean) => {
-    if (open) {
-      saveCurrentTranslate(swiperRef.current);
-    }
-    isDialogOpenRef.current = open;
-    setIsBrowseSheetOpen(open);
-  };
-
-  /** 探索シートで試着確認まで済んだら /style へ遷移して生成フローに乗せる。 */
-  const handleSelectFromBrowseSheet = (presetId: string) => {
-    setIsBrowseSheetOpen(false);
-    isDialogOpenRef.current = false;
-    router.push(`/style?style=${encodeURIComponent(presetId)}`);
-  };
-
 
   return (
     <div ref={containerRef} className="mb-8 overflow-x-hidden">
@@ -286,15 +248,16 @@ export function HomeStylePresetCarousel({
             {tHome("stylePresetCarouselCaption")}
           </p>
         </div>
-        {/* /style の「すべて見る」と同じ見た目。ホームに留まったまま探索シートを開く。 */}
-        <button
-          type="button"
-          onClick={() => handleBrowseSheetOpenChange(true)}
+        {/* /style の「すべて見る」と同じ見た目。スタイル一覧ページ(/styles)へ遷移する。
+            以前はホーム上で探索シートを開いていたが、同等のチップフィルターを持つ
+            /styles に統一した(シート用の全プリセット+集計データの受け渡しを削減)。 */}
+        <Link
+          href={localizePublicPath("/styles", locale)}
           className="inline-flex shrink-0 items-center gap-1 rounded-full border border-gray-200 bg-white px-3.5 py-1.5 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
         >
           {t("styleBrowseAll")}
           <LayoutGrid className="h-4 w-4" aria-hidden="true" />
-        </button>
+        </Link>
       </div>
       {/* Swiper's RTL mode flips translate semantics; this image rail is animated with LTR math. */}
       <div className="-mx-4 px-4" dir="ltr">
@@ -405,23 +368,6 @@ export function HomeStylePresetCarousel({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-      {/* 「すべて見る」の探索シート。/style と同じ UI で、選択(試着確認後)だけ /style へ遷移する。 */}
-      <StyleBrowseSheet
-        open={isBrowseSheetOpen}
-        onOpenChange={handleBrowseSheetOpenChange}
-        presets={browsePresets}
-        generateCounts={generateCounts}
-        generateTotals={generateTotals}
-        favoriteIds={favoritePresetIds}
-        onToggleFavorite={(presetId, next) => {
-          void toggleFavorite(presetId, next);
-        }}
-        onSelectPreset={handleSelectFromBrowseSheet}
-        isAuthenticated={isAuthenticated}
-        generatedPresetIds={generatedPresetIdSet}
-        locale={styleCardLocale}
-        selectedPresetId={null}
-      />
     </div>
   );
 }

--- a/features/style-presets/components/PublicStyleCard.tsx
+++ b/features/style-presets/components/PublicStyleCard.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+import Image from "next/image";
+import { localizePublicPath, type Locale } from "@/i18n/config";
+import type { StylePresetPublicSummary } from "@/features/style-presets/lib/schema";
+
+/**
+ * /styles(スタイル一覧)と /styles/[slug] の関連スタイルで使う公開スタイルカード。
+ * 生成画面のカルーセルカードと違い、選択ではなくスタイル紹介ページへのリンクとして働く。
+ */
+export function PublicStyleCard({
+  preset,
+  locale,
+}: {
+  preset: StylePresetPublicSummary;
+  locale: Locale;
+}) {
+  const categoryName =
+    locale === "ja"
+      ? preset.category.displayNameJa
+      : preset.category.displayNameEn;
+
+  return (
+    <Link
+      href={localizePublicPath(`/styles/${preset.slug}`, locale)}
+      className="group block overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition-shadow hover:shadow-md"
+    >
+      <div className="relative aspect-[3/4] w-full overflow-hidden bg-gray-100">
+        <Image
+          src={preset.thumbnailImageUrl}
+          alt={preset.title}
+          fill
+          sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
+          className="object-cover object-top transition-transform duration-300 group-hover:scale-105 motion-reduce:transition-none"
+        />
+      </div>
+      <div className="space-y-1 p-3">
+        <p className="line-clamp-2 text-sm font-semibold text-gray-900">
+          {preset.title}
+        </p>
+        <p className="text-xs text-gray-500">{categoryName}</p>
+      </div>
+    </Link>
+  );
+}

--- a/features/style-presets/components/PublicStyleCard.tsx
+++ b/features/style-presets/components/PublicStyleCard.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import { StyleProviderCredit } from "@/features/style/components/StyleProviderCredit";
+import { truncateStylePresetName } from "@/features/style/lib/style-preset-name";
 import { resolveStylePresetProvider } from "@/features/style-presets/lib/schema";
 import { localizePublicPath, type Locale } from "@/i18n/config";
 import type { StylePresetPublicSummary } from "@/features/style-presets/lib/schema";
@@ -92,8 +93,12 @@ export function PublicStyleCard({
             className="flex shrink-0 items-center"
           />
         )}
-        <p className="line-clamp-2 text-sm font-semibold text-gray-900">
-          {preset.title}
+        {/* ホーム/style のカードと同じ1行表示(16文字で切り詰め + truncate)。 */}
+        <p
+          className="truncate text-sm font-semibold text-gray-900"
+          title={preset.title}
+        >
+          {truncateStylePresetName(preset.title)}
         </p>
       </div>
     </Link>

--- a/features/style-presets/components/PublicStyleCard.tsx
+++ b/features/style-presets/components/PublicStyleCard.tsx
@@ -1,11 +1,19 @@
 import Link from "next/link";
 import Image from "next/image";
+import { StyleProviderCredit } from "@/features/style/components/StyleProviderCredit";
+import { resolveStylePresetProvider } from "@/features/style-presets/lib/schema";
 import { localizePublicPath, type Locale } from "@/i18n/config";
 import type { StylePresetPublicSummary } from "@/features/style-presets/lib/schema";
 
 /**
  * /styles(スタイル一覧)と /styles/[slug] の関連スタイルで使う公開スタイルカード。
  * 既定ではスタイル紹介ページへのリンクとして働く。
+ *
+ * カテゴリバッジと提供者クレジットは探索シートのカード
+ * (StylePresetPreviewCard)と同じ意匠に揃える:
+ *  - バッジは admin のプリセット管理で設定した badgeColor / badgeTextColor を使い、
+ *    サムネ画像の左下に表示(顔まわりを覆わない配置)
+ *  - default カテゴリの `coordinate` はバッジを描画しない(既存挙動と同じ)
  *
  * onSelect を渡すと、通常の左クリック/タップだけを横取りして選択ハンドラを呼ぶ
  * (/styles 一覧の「試着しますか？」モーダル用)。href はそのまま残るため、
@@ -21,10 +29,14 @@ export function PublicStyleCard({
   locale: Locale;
   onSelect?: (preset: StylePresetPublicSummary) => void;
 }) {
+  const badgeLocale = locale === "ja" ? "ja" : "en";
   const categoryName =
-    locale === "ja"
+    badgeLocale === "ja"
       ? preset.category.displayNameJa
       : preset.category.displayNameEn;
+  const shouldShowBadge = preset.category.key !== "coordinate";
+  // 提供者クレジットはプリセット単位を優先し、無ければカテゴリ単位にフォールバック。
+  const provider = resolveStylePresetProvider(preset);
 
   return (
     <Link
@@ -57,12 +69,32 @@ export function PublicStyleCard({
           sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
           className="object-cover object-top transition-transform duration-300 group-hover:scale-105 motion-reduce:transition-none"
         />
+        {shouldShowBadge && (
+          <span
+            className="absolute bottom-1.5 left-1.5 z-10 inline-flex max-w-[80%] items-center truncate rounded px-1.5 py-0.5 text-[10px] font-semibold leading-tight shadow-sm"
+            style={{
+              backgroundColor: preset.category.badgeColor,
+              color: preset.category.badgeTextColor,
+            }}
+            aria-label={categoryName}
+          >
+            {categoryName}
+          </span>
+        )}
       </div>
-      <div className="space-y-1 p-3">
+      <div className="flex items-center gap-1.5 p-3">
+        {provider && (
+          <StyleProviderCredit
+            nickname={provider.nickname}
+            avatarUrl={provider.avatarUrl}
+            locale={badgeLocale}
+            iconOnly
+            className="flex shrink-0 items-center"
+          />
+        )}
         <p className="line-clamp-2 text-sm font-semibold text-gray-900">
           {preset.title}
         </p>
-        <p className="text-xs text-gray-500">{categoryName}</p>
       </div>
     </Link>
   );

--- a/features/style-presets/components/PublicStyleCard.tsx
+++ b/features/style-presets/components/PublicStyleCard.tsx
@@ -5,14 +5,21 @@ import type { StylePresetPublicSummary } from "@/features/style-presets/lib/sche
 
 /**
  * /styles(スタイル一覧)と /styles/[slug] の関連スタイルで使う公開スタイルカード。
- * 生成画面のカルーセルカードと違い、選択ではなくスタイル紹介ページへのリンクとして働く。
+ * 既定ではスタイル紹介ページへのリンクとして働く。
+ *
+ * onSelect を渡すと、通常の左クリック/タップだけを横取りして選択ハンドラを呼ぶ
+ * (/styles 一覧の「試着しますか？」モーダル用)。href はそのまま残るため、
+ * クローラーは紹介ページへのリンクとして辿れ、Cmd/Ctrl+クリックや中クリックの
+ * 「新しいタブで開く」も既定どおり動く。
  */
 export function PublicStyleCard({
   preset,
   locale,
+  onSelect,
 }: {
   preset: StylePresetPublicSummary;
   locale: Locale;
+  onSelect?: (preset: StylePresetPublicSummary) => void;
 }) {
   const categoryName =
     locale === "ja"
@@ -22,6 +29,24 @@ export function PublicStyleCard({
   return (
     <Link
       href={localizePublicPath(`/styles/${preset.slug}`, locale)}
+      onClick={
+        onSelect
+          ? (event) => {
+              if (
+                event.defaultPrevented ||
+                event.metaKey ||
+                event.ctrlKey ||
+                event.shiftKey ||
+                event.altKey ||
+                event.button !== 0
+              ) {
+                return;
+              }
+              event.preventDefault();
+              onSelect(preset);
+            }
+          : undefined
+      }
       className="group block overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition-shadow hover:shadow-md"
     >
       <div className="relative aspect-[3/4] w-full overflow-hidden bg-gray-100">

--- a/features/style-presets/components/StyleTryOnConfirmDialog.tsx
+++ b/features/style-presets/components/StyleTryOnConfirmDialog.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import Image from "next/image";
+import { useTranslations } from "next-intl";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import type { StylePresetPublicSummary } from "@/features/style-presets/lib/schema";
+
+interface StyleTryOnConfirmDialogProps {
+  /** 確認中のプリセット。null なら閉じる。 */
+  preset: StylePresetPublicSummary | null;
+  onOpenChange: (open: boolean) => void;
+  /** 「試着する」確定。呼び出し側で /style への遷移などを行う。 */
+  onConfirm: () => void;
+}
+
+/**
+ * 「こちらを試着しますか？」の確認モーダル。
+ * ホームのスタイルカルーセルと /styles のギャラリーで共用する。
+ *
+ * 画像はサムネイルの実アスペクト比で表示する(探索シートと同じ挙動)。
+ * 横長はクロップせず全幅、縦長はダイアログが縦に伸びすぎないよう幅280pxに抑える。
+ * 文言はホーム由来の home.stylePresetConfirm* キーを共通利用する。
+ */
+export function StyleTryOnConfirmDialog({
+  preset,
+  onOpenChange,
+  onConfirm,
+}: StyleTryOnConfirmDialogProps) {
+  const t = useTranslations("style");
+  const tHome = useTranslations("home");
+
+  return (
+    <AlertDialog open={preset !== null} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {tHome("stylePresetConfirmTitle")}
+          </AlertDialogTitle>
+        </AlertDialogHeader>
+        {preset ? (
+          <div className="flex flex-col items-center gap-3 py-2">
+            <div
+              className={`relative w-full overflow-hidden rounded-lg bg-gray-100 ${
+                preset.thumbnailWidth > preset.thumbnailHeight
+                  ? ""
+                  : "max-w-[280px]"
+              }`}
+              style={{
+                aspectRatio:
+                  preset.thumbnailWidth > 0 && preset.thumbnailHeight > 0
+                    ? `${preset.thumbnailWidth} / ${preset.thumbnailHeight}`
+                    : "3 / 4",
+              }}
+            >
+              <Image
+                src={preset.thumbnailImageUrl}
+                alt={t("styleCardAlt", { name: preset.title })}
+                fill
+                sizes="(max-width: 640px) 90vw, 480px"
+                className="object-cover object-top"
+              />
+            </div>
+            <p className="text-base font-medium text-slate-900">
+              {preset.title}
+            </p>
+          </div>
+        ) : null}
+        <AlertDialogFooter>
+          <AlertDialogCancel>
+            {tHome("stylePresetConfirmCancel")}
+          </AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm}>
+            {tHome("stylePresetConfirmAction")}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/features/style-presets/components/StyleTryOnConfirmDialog.tsx
+++ b/features/style-presets/components/StyleTryOnConfirmDialog.tsx
@@ -2,15 +2,15 @@
 
 import Image from "next/image";
 import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import type { StylePresetPublicSummary } from "@/features/style-presets/lib/schema";
 
 interface StyleTryOnConfirmDialogProps {
@@ -23,10 +23,12 @@ interface StyleTryOnConfirmDialogProps {
 
 /**
  * 「こちらを試着しますか？」の確認モーダル。
- * ホームのスタイルカルーセルと /styles のギャラリーで共用する。
+ * ホームのスタイルカルーセル・企画棚と /styles のギャラリーで共用する。
  *
- * 画像はサムネイルの実アスペクト比で表示する(探索シートと同じ挙動)。
- * 横長はクロップせず全幅、縦長はダイアログが縦に伸びすぎないよう幅280pxに抑える。
+ * 気軽に眺めて戻れるよう AlertDialog ではなく通常の Dialog を使う
+ * (探索シートの拡大プレビューと同じ方針。枠外タップ・Esc・× で閉じられる)。
+ * 画像はサムネイルの実アスペクト比で表示する。横長はクロップせず全幅、
+ * 縦長はダイアログが縦に伸びすぎないよう幅280pxに抑える。
  * 文言はホーム由来の home.stylePresetConfirm* キーを共通利用する。
  */
 export function StyleTryOnConfirmDialog({
@@ -38,13 +40,17 @@ export function StyleTryOnConfirmDialog({
   const tHome = useTranslations("home");
 
   return (
-    <AlertDialog open={preset !== null} onOpenChange={onOpenChange}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>
+    <Dialog open={preset !== null} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="text-center">
             {tHome("stylePresetConfirmTitle")}
-          </AlertDialogTitle>
-        </AlertDialogHeader>
+          </DialogTitle>
+          {/* Radix の a11y 要件(aria-describedby)。視覚的には冗長なので sr-only。 */}
+          <DialogDescription className="sr-only">
+            {t("styleBrowseConfirmDescription")}
+          </DialogDescription>
+        </DialogHeader>
         {preset ? (
           <div className="flex flex-col items-center gap-3 py-2">
             <div
@@ -73,15 +79,15 @@ export function StyleTryOnConfirmDialog({
             </p>
           </div>
         ) : null}
-        <AlertDialogFooter>
-          <AlertDialogCancel>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
             {tHome("stylePresetConfirmCancel")}
-          </AlertDialogCancel>
-          <AlertDialogAction onClick={onConfirm}>
+          </Button>
+          <Button onClick={onConfirm}>
             {tHome("stylePresetConfirmAction")}
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/features/style-presets/components/StyleTryOnConfirmDialog.tsx
+++ b/features/style-presets/components/StyleTryOnConfirmDialog.tsx
@@ -7,10 +7,11 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { StyleProviderCredit } from "@/features/style/components/StyleProviderCredit";
+import { resolveStylePresetProvider } from "@/features/style-presets/lib/schema";
 import type { StylePresetPublicSummary } from "@/features/style-presets/lib/schema";
 
 interface StyleTryOnConfirmDialogProps {
@@ -19,32 +20,43 @@ interface StyleTryOnConfirmDialogProps {
   onOpenChange: (open: boolean) => void;
   /** 「試着する」確定。呼び出し側で /style への遷移などを行う。 */
   onConfirm: () => void;
+  /** 提供者クレジットの「提供/by」接頭辞用 locale。 */
+  locale: "ja" | "en";
+  /**
+   * プリセットID -> 累計生成数。「これまでに◯回つくられました」表示用
+   * (0 または未指定のプリセットでは表示しない)。
+   */
+  generateTotals?: Readonly<Record<string, number>>;
 }
 
 /**
  * 「こちらを試着しますか？」の確認モーダル。
  * ホームのスタイルカルーセル・企画棚と /styles のギャラリーで共用する。
  *
- * 気軽に眺めて戻れるよう AlertDialog ではなく通常の Dialog を使う
- * (探索シートの拡大プレビューと同じ方針。枠外タップ・Esc・× で閉じられる)。
- * 画像はサムネイルの実アスペクト比で表示する。横長はクロップせず全幅、
- * 縦長はダイアログが縦に伸びすぎないよう幅280pxに抑える。
- * 文言はホーム由来の home.stylePresetConfirm* キーを共通利用する。
+ * 構成は探索シート(StyleBrowseSheet)の拡大プレビューに揃える:
+ *  - 気軽に眺めて戻れるよう AlertDialog でなく通常の Dialog
+ *    (枠外タップ・Esc・× で閉じられる)
+ *  - 画像はサムネイルの実アスペクト比(横長はクロップせず全幅、縦長は幅280px)
+ *  - タイトルの下に提供者クレジットと累計生成数
+ *  - ボタンは「試着する」(上)・「他のスタイルをみる」(下)の縦積み
  */
 export function StyleTryOnConfirmDialog({
   preset,
   onOpenChange,
   onConfirm,
+  locale,
+  generateTotals,
 }: StyleTryOnConfirmDialogProps) {
   const t = useTranslations("style");
-  const tHome = useTranslations("home");
+  const provider = resolveStylePresetProvider(preset);
+  const generateTotal = preset ? (generateTotals?.[preset.id] ?? 0) : 0;
 
   return (
     <Dialog open={preset !== null} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle className="text-center">
-            {tHome("stylePresetConfirmTitle")}
+            {t("styleBrowseConfirmTitle")}
           </DialogTitle>
           {/* Radix の a11y 要件(aria-describedby)。視覚的には冗長なので sr-only。 */}
           <DialogDescription className="sr-only">
@@ -77,16 +89,28 @@ export function StyleTryOnConfirmDialog({
             <p className="text-base font-medium text-slate-900">
               {preset.title}
             </p>
+            {/* クリエイター表記(プリセット優先→カテゴリのフォールバック解決)。 */}
+            {provider ? (
+              <StyleProviderCredit
+                nickname={provider.nickname}
+                avatarUrl={provider.avatarUrl}
+                locale={locale}
+              />
+            ) : null}
+            {/* 累計利用回数(0回は出さない)。 */}
+            {generateTotal > 0 ? (
+              <p className="text-xs text-slate-500">
+                {t("styleUsageCount", { count: generateTotal })}
+              </p>
+            ) : null}
           </div>
         ) : null}
-        <DialogFooter>
+        <div className="flex flex-col gap-2">
+          <Button onClick={onConfirm}>{t("styleBrowseConfirmAction")}</Button>
           <Button variant="outline" onClick={() => onOpenChange(false)}>
-            {tHome("stylePresetConfirmCancel")}
+            {t("styleBrowseConfirmCancel")}
           </Button>
-          <Button onClick={onConfirm}>
-            {tHome("stylePresetConfirmAction")}
-          </Button>
-        </DialogFooter>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/features/style-presets/components/StylesGalleryClient.tsx
+++ b/features/style-presets/components/StylesGalleryClient.tsx
@@ -244,12 +244,28 @@ export function StylesGalleryClient({
           </AlertDialogHeader>
           {confirmingPreset ? (
             <div className="flex flex-col items-center gap-3 py-2">
-              <div className="relative aspect-[3/4] w-full max-w-[280px] overflow-hidden rounded-lg bg-gray-100">
+              {/* 画像はサムネの実アスペクト比で表示(探索シートと同じ挙動。横長はクロップしない)。
+                  縦長はダイアログが縦に伸びすぎないよう幅280pxに抑え、横長は全幅を使う。 */}
+              <div
+                className={`relative w-full overflow-hidden rounded-lg bg-gray-100 ${
+                  confirmingPreset.thumbnailWidth >
+                  confirmingPreset.thumbnailHeight
+                    ? ""
+                    : "max-w-[280px]"
+                }`}
+                style={{
+                  aspectRatio:
+                    confirmingPreset.thumbnailWidth > 0 &&
+                    confirmingPreset.thumbnailHeight > 0
+                      ? `${confirmingPreset.thumbnailWidth} / ${confirmingPreset.thumbnailHeight}`
+                      : "3 / 4",
+                }}
+              >
                 <Image
                   src={confirmingPreset.thumbnailImageUrl}
                   alt={t("styleCardAlt", { name: confirmingPreset.title })}
                   fill
-                  sizes="280px"
+                  sizes="(max-width: 640px) 90vw, 480px"
                   className="object-cover object-top"
                 />
               </div>

--- a/features/style-presets/components/StylesGalleryClient.tsx
+++ b/features/style-presets/components/StylesGalleryClient.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
+import { createClient } from "@/lib/supabase/client";
+import { PublicStyleCard } from "@/features/style-presets/components/PublicStyleCard";
+import {
+  deriveStyleBrowseChips,
+  filterStyleBrowsePresets,
+  STYLE_NEW_WINDOW_DAYS,
+  type StyleBrowseChipId,
+} from "@/features/style/lib/style-browse-filter";
+import type { StylePresetPublicSummary } from "@/features/style-presets/lib/schema";
+import type { Locale } from "@/i18n/config";
+
+/** チップ先頭の絵文字(装飾)。探索シート(StyleBrowseSheet)と同じ見た目に揃える。 */
+const CHIP_EMOJI: Partial<Record<string, string>> = {
+  event: "🎉",
+  favorites: "🔖",
+  new: "✨",
+  popular: "👑",
+  creator: "🤝",
+};
+
+interface StylesGalleryClientProps {
+  presets: StylePresetPublicSummary[];
+  /** プリセットID -> 直近生成数(👑人気チップの表示判定と並び替え)。 */
+  generateCounts: Record<string, number>;
+  /**
+   * 「✨新着」「🎉イベント」判定の基準時刻(ISO)。
+   * サーバー("use cache" スコープ)で確定した値を受け取ることで、
+   * SSR とハイドレーションでチップ構成が一致する。
+   */
+  nowIso: string;
+  locale: Locale;
+}
+
+/**
+ * /styles のチップフィルター付きギャラリー。
+ * 絞り込みロジックは /style の探索シートと同じ純関数
+ * (deriveStyleBrowseChips / filterStyleBrowsePresets)を再利用する。
+ *
+ * SEO 上の要点: 初期状態(すべて)では全カードが SSR で HTML に含まれる。
+ * チップはクライアント側の絞り込み表示であり、クローラーは常に全件を見る。
+ * お気に入り(🔖)などのユーザー状態は静的プリレンダを壊さないよう、
+ * マウント後にブラウザ側で取得する。
+ */
+export function StylesGalleryClient({
+  presets,
+  generateCounts,
+  nowIso,
+  locale,
+}: StylesGalleryClientProps) {
+  const t = useTranslations("style");
+  const [activeChip, setActiveChip] = useState<StyleBrowseChipId>("all");
+  const [favoriteIds, setFavoriteIds] = useState<ReadonlySet<string>>(
+    () => new Set()
+  );
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+  // ログイン済みならお気に入り(しおり)を取得して 🔖 チップを有効化する。
+  // 未ログイン・取得失敗時はチップが出ないだけで、一覧表示には影響しない。
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const supabase = createClient();
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+        if (cancelled || !user) {
+          return;
+        }
+        setIsAuthenticated(true);
+        const { data } = await supabase
+          .from("style_preset_favorites")
+          .select("preset_id");
+        if (cancelled) {
+          return;
+        }
+        setFavoriteIds(
+          new Set(
+            (data ?? [])
+              .map((row) => row.preset_id as string)
+              .filter(Boolean)
+          )
+        );
+      } catch {
+        // 認証状態の取得に失敗してもゲスト表示として成立する
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const context = useMemo(
+    () => ({
+      favoriteIds,
+      generateCounts,
+      now: new Date(nowIso),
+      isAuthenticated,
+    }),
+    [favoriteIds, generateCounts, nowIso, isAuthenticated]
+  );
+  const chips = useMemo(
+    () => deriveStyleBrowseChips(presets, context),
+    [presets, context]
+  );
+  const filtered = useMemo(
+    () => filterStyleBrowsePresets(presets, activeChip, context),
+    [presets, activeChip, context]
+  );
+
+  function chipLabel(chip: (typeof chips)[number]): string {
+    if (chip.id.startsWith("category:")) {
+      return (
+        (locale === "ja" ? chip.categoryLabelJa : chip.categoryLabelEn) ??
+        chip.id
+      );
+    }
+    switch (chip.id) {
+      case "all":
+        return t("styleChipAll");
+      case "event":
+        return t("styleChipEvent");
+      case "favorites":
+        return t("styleChipFavorites");
+      case "new":
+        return t("styleChipNew");
+      case "popular":
+        return t("styleChipPopular");
+      case "creator":
+        return t("styleChipCreator");
+      default:
+        return chip.id;
+    }
+  }
+
+  return (
+    <div>
+      {/* チップ列(横スクロール)。探索シートと同じ操作感。 */}
+      <div
+        className="-mx-1 mb-4 flex gap-2 overflow-x-auto px-1 pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        role="tablist"
+        aria-label={t("styleBrowseSheetTitle")}
+      >
+        {chips.map((chip) => {
+          const active = chip.id === activeChip;
+          const emoji = CHIP_EMOJI[chip.id];
+          return (
+            <button
+              key={chip.id}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              onClick={() => setActiveChip(chip.id)}
+              className={`shrink-0 whitespace-nowrap rounded-full border px-3.5 py-1.5 text-sm font-medium transition-colors ${
+                active
+                  ? "border-primary bg-primary text-white"
+                  : "border-gray-200 bg-white text-gray-700 hover:bg-gray-50"
+              }`}
+            >
+              {emoji ? `${emoji} ` : ""}
+              {chipLabel(chip)}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* 人気/新着の基準を明示する(探索シートと同じ注記)。 */}
+      {activeChip === "popular" && filtered.length > 0 ? (
+        <p className="mb-3 text-xs text-slate-500">
+          {t("stylePopularSortNote")}
+        </p>
+      ) : null}
+      {activeChip === "new" && filtered.length > 0 ? (
+        <p className="mb-3 text-xs text-slate-500">
+          {t("styleNewSortNote", { days: STYLE_NEW_WINDOW_DAYS })}
+        </p>
+      ) : null}
+
+      {filtered.length === 0 ? (
+        <p className="py-16 text-center text-sm text-gray-500">
+          {activeChip === "favorites"
+            ? t("styleFavoritesEmpty")
+            : t("styleBrowseEmpty")}
+        </p>
+      ) : (
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:gap-4 lg:grid-cols-4">
+          {filtered.map((preset) => (
+            <PublicStyleCard key={preset.id} preset={preset} locale={locale} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/features/style-presets/components/StylesGalleryClient.tsx
+++ b/features/style-presets/components/StylesGalleryClient.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from "next-intl";
 import { Bookmark } from "lucide-react";
 import { createClient } from "@/lib/supabase/client";
 import { useStyleFavorites } from "@/features/style/hooks/useStyleFavorites";
+import { useHorizontalScrollIndicator } from "@/features/style/hooks/useHorizontalScrollIndicator";
 import { PublicStyleCard } from "@/features/style-presets/components/PublicStyleCard";
 import { StyleTryOnConfirmDialog } from "@/features/style-presets/components/StyleTryOnConfirmDialog";
 import {
@@ -131,6 +132,13 @@ export function StylesGalleryClient({
     () => deriveStyleBrowseChips(presets, context),
     [presets, context]
   );
+
+  // チップ列の常時表示スクロールインジケーター(探索シートと共通のフック)。
+  const {
+    setScrollEl: setChipRowEl,
+    trackRef: chipIndicatorTrackRef,
+    thumbRef: chipIndicatorThumbRef,
+  } = useHorizontalScrollIndicator({ remeasureKey: chips });
   const filtered = useMemo(
     () => filterStyleBrowsePresets(presets, activeChip, context),
     [presets, activeChip, context]
@@ -165,7 +173,8 @@ export function StylesGalleryClient({
     <div>
       {/* チップ列(横スクロール)。探索シートと同じ操作感。 */}
       <div
-        className="-mx-1 mb-4 flex gap-2 overflow-x-auto px-1 pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        ref={setChipRowEl}
+        className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
         role="tablist"
         aria-label={t("styleBrowseSheetTitle")}
       >
@@ -190,6 +199,21 @@ export function StylesGalleryClient({
             </button>
           );
         })}
+      </div>
+      {/* チップ列の常時表示スクロールインジケーター。iOS はスクロール中しか
+          ネイティブバーが出ず「横に続きがある」ことに気づきにくいため自前描画。
+          位置・表示はフックが DOM を直接更新する(visibility 初期値 hidden、
+          はみ出しがあるときだけ表示)。高さは常に確保しレイアウトシフトを防ぐ。 */}
+      <div
+        ref={chipIndicatorTrackRef}
+        className="relative mx-1 mb-4 mt-1 h-1 overflow-hidden rounded-full bg-slate-100"
+        style={{ visibility: "hidden" }}
+        aria-hidden="true"
+      >
+        <div
+          ref={chipIndicatorThumbRef}
+          className="absolute top-0 h-full rounded-full bg-slate-300 [inset-inline-start:0]"
+        />
       </div>
 
       {/* 人気/新着の基準を明示する(探索シートと同じ注記)。 */}

--- a/features/style-presets/components/StylesGalleryClient.tsx
+++ b/features/style-presets/components/StylesGalleryClient.tsx
@@ -1,20 +1,11 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import { createClient } from "@/lib/supabase/client";
 import { PublicStyleCard } from "@/features/style-presets/components/PublicStyleCard";
+import { StyleTryOnConfirmDialog } from "@/features/style-presets/components/StyleTryOnConfirmDialog";
 import {
   deriveStyleBrowseChips,
   filterStyleBrowsePresets,
@@ -63,7 +54,6 @@ export function StylesGalleryClient({
   locale,
 }: StylesGalleryClientProps) {
   const t = useTranslations("style");
-  const tHome = useTranslations("home");
   const router = useRouter();
   const [activeChip, setActiveChip] = useState<StyleBrowseChipId>("all");
   const [favoriteIds, setFavoriteIds] = useState<ReadonlySet<string>>(
@@ -227,63 +217,16 @@ export function StylesGalleryClient({
         </div>
       )}
 
-      {/* ホームのカルーセルと同じ試着確認モーダル。「試着する」で /style へ遷移する。 */}
-      <AlertDialog
-        open={confirmingPreset !== null}
+      {/* ホームのカルーセルと共通の試着確認モーダル。「試着する」で /style へ遷移する。 */}
+      <StyleTryOnConfirmDialog
+        preset={confirmingPreset}
         onOpenChange={(open) => {
           if (!open) {
             setConfirmingPreset(null);
           }
         }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              {tHome("stylePresetConfirmTitle")}
-            </AlertDialogTitle>
-          </AlertDialogHeader>
-          {confirmingPreset ? (
-            <div className="flex flex-col items-center gap-3 py-2">
-              {/* 画像はサムネの実アスペクト比で表示(探索シートと同じ挙動。横長はクロップしない)。
-                  縦長はダイアログが縦に伸びすぎないよう幅280pxに抑え、横長は全幅を使う。 */}
-              <div
-                className={`relative w-full overflow-hidden rounded-lg bg-gray-100 ${
-                  confirmingPreset.thumbnailWidth >
-                  confirmingPreset.thumbnailHeight
-                    ? ""
-                    : "max-w-[280px]"
-                }`}
-                style={{
-                  aspectRatio:
-                    confirmingPreset.thumbnailWidth > 0 &&
-                    confirmingPreset.thumbnailHeight > 0
-                      ? `${confirmingPreset.thumbnailWidth} / ${confirmingPreset.thumbnailHeight}`
-                      : "3 / 4",
-                }}
-              >
-                <Image
-                  src={confirmingPreset.thumbnailImageUrl}
-                  alt={t("styleCardAlt", { name: confirmingPreset.title })}
-                  fill
-                  sizes="(max-width: 640px) 90vw, 480px"
-                  className="object-cover object-top"
-                />
-              </div>
-              <p className="text-base font-medium text-slate-900">
-                {confirmingPreset.title}
-              </p>
-            </div>
-          ) : null}
-          <AlertDialogFooter>
-            <AlertDialogCancel>
-              {tHome("stylePresetConfirmCancel")}
-            </AlertDialogCancel>
-            <AlertDialogAction onClick={handleConfirm}>
-              {tHome("stylePresetConfirmAction")}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        onConfirm={handleConfirm}
+      />
     </div>
   );
 }

--- a/features/style-presets/components/StylesGalleryClient.tsx
+++ b/features/style-presets/components/StylesGalleryClient.tsx
@@ -30,6 +30,8 @@ interface StylesGalleryClientProps {
   presets: StylePresetPublicSummary[];
   /** プリセットID -> 直近生成数(👑人気チップの表示判定と並び替え)。 */
   generateCounts: Record<string, number>;
+  /** プリセットID -> 累計生成数(試着確認モーダルの「これまでに◯回」表示)。 */
+  generateTotals: Record<string, number>;
   /**
    * 「✨新着」「🎉イベント」判定の基準時刻(ISO)。
    * サーバー("use cache" スコープ)で確定した値を受け取ることで、
@@ -52,6 +54,7 @@ interface StylesGalleryClientProps {
 export function StylesGalleryClient({
   presets,
   generateCounts,
+  generateTotals,
   nowIso,
   locale,
 }: StylesGalleryClientProps) {
@@ -256,6 +259,8 @@ export function StylesGalleryClient({
           }
         }}
         onConfirm={handleConfirm}
+        locale={locale === "ja" ? "ja" : "en"}
+        generateTotals={generateTotals}
       />
     </div>
   );

--- a/features/style-presets/components/StylesGalleryClient.tsx
+++ b/features/style-presets/components/StylesGalleryClient.tsx
@@ -1,7 +1,18 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { createClient } from "@/lib/supabase/client";
 import { PublicStyleCard } from "@/features/style-presets/components/PublicStyleCard";
 import {
@@ -11,7 +22,7 @@ import {
   type StyleBrowseChipId,
 } from "@/features/style/lib/style-browse-filter";
 import type { StylePresetPublicSummary } from "@/features/style-presets/lib/schema";
-import type { Locale } from "@/i18n/config";
+import { localizePublicPath, type Locale } from "@/i18n/config";
 
 /** チップ先頭の絵文字(装飾)。探索シート(StyleBrowseSheet)と同じ見た目に揃える。 */
 const CHIP_EMOJI: Partial<Record<string, string>> = {
@@ -52,11 +63,28 @@ export function StylesGalleryClient({
   locale,
 }: StylesGalleryClientProps) {
   const t = useTranslations("style");
+  const tHome = useTranslations("home");
+  const router = useRouter();
   const [activeChip, setActiveChip] = useState<StyleBrowseChipId>("all");
   const [favoriteIds, setFavoriteIds] = useState<ReadonlySet<string>>(
     () => new Set()
   );
   const [isAuthenticated, setIsAuthenticated] = useState(false);
+  // カードタップは即遷移せず、ホームのカルーセルと同じ「試着しますか？」確認を挟む。
+  // 紹介ページ(/styles/[slug])へは href(修飾キー付きクリック/クローラー)で辿れる。
+  const [confirmingPreset, setConfirmingPreset] =
+    useState<StylePresetPublicSummary | null>(null);
+
+  const handleConfirm = () => {
+    const preset = confirmingPreset;
+    if (!preset) {
+      return;
+    }
+    setConfirmingPreset(null);
+    router.push(
+      `${localizePublicPath("/style", locale)}?style=${encodeURIComponent(preset.id)}`
+    );
+  };
 
   // ログイン済みならお気に入り(しおり)を取得して 🔖 チップを有効化する。
   // 未ログイン・取得失敗時はチップが出ないだけで、一覧表示には影響しない。
@@ -189,10 +217,57 @@ export function StylesGalleryClient({
       ) : (
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:gap-4 lg:grid-cols-4">
           {filtered.map((preset) => (
-            <PublicStyleCard key={preset.id} preset={preset} locale={locale} />
+            <PublicStyleCard
+              key={preset.id}
+              preset={preset}
+              locale={locale}
+              onSelect={setConfirmingPreset}
+            />
           ))}
         </div>
       )}
+
+      {/* ホームのカルーセルと同じ試着確認モーダル。「試着する」で /style へ遷移する。 */}
+      <AlertDialog
+        open={confirmingPreset !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setConfirmingPreset(null);
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {tHome("stylePresetConfirmTitle")}
+            </AlertDialogTitle>
+          </AlertDialogHeader>
+          {confirmingPreset ? (
+            <div className="flex flex-col items-center gap-3 py-2">
+              <div className="relative aspect-[3/4] w-full max-w-[280px] overflow-hidden rounded-lg bg-gray-100">
+                <Image
+                  src={confirmingPreset.thumbnailImageUrl}
+                  alt={t("styleCardAlt", { name: confirmingPreset.title })}
+                  fill
+                  sizes="280px"
+                  className="object-cover object-top"
+                />
+              </div>
+              <p className="text-base font-medium text-slate-900">
+                {confirmingPreset.title}
+              </p>
+            </div>
+          ) : null}
+          <AlertDialogFooter>
+            <AlertDialogCancel>
+              {tHome("stylePresetConfirmCancel")}
+            </AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirm}>
+              {tHome("stylePresetConfirmAction")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/features/style-presets/components/StylesGalleryClient.tsx
+++ b/features/style-presets/components/StylesGalleryClient.tsx
@@ -3,7 +3,9 @@
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
+import { Bookmark } from "lucide-react";
 import { createClient } from "@/lib/supabase/client";
+import { useStyleFavorites } from "@/features/style/hooks/useStyleFavorites";
 import { PublicStyleCard } from "@/features/style-presets/components/PublicStyleCard";
 import { StyleTryOnConfirmDialog } from "@/features/style-presets/components/StyleTryOnConfirmDialog";
 import {
@@ -56,10 +58,11 @@ export function StylesGalleryClient({
   const t = useTranslations("style");
   const router = useRouter();
   const [activeChip, setActiveChip] = useState<StyleBrowseChipId>("all");
-  const [favoriteIds, setFavoriteIds] = useState<ReadonlySet<string>>(
-    () => new Set()
-  );
   const [isAuthenticated, setIsAuthenticated] = useState(false);
+  // お気に入り(しおり)の集合と楽観更新トグル。/style・ホームと同じフックを共用する
+  // (ゲストのタップはフック側がログイン誘導トーストを出す)。
+  const { favoritePresetIds, toggleFavorite, hydrateFavorites } =
+    useStyleFavorites({ isAuthenticated });
   // カードタップは即遷移せず、ホームのカルーセルと同じ「試着しますか？」確認を挟む。
   // 紹介ページ(/styles/[slug])へは href(修飾キー付きクリック/クローラー)で辿れる。
   const [confirmingPreset, setConfirmingPreset] =
@@ -96,12 +99,10 @@ export function StylesGalleryClient({
         if (cancelled) {
           return;
         }
-        setFavoriteIds(
-          new Set(
-            (data ?? [])
-              .map((row) => row.preset_id as string)
-              .filter(Boolean)
-          )
+        hydrateFavorites(
+          (data ?? [])
+            .map((row) => row.preset_id as string)
+            .filter(Boolean)
         );
       } catch {
         // 認証状態の取得に失敗してもゲスト表示として成立する
@@ -110,16 +111,18 @@ export function StylesGalleryClient({
     return () => {
       cancelled = true;
     };
+    // hydrateFavorites は useCallback で安定しているためマウント時のみ実行する
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const context = useMemo(
     () => ({
-      favoriteIds,
+      favoriteIds: favoritePresetIds,
       generateCounts,
       now: new Date(nowIso),
       isAuthenticated,
     }),
-    [favoriteIds, generateCounts, nowIso, isAuthenticated]
+    [favoritePresetIds, generateCounts, nowIso, isAuthenticated]
   );
   const chips = useMemo(
     () => deriveStyleBrowseChips(presets, context),
@@ -206,14 +209,41 @@ export function StylesGalleryClient({
         </p>
       ) : (
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:gap-4 lg:grid-cols-4">
-          {filtered.map((preset) => (
-            <PublicStyleCard
-              key={preset.id}
-              preset={preset}
-              locale={locale}
-              onSelect={setConfirmingPreset}
-            />
-          ))}
+          {filtered.map((preset) => {
+            const isFavorite = favoritePresetIds.has(preset.id);
+            return (
+              <div key={preset.id} className="relative">
+                <PublicStyleCard
+                  preset={preset}
+                  locale={locale}
+                  onSelect={setConfirmingPreset}
+                />
+                {/* お気に入り(しおり)はカード(リンク)の兄弟としてオーバーレイ配置
+                    (a 要素への button ネスト回避)。探索シートと同じ意匠。
+                    ゲストのタップはフック側がログイン誘導トーストを出す。 */}
+                <button
+                  type="button"
+                  onClick={() => void toggleFavorite(preset.id, !isFavorite)}
+                  aria-label={
+                    isFavorite
+                      ? t("styleFavoriteRemove")
+                      : t("styleFavoriteAdd")
+                  }
+                  aria-pressed={isFavorite}
+                  className="absolute left-1.5 top-1.5 z-20 flex h-7 w-7 items-center justify-center rounded-full bg-white/90 shadow transition-transform hover:scale-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 sm:left-2 sm:top-2 sm:h-9 sm:w-9"
+                >
+                  <Bookmark
+                    className={`h-4 w-4 sm:h-5 sm:w-5 ${
+                      isFavorite
+                        ? "fill-pink-500 text-pink-500"
+                        : "text-slate-400"
+                    }`}
+                    aria-hidden="true"
+                  />
+                </button>
+              </div>
+            );
+          })}
         </div>
       )}
 

--- a/features/style-presets/lib/get-public-style-presets.ts
+++ b/features/style-presets/lib/get-public-style-presets.ts
@@ -1,6 +1,7 @@
 import { cacheLife, cacheTag } from "next/cache";
 import {
   getPublishedStylePresetById,
+  getPublishedStylePresetBySlug,
   listPublishedStylePresets,
 } from "./style-preset-repository";
 import type { StylePresetPublicSummary } from "./schema";
@@ -39,6 +40,16 @@ async function getPublishedStylePresetCached(
   return getPublishedStylePresetById(id);
 }
 
+async function getPublishedStylePresetBySlugCached(
+  slug: string
+): Promise<StylePresetPublicSummary | null> {
+  "use cache";
+  cacheTag("style-presets");
+  cacheLife("minutes");
+
+  return getPublishedStylePresetBySlug(slug);
+}
+
 async function getPublishedStylePresetForAdminCached(
   id: string
 ): Promise<StylePresetPublicSummary | null> {
@@ -64,4 +75,13 @@ export async function getPublishedStylePreset(
   return options.includeAdminOnly === true
     ? getPublishedStylePresetForAdminCached(id)
     : getPublishedStylePresetCached(id);
+}
+
+/**
+ * /styles/[slug] の公開スタイル紹介ページ用。published かつ非 admin_only のみ返す。
+ */
+export async function getPublishedStylePresetBySlugPublic(
+  slug: string
+): Promise<StylePresetPublicSummary | null> {
+  return getPublishedStylePresetBySlugCached(slug);
 }

--- a/features/style-presets/lib/schema.ts
+++ b/features/style-presets/lib/schema.ts
@@ -148,6 +148,8 @@ export interface StylePresetAdmin {
 
 export interface StylePresetPublicSummary {
   id: string;
+  /** 一意 slug。/styles/[slug] の公開スタイル紹介ページ URL に使う。 */
+  slug: string;
   title: string;
   thumbnailImageUrl: string;
   thumbnailWidth: number;

--- a/features/style-presets/lib/style-preset-repository.ts
+++ b/features/style-presets/lib/style-preset-repository.ts
@@ -306,6 +306,7 @@ function mapRowToPublicSummary(row: StylePresetRow): StylePresetPublicSummary {
   const provider = extractProvider(row.provider);
   return {
     id: row.id,
+    slug: row.slug,
     title: row.title,
     thumbnailImageUrl: row.thumbnail_image_url,
     thumbnailWidth: row.thumbnail_width,
@@ -494,6 +495,32 @@ export async function getPublishedStylePresetById(
 
   if (error) {
     console.error("[style-preset-repository] get published by id error:", error);
+    return null;
+  }
+
+  if (!data) return null;
+  const preset = mapRowToPublicSummary(data as StylePresetRow);
+  return canAccessCategory(preset.category, options) ? preset : null;
+}
+
+export async function getPublishedStylePresetBySlug(
+  slug: string,
+  options: PublishedStylePresetAccessOptions = {},
+  client?: SupabaseClient
+): Promise<StylePresetPublicSummary | null> {
+  const supabase = getSupabase(client);
+  const { data, error } = await supabase
+    .from("style_presets")
+    .select(STYLE_PRESET_WITH_CATEGORY_SELECT)
+    .eq("slug", slug)
+    .eq("status", "published")
+    .maybeSingle();
+
+  if (error) {
+    console.error(
+      "[style-preset-repository] get published by slug error:",
+      error
+    );
     return null;
   }
 

--- a/features/style/components/StyleBrowseSheet.tsx
+++ b/features/style/components/StyleBrowseSheet.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/components/ui/sheet";
 import { StylePresetPreviewCard } from "@/features/style/components/StylePresetPreviewCard";
 import { StyleProviderCredit } from "@/features/style/components/StyleProviderCredit";
+import { useHorizontalScrollIndicator } from "@/features/style/hooks/useHorizontalScrollIndicator";
 import { resolveStylePresetProvider } from "@/features/style-presets/lib/schema";
 import {
   deriveStyleBrowseChips,
@@ -105,16 +106,6 @@ export function StyleBrowseSheet({
   // (ホーム企画棚と同じ体験。小さいグリッドの誤タップ防止も兼ねる)。
   const [confirmingPreset, setConfirmingPreset] =
     useState<StylePresetPublicSummary | null>(null);
-  // チップ列の常時表示スクロールインジケーター用。iOS Safari は
-  // ::-webkit-scrollbar による常時表示に非対応のため、自前の細いバーを描画する。
-  // スクロールのたびに再レンダリングするとグリッド全体が再描画されてカクつくため、
-  // React state を使わず effect 内で thumb の DOM スタイルを直接更新する。
-  // チップ列は Radix の Portal 内にあり open と同一コミットではマウントされない
-  // (ref が null のまま effect が走って終わる)ため、callback ref + state で
-  // 「実際に DOM が生えたとき」に effect を再実行させる。
-  const [chipRowEl, setChipRowEl] = useState<HTMLDivElement | null>(null);
-  const chipIndicatorTrackRef = useRef<HTMLDivElement | null>(null);
-  const chipIndicatorThumbRef = useRef<HTMLDivElement | null>(null);
 
   // 「下スワイプで閉じる」用: スワイプ開始Y座標(モバイルの自然な閉じ操作)。
   // touch イベントでなく Pointer Events を使う(DevTools のデバイスモードや
@@ -223,56 +214,13 @@ export function StyleBrowseSheet({
     [presets, activeChip, context],
   );
 
-  // チップ列のスクロールインジケーター更新。開いている間だけ監視する。
-  // rAF で間引き、位置は transform(合成のみ・レイアウト不発)で動かす。
-  useEffect(() => {
-    if (!open) {
-      return;
-    }
-    const el = chipRowEl;
-    const track = chipIndicatorTrackRef.current;
-    const thumb = chipIndicatorThumbRef.current;
-    if (!el || !track || !thumb) {
-      return;
-    }
-    let rafId: number | null = null;
-    const measure = () => {
-      rafId = null;
-      const { scrollWidth, clientWidth, scrollLeft } = el;
-      if (scrollWidth <= clientWidth + 1) {
-        track.style.visibility = "hidden";
-        return;
-      }
-      track.style.visibility = "visible";
-      const trackWidth = track.clientWidth;
-      const thumbWidth = trackWidth * (clientWidth / scrollWidth);
-      const maxScroll = scrollWidth - clientWidth;
-      // RTL では scrollLeft が負になるため絶対値で進捗率にし、移動方向を反転する。
-      const progress = Math.min(Math.abs(scrollLeft) / maxScroll, 1);
-      const direction =
-        getComputedStyle(track).direction === "rtl" ? -1 : 1;
-      thumb.style.width = `${thumbWidth}px`;
-      thumb.style.transform = `translateX(${
-        direction * progress * (trackWidth - thumbWidth)
-      }px)`;
-    };
-    const schedule = () => {
-      if (rafId === null) {
-        rafId = requestAnimationFrame(measure);
-      }
-    };
-    measure();
-    el.addEventListener("scroll", schedule, { passive: true });
-    const resizeObserver = new ResizeObserver(schedule);
-    resizeObserver.observe(el);
-    return () => {
-      if (rafId !== null) {
-        cancelAnimationFrame(rafId);
-      }
-      el.removeEventListener("scroll", schedule);
-      resizeObserver.disconnect();
-    };
-  }, [open, chips, chipRowEl]);
+  // チップ列の常時表示スクロールインジケーター(/styles と共通のフック)。
+  // 開いている間だけ監視し、チップ構成が変わったら再計測する。
+  const {
+    setScrollEl: setChipRowEl,
+    trackRef: chipIndicatorTrackRef,
+    thumbRef: chipIndicatorThumbRef,
+  } = useHorizontalScrollIndicator({ active: open, remeasureKey: chips });
 
   function chipLabel(chip: (typeof chips)[number]): string {
     if (chip.id.startsWith("category:")) {

--- a/features/style/components/StylePresetPreviewCard.tsx
+++ b/features/style/components/StylePresetPreviewCard.tsx
@@ -5,9 +5,9 @@ import Image from "next/image";
 import { Lock } from "lucide-react";
 import { Card } from "@/components/ui/card";
 import { StyleProviderCredit } from "@/features/style/components/StyleProviderCredit";
+import { truncateStylePresetName } from "@/features/style/lib/style-preset-name";
 import { resolveStylePresetProvider } from "@/features/style-presets/lib/schema";
 
-const PRESET_NAME_MAX_CHARACTERS = 16;
 const STYLE_PRESET_CARD_WIDTH_PX = 180;
 const STYLE_PRESET_CARD_IMAGE_HEIGHT_PX = 240;
 const STYLE_PRESET_CARD_TITLE_HEIGHT_PX = 44;
@@ -100,13 +100,9 @@ export function buildStylePresetImageSrc(
   return preset.thumbnailImageUrl;
 }
 
-export function truncateStylePresetName(name: string): string {
-  const characters = Array.from(name);
-  if (characters.length <= PRESET_NAME_MAX_CHARACTERS) {
-    return name;
-  }
-  return `${characters.slice(0, PRESET_NAME_MAX_CHARACTERS).join("")}...`;
-}
+// 切り詰めロジックはサーバーでも描画される PublicStyleCard と共有するため
+// features/style/lib/style-preset-name.ts に移動した(既存importの互換で再export)。
+export { truncateStylePresetName } from "@/features/style/lib/style-preset-name";
 
 export function StylePresetPreviewCard({
   preset,

--- a/features/style/hooks/useHorizontalScrollIndicator.ts
+++ b/features/style/hooks/useHorizontalScrollIndicator.ts
@@ -1,0 +1,83 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * チップ列などの横スクロール領域に「常時表示のスクロールインジケーター」を
+ * 付けるためのフック。探索シート(StyleBrowseSheet)と /styles のギャラリーで共用する。
+ *
+ * iOS Safari は ::-webkit-scrollbar による常時表示に非対応のため、自前の細い
+ * バーを描画する。スクロールのたびに React state を更新するとリスト全体が
+ * 再レンダリングされてカクつくため、effect 内で thumb の DOM スタイルを直接
+ * 更新する(rAF で間引き、transform のみ動かしてレイアウトを発生させない)。
+ *
+ * 使い方:
+ *  - スクロール領域(overflow-x-auto の要素)に `ref={setScrollEl}` を渡す
+ *    (Radix の Portal 内など「open と同一コミットでマウントされない」ケースでも
+ *     実際に DOM が生えたときに effect を再実行させるため callback ref を使う)
+ *  - トラックは `style={{ visibility: "hidden" }}` で初期化し、はみ出しがある
+ *    ときだけこのフックが表示に切り替える
+ */
+export function useHorizontalScrollIndicator({
+  active = true,
+  remeasureKey,
+}: {
+  /** false の間は監視しない(シートが閉じている間など)。 */
+  active?: boolean;
+  /** チップ構成の変化など、再計測をトリガーしたい値。 */
+  remeasureKey?: unknown;
+} = {}) {
+  const [scrollEl, setScrollEl] = useState<HTMLDivElement | null>(null);
+  const trackRef = useRef<HTMLDivElement | null>(null);
+  const thumbRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!active) {
+      return;
+    }
+    const el = scrollEl;
+    const track = trackRef.current;
+    const thumb = thumbRef.current;
+    if (!el || !track || !thumb) {
+      return;
+    }
+    let rafId: number | null = null;
+    const measure = () => {
+      rafId = null;
+      const { scrollWidth, clientWidth, scrollLeft } = el;
+      if (scrollWidth <= clientWidth + 1) {
+        track.style.visibility = "hidden";
+        return;
+      }
+      track.style.visibility = "visible";
+      const trackWidth = track.clientWidth;
+      const thumbWidth = trackWidth * (clientWidth / scrollWidth);
+      const maxScroll = scrollWidth - clientWidth;
+      // RTL では scrollLeft が負になるため絶対値で進捗率にし、移動方向を反転する。
+      const progress = Math.min(Math.abs(scrollLeft) / maxScroll, 1);
+      const direction = getComputedStyle(track).direction === "rtl" ? -1 : 1;
+      thumb.style.width = `${thumbWidth}px`;
+      thumb.style.transform = `translateX(${
+        direction * progress * (trackWidth - thumbWidth)
+      }px)`;
+    };
+    const schedule = () => {
+      if (rafId === null) {
+        rafId = requestAnimationFrame(measure);
+      }
+    };
+    measure();
+    el.addEventListener("scroll", schedule, { passive: true });
+    const resizeObserver = new ResizeObserver(schedule);
+    resizeObserver.observe(el);
+    return () => {
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
+      }
+      el.removeEventListener("scroll", schedule);
+      resizeObserver.disconnect();
+    };
+  }, [active, scrollEl, remeasureKey]);
+
+  return { setScrollEl, trackRef, thumbRef };
+}

--- a/features/style/hooks/useStyleFavorites.ts
+++ b/features/style/hooks/useStyleFavorites.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import { useToast } from "@/components/ui/use-toast";
 
@@ -76,5 +76,14 @@ export function useStyleFavorites({
     }
   };
 
-  return { favoritePresetIds, toggleFavorite };
+  /**
+   * 遅延取得した初期お気に入りを反映する(/styles のように認証状態を
+   * クライアント側で解決するページ用)。既存の集合を丸ごと置き換えるため、
+   * マウント直後の初期化にのみ使い、楽観更新後には呼ばないこと。
+   */
+  const hydrateFavorites = useCallback((presetIds: readonly string[]) => {
+    setFavoritePresetIds(new Set(presetIds));
+  }, []);
+
+  return { favoritePresetIds, toggleFavorite, hydrateFavorites };
 }

--- a/features/style/lib/style-preset-name.ts
+++ b/features/style/lib/style-preset-name.ts
@@ -1,0 +1,14 @@
+const PRESET_NAME_MAX_CHARACTERS = 16;
+
+/**
+ * スタイルカードの1行タイトル用にプリセット名を切り詰める。
+ * StylePresetPreviewCard(クライアント)と PublicStyleCard(サーバーでも描画)の
+ * 両方から使うため、"use client" を付けない共有 lib に置く。
+ */
+export function truncateStylePresetName(name: string): string {
+  const characters = Array.from(name);
+  if (characters.length <= PRESET_NAME_MAX_CHARACTERS) {
+    return name;
+  }
+  return `${characters.slice(0, PRESET_NAME_MAX_CHARACTERS).join("")}...`;
+}

--- a/i18n/config.ts
+++ b/i18n/config.ts
@@ -53,6 +53,13 @@ const PUBLIC_PATH_PATTERNS = [
   /^\/catalog\/[^/]+\/p\/[^/]+$/,
   /^\/catalog\/submit$/,
   /^\/catalog\/submit\/thanks$/,
+  // 生成ページ(ゲスト生成可)とスタイル紹介ページもロケール付き URL で公開する。
+  // ここに追加すると proxy がロケール無しアクセスを /{locale}/... へリダイレクトするため、
+  // 対応する app/[locale]/ 配下の re-export ルートが必須(無いと 404 になる)。
+  /^\/style$/,
+  /^\/coordinate$/,
+  /^\/styles$/,
+  /^\/styles\/[^/]+$/,
 ];
 
 export function isLocale(value: string | undefined | null): value is Locale {

--- a/i18n/page-copy.ts
+++ b/i18n/page-copy.ts
@@ -3,236 +3,245 @@ import type {Locale} from "@/i18n/config";
 const siteCopy = {
   ja: {
     title:
-      "Persta.AI (ペルスタ) - 着てみたいも、なりたいも。AIスタイリングプラットフォーム",
+      "Persta.AI (ペルスタ) - AI着せ替え・AIイラスト生成のスタイリングプラットフォーム",
     description:
-      "Persta（ペルスタ）は、AIでファッション・キャラクターなどのビジュアル表現を自由にスタイリングできるプラットフォームです。persta.aiで、みんなの作品を見て、インスピレーションを得ましょう。",
+      "Persta（ペルスタ）は、うちの子・推しキャラのイラストをAIで着せ替え・コーディネートできるAIイラスト生成プラットフォームです。無料で試して、persta.aiでみんなの作品からインスピレーションを得ましょう。",
   },
   en: {
     title:
-      "Persta.AI - An AI styling platform for fashion, characters, and visual expression",
+      "Persta.AI - AI Dress-Up, Outfit Swap & Character Illustration Generator",
     description:
-      "Persta is an AI styling platform where you can explore fashion, character, and visual expression ideas, then discover inspiration from the community on persta.ai.",
+      "Persta is an AI platform for dressing up your OCs and favorite characters: generate outfit swaps, coordinated looks, and new illustration styles, then discover inspiration from the community on persta.ai.",
   },
   ko: {
     title:
-      "Persta.AI — 패션, 캐릭터, 비주얼 표현을 위한 AI 스타일링 플랫폼",
+      "Persta.AI — AI 옷 갈아입히기·AI 일러스트 생성 스타일링 플랫폼",
     description:
-      "Persta는 패션, 캐릭터, 비주얼 표현 아이디어를 자유롭게 스타일링할 수 있는 AI 플랫폼입니다. persta.ai에서 다른 사용자의 작품을 보고 영감을 얻어보세요.",
+      "Persta는 내 캐릭터(오리캐)와 최애 일러스트를 AI로 옷 갈아입히기·코디할 수 있는 AI 일러스트 생성 플랫폼입니다. 무료로 체험하고 persta.ai에서 다른 사용자의 작품을 보고 영감을 얻어보세요.",
   },
   "zh-CN": {
     title:
-      "Persta.AI — 时尚、角色和视觉表达的 AI 造型平台",
+      "Persta.AI — AI 换装与 AI 插画生成的造型平台",
     description:
-      "Persta 是一个 AI 造型平台，让你自由探索时尚、角色和视觉表达的创意。来 persta.ai 浏览社区作品，激发你的灵感。",
+      "Persta 是一个 AI 插画生成平台，用 AI 为你的自设角色（OC）和本命角色换装、搭配服装。免费体验，并在 persta.ai 浏览社区作品，激发你的灵感。",
   },
   "zh-TW": {
     title:
-      "Persta.AI — 時尚、角色與視覺表達的 AI 造型平台",
+      "Persta.AI — AI 換裝與 AI 插畫生成的造型平台",
     description:
-      "Persta 是一個 AI 造型平台，讓你自由探索時尚、角色與視覺表達的創意。來 persta.ai 瀏覽社群作品，激發你的靈感。",
+      "Persta 是一個 AI 插畫生成平台，用 AI 為你的自創角色（OC）和本命角色換裝、搭配服裝。免費體驗，並在 persta.ai 瀏覽社群作品，激發你的靈感。",
   },
   es: {
     title:
-      "Persta.AI — Plataforma de estilismo con IA para moda, personajes y expresión visual",
+      "Persta.AI — Cambio de ropa con IA y generación de ilustraciones de personajes",
     description:
-      "Persta es una plataforma de estilismo con IA donde puedes explorar ideas de moda, personajes y expresión visual, y descubrir inspiración de la comunidad en persta.ai.",
+      "Persta es una plataforma de IA para vestir a tus OCs y personajes favoritos: genera cambios de outfit, looks coordinados y nuevos estilos de ilustración. Pruébalo gratis y descubre inspiración de la comunidad en persta.ai.",
   },
   pt: {
     title:
-      "Persta.AI — Plataforma de styling com IA para moda, personagens e expressão visual",
+      "Persta.AI — Troca de roupa com IA e geração de ilustrações de personagens",
     description:
-      "Persta é uma plataforma de styling com IA onde você pode explorar ideias de moda, personagens e expressão visual, e encontrar inspiração da comunidade em persta.ai.",
+      "Persta é uma plataforma de IA para vestir seus OCs e personagens favoritos: gere trocas de roupa, looks coordenados e novos estilos de ilustração. Experimente grátis e encontre inspiração da comunidade em persta.ai.",
   },
   fr: {
     title:
-      "Persta.AI — Plateforme de stylisme IA pour la mode, les personnages et l'expression visuelle",
+      "Persta.AI — Habillage IA et génération d'illustrations de personnages",
     description:
-      "Persta est une plateforme de stylisme IA où vous pouvez explorer des idées de mode, de personnages et d'expression visuelle, puis trouver l'inspiration auprès de la communauté sur persta.ai.",
+      "Persta est une plateforme d'IA pour habiller vos OC et personnages préférés : générez des changements de tenue, des looks coordonnés et de nouveaux styles d'illustration. Essayez gratuitement et trouvez l'inspiration auprès de la communauté sur persta.ai.",
   },
   de: {
     title:
-      "Persta.AI – KI-Styling-Plattform für Mode, Charaktere und visuellen Ausdruck",
+      "Persta.AI – KI-Anziehen & KI-Illustrationsgenerator für Charaktere",
     description:
-      "Persta ist eine KI-Styling-Plattform, auf der du Ideen für Mode, Charaktere und visuellen Ausdruck erkunden und dich von der Community auf persta.ai inspirieren lassen kannst.",
+      "Persta ist eine KI-Plattform, mit der du deine OCs und Lieblingscharaktere umziehst: Erstelle Outfit-Wechsel, abgestimmte Looks und neue Illustrationsstile. Kostenlos ausprobieren und dich von der Community auf persta.ai inspirieren lassen.",
   },
   it: {
     title:
-      "Persta.AI — Piattaforma di styling con IA per moda, personaggi ed espressione visiva",
+      "Persta.AI — Cambio d'abito con IA e generazione di illustrazioni di personaggi",
     description:
-      "Persta è una piattaforma di styling con IA in cui puoi esplorare idee di moda, personaggi ed espressione visiva, e trovare ispirazione dalla community su persta.ai.",
+      "Persta è una piattaforma di IA per vestire i tuoi OC e personaggi preferiti: genera cambi d'abito, look coordinati e nuovi stili di illustrazione. Provala gratis e trova ispirazione dalla community su persta.ai.",
   },
   id: {
     title:
-      "Persta.AI — Platform styling AI untuk fashion, karakter, dan ekspresi visual",
+      "Persta.AI — Ganti baju AI & generator ilustrasi karakter",
     description:
-      "Persta adalah platform styling AI tempat kamu bisa menjelajahi ide fashion, karakter, dan ekspresi visual, lalu menemukan inspirasi dari komunitas di persta.ai.",
+      "Persta adalah platform AI untuk mendandani OC dan karakter favoritmu: buat pergantian outfit, padu padan gaya, dan gaya ilustrasi baru. Coba gratis dan temukan inspirasi dari komunitas di persta.ai.",
   },
   th: {
     title:
-      "Persta.AI — แพลตฟอร์ม AI สไตลิ่งสำหรับแฟชั่น คาแรกเตอร์ และการแสดงออกทางภาพ",
+      "Persta.AI — แพลตฟอร์ม AI เปลี่ยนชุดตัวละครและสร้างภาพประกอบด้วย AI",
     description:
-      "Persta คือแพลตฟอร์ม AI สไตลิ่ง ที่คุณสามารถสำรวจไอเดียแฟชั่น คาแรกเตอร์ และการแสดงออกทางภาพ และค้นพบแรงบันดาลใจจากชุมชนได้ที่ persta.ai",
+      "Persta คือแพลตฟอร์ม AI สำหรับเปลี่ยนชุดให้ OC และตัวละครที่คุณรัก สร้างการเปลี่ยนชุด การแต่งตัว และสไตล์ภาพประกอบใหม่ ๆ ทดลองฟรีและค้นพบแรงบันดาลใจจากชุมชนได้ที่ persta.ai",
   },
   vi: {
     title:
-      "Persta.AI — Nền tảng styling AI cho thời trang, nhân vật và biểu đạt hình ảnh",
+      "Persta.AI — Thay trang phục AI & tạo ảnh minh họa nhân vật bằng AI",
     description:
-      "Persta là nền tảng styling AI nơi bạn có thể khám phá ý tưởng thời trang, nhân vật và biểu đạt hình ảnh, đồng thời tìm cảm hứng từ cộng đồng tại persta.ai.",
+      "Persta là nền tảng AI giúp thay trang phục cho OC và nhân vật yêu thích của bạn: tạo outfit mới, phối đồ và các phong cách minh họa khác nhau. Dùng thử miễn phí và tìm cảm hứng từ cộng đồng tại persta.ai.",
   },
   hi: {
     title:
-      "Persta.AI — फ़ैशन, किरदार और विज़ुअल अभिव्यक्ति के लिए AI स्टाइलिंग प्लैटफ़ॉर्म",
+      "Persta.AI — AI ड्रेस-अप और किरदारों के लिए AI इलस्ट्रेशन जेनरेटर",
     description:
-      "Persta एक AI स्टाइलिंग प्लैटफ़ॉर्म है जहाँ आप फ़ैशन, किरदार और विज़ुअल अभिव्यक्ति के आइडिया एक्सप्लोर कर सकते हैं और persta.ai पर कम्यूनिटी से प्रेरणा पा सकते हैं।",
+      "Persta एक AI प्लैटफ़ॉर्म है जहाँ आप अपने OC और पसंदीदा किरदारों को नए आउटफ़िट पहना सकते हैं: आउटफ़िट बदलें, कोऑर्डिनेटेड लुक और नए इलस्ट्रेशन स्टाइल बनाएँ। मुफ़्त आज़माएँ और persta.ai पर कम्यूनिटी से प्रेरणा पाएँ।",
   },
   ar: {
     title:
-      "Persta.AI — منصّة تنسيق المظهر بالذكاء الاصطناعي للأزياء والشخصيات والتعبير البصري",
+      "Persta.AI — تبديل ملابس الشخصيات وتوليد الرسوم التوضيحية بالذكاء الاصطناعي",
     description:
-      "Persta منصّة تنسيق مظهر تعتمد على الذكاء الاصطناعي، تتيح لك استكشاف أفكار الأزياء والشخصيات والتعبير البصري، والاستلهام من أعمال المجتمع على persta.ai.",
+      "Persta منصّة ذكاء اصطناعي لتبديل ملابس شخصياتك الأصلية وشخصياتك المفضلة: أنشئ إطلالات منسّقة وأنماط رسوم جديدة بلمسة واحدة. جرّب مجانًا واستلهم من أعمال المجتمع على persta.ai.",
   },
 } as const satisfies Record<Locale, {title: string; description: string}>;
 
 const homeCopy = {
   ja: {
-    metadataTitle: "Persta.AI (ペルスタ)",
-    metadataDescription: "着てみたいも、なりたいも。AIスタイリングプラットフォーム",
+    metadataTitle:
+      "Persta.AI (ペルスタ) | AIでキャラクターを着せ替え・イラスト生成",
+    metadataDescription:
+      "うちの子・推しキャラのイラストをAIでワンタップ着せ替え。コーディネートやスタイル変更のAIイラスト生成を無料で試せるAIスタイリングプラットフォームです。作品を投稿してコミュニティで共有しよう。",
     heading: "Persta | ペルスタ",
     subtitle: "着てみたいも、なりたいも。AIスタイリングプラットフォーム",
     organizationDescription:
-      "Persta（ペルスタ）は、AIでファッション・キャラクターなどのビジュアル表現を自由にスタイリングできるプラットフォームです。",
+      "Persta（ペルスタ）は、うちの子・推しキャラなどのイラストをAIで着せ替え・コーディネートできるAIイラスト生成／スタイリングプラットフォームです。",
   },
   en: {
-    metadataTitle: "Persta.AI",
+    metadataTitle: "Persta.AI | AI Dress-Up & Character Illustration Generator",
     metadataDescription:
-      "An AI styling platform for the looks and characters you want to create.",
+      "Dress up your OCs and favorite characters with AI. Generate outfit swaps, coordinated looks, and new illustration styles in one tap — free to try on Persta.AI.",
     heading: "Persta",
     subtitle:
       "An AI styling platform for the looks and characters you want to create.",
     organizationDescription:
-      "Persta is an AI styling platform for freely styling fashion, characters, and other visual ideas.",
+      "Persta is an AI platform for dressing up and styling OCs, fashion, and other character illustrations with AI-generated outfit swaps.",
   },
   ko: {
-    metadataTitle: "Persta.AI",
+    metadataTitle: "Persta.AI | AI 옷 갈아입히기·AI 일러스트 생성",
     metadataDescription:
-      "입고 싶은 모습도, 되고 싶은 모습도. AI 스타일링 플랫폼.",
+      "내 캐릭터(오리캐)와 최애 일러스트를 AI로 원탭 옷 갈아입히기. 코디와 스타일 변경 AI 일러스트 생성을 무료로 체험할 수 있는 AI 스타일링 플랫폼입니다.",
     heading: "Persta",
     subtitle: "입고 싶은 모습도, 되고 싶은 모습도. AI 스타일링 플랫폼.",
     organizationDescription:
-      "Persta는 패션, 캐릭터 등 비주얼 표현을 자유롭게 스타일링할 수 있는 AI 플랫폼입니다.",
+      "Persta는 내 캐릭터와 최애 일러스트를 AI로 옷 갈아입히기·코디할 수 있는 AI 일러스트 생성 플랫폼입니다.",
   },
   "zh-CN": {
-    metadataTitle: "Persta.AI",
-    metadataDescription: "想穿的样子，想成为的样子。AI 造型平台。",
+    metadataTitle: "Persta.AI | AI 换装・AI 插画生成",
+    metadataDescription:
+      "用 AI 一键为你的自设角色（OC）和本命角色换装。免费体验服装搭配与风格变化的 AI 插画生成，并在社区分享作品。",
     heading: "Persta",
     subtitle: "想穿的样子，想成为的样子。AI 造型平台。",
     organizationDescription:
-      "Persta 是一个 AI 造型平台，让你自由探索时尚、角色等视觉表达的创意。",
+      "Persta 是一个 AI 插画生成平台，用 AI 为自设角色（OC）和喜欢的角色换装、搭配造型。",
   },
   "zh-TW": {
-    metadataTitle: "Persta.AI",
-    metadataDescription: "想穿的樣子，想成為的樣子。AI 造型平台。",
+    metadataTitle: "Persta.AI | AI 換裝・AI 插畫生成",
+    metadataDescription:
+      "用 AI 一鍵為你的自創角色（OC）和本命角色換裝。免費體驗服裝搭配與風格變化的 AI 插畫生成，並在社群分享作品。",
     heading: "Persta",
     subtitle: "想穿的樣子，想成為的樣子。AI 造型平台。",
     organizationDescription:
-      "Persta 是一個 AI 造型平台，讓你自由探索時尚、角色等視覺表達的創意。",
+      "Persta 是一個 AI 插畫生成平台，用 AI 為自創角色（OC）和喜歡的角色換裝、搭配造型。",
   },
   es: {
-    metadataTitle: "Persta.AI",
+    metadataTitle:
+      "Persta.AI | Cambio de ropa con IA y generación de ilustraciones",
     metadataDescription:
-      "Lo que quieres llevar, lo que quieres ser. Plataforma de estilismo con IA.",
+      "Viste a tus OCs y personajes favoritos con IA. Genera cambios de outfit, looks coordinados y nuevos estilos de ilustración con un toque. Pruébalo gratis en Persta.AI.",
     heading: "Persta",
     subtitle:
       "Lo que quieres llevar, lo que quieres ser. Plataforma de estilismo con IA.",
     organizationDescription:
-      "Persta es una plataforma de estilismo con IA para explorar libremente moda, personajes y otras expresiones visuales.",
+      "Persta es una plataforma de IA para vestir y estilizar OCs, moda y otras ilustraciones de personajes con cambios de ropa generados por IA.",
   },
   pt: {
-    metadataTitle: "Persta.AI",
+    metadataTitle:
+      "Persta.AI | Troca de roupa com IA e geração de ilustrações",
     metadataDescription:
-      "O que você quer vestir, quem você quer ser. Plataforma de styling com IA.",
+      "Vista seus OCs e personagens favoritos com IA. Gere trocas de roupa, looks coordenados e novos estilos de ilustração com um toque. Experimente grátis no Persta.AI.",
     heading: "Persta",
     subtitle:
       "O que você quer vestir, quem você quer ser. Plataforma de styling com IA.",
     organizationDescription:
-      "Persta é uma plataforma de styling com IA para explorar livremente moda, personagens e outras expressões visuais.",
+      "Persta é uma plataforma de IA para vestir e estilizar OCs, moda e outras ilustrações de personagens com trocas de roupa geradas por IA.",
   },
   fr: {
-    metadataTitle: "Persta.AI",
+    metadataTitle:
+      "Persta.AI | Habillage IA et génération d'illustrations",
     metadataDescription:
-      "Ce que vous voulez porter, ce que vous voulez devenir. Plateforme de stylisme IA.",
+      "Habillez vos OC et personnages préférés grâce à l'IA. Générez changements de tenue, looks coordonnés et nouveaux styles d'illustration en un geste. Essai gratuit sur Persta.AI.",
     heading: "Persta",
     subtitle:
       "Ce que vous voulez porter, ce que vous voulez devenir. Plateforme de stylisme IA.",
     organizationDescription:
-      "Persta est une plateforme de stylisme IA qui vous permet d'explorer librement la mode, les personnages et d'autres expressions visuelles.",
+      "Persta est une plateforme d'IA pour habiller et styliser des OC, de la mode et d'autres illustrations de personnages grâce à des changements de tenue générés par IA.",
   },
   de: {
-    metadataTitle: "Persta.AI",
+    metadataTitle: "Persta.AI | KI-Anziehen & KI-Illustrationsgenerator",
     metadataDescription:
-      "Was du tragen willst, wer du sein willst. KI-Styling-Plattform.",
+      "Ziehe deine OCs und Lieblingscharaktere mit KI um. Erstelle Outfit-Wechsel, abgestimmte Looks und neue Illustrationsstile mit einem Tipp – kostenlos ausprobieren auf Persta.AI.",
     heading: "Persta",
     subtitle: "Was du tragen willst, wer du sein willst. KI-Styling-Plattform.",
     organizationDescription:
-      "Persta ist eine KI-Styling-Plattform, auf der du Mode, Charaktere und andere visuelle Ausdrucksformen frei erkunden kannst.",
+      "Persta ist eine KI-Plattform, mit der du OCs, Mode und andere Charakter-Illustrationen mit KI-generierten Outfit-Wechseln stylst.",
   },
   it: {
-    metadataTitle: "Persta.AI",
+    metadataTitle:
+      "Persta.AI | Cambio d'abito con IA e generazione di illustrazioni",
     metadataDescription:
-      "Quello che vuoi indossare, quello che vuoi essere. Piattaforma di styling con IA.",
+      "Vesti i tuoi OC e personaggi preferiti con l'IA. Genera cambi d'abito, look coordinati e nuovi stili di illustrazione con un tocco. Provalo gratis su Persta.AI.",
     heading: "Persta",
     subtitle:
       "Quello che vuoi indossare, quello che vuoi essere. Piattaforma di styling con IA.",
     organizationDescription:
-      "Persta è una piattaforma di styling con IA per esplorare liberamente moda, personaggi e altre espressioni visive.",
+      "Persta è una piattaforma di IA per vestire e stilizzare OC, moda e altre illustrazioni di personaggi con cambi d'abito generati dall'IA.",
   },
   id: {
-    metadataTitle: "Persta.AI",
+    metadataTitle: "Persta.AI | Ganti Baju AI & Generator Ilustrasi AI",
     metadataDescription:
-      "Yang ingin kamu pakai, yang ingin kamu jadikan. Platform styling AI.",
+      "Ganti baju OC dan karakter favoritmu dengan AI. Buat pergantian outfit, padu padan gaya, dan gaya ilustrasi baru dalam sekali tap — coba gratis di Persta.AI.",
     heading: "Persta",
     subtitle:
       "Yang ingin kamu pakai, yang ingin kamu jadikan. Platform styling AI.",
     organizationDescription:
-      "Persta adalah platform styling AI tempat kamu bisa bebas menjelajahi fashion, karakter, dan ekspresi visual lainnya.",
+      "Persta adalah platform AI untuk mendandani OC, fashion, dan ilustrasi karakter lainnya dengan pergantian outfit hasil AI.",
   },
   th: {
-    metadataTitle: "Persta.AI",
+    metadataTitle: "Persta.AI | AI เปลี่ยนชุดตัวละคร & สร้างภาพประกอบด้วย AI",
     metadataDescription:
-      "สิ่งที่อยากใส่ สิ่งที่อยากเป็น แพลตฟอร์ม AI สไตลิ่ง",
+      "เปลี่ยนชุดให้ OC และตัวละครที่คุณรักด้วย AI สร้างการเปลี่ยนชุด การแต่งตัว และสไตล์ภาพประกอบใหม่ ๆ ในแตะเดียว ทดลองฟรีที่ Persta.AI",
     heading: "Persta",
     subtitle: "สิ่งที่อยากใส่ สิ่งที่อยากเป็น แพลตฟอร์ม AI สไตลิ่ง",
     organizationDescription:
-      "Persta คือแพลตฟอร์ม AI สไตลิ่ง ที่คุณสามารถสำรวจไอเดียแฟชั่น คาแรกเตอร์ และการแสดงออกทางภาพอื่น ๆ ได้อย่างอิสระ",
+      "Persta คือแพลตฟอร์ม AI สำหรับเปลี่ยนชุดและจัดสไตล์ให้ OC แฟชั่น และภาพประกอบตัวละครอื่น ๆ ด้วยการเปลี่ยนชุดที่สร้างโดย AI",
   },
   vi: {
-    metadataTitle: "Persta.AI",
+    metadataTitle: "Persta.AI | Thay trang phục AI & tạo ảnh minh họa AI",
     metadataDescription:
-      "Điều bạn muốn mặc, điều bạn muốn trở thành. Nền tảng styling AI.",
+      "Thay trang phục cho OC và nhân vật yêu thích bằng AI. Tạo outfit mới, phối đồ và các phong cách minh họa khác nhau chỉ với một chạm — dùng thử miễn phí trên Persta.AI.",
     heading: "Persta",
     subtitle:
       "Điều bạn muốn mặc, điều bạn muốn trở thành. Nền tảng styling AI.",
     organizationDescription:
-      "Persta là nền tảng styling AI cho phép bạn tự do khám phá thời trang, nhân vật và các hình thức biểu đạt hình ảnh khác.",
+      "Persta là nền tảng AI giúp thay trang phục và tạo phong cách cho OC, thời trang và các ảnh minh họa nhân vật khác bằng trang phục do AI tạo ra.",
   },
   hi: {
-    metadataTitle: "Persta.AI",
+    metadataTitle: "Persta.AI | AI ड्रेस-अप और AI इलस्ट्रेशन जेनरेटर",
     metadataDescription:
-      "जो पहनना चाहें, जो बनना चाहें — AI स्टाइलिंग प्लैटफ़ॉर्म।",
+      "अपने OC और पसंदीदा किरदारों को AI से नए आउटफ़िट पहनाएँ। एक टैप में आउटफ़िट बदलें, कोऑर्डिनेटेड लुक और नए इलस्ट्रेशन स्टाइल बनाएँ — Persta.AI पर मुफ़्त आज़माएँ।",
     heading: "Persta",
     subtitle: "जो पहनना चाहें, जो बनना चाहें — AI स्टाइलिंग प्लैटफ़ॉर्म।",
     organizationDescription:
-      "Persta एक AI स्टाइलिंग प्लैटफ़ॉर्म है जहाँ आप फ़ैशन, किरदार और दूसरे विज़ुअल एक्सप्रेशन को आज़ादी से एक्सप्लोर कर सकते हैं।",
+      "Persta एक AI प्लैटफ़ॉर्म है जहाँ OC, फ़ैशन और दूसरे किरदारों के इलस्ट्रेशन को AI-जेनरेटेड आउटफ़िट बदलाव से स्टाइल किया जा सकता है।",
   },
   ar: {
-    metadataTitle: "Persta.AI",
+    metadataTitle:
+      "Persta.AI | تبديل ملابس الشخصيات وتوليد الرسوم بالذكاء الاصطناعي",
     metadataDescription:
-      "ما تريد ارتداءه، ومن تريد أن تكون. منصّة تنسيق المظهر بالذكاء الاصطناعي.",
+      "بدّل ملابس شخصياتك الأصلية وشخصياتك المفضلة بالذكاء الاصطناعي. أنشئ إطلالات منسّقة وأنماط رسوم جديدة بلمسة واحدة — جرّب مجانًا على Persta.AI.",
     heading: "Persta",
     subtitle:
       "ما تريد ارتداءه، ومن تريد أن تكون. منصّة تنسيق المظهر بالذكاء الاصطناعي.",
     organizationDescription:
-      "Persta منصّة تنسيق مظهر بالذكاء الاصطناعي تتيح لك استكشاف الأزياء والشخصيات وأشكال التعبير البصري الأخرى بحرية.",
+      "Persta منصّة ذكاء اصطناعي لتبديل ملابس الشخصيات الأصلية والأزياء وسائر رسوم الشخصيات وتنسيق مظهرها بإطلالات مولّدة بالذكاء الاصطناعي.",
   },
 } as const satisfies Record<
   Locale,
@@ -693,8 +702,256 @@ const postPageCopy = {
   }
 >;
 
+// /styles(スタイル一覧)と /styles/[slug](スタイル紹介)の SEO 向けコピー。
+// detailDescription の {title} はスタイル名で置換して使う。
+const stylesCopy = {
+  ja: {
+    indexTitle: "AI着せ替えスタイル一覧 | Persta.AI",
+    indexDescription:
+      "Perstaで使えるAI着せ替え・AIイラスト生成のスタイル一覧。制服・ドレス・ファンタジー衣装など、うちの子や推しキャラをワンタップで着せ替えられるスタイルを探せます。",
+    indexHeading: "スタイル一覧",
+    indexIntro:
+      "うちの子・推しキャラのイラストをワンタップで着せ替えできるAIスタイルのカタログです。気になるスタイルを選んで、無料で試してみましょう。",
+    detailTitleSuffix: "AI着せ替えスタイル | Persta.AI",
+    detailDescription:
+      "「{title}」スタイルで、うちの子・推しキャラのイラストをAIが着せ替え。画像をアップロードするだけで、{title}のAIイラストをワンタップ生成。無料でお試しできます。",
+    cta: "このスタイルで着せ替える",
+    related: "同じカテゴリのスタイル",
+    allStyles: "スタイル一覧へ戻る",
+    providerLabel: "提供: {name}",
+  },
+  en: {
+    indexTitle: "AI Dress-Up Style Gallery | Persta.AI",
+    indexDescription:
+      "Browse AI dress-up and illustration styles on Persta: uniforms, dresses, fantasy outfits, and more. Restyle your OCs and favorite characters in one tap.",
+    indexHeading: "Style Gallery",
+    indexIntro:
+      "A catalog of AI styles that dress up your OCs and favorite character illustrations in one tap. Pick a style and try it for free.",
+    detailTitleSuffix: "AI Dress-Up Style | Persta.AI",
+    detailDescription:
+      "Dress up your OCs and favorite characters in the \"{title}\" style. Just upload an image and generate a {title} AI illustration in one tap — free to try.",
+    cta: "Dress up with this style",
+    related: "Styles in the same category",
+    allStyles: "Back to Style Gallery",
+    providerLabel: "By {name}",
+  },
+  ko: {
+    indexTitle: "AI 옷 갈아입히기 스타일 목록 | Persta.AI",
+    indexDescription:
+      "Persta에서 쓸 수 있는 AI 옷 갈아입히기·AI 일러스트 생성 스타일 목록. 교복, 드레스, 판타지 의상 등 내 캐릭터와 최애를 원탭으로 갈아입혀 보세요.",
+    indexHeading: "스타일 목록",
+    indexIntro:
+      "내 캐릭터(오리캐)와 최애 일러스트를 원탭으로 갈아입힐 수 있는 AI 스타일 카탈로그입니다. 마음에 드는 스타일을 골라 무료로 체험해 보세요.",
+    detailTitleSuffix: "AI 옷 갈아입히기 스타일 | Persta.AI",
+    detailDescription:
+      "\"{title}\" 스타일로 내 캐릭터와 최애 일러스트를 AI가 갈아입혀 드립니다. 이미지를 업로드하면 {title} AI 일러스트를 원탭으로 생성. 무료 체험 가능.",
+    cta: "이 스타일로 갈아입히기",
+    related: "같은 카테고리의 스타일",
+    allStyles: "스타일 목록으로 돌아가기",
+    providerLabel: "제공: {name}",
+  },
+  "zh-CN": {
+    indexTitle: "AI 换装风格一览 | Persta.AI",
+    indexDescription:
+      "浏览 Persta 上可用的 AI 换装·AI 插画生成风格：制服、礼服、奇幻服装等。一键为你的自设角色（OC）和本命角色换装。",
+    indexHeading: "风格一览",
+    indexIntro:
+      "这是可一键为自设角色（OC）和本命角色插画换装的 AI 风格目录。挑选喜欢的风格，免费体验吧。",
+    detailTitleSuffix: "AI 换装风格 | Persta.AI",
+    detailDescription:
+      "用「{title}」风格为你的自设角色和本命角色换装。只需上传图片，即可一键生成 {title} 的 AI 插画，免费体验。",
+    cta: "用这个风格换装",
+    related: "同类风格",
+    allStyles: "返回风格一览",
+    providerLabel: "提供：{name}",
+  },
+  "zh-TW": {
+    indexTitle: "AI 換裝風格一覽 | Persta.AI",
+    indexDescription:
+      "瀏覽 Persta 上可用的 AI 換裝·AI 插畫生成風格：制服、禮服、奇幻服裝等。一鍵為你的自創角色（OC）和本命角色換裝。",
+    indexHeading: "風格一覽",
+    indexIntro:
+      "這是可一鍵為自創角色（OC）和本命角色插畫換裝的 AI 風格目錄。挑選喜歡的風格，免費體驗吧。",
+    detailTitleSuffix: "AI 換裝風格 | Persta.AI",
+    detailDescription:
+      "用「{title}」風格為你的自創角色和本命角色換裝。只需上傳圖片，即可一鍵生成 {title} 的 AI 插畫，免費體驗。",
+    cta: "用這個風格換裝",
+    related: "同類風格",
+    allStyles: "返回風格一覽",
+    providerLabel: "提供：{name}",
+  },
+  es: {
+    indexTitle: "Galería de estilos de cambio de ropa con IA | Persta.AI",
+    indexDescription:
+      "Explora los estilos de cambio de ropa e ilustración con IA de Persta: uniformes, vestidos, trajes de fantasía y más. Cambia el look de tus OCs y personajes favoritos con un toque.",
+    indexHeading: "Galería de estilos",
+    indexIntro:
+      "Un catálogo de estilos de IA para vestir a tus OCs y personajes favoritos con un toque. Elige un estilo y pruébalo gratis.",
+    detailTitleSuffix: "Estilo de cambio de ropa con IA | Persta.AI",
+    detailDescription:
+      "Viste a tus OCs y personajes favoritos con el estilo «{title}». Solo sube una imagen y genera una ilustración de IA de {title} con un toque. Prueba gratis.",
+    cta: "Vestir con este estilo",
+    related: "Estilos de la misma categoría",
+    allStyles: "Volver a la galería de estilos",
+    providerLabel: "De {name}",
+  },
+  pt: {
+    indexTitle: "Galeria de estilos de troca de roupa com IA | Persta.AI",
+    indexDescription:
+      "Explore os estilos de troca de roupa e ilustração com IA do Persta: uniformes, vestidos, trajes de fantasia e mais. Mude o visual dos seus OCs e personagens favoritos com um toque.",
+    indexHeading: "Galeria de estilos",
+    indexIntro:
+      "Um catálogo de estilos de IA para vestir seus OCs e personagens favoritos com um toque. Escolha um estilo e experimente grátis.",
+    detailTitleSuffix: "Estilo de troca de roupa com IA | Persta.AI",
+    detailDescription:
+      "Vista seus OCs e personagens favoritos com o estilo \"{title}\". Basta enviar uma imagem para gerar uma ilustração de IA de {title} com um toque. Experimente grátis.",
+    cta: "Vestir com este estilo",
+    related: "Estilos da mesma categoria",
+    allStyles: "Voltar à galeria de estilos",
+    providerLabel: "Por {name}",
+  },
+  fr: {
+    indexTitle: "Galerie de styles d'habillage IA | Persta.AI",
+    indexDescription:
+      "Parcourez les styles d'habillage et d'illustration IA de Persta : uniformes, robes, tenues fantastiques et plus. Relookez vos OC et personnages préférés en un geste.",
+    indexHeading: "Galerie de styles",
+    indexIntro:
+      "Un catalogue de styles IA pour habiller vos OC et personnages préférés en un geste. Choisissez un style et essayez-le gratuitement.",
+    detailTitleSuffix: "Style d'habillage IA | Persta.AI",
+    detailDescription:
+      "Habillez vos OC et personnages préférés avec le style « {title} ». Téléversez une image et générez une illustration IA {title} en un geste. Essai gratuit.",
+    cta: "Habiller avec ce style",
+    related: "Styles de la même catégorie",
+    allStyles: "Retour à la galerie de styles",
+    providerLabel: "Par {name}",
+  },
+  de: {
+    indexTitle: "KI-Anzieh-Stile im Überblick | Persta.AI",
+    indexDescription:
+      "Entdecke die KI-Anzieh- und Illustrationsstile von Persta: Uniformen, Kleider, Fantasy-Outfits und mehr. Style deine OCs und Lieblingscharaktere mit einem Tipp um.",
+    indexHeading: "Stil-Galerie",
+    indexIntro:
+      "Ein Katalog von KI-Stilen, mit denen du OCs und Lieblingscharakter-Illustrationen mit einem Tipp umziehst. Wähle einen Stil und probiere ihn kostenlos aus.",
+    detailTitleSuffix: "KI-Anzieh-Stil | Persta.AI",
+    detailDescription:
+      "Ziehe deine OCs und Lieblingscharaktere im Stil „{title}“ um. Einfach ein Bild hochladen und mit einem Tipp eine {title}-KI-Illustration erstellen. Kostenlos testen.",
+    cta: "Mit diesem Stil anziehen",
+    related: "Stile derselben Kategorie",
+    allStyles: "Zurück zur Stil-Galerie",
+    providerLabel: "Von {name}",
+  },
+  it: {
+    indexTitle: "Galleria di stili di cambio d'abito con IA | Persta.AI",
+    indexDescription:
+      "Sfoglia gli stili di cambio d'abito e illustrazione con IA di Persta: uniformi, abiti, costumi fantasy e altro. Cambia look ai tuoi OC e personaggi preferiti con un tocco.",
+    indexHeading: "Galleria di stili",
+    indexIntro:
+      "Un catalogo di stili IA per vestire i tuoi OC e personaggi preferiti con un tocco. Scegli uno stile e provalo gratis.",
+    detailTitleSuffix: "Stile di cambio d'abito con IA | Persta.AI",
+    detailDescription:
+      "Vesti i tuoi OC e personaggi preferiti con lo stile «{title}». Carica un'immagine e genera un'illustrazione IA di {title} con un tocco. Prova gratuita.",
+    cta: "Vesti con questo stile",
+    related: "Stili della stessa categoria",
+    allStyles: "Torna alla galleria di stili",
+    providerLabel: "Di {name}",
+  },
+  id: {
+    indexTitle: "Daftar gaya ganti baju AI | Persta.AI",
+    indexDescription:
+      "Jelajahi gaya ganti baju dan ilustrasi AI di Persta: seragam, gaun, kostum fantasi, dan lainnya. Ganti gaya OC dan karakter favoritmu dalam sekali tap.",
+    indexHeading: "Galeri gaya",
+    indexIntro:
+      "Katalog gaya AI untuk mendandani ilustrasi OC dan karakter favoritmu dalam sekali tap. Pilih gaya dan coba gratis.",
+    detailTitleSuffix: "Gaya ganti baju AI | Persta.AI",
+    detailDescription:
+      "Dandani OC dan karakter favoritmu dengan gaya \"{title}\". Cukup unggah gambar dan buat ilustrasi AI {title} dalam sekali tap. Coba gratis.",
+    cta: "Ganti baju dengan gaya ini",
+    related: "Gaya dalam kategori yang sama",
+    allStyles: "Kembali ke galeri gaya",
+    providerLabel: "Oleh {name}",
+  },
+  th: {
+    indexTitle: "รวมสไตล์ AI เปลี่ยนชุด | Persta.AI",
+    indexDescription:
+      "เลือกชมสไตล์ AI เปลี่ยนชุดและสร้างภาพประกอบบน Persta ทั้งชุดนักเรียน เดรส ชุดแฟนตาซี และอีกมากมาย เปลี่ยนชุดให้ OC และตัวละครที่คุณรักได้ในแตะเดียว",
+    indexHeading: "แกลเลอรีสไตล์",
+    indexIntro:
+      "แคตตาล็อกสไตล์ AI สำหรับเปลี่ยนชุดให้ภาพ OC และตัวละครที่คุณรักในแตะเดียว เลือกสไตล์ที่ชอบแล้วทดลองฟรี",
+    detailTitleSuffix: "สไตล์ AI เปลี่ยนชุด | Persta.AI",
+    detailDescription:
+      "เปลี่ยนชุดให้ OC และตัวละครที่คุณรักด้วยสไตล์ \"{title}\" แค่อัปโหลดภาพก็สร้างภาพประกอบ AI สไตล์ {title} ได้ในแตะเดียว ทดลองฟรี",
+    cta: "เปลี่ยนชุดด้วยสไตล์นี้",
+    related: "สไตล์ในหมวดเดียวกัน",
+    allStyles: "กลับไปที่แกลเลอรีสไตล์",
+    providerLabel: "โดย {name}",
+  },
+  vi: {
+    indexTitle: "Danh sách phong cách thay trang phục AI | Persta.AI",
+    indexDescription:
+      "Khám phá các phong cách thay trang phục và minh họa AI trên Persta: đồng phục, váy, trang phục fantasy và nhiều hơn nữa. Đổi phong cách cho OC và nhân vật yêu thích chỉ với một chạm.",
+    indexHeading: "Thư viện phong cách",
+    indexIntro:
+      "Danh mục các phong cách AI giúp thay trang phục cho ảnh minh họa OC và nhân vật yêu thích chỉ với một chạm. Chọn phong cách và dùng thử miễn phí.",
+    detailTitleSuffix: "Phong cách thay trang phục AI | Persta.AI",
+    detailDescription:
+      "Thay trang phục cho OC và nhân vật yêu thích với phong cách \"{title}\". Chỉ cần tải ảnh lên là tạo được ảnh minh họa AI {title} trong một chạm. Dùng thử miễn phí.",
+    cta: "Thay trang phục với phong cách này",
+    related: "Phong cách cùng danh mục",
+    allStyles: "Quay lại thư viện phong cách",
+    providerLabel: "Bởi {name}",
+  },
+  hi: {
+    indexTitle: "AI ड्रेस-अप स्टाइल गैलरी | Persta.AI",
+    indexDescription:
+      "Persta पर उपलब्ध AI ड्रेस-अप और इलस्ट्रेशन स्टाइल देखें: यूनिफ़ॉर्म, ड्रेस, फ़ैंटेसी आउटफ़िट और भी बहुत कुछ। एक टैप में अपने OC और पसंदीदा किरदारों का लुक बदलें।",
+    indexHeading: "स्टाइल गैलरी",
+    indexIntro:
+      "एक टैप में OC और पसंदीदा किरदारों के इलस्ट्रेशन को नए आउटफ़िट पहनाने वाले AI स्टाइल का कैटलॉग। कोई स्टाइल चुनें और मुफ़्त आज़माएँ।",
+    detailTitleSuffix: "AI ड्रेस-अप स्टाइल | Persta.AI",
+    detailDescription:
+      "\"{title}\" स्टाइल में अपने OC और पसंदीदा किरदारों को सजाएँ। बस एक इमेज अपलोड करें और एक टैप में {title} की AI इलस्ट्रेशन बनाएँ। मुफ़्त आज़माएँ।",
+    cta: "इस स्टाइल से ड्रेस-अप करें",
+    related: "इसी कैटेगरी के स्टाइल",
+    allStyles: "स्टाइल गैलरी पर वापस जाएँ",
+    providerLabel: "{name} द्वारा",
+  },
+  ar: {
+    indexTitle: "معرض أنماط تبديل الملابس بالذكاء الاصطناعي | Persta.AI",
+    indexDescription:
+      "تصفّح أنماط تبديل الملابس وتوليد الرسوم بالذكاء الاصطناعي على Persta: أزياء مدرسية وفساتين وأزياء خيالية والمزيد. غيّر إطلالة شخصياتك الأصلية وشخصياتك المفضلة بلمسة واحدة.",
+    indexHeading: "معرض الأنماط",
+    indexIntro:
+      "دليل أنماط الذكاء الاصطناعي لتبديل ملابس رسوم شخصياتك الأصلية وشخصياتك المفضلة بلمسة واحدة. اختر نمطًا وجرّبه مجانًا.",
+    detailTitleSuffix: "نمط تبديل الملابس بالذكاء الاصطناعي | Persta.AI",
+    detailDescription:
+      "بدّل ملابس شخصياتك الأصلية وشخصياتك المفضلة بنمط «{title}». ما عليك سوى رفع صورة لتوليد رسم بالذكاء الاصطناعي بنمط {title} بلمسة واحدة. جرّب مجانًا.",
+    cta: "بدّل الملابس بهذا النمط",
+    related: "أنماط من الفئة نفسها",
+    allStyles: "العودة إلى معرض الأنماط",
+    providerLabel: "بواسطة {name}",
+  },
+} as const satisfies Record<
+  Locale,
+  {
+    indexTitle: string;
+    indexDescription: string;
+    indexHeading: string;
+    indexIntro: string;
+    detailTitleSuffix: string;
+    detailDescription: string;
+    cta: string;
+    related: string;
+    allStyles: string;
+    providerLabel: string;
+  }
+>;
+
 export function getSiteCopy(locale: Locale) {
   return siteCopy[locale];
+}
+
+export function getStylesCopy(locale: Locale) {
+  return stylesCopy[locale];
 }
 
 export function getHomeCopy(locale: Locale) {

--- a/i18n/page-copy.ts
+++ b/i18n/page-copy.ts
@@ -711,10 +711,10 @@ const stylesCopy = {
       "Perstaで使えるAI着せ替え・AIイラスト生成のスタイル一覧。制服・ドレス・ファンタジー衣装など、うちの子や推しキャラをワンタップで着せ替えられるスタイルを探せます。",
     indexHeading: "スタイル一覧",
     indexIntro:
-      "うちの子・推しキャラのイラストをワンタップで着せ替えできるAIスタイルのカタログです。気になるスタイルを選んで、無料で試してみましょう。",
+      "キャラクターのイラストをワンタップで着せ替えできるAIスタイルのカタログです。",
     detailTitleSuffix: "AI着せ替えスタイル | Persta.AI",
     detailDescription:
-      "「{title}」スタイルで、うちの子・推しキャラのイラストをAIが着せ替え。画像をアップロードするだけで、{title}のAIイラストをワンタップ生成。無料でお試しできます。",
+      "「{title}」スタイルで、うちの子・推しキャラのイラストをAIが着せ替え。画像をアップロードするだけで、{title}のAIイラストをワンタップ生成できます。",
     cta: "このスタイルで着せ替える",
     related: "同じカテゴリのスタイル",
     allStyles: "スタイル一覧へ戻る",
@@ -726,10 +726,10 @@ const stylesCopy = {
       "Browse AI dress-up and illustration styles on Persta: uniforms, dresses, fantasy outfits, and more. Restyle your OCs and favorite characters in one tap.",
     indexHeading: "Style Gallery",
     indexIntro:
-      "A catalog of AI styles that dress up your OCs and favorite character illustrations in one tap. Pick a style and try it for free.",
+      "A catalog of AI styles that dress up character illustrations in one tap.",
     detailTitleSuffix: "AI Dress-Up Style | Persta.AI",
     detailDescription:
-      "Dress up your OCs and favorite characters in the \"{title}\" style. Just upload an image and generate a {title} AI illustration in one tap — free to try.",
+      "Dress up your OCs and favorite characters in the \"{title}\" style. Just upload an image and generate a {title} AI illustration in one tap.",
     cta: "Dress up with this style",
     related: "Styles in the same category",
     allStyles: "Back to Style Gallery",
@@ -741,10 +741,10 @@ const stylesCopy = {
       "Persta에서 쓸 수 있는 AI 옷 갈아입히기·AI 일러스트 생성 스타일 목록. 교복, 드레스, 판타지 의상 등 내 캐릭터와 최애를 원탭으로 갈아입혀 보세요.",
     indexHeading: "스타일 목록",
     indexIntro:
-      "내 캐릭터(오리캐)와 최애 일러스트를 원탭으로 갈아입힐 수 있는 AI 스타일 카탈로그입니다. 마음에 드는 스타일을 골라 무료로 체험해 보세요.",
+      "캐릭터 일러스트를 원탭으로 갈아입힐 수 있는 AI 스타일 카탈로그입니다.",
     detailTitleSuffix: "AI 옷 갈아입히기 스타일 | Persta.AI",
     detailDescription:
-      "\"{title}\" 스타일로 내 캐릭터와 최애 일러스트를 AI가 갈아입혀 드립니다. 이미지를 업로드하면 {title} AI 일러스트를 원탭으로 생성. 무료 체험 가능.",
+      "\"{title}\" 스타일로 내 캐릭터와 최애 일러스트를 AI가 갈아입혀 드립니다. 이미지를 업로드하면 {title} AI 일러스트를 원탭으로 생성할 수 있습니다.",
     cta: "이 스타일로 갈아입히기",
     related: "같은 카테고리의 스타일",
     allStyles: "스타일 목록으로 돌아가기",
@@ -756,10 +756,10 @@ const stylesCopy = {
       "浏览 Persta 上可用的 AI 换装·AI 插画生成风格：制服、礼服、奇幻服装等。一键为你的自设角色（OC）和本命角色换装。",
     indexHeading: "风格一览",
     indexIntro:
-      "这是可一键为自设角色（OC）和本命角色插画换装的 AI 风格目录。挑选喜欢的风格，免费体验吧。",
+      "一键为角色插画换装的 AI 风格目录。",
     detailTitleSuffix: "AI 换装风格 | Persta.AI",
     detailDescription:
-      "用「{title}」风格为你的自设角色和本命角色换装。只需上传图片，即可一键生成 {title} 的 AI 插画，免费体验。",
+      "用「{title}」风格为你的自设角色和本命角色换装。只需上传图片，即可一键生成 {title} 的 AI 插画。",
     cta: "用这个风格换装",
     related: "同类风格",
     allStyles: "返回风格一览",
@@ -771,10 +771,10 @@ const stylesCopy = {
       "瀏覽 Persta 上可用的 AI 換裝·AI 插畫生成風格：制服、禮服、奇幻服裝等。一鍵為你的自創角色（OC）和本命角色換裝。",
     indexHeading: "風格一覽",
     indexIntro:
-      "這是可一鍵為自創角色（OC）和本命角色插畫換裝的 AI 風格目錄。挑選喜歡的風格，免費體驗吧。",
+      "一鍵為角色插畫換裝的 AI 風格目錄。",
     detailTitleSuffix: "AI 換裝風格 | Persta.AI",
     detailDescription:
-      "用「{title}」風格為你的自創角色和本命角色換裝。只需上傳圖片，即可一鍵生成 {title} 的 AI 插畫，免費體驗。",
+      "用「{title}」風格為你的自創角色和本命角色換裝。只需上傳圖片，即可一鍵生成 {title} 的 AI 插畫。",
     cta: "用這個風格換裝",
     related: "同類風格",
     allStyles: "返回風格一覽",
@@ -786,10 +786,10 @@ const stylesCopy = {
       "Explora los estilos de cambio de ropa e ilustración con IA de Persta: uniformes, vestidos, trajes de fantasía y más. Cambia el look de tus OCs y personajes favoritos con un toque.",
     indexHeading: "Galería de estilos",
     indexIntro:
-      "Un catálogo de estilos de IA para vestir a tus OCs y personajes favoritos con un toque. Elige un estilo y pruébalo gratis.",
+      "Un catálogo de estilos de IA para vestir ilustraciones de personajes con un toque.",
     detailTitleSuffix: "Estilo de cambio de ropa con IA | Persta.AI",
     detailDescription:
-      "Viste a tus OCs y personajes favoritos con el estilo «{title}». Solo sube una imagen y genera una ilustración de IA de {title} con un toque. Prueba gratis.",
+      "Viste a tus OCs y personajes favoritos con el estilo «{title}». Solo sube una imagen y genera una ilustración de IA de {title} con un toque.",
     cta: "Vestir con este estilo",
     related: "Estilos de la misma categoría",
     allStyles: "Volver a la galería de estilos",
@@ -801,10 +801,10 @@ const stylesCopy = {
       "Explore os estilos de troca de roupa e ilustração com IA do Persta: uniformes, vestidos, trajes de fantasia e mais. Mude o visual dos seus OCs e personagens favoritos com um toque.",
     indexHeading: "Galeria de estilos",
     indexIntro:
-      "Um catálogo de estilos de IA para vestir seus OCs e personagens favoritos com um toque. Escolha um estilo e experimente grátis.",
+      "Um catálogo de estilos de IA para vestir ilustrações de personagens com um toque.",
     detailTitleSuffix: "Estilo de troca de roupa com IA | Persta.AI",
     detailDescription:
-      "Vista seus OCs e personagens favoritos com o estilo \"{title}\". Basta enviar uma imagem para gerar uma ilustração de IA de {title} com um toque. Experimente grátis.",
+      "Vista seus OCs e personagens favoritos com o estilo \"{title}\". Basta enviar uma imagem para gerar uma ilustração de IA de {title} com um toque.",
     cta: "Vestir com este estilo",
     related: "Estilos da mesma categoria",
     allStyles: "Voltar à galeria de estilos",
@@ -816,10 +816,10 @@ const stylesCopy = {
       "Parcourez les styles d'habillage et d'illustration IA de Persta : uniformes, robes, tenues fantastiques et plus. Relookez vos OC et personnages préférés en un geste.",
     indexHeading: "Galerie de styles",
     indexIntro:
-      "Un catalogue de styles IA pour habiller vos OC et personnages préférés en un geste. Choisissez un style et essayez-le gratuitement.",
+      "Un catalogue de styles IA pour habiller des illustrations de personnages en un geste.",
     detailTitleSuffix: "Style d'habillage IA | Persta.AI",
     detailDescription:
-      "Habillez vos OC et personnages préférés avec le style « {title} ». Téléversez une image et générez une illustration IA {title} en un geste. Essai gratuit.",
+      "Habillez vos OC et personnages préférés avec le style « {title} ». Téléversez une image et générez une illustration IA {title} en un geste.",
     cta: "Habiller avec ce style",
     related: "Styles de la même catégorie",
     allStyles: "Retour à la galerie de styles",
@@ -831,10 +831,10 @@ const stylesCopy = {
       "Entdecke die KI-Anzieh- und Illustrationsstile von Persta: Uniformen, Kleider, Fantasy-Outfits und mehr. Style deine OCs und Lieblingscharaktere mit einem Tipp um.",
     indexHeading: "Stil-Galerie",
     indexIntro:
-      "Ein Katalog von KI-Stilen, mit denen du OCs und Lieblingscharakter-Illustrationen mit einem Tipp umziehst. Wähle einen Stil und probiere ihn kostenlos aus.",
+      "Ein Katalog von KI-Stilen, mit denen du Charakter-Illustrationen mit einem Tipp umziehst.",
     detailTitleSuffix: "KI-Anzieh-Stil | Persta.AI",
     detailDescription:
-      "Ziehe deine OCs und Lieblingscharaktere im Stil „{title}“ um. Einfach ein Bild hochladen und mit einem Tipp eine {title}-KI-Illustration erstellen. Kostenlos testen.",
+      "Ziehe deine OCs und Lieblingscharaktere im Stil „{title}“ um. Einfach ein Bild hochladen und mit einem Tipp eine {title}-KI-Illustration erstellen.",
     cta: "Mit diesem Stil anziehen",
     related: "Stile derselben Kategorie",
     allStyles: "Zurück zur Stil-Galerie",
@@ -846,10 +846,10 @@ const stylesCopy = {
       "Sfoglia gli stili di cambio d'abito e illustrazione con IA di Persta: uniformi, abiti, costumi fantasy e altro. Cambia look ai tuoi OC e personaggi preferiti con un tocco.",
     indexHeading: "Galleria di stili",
     indexIntro:
-      "Un catalogo di stili IA per vestire i tuoi OC e personaggi preferiti con un tocco. Scegli uno stile e provalo gratis.",
+      "Un catalogo di stili IA per vestire illustrazioni di personaggi con un tocco.",
     detailTitleSuffix: "Stile di cambio d'abito con IA | Persta.AI",
     detailDescription:
-      "Vesti i tuoi OC e personaggi preferiti con lo stile «{title}». Carica un'immagine e genera un'illustrazione IA di {title} con un tocco. Prova gratuita.",
+      "Vesti i tuoi OC e personaggi preferiti con lo stile «{title}». Carica un'immagine e genera un'illustrazione IA di {title} con un tocco.",
     cta: "Vesti con questo stile",
     related: "Stili della stessa categoria",
     allStyles: "Torna alla galleria di stili",
@@ -861,10 +861,10 @@ const stylesCopy = {
       "Jelajahi gaya ganti baju dan ilustrasi AI di Persta: seragam, gaun, kostum fantasi, dan lainnya. Ganti gaya OC dan karakter favoritmu dalam sekali tap.",
     indexHeading: "Galeri gaya",
     indexIntro:
-      "Katalog gaya AI untuk mendandani ilustrasi OC dan karakter favoritmu dalam sekali tap. Pilih gaya dan coba gratis.",
+      "Katalog gaya AI untuk mendandani ilustrasi karakter dalam sekali tap.",
     detailTitleSuffix: "Gaya ganti baju AI | Persta.AI",
     detailDescription:
-      "Dandani OC dan karakter favoritmu dengan gaya \"{title}\". Cukup unggah gambar dan buat ilustrasi AI {title} dalam sekali tap. Coba gratis.",
+      "Dandani OC dan karakter favoritmu dengan gaya \"{title}\". Cukup unggah gambar dan buat ilustrasi AI {title} dalam sekali tap.",
     cta: "Ganti baju dengan gaya ini",
     related: "Gaya dalam kategori yang sama",
     allStyles: "Kembali ke galeri gaya",
@@ -876,10 +876,10 @@ const stylesCopy = {
       "เลือกชมสไตล์ AI เปลี่ยนชุดและสร้างภาพประกอบบน Persta ทั้งชุดนักเรียน เดรส ชุดแฟนตาซี และอีกมากมาย เปลี่ยนชุดให้ OC และตัวละครที่คุณรักได้ในแตะเดียว",
     indexHeading: "แกลเลอรีสไตล์",
     indexIntro:
-      "แคตตาล็อกสไตล์ AI สำหรับเปลี่ยนชุดให้ภาพ OC และตัวละครที่คุณรักในแตะเดียว เลือกสไตล์ที่ชอบแล้วทดลองฟรี",
+      "แคตตาล็อกสไตล์ AI สำหรับเปลี่ยนชุดให้ภาพประกอบตัวละครในแตะเดียว",
     detailTitleSuffix: "สไตล์ AI เปลี่ยนชุด | Persta.AI",
     detailDescription:
-      "เปลี่ยนชุดให้ OC และตัวละครที่คุณรักด้วยสไตล์ \"{title}\" แค่อัปโหลดภาพก็สร้างภาพประกอบ AI สไตล์ {title} ได้ในแตะเดียว ทดลองฟรี",
+      "เปลี่ยนชุดให้ OC และตัวละครที่คุณรักด้วยสไตล์ \"{title}\" แค่อัปโหลดภาพก็สร้างภาพประกอบ AI สไตล์ {title} ได้ในแตะเดียว",
     cta: "เปลี่ยนชุดด้วยสไตล์นี้",
     related: "สไตล์ในหมวดเดียวกัน",
     allStyles: "กลับไปที่แกลเลอรีสไตล์",
@@ -891,10 +891,10 @@ const stylesCopy = {
       "Khám phá các phong cách thay trang phục và minh họa AI trên Persta: đồng phục, váy, trang phục fantasy và nhiều hơn nữa. Đổi phong cách cho OC và nhân vật yêu thích chỉ với một chạm.",
     indexHeading: "Thư viện phong cách",
     indexIntro:
-      "Danh mục các phong cách AI giúp thay trang phục cho ảnh minh họa OC và nhân vật yêu thích chỉ với một chạm. Chọn phong cách và dùng thử miễn phí.",
+      "Danh mục các phong cách AI giúp thay trang phục cho ảnh minh họa nhân vật chỉ với một chạm.",
     detailTitleSuffix: "Phong cách thay trang phục AI | Persta.AI",
     detailDescription:
-      "Thay trang phục cho OC và nhân vật yêu thích với phong cách \"{title}\". Chỉ cần tải ảnh lên là tạo được ảnh minh họa AI {title} trong một chạm. Dùng thử miễn phí.",
+      "Thay trang phục cho OC và nhân vật yêu thích với phong cách \"{title}\". Chỉ cần tải ảnh lên là tạo được ảnh minh họa AI {title} trong một chạm.",
     cta: "Thay trang phục với phong cách này",
     related: "Phong cách cùng danh mục",
     allStyles: "Quay lại thư viện phong cách",
@@ -906,10 +906,10 @@ const stylesCopy = {
       "Persta पर उपलब्ध AI ड्रेस-अप और इलस्ट्रेशन स्टाइल देखें: यूनिफ़ॉर्म, ड्रेस, फ़ैंटेसी आउटफ़िट और भी बहुत कुछ। एक टैप में अपने OC और पसंदीदा किरदारों का लुक बदलें।",
     indexHeading: "स्टाइल गैलरी",
     indexIntro:
-      "एक टैप में OC और पसंदीदा किरदारों के इलस्ट्रेशन को नए आउटफ़िट पहनाने वाले AI स्टाइल का कैटलॉग। कोई स्टाइल चुनें और मुफ़्त आज़माएँ।",
+      "एक टैप में किरदारों के इलस्ट्रेशन को नए आउटफ़िट पहनाने वाले AI स्टाइल का कैटलॉग।",
     detailTitleSuffix: "AI ड्रेस-अप स्टाइल | Persta.AI",
     detailDescription:
-      "\"{title}\" स्टाइल में अपने OC और पसंदीदा किरदारों को सजाएँ। बस एक इमेज अपलोड करें और एक टैप में {title} की AI इलस्ट्रेशन बनाएँ। मुफ़्त आज़माएँ।",
+      "\"{title}\" स्टाइल में अपने OC और पसंदीदा किरदारों को सजाएँ। बस एक इमेज अपलोड करें और एक टैप में {title} की AI इलस्ट्रेशन बनाएँ।",
     cta: "इस स्टाइल से ड्रेस-अप करें",
     related: "इसी कैटेगरी के स्टाइल",
     allStyles: "स्टाइल गैलरी पर वापस जाएँ",
@@ -921,10 +921,10 @@ const stylesCopy = {
       "تصفّح أنماط تبديل الملابس وتوليد الرسوم بالذكاء الاصطناعي على Persta: أزياء مدرسية وفساتين وأزياء خيالية والمزيد. غيّر إطلالة شخصياتك الأصلية وشخصياتك المفضلة بلمسة واحدة.",
     indexHeading: "معرض الأنماط",
     indexIntro:
-      "دليل أنماط الذكاء الاصطناعي لتبديل ملابس رسوم شخصياتك الأصلية وشخصياتك المفضلة بلمسة واحدة. اختر نمطًا وجرّبه مجانًا.",
+      "دليل أنماط الذكاء الاصطناعي لتبديل ملابس رسوم الشخصيات بلمسة واحدة.",
     detailTitleSuffix: "نمط تبديل الملابس بالذكاء الاصطناعي | Persta.AI",
     detailDescription:
-      "بدّل ملابس شخصياتك الأصلية وشخصياتك المفضلة بنمط «{title}». ما عليك سوى رفع صورة لتوليد رسم بالذكاء الاصطناعي بنمط {title} بلمسة واحدة. جرّب مجانًا.",
+      "بدّل ملابس شخصياتك الأصلية وشخصياتك المفضلة بنمط «{title}». ما عليك سوى رفع صورة لتوليد رسم بالذكاء الاصطناعي بنمط {title} بلمسة واحدة.",
     cta: "بدّل الملابس بهذا النمط",
     related: "أنماط من الفئة نفسها",
     allStyles: "العودة إلى معرض الأنماط",

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -31,6 +31,11 @@ const envSchema = {
   // Site URL
   NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,
 
+  // Google Search Console のサイト所有権確認トークン(メタタグ方式)。
+  // 未設定なら verification メタタグ自体を出力しない。
+  NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION:
+    process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION,
+
   // Event
   NEXT_PUBLIC_EVENT_USER_ID: process.env.NEXT_PUBLIC_EVENT_USER_ID,
 
@@ -152,6 +157,8 @@ function getEnv() {
       envSchema.NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID || "",
     NEXT_PUBLIC_SITE_URL:
       envSchema.NEXT_PUBLIC_SITE_URL || "",
+    NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION:
+      envSchema.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION || "",
     NEXT_PUBLIC_EVENT_USER_ID:
       envSchema.NEXT_PUBLIC_EVENT_USER_ID || "",
     NEXT_PUBLIC_GA4_MEASUREMENT_ID:

--- a/lib/guest-id.ts
+++ b/lib/guest-id.ts
@@ -82,12 +82,15 @@ export function ensureGuestIdOnResponse(
  * 例:
  *  - `/style`, `/style/...` → true
  *  - `/coordinate`, `/coordinate/...` → true
- *  - `/en/style`, `/ja/coordinate/foo` → true
+ *  - `/en/style`, `/ja/coordinate/foo`, `/zh-CN/style` → true
  *  - `/posts/123`, `/api/...` → false
  */
 export function shouldIssueGuestIdForPathname(pathname: string): boolean {
   return GUEST_ID_PATHNAME_PATTERN.test(pathname);
 }
 
+// ロケールプレフィックスは `ja` 等の 2 文字に加え、`zh-CN` / `zh-TW` のような
+// 地域付きタグも許容する(非ロケール文字列に過剰一致しても Cookie が余分に
+// 発行されるだけで、レート制限の抜け道にはならない)。
 const GUEST_ID_PATHNAME_PATTERN =
-  /^\/(?:[a-z]{2}\/)?(?:style|coordinate)(?:\/|$)/i;
+  /^\/(?:[a-zA-Z]{2}(?:-[a-zA-Z]{2,4})?\/)?(?:style|coordinate)(?:\/|$)/i;

--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -1,6 +1,11 @@
 import type { Metadata } from "next";
 import { getSiteUrl } from "@/lib/env";
-import { localizePublicPath, locales, type Locale } from "@/i18n/config";
+import {
+  DEFAULT_LOCALE,
+  localizePublicPath,
+  locales,
+  type Locale,
+} from "@/i18n/config";
 
 const DEFAULT_OPEN_GRAPH_IMAGE = {
   path: "/opengraph-image.png",
@@ -27,9 +32,28 @@ export function createLocaleAlternates(path: string, locale: Locale) {
 
   return {
     canonical: `${siteUrl}${canonicalPath}`,
-    languages: Object.fromEntries(
-      locales.map((entry) => [entry, `${siteUrl}${localizePublicPath(path, entry)}`])
-    ),
+    languages: {
+      ...Object.fromEntries(
+        locales.map((entry) => [entry, `${siteUrl}${localizePublicPath(path, entry)}`])
+      ),
+      // 言語が一致しない訪問者の既定 URL(hreflang x-default)はデフォルトロケール版
+      "x-default": `${siteUrl}${localizePublicPath(path, DEFAULT_LOCALE)}`,
+    },
+  };
+}
+
+/**
+ * ロケール分割していない公開ページ(/collections, /creators, /users/[id] 等)用の
+ * 自己参照 canonical を生成する。
+ *
+ * root layout にサイト全体の alternates を置くと、alternates 未定義の全ページが
+ * トップページを canonical として継承してしまう(= 検索エンジンに「トップの複製」と
+ * 伝わりインデックス対象から外れる)ため、各ページが必ず自分の canonical を宣言する。
+ */
+export function createCanonicalAlternates(path: string) {
+  const siteUrl = getSiteUrl();
+  return {
+    canonical: siteUrl ? `${siteUrl}${path}` : path,
   };
 }
 

--- a/messages/ar.ts
+++ b/messages/ar.ts
@@ -49,6 +49,11 @@ export const arMessages = {
     privacy: "سياسة الخصوصية",
     communityGuidelines: "إرشادات المجتمع",
     disclosure: "الإفصاح التجاري",
+    styles: "معرض الأنماط",
+    catalog: "دليل الرسّامين",
+    collections: "المجموعات",
+    freeMaterials: "مواد مجانية لتبديل الملابس",
+    creators: "للمبدعين",
   },
   searchBar: {
     placeholder: "ابحث في النصوص الموجِّهة",

--- a/messages/de.ts
+++ b/messages/de.ts
@@ -49,6 +49,11 @@ export const deMessages = {
     privacy: "Datenschutz",
     communityGuidelines: "Community-Richtlinien",
     disclosure: "Impressum",
+    styles: "Stil-Galerie",
+    catalog: "Künstlerkatalog",
+    collections: "Sammlungen",
+    freeMaterials: "Kostenlose Vorlagen",
+    creators: "Für Creator",
   },
   searchBar: {
     placeholder: "Prompts suchen",

--- a/messages/en.ts
+++ b/messages/en.ts
@@ -49,6 +49,11 @@ export const enMessages = {
     privacy: "Privacy Policy",
     communityGuidelines: "Community Guidelines",
     disclosure: "Commercial Disclosure",
+    styles: "Style Gallery",
+    catalog: "Artist Catalog",
+    collections: "Collections",
+    freeMaterials: "Free Dress-Up Materials",
+    creators: "For Creators",
   },
   searchBar: {
     placeholder: "Search prompts",

--- a/messages/es.ts
+++ b/messages/es.ts
@@ -49,6 +49,11 @@ export const esMessages = {
     privacy: "Política de privacidad",
     communityGuidelines: "Normas de la comunidad",
     disclosure: "Divulgación comercial",
+    styles: "Galería de estilos",
+    catalog: "Catálogo de artistas",
+    collections: "Colecciones",
+    freeMaterials: "Materiales gratuitos",
+    creators: "Para creadores",
   },
   searchBar: {
     placeholder: "Buscar prompts",

--- a/messages/fr.ts
+++ b/messages/fr.ts
@@ -49,6 +49,11 @@ export const frMessages = {
     privacy: "Politique de confidentialité",
     communityGuidelines: "Règles de la communauté",
     disclosure: "Mentions légales",
+    styles: "Galerie de styles",
+    catalog: "Catalogue d'artistes",
+    collections: "Collections",
+    freeMaterials: "Matériaux gratuits",
+    creators: "Pour les créateurs",
   },
   searchBar: {
     placeholder: "Rechercher des prompts",

--- a/messages/hi.ts
+++ b/messages/hi.ts
@@ -49,6 +49,11 @@ export const hiMessages = {
     privacy: "गोपनीयता नीति",
     communityGuidelines: "सामुदायिक दिशानिर्देश",
     disclosure: "व्यावसायिक प्रकटीकरण",
+    styles: "स्टाइल गैलरी",
+    catalog: "आर्टिस्ट कैटलॉग",
+    collections: "कलेक्शन",
+    freeMaterials: "मुफ़्त ड्रेस-अप सामग्री",
+    creators: "क्रिएटर्स के लिए",
   },
   searchBar: {
     placeholder: "प्रॉम्प्ट खोजें",

--- a/messages/id.ts
+++ b/messages/id.ts
@@ -49,6 +49,11 @@ export const idMessages = {
     privacy: "Kebijakan Privasi",
     communityGuidelines: "Pedoman Komunitas",
     disclosure: "Pengungkapan Komersial",
+    styles: "Galeri gaya",
+    catalog: "Katalog ilustrator",
+    collections: "Koleksi",
+    freeMaterials: "Materi gratis ganti baju",
+    creators: "Untuk kreator",
   },
   searchBar: {
     placeholder: "Cari prompt",

--- a/messages/it.ts
+++ b/messages/it.ts
@@ -49,6 +49,11 @@ export const itMessages = {
     privacy: "Informativa sulla privacy",
     communityGuidelines: "Linee guida della community",
     disclosure: "Informativa commerciale",
+    styles: "Galleria di stili",
+    catalog: "Catalogo artisti",
+    collections: "Collezioni",
+    freeMaterials: "Materiali gratuiti",
+    creators: "Per i creator",
   },
   searchBar: {
     placeholder: "Cerca prompt",

--- a/messages/ja.ts
+++ b/messages/ja.ts
@@ -46,6 +46,11 @@ export const jaMessages = {
     privacy: "プライバシーポリシー",
     communityGuidelines: "コミュニティガイドライン",
     disclosure: "商取引に関する開示",
+    styles: "スタイル一覧",
+    catalog: "絵師カタログ",
+    collections: "コレクション図鑑",
+    freeMaterials: "着せ替えフリー素材",
+    creators: "クリエイター募集",
   },
   searchBar: {
     placeholder: "プロンプト検索",

--- a/messages/ko.ts
+++ b/messages/ko.ts
@@ -49,6 +49,11 @@ export const koMessages = {
     privacy: "개인정보 처리방침",
     communityGuidelines: "커뮤니티 가이드라인",
     disclosure: "특정상거래법 표시",
+    styles: "스타일 목록",
+    catalog: "일러스트레이터 카탈로그",
+    collections: "컬렉션 도감",
+    freeMaterials: "옷 갈아입히기 무료 소재",
+    creators: "크리에이터 모집",
   },
   searchBar: {
     placeholder: "프롬프트 검색",

--- a/messages/pt.ts
+++ b/messages/pt.ts
@@ -49,6 +49,11 @@ export const ptMessages = {
     privacy: "Política de privacidade",
     communityGuidelines: "Diretrizes da comunidade",
     disclosure: "Divulgação comercial",
+    styles: "Galeria de estilos",
+    catalog: "Catálogo de artistas",
+    collections: "Coleções",
+    freeMaterials: "Materiais gratuitos",
+    creators: "Para criadores",
   },
   searchBar: {
     placeholder: "Buscar prompts",

--- a/messages/th.ts
+++ b/messages/th.ts
@@ -49,6 +49,11 @@ export const thMessages = {
     privacy: "นโยบายความเป็นส่วนตัว",
     communityGuidelines: "แนวปฏิบัติของชุมชน",
     disclosure: "การเปิดเผยทางการค้า",
+    styles: "แกลเลอรีสไตล์",
+    catalog: "แคตตาล็อกนักวาด",
+    collections: "คอลเลกชัน",
+    freeMaterials: "สื่อฟรีสำหรับเปลี่ยนชุด",
+    creators: "รับสมัครครีเอเตอร์",
   },
   searchBar: {
     placeholder: "ค้นหาพรอมป์",

--- a/messages/vi.ts
+++ b/messages/vi.ts
@@ -49,6 +49,11 @@ export const viMessages = {
     privacy: "Chính sách bảo mật",
     communityGuidelines: "Nguyên tắc cộng đồng",
     disclosure: "Công bố thương mại",
+    styles: "Thư viện phong cách",
+    catalog: "Danh mục họa sĩ",
+    collections: "Bộ sưu tập",
+    freeMaterials: "Tài nguyên miễn phí",
+    creators: "Dành cho nhà sáng tạo",
   },
   searchBar: {
     placeholder: "Tìm prompt",

--- a/messages/zh-CN.ts
+++ b/messages/zh-CN.ts
@@ -49,6 +49,11 @@ export const zhCnMessages = {
     privacy: "隐私政策",
     communityGuidelines: "社区准则",
     disclosure: "商业披露",
+    styles: "风格一览",
+    catalog: "画师目录",
+    collections: "收藏图鉴",
+    freeMaterials: "换装免费素材",
+    creators: "创作者招募",
   },
   searchBar: {
     placeholder: "搜索提示词",

--- a/messages/zh-TW.ts
+++ b/messages/zh-TW.ts
@@ -49,6 +49,11 @@ export const zhTwMessages = {
     privacy: "隱私權政策",
     communityGuidelines: "社群守則",
     disclosure: "商業揭露",
+    styles: "風格一覽",
+    catalog: "繪師目錄",
+    collections: "收藏圖鑑",
+    freeMaterials: "換裝免費素材",
+    creators: "創作者招募",
   },
   searchBar: {
     placeholder: "搜尋提示詞",

--- a/proxy.ts
+++ b/proxy.ts
@@ -48,6 +48,11 @@ export async function proxy(request: NextRequest) {
 
     const redirectResponse = NextResponse.redirect(redirectUrl);
     applyLocaleCookie(redirectResponse, resolvedLocale);
+    // /style・/coordinate はロケール付き URL へのリダイレクト時にも
+    // ゲスト識別 Cookie を発行しておく(初回アクセスから確実に識別できるようにする)。
+    if (shouldIssueGuestIdForPathname(pathname)) {
+      ensureGuestIdOnResponse(request, redirectResponse);
+    }
     return redirectResponse;
   }
 

--- a/tests/unit/features/style-presets/styles-gallery-client.test.tsx
+++ b/tests/unit/features/style-presets/styles-gallery-client.test.tsx
@@ -25,11 +25,26 @@ const T: Record<string, string> = {
   stylePopularSortNote: "直近30日の生成数順",
 };
 
+const HOME_T: Record<string, string> = {
+  stylePresetConfirmTitle: "こちらを試着しますか？",
+  stylePresetConfirmCancel: "キャンセル",
+  stylePresetConfirmAction: "試着する",
+};
+
 jest.mock("next-intl", () => ({
-  useTranslations: () => (key: string, values?: Record<string, unknown>) => {
-    if (key === "styleNewSortNote") return `直近${values?.days}日の新着`;
-    return T[key] ?? key;
-  },
+  useTranslations:
+    (namespace?: string) =>
+    (key: string, values?: Record<string, unknown>) => {
+      if (namespace === "home") return HOME_T[key] ?? key;
+      if (key === "styleNewSortNote") return `直近${values?.days}日の新着`;
+      if (key === "styleCardAlt") return `スタイル ${values?.name}`;
+      return T[key] ?? key;
+    },
+}));
+
+const routerPushMock = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: routerPushMock }),
 }));
 
 // /styles は静的ページのため、認証状態とお気に入りはブラウザ側で取得する。
@@ -187,6 +202,40 @@ describe("StylesGalleryClient", () => {
 
     expect(screen.queryByText("style-old")).toBeNull();
     expect(screen.getByText("style-new")).toBeTruthy();
+  });
+
+  test("カード選択_試着確認モーダルを開き「試着する」で/styleへ遷移する", () => {
+    render(
+      <StylesGalleryClient
+        presets={[preset("style-a")]}
+        generateCounts={{}}
+        nowIso={NOW_ISO}
+        locale="ja"
+      />,
+    );
+
+    fireEvent.click(screen.getByText("style-a"));
+
+    // 紹介ページへ即遷移せず、ホームと同じ試着確認モーダルを出す
+    expect(screen.getByText("こちらを試着しますか？")).toBeTruthy();
+    fireEvent.click(screen.getByText("試着する"));
+
+    expect(routerPushMock).toHaveBeenCalledWith("/ja/style?style=style-a");
+  });
+
+  test("カード選択_修飾キー付きクリックはモーダルを開かない(リンク既定動作)", () => {
+    render(
+      <StylesGalleryClient
+        presets={[preset("style-a")]}
+        generateCounts={{}}
+        nowIso={NOW_ISO}
+        locale="ja"
+      />,
+    );
+
+    fireEvent.click(screen.getByText("style-a"), { metaKey: true });
+
+    expect(screen.queryByText("こちらを試着しますか？")).toBeNull();
   });
 
   test("ログイン済み_お気に入りチップが現れ絞り込める", async () => {

--- a/tests/unit/features/style-presets/styles-gallery-client.test.tsx
+++ b/tests/unit/features/style-presets/styles-gallery-client.test.tsx
@@ -313,6 +313,41 @@ describe("StylesGalleryClient", () => {
     expect(frame.className).not.toContain("aspect-[3/4]");
   });
 
+  test("モーダル_Escで閉じられる(AlertDialogではなく通常のDialog)", async () => {
+    render(
+      <StylesGalleryClient
+        presets={[preset("style-a")]}
+        generateCounts={{}}
+        nowIso={NOW_ISO}
+        locale="ja"
+      />,
+    );
+
+    fireEvent.click(screen.getByText("style-a"));
+    expect(screen.getByText("こちらを試着しますか？")).toBeTruthy();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    await waitFor(() =>
+      expect(screen.queryByText("こちらを試着しますか？")).toBeNull(),
+    );
+  });
+
+  test("カードタイトル_16文字を超える場合は1行に切り詰める", () => {
+    render(
+      <StylesGalleryClient
+        presets={[preset("あいうえおかきくけこさしすせそたちつてと")]}
+        generateCounts={{}}
+        nowIso={NOW_ISO}
+        locale="ja"
+      />,
+    );
+
+    expect(
+      screen.getByText("あいうえおかきくけこさしすせそた..."),
+    ).toBeTruthy();
+  });
+
   test("カード選択_修飾キー付きクリックはモーダルを開かない(リンク既定動作)", () => {
     render(
       <StylesGalleryClient

--- a/tests/unit/features/style-presets/styles-gallery-client.test.tsx
+++ b/tests/unit/features/style-presets/styles-gallery-client.test.tsx
@@ -98,6 +98,8 @@ function preset(
       key: categoryKey,
       displayNameJa: categoryLabelJa,
       displayNameEn: categoryLabelJa,
+      badgeColor: "rgb(255, 87, 34)",
+      badgeTextColor: "rgb(255, 255, 255)",
       isCollectionSeries: false,
       collectionDisplayStartsAt: null,
       collectionDisplayEndsAt: null,
@@ -137,6 +139,36 @@ describe("StylesGalleryClient", () => {
     // 未ログインではお気に入りチップは出さない
     await waitFor(() => expect(getUserMock).toHaveBeenCalled());
     expect(screen.queryByRole("tab", { name: /お気に入り/ })).toBeNull();
+  });
+
+  test("カード_admin設定色のカテゴリバッジを表示しcoordinateには出さない", () => {
+    render(
+      <StylesGalleryClient
+        presets={[
+          preset("style-a"),
+          preset("style-b", {
+            categoryKey: "character_remix",
+            categoryLabelJa: "アレンジ",
+          }),
+        ]}
+        generateCounts={{}}
+        nowIso={NOW_ISO}
+        locale="ja"
+      />,
+    );
+
+    // 「アレンジ」はチップ + カード上のバッジの2箇所(バッジは aria-label 付き span)
+    const badge = screen
+      .getAllByText("アレンジ")
+      .find((el) => el.tagName === "SPAN" && el.getAttribute("aria-label"));
+    expect(badge).toBeTruthy();
+    expect((badge as HTMLElement).style.backgroundColor).toBe(
+      "rgb(255, 87, 34)",
+    );
+    expect((badge as HTMLElement).style.color).toBe("rgb(255, 255, 255)");
+
+    // default カテゴリの coordinate はバッジ非表示(チップの1箇所のみ)
+    expect(screen.getAllByText("コーディネート")).toHaveLength(1);
   });
 
   test("カテゴリチップ_選択でグリッドを絞り込む", () => {

--- a/tests/unit/features/style-presets/styles-gallery-client.test.tsx
+++ b/tests/unit/features/style-presets/styles-gallery-client.test.tsx
@@ -22,6 +22,8 @@ const T: Record<string, string> = {
   styleChipPopular: "人気",
   styleChipCreator: "クリエイター",
   styleFavoritesEmpty: "お気に入りはまだありません",
+  styleFavoriteAdd: "お気に入りに追加",
+  styleFavoriteRemove: "お気に入りを解除",
   stylePopularSortNote: "直近30日の生成数順",
 };
 
@@ -109,10 +111,14 @@ function preset(
 }
 
 describe("StylesGalleryClient", () => {
+  const fetchMock = jest.fn();
+
   beforeEach(() => {
     jest.clearAllMocks();
     getUserMock.mockResolvedValue({ data: { user: null } });
     favoritesSelectMock.mockResolvedValue({ data: [] });
+    fetchMock.mockResolvedValue({ ok: true });
+    global.fetch = fetchMock as unknown as typeof fetch;
   });
 
   test("初期表示_全プリセットとカテゴリチップを表示する", async () => {
@@ -320,6 +326,56 @@ describe("StylesGalleryClient", () => {
     fireEvent.click(screen.getByText("style-a"), { metaKey: true });
 
     expect(screen.queryByText("こちらを試着しますか？")).toBeNull();
+  });
+
+  test("しおり_ログイン済みはトグルでAPIを呼び楽観更新する", async () => {
+    getUserMock.mockResolvedValue({ data: { user: { id: "user-1" } } });
+
+    render(
+      <StylesGalleryClient
+        presets={[preset("style-a")]}
+        generateCounts={{}}
+        nowIso={NOW_ISO}
+        locale="ja"
+      />,
+    );
+
+    // 認証状態がクライアントで解決されるのを待つ(お気に入りチップの出現で判定)
+    await screen.findByRole("tab", { name: /お気に入り/ });
+
+    fireEvent.click(screen.getByRole("button", { name: "お気に入りに追加" }));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/style-presets/favorites",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ presetId: "style-a" }),
+      }),
+    );
+    // 楽観更新でしおりが「解除」表示に切り替わる
+    expect(
+      screen.getByRole("button", { name: "お気に入りを解除" }),
+    ).toBeTruthy();
+  });
+
+  test("しおり_未ログインはAPIを呼ばない(ログイン誘導のみ)", async () => {
+    render(
+      <StylesGalleryClient
+        presets={[preset("style-a")]}
+        generateCounts={{}}
+        nowIso={NOW_ISO}
+        locale="ja"
+      />,
+    );
+    await waitFor(() => expect(getUserMock).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole("button", { name: "お気に入りに追加" }));
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    // 集合は変更されない(「追加」表示のまま)
+    expect(
+      screen.getByRole("button", { name: "お気に入りに追加" }),
+    ).toBeTruthy();
   });
 
   test("ログイン済み_お気に入りチップが現れ絞り込める", async () => {

--- a/tests/unit/features/style-presets/styles-gallery-client.test.tsx
+++ b/tests/unit/features/style-presets/styles-gallery-client.test.tsx
@@ -1,6 +1,12 @@
 /** @jest-environment jsdom */
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { StylesGalleryClient } from "@/features/style-presets/components/StylesGalleryClient";
 import type { StylePresetPublicSummary } from "@/features/style-presets/lib/schema";
 
@@ -25,6 +31,9 @@ const T: Record<string, string> = {
   styleFavoriteAdd: "お気に入りに追加",
   styleFavoriteRemove: "お気に入りを解除",
   stylePopularSortNote: "直近30日の生成数順",
+  styleBrowseConfirmTitle: "こちらを試着しますか？",
+  styleBrowseConfirmAction: "試着する",
+  styleBrowseConfirmCancel: "他のスタイルをみる",
 };
 
 const HOME_T: Record<string, string> = {
@@ -40,6 +49,8 @@ jest.mock("next-intl", () => ({
       if (namespace === "home") return HOME_T[key] ?? key;
       if (key === "styleNewSortNote") return `直近${values?.days}日の新着`;
       if (key === "styleCardAlt") return `スタイル ${values?.name}`;
+      if (key === "styleUsageCount")
+        return `これまでに${values?.count}回つくられました`;
       return T[key] ?? key;
     },
 }));
@@ -71,6 +82,7 @@ function preset(
     publishedDaysAgo: number;
     thumbnailWidth: number;
     thumbnailHeight: number;
+    providerNickname: string;
   }> = {},
 ): StylePresetPublicSummary {
   const {
@@ -79,6 +91,7 @@ function preset(
     publishedDaysAgo = 100,
     thumbnailWidth = 912,
     thumbnailHeight = 1173,
+    providerNickname,
   } = overrides;
   const publishedAt = new Date(
     Date.parse(NOW_ISO) - publishedDaysAgo * 86400000,
@@ -95,6 +108,9 @@ function preset(
     publishedAt,
     imageInputMode: "single",
     dualReferenceSource: "admin",
+    providerUserId: providerNickname ? "provider-1" : null,
+    providerNickname: providerNickname ?? null,
+    providerAvatarUrl: null,
     category: {
       id: `cat-${categoryKey}`,
       key: categoryKey,
@@ -132,6 +148,7 @@ describe("StylesGalleryClient", () => {
           }),
         ]}
         generateCounts={{}}
+        generateTotals={{}}
         nowIso={NOW_ISO}
         locale="ja"
       />,
@@ -158,6 +175,7 @@ describe("StylesGalleryClient", () => {
           }),
         ]}
         generateCounts={{}}
+        generateTotals={{}}
         nowIso={NOW_ISO}
         locale="ja"
       />,
@@ -188,6 +206,7 @@ describe("StylesGalleryClient", () => {
           }),
         ]}
         generateCounts={{}}
+        generateTotals={{}}
         nowIso={NOW_ISO}
         locale="ja"
       />,
@@ -211,6 +230,7 @@ describe("StylesGalleryClient", () => {
           preset("style-c"),
         ]}
         generateCounts={{ "style-a": 2, "style-b": 10 }}
+        generateTotals={{}}
         nowIso={NOW_ISO}
         locale="ja"
       />,
@@ -235,6 +255,7 @@ describe("StylesGalleryClient", () => {
           preset("style-new", { publishedDaysAgo: 3 }),
         ]}
         generateCounts={{}}
+        generateTotals={{}}
         nowIso={NOW_ISO}
         locale="ja"
       />,
@@ -251,6 +272,7 @@ describe("StylesGalleryClient", () => {
       <StylesGalleryClient
         presets={[preset("style-a")]}
         generateCounts={{}}
+        generateTotals={{}}
         nowIso={NOW_ISO}
         locale="ja"
       />,
@@ -283,6 +305,7 @@ describe("StylesGalleryClient", () => {
           preset("style-wide", { thumbnailWidth: 1200, thumbnailHeight: 800 }),
         ]}
         generateCounts={{}}
+        generateTotals={{}}
         nowIso={NOW_ISO}
         locale="ja"
       />,
@@ -301,6 +324,7 @@ describe("StylesGalleryClient", () => {
       <StylesGalleryClient
         presets={[preset("style-tall")]}
         generateCounts={{}}
+        generateTotals={{}}
         nowIso={NOW_ISO}
         locale="ja"
       />,
@@ -313,11 +337,50 @@ describe("StylesGalleryClient", () => {
     expect(frame.className).not.toContain("aspect-[3/4]");
   });
 
+  test("モーダル_提供者クレジットと累計生成数を表示する", () => {
+    render(
+      <StylesGalleryClient
+        presets={[preset("style-a", { providerNickname: "氷洞つらら" })]}
+        generateCounts={{}}
+        generateTotals={{ "style-a": 12 }}
+        nowIso={NOW_ISO}
+        locale="ja"
+      />,
+    );
+
+    fireEvent.click(screen.getByText("style-a"));
+
+    // モーダル内に提供者クレジットと累計生成数が表示される
+    const dialog = within(screen.getByRole("dialog"));
+    expect(dialog.getByText(/氷洞つらら/)).toBeTruthy();
+    expect(dialog.getByText("これまでに12回つくられました")).toBeTruthy();
+    // 探索シートと同じボタン構成(「他のスタイルをみる」で閉じる)
+    expect(dialog.getByText("他のスタイルをみる")).toBeTruthy();
+  });
+
+  test("モーダル_累計0回のプリセットでは回数を表示しない", () => {
+    render(
+      <StylesGalleryClient
+        presets={[preset("style-a")]}
+        generateCounts={{}}
+        generateTotals={{}}
+        nowIso={NOW_ISO}
+        locale="ja"
+      />,
+    );
+
+    fireEvent.click(screen.getByText("style-a"));
+
+    expect(screen.getByText("こちらを試着しますか？")).toBeTruthy();
+    expect(screen.queryByText(/これまでに/)).toBeNull();
+  });
+
   test("モーダル_Escで閉じられる(AlertDialogではなく通常のDialog)", async () => {
     render(
       <StylesGalleryClient
         presets={[preset("style-a")]}
         generateCounts={{}}
+        generateTotals={{}}
         nowIso={NOW_ISO}
         locale="ja"
       />,
@@ -338,6 +401,7 @@ describe("StylesGalleryClient", () => {
       <StylesGalleryClient
         presets={[preset("あいうえおかきくけこさしすせそたちつてと")]}
         generateCounts={{}}
+        generateTotals={{}}
         nowIso={NOW_ISO}
         locale="ja"
       />,
@@ -353,6 +417,7 @@ describe("StylesGalleryClient", () => {
       <StylesGalleryClient
         presets={[preset("style-a")]}
         generateCounts={{}}
+        generateTotals={{}}
         nowIso={NOW_ISO}
         locale="ja"
       />,
@@ -370,6 +435,7 @@ describe("StylesGalleryClient", () => {
       <StylesGalleryClient
         presets={[preset("style-a")]}
         generateCounts={{}}
+        generateTotals={{}}
         nowIso={NOW_ISO}
         locale="ja"
       />,
@@ -398,6 +464,7 @@ describe("StylesGalleryClient", () => {
       <StylesGalleryClient
         presets={[preset("style-a")]}
         generateCounts={{}}
+        generateTotals={{}}
         nowIso={NOW_ISO}
         locale="ja"
       />,
@@ -429,6 +496,7 @@ describe("StylesGalleryClient", () => {
           }),
         ]}
         generateCounts={{}}
+        generateTotals={{}}
         nowIso={NOW_ISO}
         locale="ja"
       />,

--- a/tests/unit/features/style-presets/styles-gallery-client.test.tsx
+++ b/tests/unit/features/style-presets/styles-gallery-client.test.tsx
@@ -1,0 +1,221 @@
+/** @jest-environment jsdom */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { StylesGalleryClient } from "@/features/style-presets/components/StylesGalleryClient";
+import type { StylePresetPublicSummary } from "@/features/style-presets/lib/schema";
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({ alt }: { alt: string }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={alt} src="" />
+  ),
+}));
+
+const T: Record<string, string> = {
+  styleBrowseSheetTitle: "スタイルをさがす",
+  styleBrowseEmpty: "該当するスタイルがありません",
+  styleChipAll: "すべて",
+  styleChipEvent: "イベント",
+  styleChipFavorites: "お気に入り",
+  styleChipNew: "新着",
+  styleChipPopular: "人気",
+  styleChipCreator: "クリエイター",
+  styleFavoritesEmpty: "お気に入りはまだありません",
+  stylePopularSortNote: "直近30日の生成数順",
+};
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => (key: string, values?: Record<string, unknown>) => {
+    if (key === "styleNewSortNote") return `直近${values?.days}日の新着`;
+    return T[key] ?? key;
+  },
+}));
+
+// /styles は静的ページのため、認証状態とお気に入りはブラウザ側で取得する。
+const getUserMock = jest.fn();
+const favoritesSelectMock = jest.fn();
+jest.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    auth: { getUser: (...args: unknown[]) => getUserMock(...args) },
+    from: () => ({
+      select: (...args: unknown[]) => favoritesSelectMock(...args),
+    }),
+  }),
+}));
+
+const NOW_ISO = "2026-07-25T00:00:00.000Z";
+
+function preset(
+  id: string,
+  overrides: Partial<{
+    categoryKey: string;
+    categoryLabelJa: string;
+    publishedDaysAgo: number;
+  }> = {},
+): StylePresetPublicSummary {
+  const {
+    categoryKey = "coordinate",
+    categoryLabelJa = "コーディネート",
+    publishedDaysAgo = 100,
+  } = overrides;
+  const publishedAt = new Date(
+    Date.parse(NOW_ISO) - publishedDaysAgo * 86400000,
+  ).toISOString();
+  return {
+    id,
+    slug: id,
+    title: id,
+    thumbnailImageUrl: "https://example.com/x.webp",
+    thumbnailWidth: 912,
+    thumbnailHeight: 1173,
+    hasBackgroundPrompt: false,
+    createdAt: publishedAt,
+    publishedAt,
+    imageInputMode: "single",
+    dualReferenceSource: "admin",
+    category: {
+      id: `cat-${categoryKey}`,
+      key: categoryKey,
+      displayNameJa: categoryLabelJa,
+      displayNameEn: categoryLabelJa,
+      isCollectionSeries: false,
+      collectionDisplayStartsAt: null,
+      collectionDisplayEndsAt: null,
+      providerUserId: null,
+    },
+  } as unknown as StylePresetPublicSummary;
+}
+
+describe("StylesGalleryClient", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getUserMock.mockResolvedValue({ data: { user: null } });
+    favoritesSelectMock.mockResolvedValue({ data: [] });
+  });
+
+  test("初期表示_全プリセットとカテゴリチップを表示する", async () => {
+    render(
+      <StylesGalleryClient
+        presets={[
+          preset("style-a"),
+          preset("style-b", {
+            categoryKey: "character_remix",
+            categoryLabelJa: "アレンジ",
+          }),
+        ]}
+        generateCounts={{}}
+        nowIso={NOW_ISO}
+        locale="ja"
+      />,
+    );
+
+    expect(screen.getByText("style-a")).toBeTruthy();
+    expect(screen.getByText("style-b")).toBeTruthy();
+    expect(screen.getByRole("tab", { name: "すべて" })).toBeTruthy();
+    expect(screen.getByRole("tab", { name: "コーディネート" })).toBeTruthy();
+    expect(screen.getByRole("tab", { name: "アレンジ" })).toBeTruthy();
+    // 未ログインではお気に入りチップは出さない
+    await waitFor(() => expect(getUserMock).toHaveBeenCalled());
+    expect(screen.queryByRole("tab", { name: /お気に入り/ })).toBeNull();
+  });
+
+  test("カテゴリチップ_選択でグリッドを絞り込む", () => {
+    render(
+      <StylesGalleryClient
+        presets={[
+          preset("style-a"),
+          preset("style-b", {
+            categoryKey: "character_remix",
+            categoryLabelJa: "アレンジ",
+          }),
+        ]}
+        generateCounts={{}}
+        nowIso={NOW_ISO}
+        locale="ja"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: "アレンジ" }));
+
+    expect(screen.queryByText("style-a")).toBeNull();
+    expect(screen.getByText("style-b")).toBeTruthy();
+  });
+
+  test("人気チップ_生成数の降順で並び替え注記も表示する", () => {
+    render(
+      <StylesGalleryClient
+        presets={[
+          preset("style-a"),
+          preset("style-b", {
+            categoryKey: "character_remix",
+            categoryLabelJa: "アレンジ",
+          }),
+          preset("style-c"),
+        ]}
+        generateCounts={{ "style-a": 2, "style-b": 10 }}
+        nowIso={NOW_ISO}
+        locale="ja"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: /人気/ }));
+
+    // 生成数 0 の style-c は人気に出ない
+    expect(screen.queryByText("style-c")).toBeNull();
+    expect(screen.getByText("直近30日の生成数順")).toBeTruthy();
+    const titles = screen
+      .getAllByText(/^style-/)
+      .map((el) => el.textContent);
+    expect(titles).toEqual(["style-b", "style-a"]);
+  });
+
+  test("新着チップ_公開14日以内のみ表示する", () => {
+    render(
+      <StylesGalleryClient
+        presets={[
+          preset("style-old", { publishedDaysAgo: 100 }),
+          preset("style-new", { publishedDaysAgo: 3 }),
+        ]}
+        generateCounts={{}}
+        nowIso={NOW_ISO}
+        locale="ja"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: /新着/ }));
+
+    expect(screen.queryByText("style-old")).toBeNull();
+    expect(screen.getByText("style-new")).toBeTruthy();
+  });
+
+  test("ログイン済み_お気に入りチップが現れ絞り込める", async () => {
+    getUserMock.mockResolvedValue({ data: { user: { id: "user-1" } } });
+    favoritesSelectMock.mockResolvedValue({
+      data: [{ preset_id: "style-b" }],
+    });
+
+    render(
+      <StylesGalleryClient
+        presets={[
+          preset("style-a"),
+          preset("style-b", {
+            categoryKey: "character_remix",
+            categoryLabelJa: "アレンジ",
+          }),
+        ]}
+        generateCounts={{}}
+        nowIso={NOW_ISO}
+        locale="ja"
+      />,
+    );
+
+    const favoritesChip = await screen.findByRole("tab", {
+      name: /お気に入り/,
+    });
+    fireEvent.click(favoritesChip);
+
+    expect(screen.queryByText("style-a")).toBeNull();
+    expect(screen.getByText("style-b")).toBeTruthy();
+  });
+});

--- a/tests/unit/features/style-presets/styles-gallery-client.test.tsx
+++ b/tests/unit/features/style-presets/styles-gallery-client.test.tsx
@@ -67,12 +67,16 @@ function preset(
     categoryKey: string;
     categoryLabelJa: string;
     publishedDaysAgo: number;
+    thumbnailWidth: number;
+    thumbnailHeight: number;
   }> = {},
 ): StylePresetPublicSummary {
   const {
     categoryKey = "coordinate",
     categoryLabelJa = "コーディネート",
     publishedDaysAgo = 100,
+    thumbnailWidth = 912,
+    thumbnailHeight = 1173,
   } = overrides;
   const publishedAt = new Date(
     Date.parse(NOW_ISO) - publishedDaysAgo * 86400000,
@@ -82,8 +86,8 @@ function preset(
     slug: id,
     title: id,
     thumbnailImageUrl: "https://example.com/x.webp",
-    thumbnailWidth: 912,
-    thumbnailHeight: 1173,
+    thumbnailWidth,
+    thumbnailHeight,
     hasBackgroundPrompt: false,
     createdAt: publishedAt,
     publishedAt,
@@ -221,6 +225,54 @@ describe("StylesGalleryClient", () => {
     fireEvent.click(screen.getByText("試着する"));
 
     expect(routerPushMock).toHaveBeenCalledWith("/ja/style?style=style-a");
+  });
+
+  // jsdom は aspect-ratio プロパティを解釈せず style 属性から落とすため、
+  // 実比率表示の分岐は「横長=全幅 / 縦長=幅280px制限」の class 切替で検証する
+  // (探索シートと同じ表示ロジック)。
+  function getConfirmImageFrame(presetId: string): HTMLElement {
+    // 1枚目はグリッドのカード画像、2枚目がモーダル内の拡大画像
+    const images = screen.getAllByAltText(`スタイル ${presetId}`);
+    const frame = images[images.length - 1]?.parentElement;
+    expect(frame).toBeTruthy();
+    return frame as HTMLElement;
+  }
+
+  test("カード選択_横長サムネイルはクロップせず全幅で表示する", () => {
+    render(
+      <StylesGalleryClient
+        presets={[
+          preset("style-wide", { thumbnailWidth: 1200, thumbnailHeight: 800 }),
+        ]}
+        generateCounts={{}}
+        nowIso={NOW_ISO}
+        locale="ja"
+      />,
+    );
+
+    fireEvent.click(screen.getByText("style-wide"));
+
+    const frame = getConfirmImageFrame("style-wide");
+    expect(frame.className).not.toContain("max-w-[280px]");
+    // 3:4 固定クロップ(旧実装)に戻っていないこと
+    expect(frame.className).not.toContain("aspect-[3/4]");
+  });
+
+  test("カード選択_縦長サムネイルは幅280pxに制限する", () => {
+    render(
+      <StylesGalleryClient
+        presets={[preset("style-tall")]}
+        generateCounts={{}}
+        nowIso={NOW_ISO}
+        locale="ja"
+      />,
+    );
+
+    fireEvent.click(screen.getByText("style-tall"));
+
+    const frame = getConfirmImageFrame("style-tall");
+    expect(frame.className).toContain("max-w-[280px]");
+    expect(frame.className).not.toContain("aspect-[3/4]");
   });
 
   test("カード選択_修飾キー付きクリックはモーダルを開かない(リンク既定動作)", () => {

--- a/tests/unit/lib/get-public-style-presets.test.ts
+++ b/tests/unit/lib/get-public-style-presets.test.ts
@@ -7,16 +7,19 @@ jest.mock("next/cache", () => ({
 
 jest.mock("@/features/style-presets/lib/style-preset-repository", () => ({
   getPublishedStylePresetById: jest.fn(),
+  getPublishedStylePresetBySlug: jest.fn(),
   listPublishedStylePresets: jest.fn(),
 }));
 
 import { cacheLife, cacheTag } from "next/cache";
 import {
   getPublishedStylePreset,
+  getPublishedStylePresetBySlugPublic,
   getPublishedStylePresets,
 } from "@/features/style-presets/lib/get-public-style-presets";
 import {
   getPublishedStylePresetById,
+  getPublishedStylePresetBySlug,
   listPublishedStylePresets,
 } from "@/features/style-presets/lib/style-preset-repository";
 
@@ -25,6 +28,10 @@ const mockCacheTag = cacheTag as jest.MockedFunction<typeof cacheTag>;
 const mockGetPublishedStylePresetById =
   getPublishedStylePresetById as jest.MockedFunction<
     typeof getPublishedStylePresetById
+  >;
+const mockGetPublishedStylePresetBySlug =
+  getPublishedStylePresetBySlug as jest.MockedFunction<
+    typeof getPublishedStylePresetBySlug
   >;
 const mockListPublishedStylePresets =
   listPublishedStylePresets as jest.MockedFunction<
@@ -123,5 +130,40 @@ describe("get-public-style-presets", () => {
       "preset-admin",
       { includeAdminOnly: true }
     );
+  });
+
+  test("getPublishedStylePresetBySlugPublic_slug指定で公開プリセットを返す", async () => {
+    mockGetPublishedStylePresetBySlug.mockResolvedValueOnce({
+      id: "preset-1",
+      slug: "paris-code",
+      title: "PARIS CODE",
+      thumbnailImageUrl: "https://example.com/style.webp",
+      thumbnailWidth: 912,
+      thumbnailHeight: 1173,
+      hasBackgroundPrompt: true,
+      createdAt: "2026-03-22T00:00:00.000Z",
+      publishedAt: null,
+      category: baseCategory,
+      imageInputMode: "single",
+      dualReferenceSource: "admin",
+    } as never);
+
+    const result = await getPublishedStylePresetBySlugPublic("paris-code");
+
+    expect(mockCacheTag).toHaveBeenCalledWith("style-presets");
+    expect(mockCacheLife).toHaveBeenCalledWith("minutes");
+    expect(mockGetPublishedStylePresetBySlug).toHaveBeenCalledWith(
+      "paris-code"
+    );
+    expect(result?.slug).toBe("paris-code");
+    expect(result?.id).toBe("preset-1");
+  });
+
+  test("getPublishedStylePresetBySlugPublic_見つからなければnullを返す", async () => {
+    mockGetPublishedStylePresetBySlug.mockResolvedValueOnce(null);
+
+    await expect(
+      getPublishedStylePresetBySlugPublic("unknown-slug")
+    ).resolves.toBeNull();
   });
 });

--- a/tests/unit/lib/guest-id.test.ts
+++ b/tests/unit/lib/guest-id.test.ts
@@ -112,6 +112,9 @@ describe("guest-id", () => {
     test("ロケールプレフィックス付きでも発行する", () => {
       expect(shouldIssueGuestIdForPathname("/en/style")).toBe(true);
       expect(shouldIssueGuestIdForPathname("/ja/coordinate/foo")).toBe(true);
+      // 地域付きロケール(zh-CN / zh-TW)も対象
+      expect(shouldIssueGuestIdForPathname("/zh-CN/style")).toBe(true);
+      expect(shouldIssueGuestIdForPathname("/zh-TW/coordinate")).toBe(true);
     });
 
     test("無関係なパスでは発行しない", () => {

--- a/tests/unit/lib/style-preset-repository.test.ts
+++ b/tests/unit/lib/style-preset-repository.test.ts
@@ -180,6 +180,8 @@ describe("style-preset repository", () => {
     expect(presets).toEqual([
       {
         id: "preset-1",
+        // /styles/[slug] の公開スタイル紹介ページで使う公開フィールド
+        slug: "paris-code",
         title: "PARIS CODE",
         thumbnailImageUrl: "https://example.com/style.webp",
         thumbnailWidth: 912,

--- a/tests/unit/lib/style-preset-repository.test.ts
+++ b/tests/unit/lib/style-preset-repository.test.ts
@@ -6,6 +6,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import {
   createStylePreset,
   deleteStylePreset,
+  getPublishedStylePresetBySlug,
   listPublishedStylePresets,
   reorderStylePresets,
   updateStylePreset,
@@ -235,6 +236,96 @@ describe("style-preset repository", () => {
         providerAvatarUrl: null,
       },
     ]);
+  });
+
+  // /styles/[slug] の公開スタイル紹介ページで使う slug 検索。
+  // 公開 summary への変換と、秘匿フィールド(styling_prompt 等)非公開の
+  // 回帰ガードを含む。
+  const PUBLIC_PRESET_ROW = {
+    id: "preset-1",
+    slug: "paris-code",
+    title: "PARIS CODE",
+    styling_prompt: "prompt",
+    background_prompt: "Paris street",
+    thumbnail_image_url: "https://example.com/style.webp",
+    thumbnail_storage_path: null,
+    thumbnail_width: 912,
+    thumbnail_height: 1173,
+    sort_order: 0,
+    status: "published",
+    category_id: TEST_CATEGORY_ID,
+    image_input_mode: "single",
+    reference_image_url: null,
+    reference_image_storage_path: null,
+    reference_image_width: null,
+    reference_image_height: null,
+    category: TEST_CATEGORY_ROW,
+    created_by: null,
+    updated_by: null,
+    created_at: "2026-03-22T00:00:00.000Z",
+    updated_at: "2026-03-22T00:00:00.000Z",
+  };
+
+  function mockSlugQuery(result: { data: unknown; error: unknown }) {
+    const maybeSingle = jest.fn().mockResolvedValue(result);
+    const query = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      maybeSingle,
+    };
+    mockCreateAdminClient.mockReturnValue({
+      from: jest.fn(() => query),
+    } as never);
+    return query;
+  }
+
+  test("getPublishedStylePresetBySlug_slugで公開プリセットを取得しsummaryへ変換する", async () => {
+    const query = mockSlugQuery({ data: PUBLIC_PRESET_ROW, error: null });
+
+    const preset = await getPublishedStylePresetBySlug("paris-code");
+
+    expect(query.eq).toHaveBeenCalledWith("slug", "paris-code");
+    expect(query.eq).toHaveBeenCalledWith("status", "published");
+    expect(preset?.id).toBe("preset-1");
+    expect(preset?.slug).toBe("paris-code");
+    expect(preset?.title).toBe("PARIS CODE");
+    // 秘匿フィールドは公開 summary に含めない(回帰ガード)
+    expect(preset).not.toHaveProperty("stylingPrompt");
+    expect(preset).not.toHaveProperty("backgroundPrompt");
+  });
+
+  test("getPublishedStylePresetBySlug_見つからなければnullを返す", async () => {
+    mockSlugQuery({ data: null, error: null });
+
+    await expect(
+      getPublishedStylePresetBySlug("unknown-slug")
+    ).resolves.toBeNull();
+  });
+
+  test("getPublishedStylePresetBySlug_運営限定カテゴリは既定で除外し管理者指定では返す", async () => {
+    const adminOnlyRow = {
+      ...PUBLIC_PRESET_ROW,
+      category: { ...TEST_CATEGORY_ROW, visibility: "admin_only" },
+    };
+
+    mockSlugQuery({ data: adminOnlyRow, error: null });
+    await expect(
+      getPublishedStylePresetBySlug("paris-code")
+    ).resolves.toBeNull();
+
+    mockSlugQuery({ data: adminOnlyRow, error: null });
+    const adminPreset = await getPublishedStylePresetBySlug("paris-code", {
+      includeAdminOnly: true,
+    });
+    expect(adminPreset?.slug).toBe("paris-code");
+  });
+
+  test("getPublishedStylePresetBySlug_クエリエラー時はnullを返す", async () => {
+    mockSlugQuery({ data: null, error: { message: "boom" } });
+
+    await expect(
+      getPublishedStylePresetBySlug("paris-code")
+    ).resolves.toBeNull();
   });
 
   test("listPublishedStylePresets_提供者(provider)埋め込みをクレジット情報へ変換する", async () => {


### PR DESCRIPTION
### 概要

「AIでイラスト生成・着せ替えをするユーザーの検索にできる限り引っかかるようにしたい」というSEO強化の要望に対し、本番サイトを調査したところ、**検索インデックスを直接阻害する致命的問題が2件**見つかったため修正し、あわせて検索の受け皿となるスタイル紹介ページを新設した。

1. **canonicalの暴発**: root layout の `alternates.canonical` が alternates 未定義の全ページに継承され、`/ja/catalog`・`/ja/search`・`/collections`・`/creators` などが「トップページの複製」と検索エンジンに宣言していた（＝インデックス対象外になっていた）
2. **本番 sitemap が静的165URLのみ**: `sitemap.ts` が cookie 依存の Supabase クライアントを使っておりビルド時プリレンダで例外→静的ページのみにフォールバック。さらに存在しない `generated_images.updated_at` 列を select しており、cookie 問題を直しても投稿が0件になる隠れバグも併発していた

### 変更内容

- **canonical修正**: root layout の alternates を撤去し、catalog一覧/詳細/エントリ・search・collections×4・creators に自己参照 canonical を付与（既存 `createLocaleAlternates` ＋ 新設 `createCanonicalAlternates`）。hreflang に `x-default` を追加
- **sitemap修正**: cookie 非依存の `createAdminClient` に変更し、`"use cache"` + `cacheLife("hours")` で1時間ごとに再検証。存在しない `updated_at` 列参照を修正。`/style`・`/coordinate`・`/styles`・`/collections`・`/creators`・`/pricing`・`/community-guidelines` を追加収録し、投稿・カタログ・スタイルは hreflang 注釈（`alternates.languages`）方式で肥大を防止 → **165 → 1,194 URL（投稿803件全件収録）**
- **生成ページの多言語URL化**: `/style`・`/coordinate` を `PUBLIC_PATH_PATTERNS` に追加し `/{locale}/style` 等の15言語URLで公開（`app/[locale]/(app)/` の re-export ルート新設）。ゲスト識別 Cookie はリダイレクト応答でも発行するよう proxy を修正し、guest-id のロケール判定を `zh-CN` 等の地域付きタグに対応。ボトムナビ/サイドバーはロケール付きURLへ直接遷移（307ホップ解消）
- **スタイル紹介ページ新設（プログラマティックSEO）**: `/styles`（一覧＋ItemList JSON-LD）と `/styles/[slug]`（公開スタイル144件×15言語）。サムネイルOGP・BreadcrumbList/ImageObject JSON-LD・関連スタイル・生成画面へのCTA付き。repository に slug 公開フィールドと `getPublishedStylePresetBySlug` を追加。locale をURLパラメータで解決し静的プリレンダ可能にすることで JSON-LD を初期HTMLに含める
- **メタデータ強化**: ホームとサイト既定の title/description を15言語すべて「AI着せ替え・AIイラスト生成」キーワード入りに刷新（例: `Persta.AI (ペルスタ) | AIでキャラクターを着せ替え・イラスト生成`）。UI表示文言（heading/subtitle）は変更なし
- **内部リンク強化**: フッターに スタイル一覧・絵師カタログ・コレクション図鑑・着せ替えフリー素材・クリエイター募集 の導線を追加（15言語キー追加、サイロ化解消）
- **構造化データ拡充**: WebSite スキーマに `SearchAction`（サイト内検索）、投稿詳細に `ImageObject` を追加
- **Google Search Console 対応**: 環境変数 `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION` 設定時に検証メタタグを出力
- `catalog/submit/thanks`（フォーム送信後の確認ページ）を noindex 化

### 実機テスト

- [ ] iOS Safari で主要導線を確認
- [ ] Android Chrome で主要導線を確認
- [ ] PC（Chrome）で主要導線を確認
- [ ] レスポンシブ表示崩れがないことを確認
- [ ] `/style`・`/coordinate`（ロケール付きURL）でゲスト生成が引き続き動作することを確認
- [ ] フッター新リンク5件の遷移先を確認

### テスト方法

- `npm run lint` / `npm run typecheck`: 変更・新規ファイルはエラー0（既存の lint 23件・型 532件のエラーは main 由来で本PR対象外）
- `npm run test`: 262スイート / 2,527件すべてパス（proxy の guest-id Cookie テストと repository テストは仕様変更に合わせて更新）
- `npm run build -- --webpack`: 成功（`/sitemap.xml` が revalidate 1h の静的ルートとして生成されることを確認）
- ビルド版を `next start` で起動し、実HTMLで以下を検証:
  - `/sitemap.xml` が 1,194 URL（投稿803・スタイル144・カタログ1・静的242）
  - `/ja/catalog`・`/ja/search`・`/collections`・`/creators`・`/ja/style`・`/ja/coordinate` の canonical がすべて自己参照（修正前はトップページを指していた）
  - 旧404だった `/ja/style` が 200 を返す
  - `/style` → `/ja/style` の 307 リダイレクトで `persta_guest_id` Cookie が発行される（Secure/HttpOnly/SameSite=lax）
  - `/ja/styles`・`/ja/styles/[slug]` が 200、JSON-LD（ItemList / BreadcrumbList / ImageObject）が生HTMLに出力される
  - ホーム title が新文言で出力、`SearchAction` JSON-LD、フッター新リンク5件を確認

### デプロイ後の作業（マージ後）

- Google Search Console で `https://www.persta.ai/sitemap.xml` を再送信
- （HTMLタグ方式で所有権確認する場合）Vercel に `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION` を設定

🤖 Generated with [Claude Code](https://claude.com/claude-code)
