### PR TITLE
feat(auth): Xログイン(OAuth)ボタンを再有効化

### DIFF
--- a/features/auth/components/AuthForm.tsx
+++ b/features/auth/components/AuthForm.tsx
@@ -497,8 +497,7 @@ export function AuthForm({
             {t("continueWithGoogle")}
           </Button>
 
-          {/* X (Twitter) - 一時的に非表示 */}
-          {/*
+          {/* X (Twitter) */}
           <Button
             type="button"
             variant="outline"
@@ -511,7 +510,6 @@ export function AuthForm({
             </svg>
             {t("continueWithX")}
           </Button>
-          */}
 
           {/* GitHub */}
           {/*


### PR DESCRIPTION
### 概要

集客の主導線が X（@mickey_fuku の企画投稿）である一方、ログイン手段が Google とメールのみで、X からの流入ユーザーにとって摩擦が大きい状態でした。2026年2月に不具合（X 側の 400 エラー）のため非表示にしていた X ログインボタンを再有効化します。

X の開発者基盤が刷新（console.x.com への移行・従量課金化）された後に再検証したところ、認可フローが正常に動作することを確認できたため、ボタンの封印を解除します。バックエンド側の実装（`auth-client.ts` の X 分岐、`/auth/callback` の `p=x` 分岐、`/auth/x-complete`）は実装済みのものをそのまま利用し、コード変更はボタン表示のみです。

### 変更内容

- `features/auth/components/AuthForm.tsx`
  - コメントアウトされていた「X (Twitter)で続ける」ボタンを再有効化
  - 配置は「Googleで続ける」の直下（ログイン・新規登録の両画面に反映）
  - GitHub ボタンはコメントアウトのまま維持

### 実機テスト

- [ ] PC（Chrome）で X ログイン完走を確認（ローカルでは確認済み）
- [ ] iOS Safari で X ログイン完走を確認
- [ ] Android Chrome で X ログイン完走を確認
- [ ] X アプリ内ブラウザから X ログイン完走を確認（集客経路の本命）
- [ ] メール非公開の X アカウントでのエラー表示を確認
- [ ] レスポンシブ表示崩れがないことを確認

### テスト方法

- `npm run lint`（変更ファイルへの指摘 0。既存の 23 errors / 57 warnings は main と同一のベースライン）
- `npm run typecheck`（アプリコードのエラー 0。既存の tests/** の型エラーは main と同一）
- `npm run test`（262 suites / 2527 tests パス）
- `npm run build -- --webpack`（成功）
- Playwright でローカルの `/login` から X ボタンをクリックし、x.com の認可ページに正常到達することを確認（2月当時の 400 エラーが再現しないこと）
- ローカル環境（本番 Supabase・本番 X アプリと同一設定）で X ログインの完走を手動確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZvJpKb6xWibF4KdiryaJt
