### PR TITLE
feat(collections): 終了した企画の常設化基盤（期間未設定＝常設扱い＋🎪コラボ企画チップ）

### DIFF
--- a/features/collections/lib/collection-display-period.ts
+++ b/features/collections/lib/collection-display-period.ts
@@ -28,6 +28,20 @@ export function isCollectionDisplayPeriodActive(
   return true;
 }
 
+/**
+ * 開催期間(開始または終了のいずれか)が設定されているか。
+ * 期間が未設定のコレクションシリーズは「常設(コラボ企画)」として扱い、
+ * イベント(期間限定の企画)とはみなさない。
+ */
+export function hasCollectionDisplayPeriod(
+  period: CollectionDisplayPeriod,
+): boolean {
+  return (
+    period.collectionDisplayStartsAt !== null ||
+    period.collectionDisplayEndsAt !== null
+  );
+}
+
 /** isActiveEventCategory の入力: 表示期間 + コレクションシリーズ登録の有無。 */
 export interface ActiveEventCategoryInput extends CollectionDisplayPeriod {
   isCollectionSeries: boolean;
@@ -35,7 +49,11 @@ export interface ActiveEventCategoryInput extends CollectionDisplayPeriod {
 
 /**
  * 「開催中の企画」カテゴリか。
- * コレクションシリーズ(コンプリート要素)が登録されており、かつ表示期間内。
+ * コレクションシリーズ(コンプリート要素)が登録されており、開催期間が
+ * **設定されており**、かつ表示期間内であること。
+ * 期間未設定(NULL/NULL)のシリーズは常設のコラボ企画でありイベントではない
+ * (ホームの企画棚・🎉イベントチップに出さない。生成やコンプリート機能は
+ *  isCollectionDisplayPeriodActive の「NULL=制限なし」判定によりそのまま使える)。
  * ホームの企画棚(derive-event-shelves)と探索シートの「🎉イベント」チップ
  * (style-browse-filter)が同じ判定を共有し、両者の表示期間が常に一致するようにする。
  */
@@ -44,6 +62,8 @@ export function isActiveEventCategory(
   now: Date,
 ): boolean {
   return (
-    category.isCollectionSeries && isCollectionDisplayPeriodActive(category, now)
+    category.isCollectionSeries &&
+    hasCollectionDisplayPeriod(category) &&
+    isCollectionDisplayPeriodActive(category, now)
   );
 }

--- a/features/style-presets/components/StylesGalleryClient.tsx
+++ b/features/style-presets/components/StylesGalleryClient.tsx
@@ -25,6 +25,7 @@ const CHIP_EMOJI: Partial<Record<string, string>> = {
   new: "✨",
   popular: "👑",
   creator: "🤝",
+  collab: "🎪",
 };
 
 interface StylesGalleryClientProps {
@@ -164,6 +165,8 @@ export function StylesGalleryClient({
         return t("styleChipPopular");
       case "creator":
         return t("styleChipCreator");
+      case "collab":
+        return t("styleChipCollab");
       default:
         return chip.id;
     }

--- a/features/style/components/StyleBrowseSheet.tsx
+++ b/features/style/components/StyleBrowseSheet.tsx
@@ -39,6 +39,7 @@ const CHIP_EMOJI: Partial<Record<string, string>> = {
   new: "✨",
   popular: "👑",
   creator: "🤝",
+  collab: "🎪",
 };
 
 /** 拡大プレビューを「下スワイプで閉じる」と判定する移動量(px)。 */
@@ -242,6 +243,8 @@ export function StyleBrowseSheet({
         return t("styleChipPopular");
       case "creator":
         return t("styleChipCreator");
+      case "collab":
+        return t("styleChipCollab");
       default:
         return chip.id;
     }

--- a/features/style/lib/style-browse-filter.ts
+++ b/features/style/lib/style-browse-filter.ts
@@ -45,6 +45,7 @@ export type StyleBrowseChipId =
   | "new"
   | "popular"
   | "creator"
+  | "collab"
   | `category:${string}`;
 
 export interface StyleBrowseChip {
@@ -86,7 +87,7 @@ function hasCreator(preset: StylePresetPublicSummary): boolean {
 
 /**
  * presets から表示すべきチップ列を導出する(空になる軸のチップは出さない)。
- * 並び: すべて → お気に入り(ログイン時) → イベント(開催中のみ) → 新着 → 人気 → クリエイター → カテゴリ別。
+ * 並び: すべて → お気に入り(ログイン時) → イベント(開催中のみ) → 新着 → 人気 → クリエイター → コラボ企画 → カテゴリ別。
  */
 export function deriveStyleBrowseChips(
   presets: readonly StylePresetPublicSummary[],
@@ -107,6 +108,12 @@ export function deriveStyleBrowseChips(
   }
   if (presets.some(hasCreator)) {
     chips.push({ id: "creator" });
+  }
+  // コラボ企画: コレクションシリーズ(コンプリート要素のある企画)を
+  // 開催中かどうかに関わらずまとめる(常設化した企画の受け皿。
+  // 開催中の企画は「🎉イベント」とこのチップの両方に出る)。
+  if (presets.some((p) => p.category.isCollectionSeries)) {
+    chips.push({ id: "collab" });
   }
   // カテゴリチップ: 出現順で重複排除。カテゴリが1種類しか無ければ「すべて」と同義なので出さない。
   const seen = new Map<string, StyleBrowseChip>();
@@ -175,6 +182,8 @@ export function filterStyleBrowsePresets(
     }
     case "creator":
       return presets.filter(hasCreator);
+    case "collab":
+      return presets.filter((p) => p.category.isCollectionSeries);
     default: {
       const key = chipId.slice("category:".length);
       const keys = new Set([

--- a/messages/ar.ts
+++ b/messages/ar.ts
@@ -1376,6 +1376,7 @@ export const arMessages = {
     stylePopularSortNote: "بترتيب عدد مرات الاستخدام في آخر 30 يومًا",
     styleNewSortNote: "ستايلات أُضيفت خلال آخر {days} يومًا",
     styleChipCreator: "المبدعون",
+    styleChipCollab: "مشاريع تعاونية",
     styleFavoriteAdd: "أضف إلى المفضلة",
     styleFavoriteRemove: "إزالة من المفضلة",
     styleFavoriteLoginRequired: "سجّل الدخول لاستخدام المفضلة",

--- a/messages/de.ts
+++ b/messages/de.ts
@@ -1380,6 +1380,7 @@ export const deMessages = {
     stylePopularSortNote: "Sortiert nach Nutzungen der letzten 30 Tage",
     styleNewSortNote: "Stile, die in den letzten {days} Tagen hinzugefügt wurden",
     styleChipCreator: "Creator",
+    styleChipCollab: "Kollaborationen",
     styleFavoriteAdd: "Zu Favoriten hinzufügen",
     styleFavoriteRemove: "Aus Favoriten entfernen",
     styleFavoriteLoginRequired: "Zum Nutzen der Favoriten anmelden",

--- a/messages/en.ts
+++ b/messages/en.ts
@@ -1376,6 +1376,7 @@ export const enMessages = {
     stylePopularSortNote: "Sorted by uses in the last 30 days",
     styleNewSortNote: "Styles added in the last {days} days",
     styleChipCreator: "Creators",
+    styleChipCollab: "Collabs",
     styleFavoriteAdd: "Add to favorites",
     styleFavoriteRemove: "Remove from favorites",
     styleFavoriteLoginRequired: "Log in to use favorites",

--- a/messages/es.ts
+++ b/messages/es.ts
@@ -1379,6 +1379,7 @@ export const esMessages = {
     stylePopularSortNote: "Ordenado por usos en los últimos 30 días",
     styleNewSortNote: "Estilos añadidos en los últimos {days} días",
     styleChipCreator: "Creadores",
+    styleChipCollab: "Colaboraciones",
     styleFavoriteAdd: "Añadir a favoritos",
     styleFavoriteRemove: "Quitar de favoritos",
     styleFavoriteLoginRequired: "Inicia sesión para usar favoritos",

--- a/messages/fr.ts
+++ b/messages/fr.ts
@@ -1379,6 +1379,7 @@ export const frMessages = {
     stylePopularSortNote: "Trié par utilisations des 30 derniers jours",
     styleNewSortNote: "Styles ajoutés au cours des {days} derniers jours",
     styleChipCreator: "Créateurs",
+    styleChipCollab: "Collaborations",
     styleFavoriteAdd: "Ajouter aux favoris",
     styleFavoriteRemove: "Retirer des favoris",
     styleFavoriteLoginRequired: "Connectez-vous pour utiliser les favoris",

--- a/messages/hi.ts
+++ b/messages/hi.ts
@@ -1377,6 +1377,7 @@ export const hiMessages = {
     stylePopularSortNote: "पिछले 30 दिनों में उपयोग की संख्या के अनुसार क्रमबद्ध",
     styleNewSortNote: "पिछले {days} दिनों में जोड़ी गई स्टाइलें",
     styleChipCreator: "क्रिएटर",
+    styleChipCollab: "कोलैब प्रोजेक्ट",
     styleFavoriteAdd: "पसंदीदा में जोड़ें",
     styleFavoriteRemove: "पसंदीदा से हटाएं",
     styleFavoriteLoginRequired: "पसंदीदा उपयोग करने के लिए लॉगिन करें",

--- a/messages/id.ts
+++ b/messages/id.ts
@@ -1378,6 +1378,7 @@ export const idMessages = {
     stylePopularSortNote: "Diurutkan berdasarkan penggunaan 30 hari terakhir",
     styleNewSortNote: "Gaya yang ditambahkan dalam {days} hari terakhir",
     styleChipCreator: "Kreator",
+    styleChipCollab: "Kolaborasi",
     styleFavoriteAdd: "Tambahkan ke favorit",
     styleFavoriteRemove: "Hapus dari favorit",
     styleFavoriteLoginRequired: "Masuk untuk menggunakan favorit",

--- a/messages/it.ts
+++ b/messages/it.ts
@@ -1379,6 +1379,7 @@ export const itMessages = {
     stylePopularSortNote: "In ordine di utilizzi negli ultimi 30 giorni",
     styleNewSortNote: "Stili aggiunti negli ultimi {days} giorni",
     styleChipCreator: "Creator",
+    styleChipCollab: "Collaborazioni",
     styleFavoriteAdd: "Aggiungi ai preferiti",
     styleFavoriteRemove: "Rimuovi dai preferiti",
     styleFavoriteLoginRequired: "Accedi per usare i preferiti",

--- a/messages/ja.ts
+++ b/messages/ja.ts
@@ -1319,6 +1319,7 @@ export const jaMessages = {
     stylePopularSortNote: "直近30日の利用回数順",
     styleNewSortNote: "直近{days}日以内に追加されたスタイル",
     styleChipCreator: "クリエイター",
+    styleChipCollab: "コラボ企画",
     styleFavoriteAdd: "お気に入りに追加",
     styleFavoriteRemove: "お気に入りを解除",
     styleFavoriteLoginRequired: "お気に入りはログインすると使えます",

--- a/messages/ko.ts
+++ b/messages/ko.ts
@@ -1375,6 +1375,7 @@ export const koMessages = {
     stylePopularSortNote: "최근 30일 이용 횟수순",
     styleNewSortNote: "최근 {days}일 이내에 추가된 스타일",
     styleChipCreator: "크리에이터",
+    styleChipCollab: "콜라보 기획",
     styleFavoriteAdd: "즐겨찾기에 추가",
     styleFavoriteRemove: "즐겨찾기 해제",
     styleFavoriteLoginRequired: "즐겨찾기는 로그인 후 사용할 수 있어요",

--- a/messages/pt.ts
+++ b/messages/pt.ts
@@ -1379,6 +1379,7 @@ export const ptMessages = {
     stylePopularSortNote: "Ordenado por usos nos últimos 30 dias",
     styleNewSortNote: "Estilos adicionados nos últimos {days} dias",
     styleChipCreator: "Criadores",
+    styleChipCollab: "Colaborações",
     styleFavoriteAdd: "Adicionar aos favoritos",
     styleFavoriteRemove: "Remover dos favoritos",
     styleFavoriteLoginRequired: "Faça login para usar favoritos",

--- a/messages/th.ts
+++ b/messages/th.ts
@@ -1375,6 +1375,7 @@ export const thMessages = {
     stylePopularSortNote: "เรียงตามจำนวนการใช้งานใน 30 วันล่าสุด",
     styleNewSortNote: "สไตล์ที่เพิ่มเข้ามาใน {days} วันล่าสุด",
     styleChipCreator: "ครีเอเตอร์",
+    styleChipCollab: "โปรเจกต์คอลแลบ",
     styleFavoriteAdd: "เพิ่มในรายการโปรด",
     styleFavoriteRemove: "นำออกจากรายการโปรด",
     styleFavoriteLoginRequired: "เข้าสู่ระบบเพื่อใช้รายการโปรด",

--- a/messages/vi.ts
+++ b/messages/vi.ts
@@ -1376,6 +1376,7 @@ export const viMessages = {
     stylePopularSortNote: "Xếp theo số lần sử dụng trong 30 ngày gần đây",
     styleNewSortNote: "Phong cách được thêm trong {days} ngày gần đây",
     styleChipCreator: "Nhà sáng tạo",
+    styleChipCollab: "Dự án hợp tác",
     styleFavoriteAdd: "Thêm vào yêu thích",
     styleFavoriteRemove: "Bỏ khỏi yêu thích",
     styleFavoriteLoginRequired: "Đăng nhập để dùng mục yêu thích",

--- a/messages/zh-CN.ts
+++ b/messages/zh-CN.ts
@@ -1374,6 +1374,7 @@ export const zhCnMessages = {
     stylePopularSortNote: "按最近30天使用次数排序",
     styleNewSortNote: "最近{days}天内新增的风格",
     styleChipCreator: "创作者",
+    styleChipCollab: "联动企划",
     styleFavoriteAdd: "添加到收藏",
     styleFavoriteRemove: "取消收藏",
     styleFavoriteLoginRequired: "登录后即可使用收藏",

--- a/messages/zh-TW.ts
+++ b/messages/zh-TW.ts
@@ -1374,6 +1374,7 @@ export const zhTwMessages = {
     stylePopularSortNote: "依最近30天使用次數排序",
     styleNewSortNote: "最近{days}天內新增的風格",
     styleChipCreator: "創作者",
+    styleChipCollab: "聯動企劃",
     styleFavoriteAdd: "加入收藏",
     styleFavoriteRemove: "取消收藏",
     styleFavoriteLoginRequired: "登入後即可使用收藏",

--- a/tests/unit/features/collections/collection-display-period.test.ts
+++ b/tests/unit/features/collections/collection-display-period.test.ts
@@ -1,4 +1,8 @@
-import { isCollectionDisplayPeriodActive } from "@/features/collections/lib/collection-display-period";
+import {
+  hasCollectionDisplayPeriod,
+  isActiveEventCategory,
+  isCollectionDisplayPeriodActive,
+} from "@/features/collections/lib/collection-display-period";
 
 const NOW = new Date("2026-07-15T00:00:00Z");
 
@@ -76,5 +80,85 @@ describe("isCollectionDisplayPeriodActive", () => {
         NOW,
       ),
     ).toBe(true);
+  });
+});
+
+describe("hasCollectionDisplayPeriod", () => {
+  test("両方NULLは期間未設定(=常設)", () => {
+    expect(
+      hasCollectionDisplayPeriod({
+        collectionDisplayStartsAt: null,
+        collectionDisplayEndsAt: null,
+      }),
+    ).toBe(false);
+  });
+
+  test("開始か終了のどちらかが設定されていれば期間あり", () => {
+    expect(
+      hasCollectionDisplayPeriod({
+        collectionDisplayStartsAt: "2026-07-01T00:00:00Z",
+        collectionDisplayEndsAt: null,
+      }),
+    ).toBe(true);
+    expect(
+      hasCollectionDisplayPeriod({
+        collectionDisplayStartsAt: null,
+        collectionDisplayEndsAt: "2026-07-31T00:00:00Z",
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("isActiveEventCategory", () => {
+  test("期間設定あり+期間内のコレクションシリーズはイベント", () => {
+    expect(
+      isActiveEventCategory(
+        {
+          isCollectionSeries: true,
+          collectionDisplayStartsAt: "2026-07-01T00:00:00Z",
+          collectionDisplayEndsAt: "2026-07-31T00:00:00Z",
+        },
+        NOW,
+      ),
+    ).toBe(true);
+  });
+
+  test("期間未設定(NULL/NULL)のコレクションシリーズは常設扱いでイベントではない", () => {
+    expect(
+      isActiveEventCategory(
+        {
+          isCollectionSeries: true,
+          collectionDisplayStartsAt: null,
+          collectionDisplayEndsAt: null,
+        },
+        NOW,
+      ),
+    ).toBe(false);
+  });
+
+  test("期間終了済みのコレクションシリーズはイベントではない", () => {
+    expect(
+      isActiveEventCategory(
+        {
+          isCollectionSeries: true,
+          collectionDisplayStartsAt: null,
+          collectionDisplayEndsAt: "2026-07-10T00:00:00Z",
+        },
+        NOW,
+      ),
+    ).toBe(false);
+  });
+
+  test("コレクションシリーズでないカテゴリは期間があってもイベントではない", () => {
+    expect(
+      isActiveEventCategory(
+        {
+          isCollectionSeries: false,
+          collectionDisplayStartsAt: "2026-07-01T00:00:00Z",
+          collectionDisplayEndsAt: "2026-07-31T00:00:00Z",
+        },
+        NOW,
+      ),
+    ).toBe(false);
   });
 });

--- a/tests/unit/features/style/style-browse-filter.test.ts
+++ b/tests/unit/features/style/style-browse-filter.test.ts
@@ -154,6 +154,52 @@ describe("deriveStyleBrowseChips", () => {
     expect(chips.some((c) => c.id === "event")).toBe(false);
   });
 
+  test("コラボ企画チップ: 期間未設定の常設シリーズはイベントに出ずコラボ企画に出る", () => {
+    const presets = [
+      preset("normal"),
+      preset("perm", {
+        categoryKey: "wafer_god",
+        isCollectionSeries: true,
+        collectionDisplayStartsAt: null,
+        collectionDisplayEndsAt: null,
+      }),
+    ];
+    const chips = deriveStyleBrowseChips(presets, context());
+    expect(chips.some((c) => c.id === "event")).toBe(false);
+    expect(chips.some((c) => c.id === "collab")).toBe(true);
+    expect(
+      filterStyleBrowsePresets(presets, "collab", context()).map((p) => p.id),
+    ).toEqual(["perm"]);
+  });
+
+  test("コラボ企画チップ: 開催中のシリーズはイベントとコラボ企画の両方に出る", () => {
+    const presets = [
+      preset("normal"),
+      preset("ev", {
+        categoryKey: "kotowaza_dictionary_2",
+        isCollectionSeries: true,
+        collectionDisplayEndsAt: new Date(NOW.getTime() + DAY_MS).toISOString(),
+      }),
+    ];
+    const chips = deriveStyleBrowseChips(presets, context());
+    expect(chips.some((c) => c.id === "event")).toBe(true);
+    expect(chips.some((c) => c.id === "collab")).toBe(true);
+  });
+
+  test("コラボ企画チップ: 終了済みシリーズもコラボ企画には出る(常設化の受け皿)", () => {
+    const presets = [
+      preset("normal"),
+      preset("ended", {
+        categoryKey: "old_event",
+        isCollectionSeries: true,
+        collectionDisplayEndsAt: new Date(NOW.getTime() - DAY_MS).toISOString(),
+      }),
+    ];
+    const chips = deriveStyleBrowseChips(presets, context());
+    expect(chips.some((c) => c.id === "event")).toBe(false);
+    expect(chips.some((c) => c.id === "collab")).toBe(true);
+  });
+
   test("イベントチップ: コレクションシリーズ未登録(通常カテゴリ)だけなら出さない", () => {
     const chips = deriveStyleBrowseChips(
       [preset("a"), preset("b", { categoryKey: "taste" })],
@@ -197,17 +243,18 @@ describe("deriveStyleBrowseChips", () => {
     ]);
   });
 
-  test("企画(コレクションシリーズ)は開催中/期間外を問わずカテゴリチップを出さない(イベントに集約)", () => {
+  test("企画(コレクションシリーズ)は開催中/期間外を問わずカテゴリチップを出さない(イベント/コラボ企画に集約)", () => {
     const presets = [
       preset("co", { categoryKey: "coordinate" }),
       preset("taste", { categoryKey: "character_coordinate" }),
-      // 開催中の企画: イベントチップには出るが、個別カテゴリチップは出ない。
+      // 開催中の企画: イベント+コラボ企画チップには出るが、個別カテゴリチップは出ない。
       preset("active-ev", {
         categoryKey: "kotowaza_dictionary_2",
         isCollectionSeries: true,
         collectionDisplayEndsAt: new Date(NOW.getTime() + DAY_MS).toISOString(),
       }),
-      // 期間外の企画(管理者プレビュー等で一覧に混ざるケース): どちらのチップも出ない。
+      // 期間外の企画(管理者プレビュー等で一覧に混ざるケース):
+      // イベント・個別カテゴリには出ないが、コラボ企画には集約される。
       preset("ended-ev", {
         categoryKey: "travel_to_italy",
         isCollectionSeries: true,
@@ -219,6 +266,7 @@ describe("deriveStyleBrowseChips", () => {
       "all",
       "favorites",
       "event",
+      "collab",
       "category:character_coordinate",
       "category:coordinate",
     ]);


### PR DESCRIPTION
### 概要

終了した企画（イタリア旅行・神コレクション等）を**常設化し、いつでも生成できるようにする**ための基盤変更。

これまでは開催期間が終了するとプリセットが非公開になり、生成できないだけでなく、/styles の紹介ページも404化してsitemapから消える「使い捨てコンテンツ」になっていた。本PRにより、**adminで開催期間を空にするだけで企画を常設コンテンツ化**でき、コレクション体験（段階解放・コンプリート・台紙作成）も新規/途中のユーザーがそのまま楽しめる。限定性は「期間を再設定すれば復刻イベントに戻る」運用で担保する。

### 変更内容

- **イベント判定の変更**: `isActiveEventCategory` を「コレクションシリーズ かつ **開催期間が設定されている** かつ 期間内」に変更（`hasCollectionDisplayPeriod` を新設）
  - 期間未設定（NULL/NULL）のシリーズは**常設扱い**となり、ホームの企画棚・🎉イベントチップには表示されない
  - 生成可否・段階解放・コンプリート・台紙生成APIは既存の「NULL＝制限なし」判定のため、常設化後も全機能が動作する（完走のお祝いはAppShell常駐のチェッカーが担うため、ホーム棚が無くても発火する）
- **「🎪 コラボ企画」チップ新設**（/styles ギャラリー・探索シート共通）
  - 対象: コレクションシリーズのカテゴリ全部（自社企画含む）
  - 開催中の企画は「🎉 イベント」と「🎪 コラボ企画」の両方に表示され、常設化後は🎪のみに残る
  - チップ文言を15言語追加（`styleChipCollab`）
- admin側は変更不要（カテゴリ編集フォームは日時入力を空にすると null 保存される実装を確認済み）

### 常設化の運用手順（マージ後）

1. admin「プリセットカテゴリ編集」で対象カテゴリを開く
2. 開催期間の開始・終了を両方空にして保存
3. キャッシュ更新後、/style・/styles（🎪チップ）・sitemap・紹介ページに復活する

※クリエイター提供企画は常設化前に掲載条件の合意確認を推奨。

### 実機テスト

- [ ] PC（Chrome）で /styles に「🎪 コラボ企画」チップが表示され、絞り込みできることを確認
- [ ] iOS Safari / Android Chrome で同上
- [ ] 開催中の企画がホームの企画棚・🎉イベントチップに引き続き表示されることを確認（既存挙動の非破壊）
- [ ] （マージ後の運用確認）期間を空にしたカテゴリが企画棚から消え、🎪チップ・/style 一覧に出ることを確認
- [ ] （同上）常設化した企画で生成→段階解放→コンプリート→台紙作成まで一通り動くことを確認

### テスト方法

- 新規テスト12件:
  - `collection-display-period`: `hasCollectionDisplayPeriod`（NULL/NULL→false、片方設定→true）／`isActiveEventCategory`（期間内シリーズ→true、**期間未設定シリーズ→false（常設扱い）**、終了済み→false、非シリーズ→false）
  - `style-browse-filter`: 常設シリーズは🎉に出ず🎪に出る／開催中は両方に出る／終了済みも🎪に出る（常設化の受け皿）／チップ集約仕様の既存テストを新仕様に更新
- `npm run lint` / `npm run typecheck`: 変更・新規ファイルはエラー0
- `npm run test`: 全2,565件パス
- `npm run build -- --webpack`: 成功
- ビルド版の実ブラウザ確認: /ja/styles に「🎪 コラボ企画」チップが表示され、タップで開催中シリーズ12件に絞り込まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
