### PR TITLE
feat(admin): AI原価(OpenAI/Gemini)ダッシュボードを追加

### DIFF
--- a/app/(app)/admin/page.tsx
+++ b/app/(app)/admin/page.tsx
@@ -8,6 +8,7 @@ import { AdminPageAnalyticsSectionServer } from "@/features/admin-dashboard/comp
 import { parseAdminDashboardTab } from "@/features/admin-dashboard/lib/dashboard-tab";
 import { listPresetCategories } from "@/features/style-presets/lib/preset-category-repository";
 import { getAdminDashboardData } from "@/features/admin-dashboard/lib/get-admin-dashboard-data";
+import { getAiCostActuals } from "@/features/admin-dashboard/lib/get-ai-cost-actuals";
 import {
   formatAdminDateTimeLabel,
   getCustomDashboardRangeBounds,
@@ -115,6 +116,7 @@ export default async function AdminDashboardPage({
           modelMix={data.modelMix}
           loginMethodMix={data.loginMethodMix}
           aiCostEstimate={data.aiCostEstimate}
+          aiCostActualsPromise={getAiCostActuals(range)}
         />
       )}
     </AdminDashboardView>

--- a/app/(app)/admin/page.tsx
+++ b/app/(app)/admin/page.tsx
@@ -114,6 +114,7 @@ export default async function AdminDashboardPage({
           funnel={data.funnel}
           modelMix={data.modelMix}
           loginMethodMix={data.loginMethodMix}
+          aiCostEstimate={data.aiCostEstimate}
         />
       )}
     </AdminDashboardView>

--- a/docs/planning/ai-cost-dashboard-implementation-plan.md
+++ b/docs/planning/ai-cost-dashboard-implementation-plan.md
@@ -1,0 +1,237 @@
+# AI 原価ダッシュボード実装計画（AI Cost Dashboard）
+
+作成日: 2026-07-26
+ステータス: 承認待ち → 実装中
+関連: PR #451（ログイン方法別構成チャート）と同じ分析セクションに追加する
+
+## 背景・ゴール
+
+AI 画像生成の外部 API（OpenAI gpt-image-2 / Google Gemini 系）の費用を、platform.openai.com/usage や aistudio.google.com/spend を都度開かずに /admin ダッシュボードで確認できるようにする。
+
+- 見たいもの: 期間内の総額・日別の棒グラフ・プロバイダ別/モデル別内訳（**粗利・収益対比は初版スコープ外**）
+- 表示通貨: **円メイン**（USD 単価を固定レートで換算、注記を表示）
+- CSV エクスポート: 初版不要
+- 3段構成: Phase 1 = 自前推定（単価×生成数）/ Phase 2 = OpenAI 実額（Costs API）/ Phase 3 = Google 実額（BigQuery 課金エクスポート）
+
+## コードベース調査結果
+
+| 確認項目 | 結果 | 流用先 |
+|---|---|---|
+| 生成記録 | `generated_images.model` にモデル名が記録済み（直近30日: gpt-image-2-low-1k 1,041 / gemini-3.1-flash-image-preview-1024 6 / gemini-3-pro-image-1k 1 / null 37）。`getAdminDashboardData` が既に期間分の `model` + `created_at` を取得している | Phase 1 は**新規クエリ不要** |
+| 日次バケット | `enumerateJstDateKeys` / `formatJstDateLabel`（`features/admin-dashboard/lib/dashboard-range.ts:178`）で JST 日次キー生成。`buildTrend` が使用例 | 日別集計 |
+| 積み上げ棒 | `ScrollingStackedBarChart`（共通コンポーネント、`StackedBarSeries` で色・キー指定）。使用例 `AdminEntryAccessStackedCard.tsx:104` | 日別コストバー |
+| カード配置 | `AdminTrendAndFunnelSection`（`AdminPageAnalyticsSection.tsx`）の `xl:grid-cols-12` グリッド。「モデル別構成」「ログイン方法別構成」カードと同型 | 配置・Card スタイル |
+| 遅延ロード | `AdminModelMixChartPanel` の dynamic import (ssr:false) パターン | チャート Panel |
+| 外部データの分離ロード | GA4 は `ga4Promise` + Suspense + status("ready"/"error") + `AnalyticsUnavailableCard` で優雅に劣化 | Phase 2/3 実額の取得 |
+| BigQuery 基盤 | `@google-cloud/bigquery` 導入済み。`ga4-bigquery-client.ts`（サービスアカウント= `GA4_SERVICE_ACCOUNT_JSON_BASE64`、`GA4_BIGQUERY_PROJECT_ID/DATASET/LOCATION`） | Phase 3 の課金クエリ |
+| env 追加 | `lib/env.ts` の env オブジェクトにキーを足す方式 | Phase 2/3 の設定 |
+| 認証 | /admin ページ自体が管理者認証で保護済み。新規 API Route・RPC は作らない（すべてサーバーコンポーネント内で取得） | — |
+| DB 変更 | **なし**（単価・レートはコード定数、実額は非永続・都度フェッチ） | — |
+
+Supabase 接続: 確認済み（本セッションで `supabase db query --linked` 実行実績あり）。ただし本機能に DB 変更はない。
+
+## 概要図
+
+### アーキテクチャ
+
+```mermaid
+flowchart TD
+    A["/admin ページ(サーバー)"] --> B["getAdminDashboardData"]
+    B --> C["generated_images から model と created_at を取得(既存クエリ)"]
+    C --> D["buildAiCostEstimate: 単価表 x 生成数 で日別・モデル別に集計"]
+    A --> E["getAiCostActuals Promise(Phase2/3)"]
+    E --> F["OpenAI Costs API 日次実額"]
+    E --> G["BigQuery 課金エクスポート Gemini 実額"]
+    D --> H["AdminAiCostCard"]
+    E -. Suspense .-> H
+    H --> I["KPI 期間内総額(円)"]
+    H --> J["日別積み上げバー OpenAI と Google"]
+    H --> K["モデル別内訳リスト"]
+```
+
+### 表示までのシーケンス（Phase 2/3 込み）
+
+```mermaid
+sequenceDiagram
+    participant P as AdminPage
+    participant D as getAdminDashboardData
+    participant DB as Supabase
+    participant AC as getAiCostActuals
+    participant OA as OpenAICostsAPI
+    participant BQ as BigQuery
+    P->>D: range
+    D->>DB: generated_images select model created_at
+    DB-->>D: rows
+    D-->>P: aiCostEstimate 含む dashboardData
+    P->>AC: actualsPromise 開始(待たない)
+    P-->>P: カード即描画(推定)
+    AC->>OA: GET organization costs
+    AC->>BQ: SELECT billing export
+    OA-->>AC: 日次USD
+    BQ-->>AC: 日次JPY
+    AC-->>P: Suspense 解決で実額行を追記表示
+```
+
+## EARS 要件定義
+
+| # | タイプ | 要件 |
+|---|---|---|
+| E1 | イベント駆動 | When 管理者が /admin の分析セクションを開いた時, the system shall 選択中の期間タブ(24h/7d/30d/90d)に対応する推定 AI コスト（円換算）を表示する。<br>管理者が分析セクションを開いたとき、期間タブに連動した推定AIコストを円で表示すること |
+| E2 | イベント駆動 | When 期間タブが変更された時, the system shall 総額・日別バー・内訳を再計算して表示する |
+| S1 | 状態駆動 | While 表示中, the system shall 日別積み上げバーを JST 日付キーで OpenAI / Google の2系列で描画する |
+| S2 | 状態駆動 | While 表示中, the system shall 適用した換算レート（例 $1=¥155 固定）を注記として表示する |
+| O1 | オプション | Where OPENAI_ADMIN_API_KEY が設定されている, the system shall OpenAI の期間内実額（全 API 用途込み）を KPI 行に併記する |
+| O2 | オプション | Where 課金エクスポートの BigQuery 設定が揃っている, the system shall Google の期間内実額を KPI 行に併記する |
+| F1 | 異常系 | If model が null または単価表に存在しない, then the system shall 該当件数を「単価未設定」として内訳末尾に件数のみ表示し、金額合計には含めない |
+| F2 | 異常系 | If 実額 API / BigQuery がエラーまたはタイムアウトした, then the system shall 推定表示を維持したまま実額行に「取得できませんでした」を表示する（ダッシュボード全体を壊さない） |
+| F3 | 異常系 | If 実額連携が未設定（env 無し）, then the system shall 実額行自体を表示しない（エラー扱いにしない） |
+| A1 | 権限 | While 非管理者がアクセスした場合, the system shall 既存の /admin ページ認証によりページごと拒否する（本機能専用の API Route は新設しない） |
+
+## ADR（設計判断記録）
+
+### ADR-001: 単価・換算レートはコード内定数で管理
+
+- **Context**: モデル別単価（USD）と USD→JPY レートの保持方法。
+- **Decision**: `features/admin-dashboard/lib/ai-cost-rates.ts` に定数として定義。DB テーブル・管理画面編集は作らない。
+- **Reason**: 改定頻度は年数回・編集者は運営1名。git 履歴とレビューが効き、DB/RLS/編集UIの実装コスト(+40%)を回避（ユーザー承認済み）。
+- **Consequence**: 単価改定はデプロイが必要。単価に「適用開始日」を持たせ、期間をまたぐ再計算のズレを防ぐ（初版は現行単価1本でも、構造だけ `effectiveFrom` を持てる形にする）。
+
+### ADR-002: 日別バーは常に「推定」ベースで統一、実額は KPI 行に期間合計のみ併記
+
+- **Context**: Phase 2/3 で日次実額も取得可能になるが、実額は反映遅延（OpenAI 最大~24h、BigQuery 数時間〜1日）があり、日によって「推定/実額」が混在する。
+- **Decision**: バーは全期間一貫して推定値。実額は KPI 行の期間合計併記のみ（「推定 ¥X / 実額 ¥Y」）。
+- **Reason**: 1つの系列にソースの異なる値を混ぜると急増検知の基準が日によって変わり誤読を招く。1軸1定義の原則。
+- **Consequence**: 推定と実額の日次レベルの突合はできない（期間合計での妥当性確認に留まる）。必要になったら「実額バーへの表示切替」を将来追加。
+
+### ADR-003: 円換算は固定レート定数
+
+- **Context**: 単価は USD 建て、表示は円メイン（ユーザー指定）。
+- **Decision**: `USD_JPY_RATE` 定数（例 155）で換算し、カードに「$1=¥155 固定換算」を注記。
+- **Reason**: 原価把握の用途では為替の日次変動は誤差。為替 API 依存を増やさない。
+- **Consequence**: 実勢レートと数%ズレる。Google 実額（Phase 3、請求通貨が円の場合）はそのまま円で扱い、OpenAI 実額（USD）のみ換算する。
+
+### ADR-004: 実額は DB に永続化しない（都度フェッチ + Suspense 分離）
+
+- **Context**: OpenAI Costs API / BigQuery の結果の扱い。
+- **Decision**: GA4 と同じ「サーバー側フェッチ + Promise/Suspense + status で劣化」パターン。メインのダッシュボードデータをブロックしない。
+- **Reason**: 既存パターンとの一貫性。履歴は各プラットフォーム側に常に存在し、二重管理を避ける。
+- **Consequence**: 表示のたびに外部 API を叩く（GA4 と同等の特性。問題が出たら "use cache" + cacheLife で緩和）。
+
+## 実装計画
+
+### フェーズ間の依存関係
+
+```mermaid
+flowchart LR
+    P1["Phase 1: 推定コスト基盤とUI"] --> P2["Phase 2: OpenAI 実額"]
+    P1 --> P3["Phase 3: Google 実額"]
+    P2 --> P4["Phase 4: 仕上げと実機確認"]
+    P3 --> P4
+```
+
+Phase 2 と 3 は独立（並行可）。それぞれ env 未設定なら非表示のため、どの時点でもデプロイ可能。
+
+### Phase 1: 推定コスト基盤と UI（外部依存なし・即日）
+
+目的: 推定コストの KPI・日別積み上げバー・モデル別内訳をダッシュボードに表示する。
+ビルド確認: `npm run test` / `npm run build -- --webpack` 緑。env 追加なしで全環境動作。
+
+- [ ] `ai-cost-rates.ts` 新規: `MODEL_UNIT_COSTS_USD`（モデル名→1生成あたり USD。**実装時に OpenAI / Google の公式料金ページから転記し、出典 URL をコメントに残す**）+ `USD_JPY_RATE` + プロバイダ判定（`gpt-*`→openai / `gemini-*`→google）
+- [ ] `build-ai-cost.ts` 新規: `buildAiCostEstimate(generations, currentStart, now)` — 既存 `GeneratedImageRow`（model, created_at）から日別（`enumerateJstDateKeys` 使用）× プロバイダ別の推定額、モデル別内訳、単価未設定件数を算出（純関数・export）
+- [ ] `dashboard-types.ts` 修正: `DashboardAiCostEstimate` 型（total円 / days[] / byModel[] / unknownCount / rateNote）
+- [ ] `get-admin-dashboard-data.ts` 修正: `aiCostEstimate: buildAiCostEstimate(...)` を返却に追加（既存の generatedImages 取得を流用、**新規クエリなし**）
+- [ ] `AdminAiCostCard.tsx` 新規: KPI 行（期間内合計 ¥）+ `ScrollingStackedBarChart`（OpenAI / Google 2系列、エンティティ固定色・CVD検証済みパレットから割当）+ モデル別内訳リスト + レート注記。dynamic Panel（`AdminModelMixChartPanel` パターン）
+- [ ] `AdminPageAnalyticsSection(Server).tsx` / `app/(app)/admin/page.tsx` 修正: 分析セクションのグリッドにカード追加・props 配線
+- [ ] `tests/unit/features/admin-dashboard/build-ai-cost.test.ts` 新規: 日別バケット境界（JST）/ モデル→プロバイダ判定 / 単価未設定（null・未知モデル）の除外と件数 / 円換算丸め
+
+### Phase 2: OpenAI 実額（Costs API）
+
+目的: OPENAI_ADMIN_API_KEY が設定されていれば、期間内の OpenAI 実額（USD→円換算）を KPI 行に併記する。
+ビルド確認: env 未設定環境でもビルド・表示が壊れない（実額行が出ないだけ）。
+事前作業（ユーザー）: platform.openai.com → Organization → Admin Keys でキー発行 → Vercel/.env.local に `OPENAI_ADMIN_API_KEY` 登録。
+
+- [ ] `lib/env.ts` 修正: `OPENAI_ADMIN_API_KEY` 追加（サーバー専用）
+- [ ] `openai-costs-client.ts` 新規: `GET https://api.openai.com/v1/organization/costs?start_time=...&bucket_width=1d` を叩き期間内合計 USD を返す（`server-only`、タイムアウト・非200は status:"error" で返す。GA4 の status パターン踏襲）
+- [ ] `get-ai-cost-actuals.ts` 新規: 実額取得の Promise を返す（Phase 3 と合流する集約点）。`AdminPageAnalyticsSectionServer` に `aiCostActualsPromise` を追加し、カード内の Suspense 子コンポーネントで実額行を遅延表示
+- [ ] テスト: レスポンスパース・エラー時 status の単体テスト（fetch はモック）
+
+### Phase 3: Google 実額（BigQuery 課金エクスポート）
+
+目的: 課金エクスポート設定が揃っていれば、期間内の Google（Generative Language API）実額を KPI 行に併記する。
+ビルド確認: env 未設定環境でもビルド・表示が壊れない。
+事前作業（ユーザー・一回のみ）:
+1. GCP Cloud Billing → 課金エクスポート → **標準使用料金の BigQuery エクスポート**を有効化（Gemini プロジェクト `gen-lang-client-0265955886` を支払う請求先アカウントで。データセットは GA4 と同じプロジェクト推奨）
+2. 既存サービスアカウント（GA4 用）に該当データセットの「BigQuery データ閲覧者」を付与
+3. `BILLING_BIGQUERY_DATASET`（+ 必要ならテーブル名）を env に登録
+※ エクスポートは**有効化以降のデータのみ**。早期有効化を推奨（本計画承認後すぐやってよい）。
+
+- [ ] `lib/env.ts` 修正: `BILLING_BIGQUERY_DATASET` 追加
+- [ ] `billing-bigquery-query.ts` 新規: `ga4-bigquery-client` を流用し、`service.description = "Generative Language API"`（実装時に実データの表記を確認して合わせる）の日次 cost 合計を期間で SELECT
+- [ ] `get-ai-cost-actuals.ts` 修正: Google 実額を合流（OpenAI と独立に成功/失敗できる Promise.allSettled）
+- [ ] テスト: クエリビルダー（SQL 文字列とパラメータ）・請求通貨の扱いの単体テスト
+
+### Phase 4: 仕上げ・実機確認
+
+目的: 劣化系の確認と本番検証。
+ビルド確認: 検証4点セット（lint / typecheck / test / build --webpack）緑。
+
+- [ ] env 未設定・API エラー時の表示確認（実額行なし / 「取得できませんでした」）
+- [ ] 実機: /admin で期間タブ切替・モバイル幅・推定と実額の乖離確認（数%以内が期待値）
+- [ ] `docs/API.md` 等への追記は不要（新規公開 API なし）。env 一覧ドキュメントがあれば追記
+
+## 修正対象ファイル一覧
+
+| ファイル | 操作 | 変更内容 | フェーズ |
+|----------|------|----------|---------|
+| features/admin-dashboard/lib/ai-cost-rates.ts | 新規 | モデル別単価・換算レート定数（出典コメント付き） | 1 |
+| features/admin-dashboard/lib/build-ai-cost.ts | 新規 | 推定コスト集計の純関数 | 1 |
+| features/admin-dashboard/lib/dashboard-types.ts | 修正 | DashboardAiCostEstimate 型追加 | 1 |
+| features/admin-dashboard/lib/get-admin-dashboard-data.ts | 修正 | aiCostEstimate を算出・返却 | 1 |
+| features/admin-dashboard/components/AdminAiCostCard.tsx | 新規 | KPI+積み上げバー+内訳カード | 1 |
+| features/admin-dashboard/components/AdminAiCostCardPanel.tsx | 新規 | dynamic import ラッパー | 1 |
+| features/admin-dashboard/components/AdminPageAnalyticsSection.tsx | 修正 | カード配置・props | 1 |
+| features/admin-dashboard/components/AdminPageAnalyticsSectionServer.tsx | 修正 | props 配線（+Phase2 で actualsPromise） | 1,2 |
+| app/(app)/admin/page.tsx | 修正 | props 配線 | 1,2 |
+| tests/unit/features/admin-dashboard/build-ai-cost.test.ts | 新規 | 集計関数の単体テスト | 1 |
+| lib/env.ts | 修正 | OPENAI_ADMIN_API_KEY / BILLING_BIGQUERY_DATASET | 2,3 |
+| features/admin-dashboard/lib/openai-costs-client.ts | 新規 | Costs API クライアント | 2 |
+| features/admin-dashboard/lib/get-ai-cost-actuals.ts | 新規 | 実額取得の集約（allSettled） | 2,3 |
+| features/admin-dashboard/lib/billing-bigquery-query.ts | 新規 | 課金エクスポートのクエリ | 3 |
+| tests/unit/features/admin-dashboard/（実額系） | 新規 | パース・クエリビルダーのテスト | 2,3 |
+
+## 品質・テスト観点
+
+- [ ] エラーハンドリング: 実額系の失敗がダッシュボード全体を壊さない（F2/F3、GA4 の AnalyticsUnavailableCard と同等の劣化）
+- [ ] 権限制御: /admin ページ認証内で完結。新規 API Route なし・クライアントへ Admin キーを渡さない（`server-only`）
+- [ ] データ整合性: 単価未設定モデルの除外を金額と件数で明示（silent drop しない）
+- [ ] セキュリティ: `OPENAI_ADMIN_API_KEY` はサーバー専用 env。ログ・エラーメッセージにキーを含めない
+- [ ] i18n: admin は日本語固定（既存カード同様）のため翻訳キー追加なし
+
+| カテゴリ | テスト内容 |
+|----------|-----------|
+| 正常系 | 期間タブごとの総額・日別バケット・内訳が正しい（JST 境界含む） |
+| 異常系 | model null / 未知モデル / 実額 API 失敗 / env 未設定 |
+| 権限 | 非管理者は /admin 自体に到達不可（既存テストでカバー済みの認証に依存） |
+| 実機 | 期間切替・モバイル幅・実額との乖離確認 |
+
+テスト実装は `/test-flow` に沿って `build-ai-cost` を Target に実施する。
+
+## ロールバック方針
+
+- DB 変更ゼロのため、**revert のみで完全に戻る**（フェーズ単位でコミット）
+- Phase 2/3 は env 未設定なら不活性 → 問題時は env を消すだけでも実額行を止められる（コード revert 不要の緊急停止手段）
+- 外部への書き込みは一切なし（read-only 連携）
+
+## 使用スキル
+
+| スキル | 用途 | フェーズ |
+|--------|------|----------|
+| `/dataviz` | 積み上げバーの配色・マーク仕様（読込済み・CVD 検証は validate_palette.js） | 1 |
+| `/test-flow` 系 | build-ai-cost のテスト整備 | 1 |
+| `/git-create-pr` | フェーズごとの PR 作成 | 各 |
+
+## 未確定事項（実装時に確定）
+
+1. **モデル単価の正確な値**: 実装時に OpenAI 料金ページ（gpt-image-2 系）と Google AI 料金ページ（gemini-3.x image 系）から転記し、定数に出典 URL と取得日をコメントで残す。旧 `null` モデル 37 件は「単価未設定」扱い。
+2. **BigQuery 課金エクスポートの `service.description` 実値**: エクスポート有効化後に実データで確認（"Generative Language API" 想定）。
+3. **Google 請求通貨**: 円請求ならそのまま、USD なら OpenAI と同じ固定レート換算。

--- a/features/admin-dashboard/components/AdminAiCostActualRow.tsx
+++ b/features/admin-dashboard/components/AdminAiCostActualRow.tsx
@@ -1,0 +1,67 @@
+import { AlertTriangle } from "lucide-react";
+import type { AiCostActuals } from "../lib/ai-cost-actual-types";
+import { PROVIDER_CHART_COLORS } from "../lib/ai-cost-rates";
+
+function formatJpy(value: number): string {
+  return `¥${Math.round(value).toLocaleString("ja-JP")}`;
+}
+
+interface AdminAiCostActualRowProps {
+  actuals: AiCostActuals;
+}
+
+/**
+ * 実額（各プラットフォームの請求額）の併記行。
+ * 未設定のプロバイダは行ごと出さず、失敗時のみ注意表示にする（ADR-002）。
+ */
+export function AdminAiCostActualRow({ actuals }: AdminAiCostActualRowProps) {
+  if (!actuals.hasAnyConfigured) {
+    return null;
+  }
+
+  const visibleEntries = actuals.entries.filter(
+    (entry) => entry.status !== "not_configured"
+  );
+
+  if (visibleEntries.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2 rounded-xl border border-slate-200/80 bg-white p-4">
+      <p className="text-xs font-medium text-slate-500">
+        実額（各プラットフォームの請求額・画像以外の API 利用も含む）
+      </p>
+      <div className="flex flex-wrap gap-x-6 gap-y-2">
+        {visibleEntries.map((entry) => (
+          <div key={entry.provider} className="flex items-center gap-2">
+            <span
+              className="h-3 w-3 shrink-0 rounded-full"
+              style={{
+                backgroundColor: PROVIDER_CHART_COLORS[entry.provider],
+              }}
+            />
+            <span className="text-sm text-slate-600">
+              {entry.providerLabel}:
+            </span>
+            {entry.status === "ready" && entry.totalJpy !== null ? (
+              <span className="text-sm font-semibold text-slate-900">
+                {formatJpy(entry.totalJpy)}
+                {entry.totalOriginal !== null ? (
+                  <span className="ml-1 font-normal text-slate-500">
+                    (${entry.totalOriginal.toFixed(2)})
+                  </span>
+                ) : null}
+              </span>
+            ) : (
+              <span className="flex items-center gap-1 text-sm text-amber-700">
+                <AlertTriangle className="h-3.5 w-3.5" aria-hidden />
+                {entry.message ?? "取得できませんでした"}
+              </span>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/features/admin-dashboard/components/AdminAiCostCard.tsx
+++ b/features/admin-dashboard/components/AdminAiCostCard.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { Coins } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type {
+  DashboardAiCostDayPoint,
+  DashboardAiCostEstimate,
+} from "../lib/dashboard-types";
+import { PROVIDER_CHART_COLORS } from "../lib/ai-cost-rates";
+import {
+  ScrollingStackedBarChart,
+  type StackedBarSeries,
+} from "./ScrollingStackedBarChart";
+
+function formatJpy(value: number): string {
+  return `¥${Math.round(value).toLocaleString("ja-JP")}`;
+}
+
+function formatUsd(value: number): string {
+  return `$${value.toFixed(2)}`;
+}
+
+function AiCostTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean;
+  payload?: Array<{
+    name?: string;
+    value?: number | string;
+    dataKey?: string;
+    payload?: DashboardAiCostDayPoint;
+  }>;
+  label?: string;
+}) {
+  if (!active || !payload?.length) {
+    return null;
+  }
+
+  const point = payload[0]?.payload;
+  const visibleItems = payload.filter((item) => Number(item.value ?? 0) > 0);
+
+  return (
+    <div className="max-w-[280px] rounded-xl border border-slate-200 bg-white p-3 shadow-lg">
+      <p className="text-sm font-semibold text-slate-900">
+        {point?.bucket ?? label}
+      </p>
+      <p className="mt-1 text-xs text-slate-500">
+        合計: {formatJpy(point?.totalJpy ?? 0)}
+      </p>
+      <div className="mt-2 space-y-1 text-sm text-slate-600">
+        {visibleItems.map((item) => (
+          <p key={String(item.dataKey)}>
+            {item.name}: {formatJpy(Number(item.value ?? 0))}
+          </p>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface AdminAiCostCardProps {
+  estimate: DashboardAiCostEstimate;
+}
+
+export default function AdminAiCostCard({ estimate }: AdminAiCostCardProps) {
+  const series: StackedBarSeries<DashboardAiCostDayPoint>[] = [
+    {
+      dataKey: "openaiJpy",
+      name: "OpenAI",
+      color: PROVIDER_CHART_COLORS.openai,
+    },
+    {
+      dataKey: "googleJpy",
+      name: "Google",
+      color: PROVIDER_CHART_COLORS.google,
+    },
+  ];
+
+  const hasCost = estimate.days.some((day) => day.totalJpy > 0);
+
+  return (
+    <Card className="border-violet-200/60 bg-white/95 shadow-sm">
+      <CardHeader className="pb-4">
+        <CardTitle
+          className="text-lg text-slate-900"
+          style={{
+            fontFamily: "var(--font-admin-heading), ui-monospace, monospace",
+          }}
+        >
+          AI 原価（推定）
+        </CardTitle>
+        <CardDescription className="text-sm leading-6 text-slate-600">
+          画像生成モデルの単価 × 生成数による推定額です（{estimate.rateNote}）。
+          テキスト生成など画像以外の API 利用は含みません。
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        <div className="flex flex-wrap items-end gap-x-6 gap-y-2 rounded-xl border border-slate-200/80 bg-slate-50/70 p-4">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-violet-100 text-violet-700">
+              <Coins className="h-5 w-5" aria-hidden />
+            </div>
+            <div>
+              <p className="text-xs text-slate-500">期間内の推定コスト</p>
+              <p className="text-2xl font-semibold text-slate-900">
+                {formatJpy(estimate.totalJpy)}
+              </p>
+            </div>
+          </div>
+          <p className="text-sm text-slate-500">
+            {formatUsd(estimate.totalUsd)}
+          </p>
+          {estimate.unknownModelCount > 0 ? (
+            <p className="text-xs text-slate-500">
+              単価未設定 {estimate.unknownModelCount.toLocaleString("ja-JP")}
+              件は金額に含みません
+            </p>
+          ) : null}
+        </div>
+
+        {hasCost ? (
+          <ScrollingStackedBarChart
+            data={estimate.days}
+            xDataKey="label"
+            yAxisDataKey="totalJpy"
+            barSeries={series}
+            stackId="aiCost"
+            tooltipContent={<AiCostTooltip />}
+          />
+        ) : (
+          <div className="rounded-xl border border-dashed border-slate-200 bg-slate-50/70 p-8 text-center text-sm text-slate-500">
+            期間内に課金対象の生成はありません。
+          </div>
+        )}
+
+        {estimate.byModel.length > 0 ? (
+          <div className="space-y-2">
+            {estimate.byModel.map((item) => (
+              <div
+                key={item.model}
+                className="flex items-center justify-between gap-3 rounded-xl border border-slate-200/80 bg-slate-50/70 p-3"
+              >
+                <div className="flex min-w-0 items-center gap-3">
+                  <span
+                    className="h-3 w-3 shrink-0 rounded-full"
+                    style={{
+                      backgroundColor: PROVIDER_CHART_COLORS[item.provider],
+                    }}
+                  />
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium text-slate-900">
+                      {item.model}
+                    </p>
+                    <p className="text-xs text-slate-500">
+                      {item.providerLabel} ·{" "}
+                      {item.count.toLocaleString("ja-JP")}件
+                    </p>
+                  </div>
+                </div>
+                <span className="shrink-0 text-sm font-semibold text-slate-700">
+                  {formatJpy(item.totalJpy)}
+                </span>
+              </div>
+            ))}
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/features/admin-dashboard/components/AdminAiCostCard.tsx
+++ b/features/admin-dashboard/components/AdminAiCostCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { Coins } from "lucide-react";
 import {
   Card,
@@ -68,9 +69,13 @@ function AiCostTooltip({
 
 interface AdminAiCostCardProps {
   estimate: DashboardAiCostEstimate;
+  actualSlot?: ReactNode;
 }
 
-export default function AdminAiCostCard({ estimate }: AdminAiCostCardProps) {
+export default function AdminAiCostCard({
+  estimate,
+  actualSlot,
+}: AdminAiCostCardProps) {
   const series: StackedBarSeries<DashboardAiCostDayPoint>[] = [
     {
       dataKey: "openaiJpy",
@@ -125,6 +130,8 @@ export default function AdminAiCostCard({ estimate }: AdminAiCostCardProps) {
             </p>
           ) : null}
         </div>
+
+        {actualSlot}
 
         {hasCost ? (
           <ScrollingStackedBarChart

--- a/features/admin-dashboard/components/AdminAiCostCardPanel.tsx
+++ b/features/admin-dashboard/components/AdminAiCostCardPanel.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { Loader2 } from "lucide-react";
+import type { DashboardAiCostEstimate } from "../lib/dashboard-types";
+
+const AdminAiCostCard = dynamic(() => import("./AdminAiCostCard"), {
+  ssr: false,
+  loading: () => (
+    <div className="flex h-[420px] items-center justify-center rounded-xl border border-dashed border-slate-200 bg-slate-50/70 text-sm text-slate-500">
+      <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden />
+      チャートを読み込み中...
+    </div>
+  ),
+});
+
+interface AdminAiCostCardPanelProps {
+  estimate: DashboardAiCostEstimate;
+}
+
+export function AdminAiCostCardPanel({ estimate }: AdminAiCostCardPanelProps) {
+  return <AdminAiCostCard estimate={estimate} />;
+}

--- a/features/admin-dashboard/components/AdminAiCostCardPanel.tsx
+++ b/features/admin-dashboard/components/AdminAiCostCardPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
+import type { ReactNode } from "react";
 import { Loader2 } from "lucide-react";
 import type { DashboardAiCostEstimate } from "../lib/dashboard-types";
 
@@ -16,8 +17,13 @@ const AdminAiCostCard = dynamic(() => import("./AdminAiCostCard"), {
 
 interface AdminAiCostCardPanelProps {
   estimate: DashboardAiCostEstimate;
+  /** 実額行（サーバー側で Suspense 付きに組み立てたスロット） */
+  actualSlot?: ReactNode;
 }
 
-export function AdminAiCostCardPanel({ estimate }: AdminAiCostCardPanelProps) {
-  return <AdminAiCostCard estimate={estimate} />;
+export function AdminAiCostCardPanel({
+  estimate,
+  actualSlot,
+}: AdminAiCostCardPanelProps) {
+  return <AdminAiCostCard estimate={estimate} actualSlot={actualSlot} />;
 }

--- a/features/admin-dashboard/components/AdminPageAnalyticsSection.tsx
+++ b/features/admin-dashboard/components/AdminPageAnalyticsSection.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { Activity, AlertTriangle, ArrowRightLeft, Info } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type {
@@ -39,6 +40,8 @@ interface AdminTrendAndFunnelSectionProps {
   modelMix: DashboardModelMixItem[];
   loginMethodMix: DashboardLoginMethodMixItem[];
   aiCostEstimate: DashboardAiCostEstimate;
+  /** 実額行（サーバー側で Suspense 付きに組み立てたスロット） */
+  aiCostActualSlot?: ReactNode;
 }
 
 interface AnalyticsUnavailableCardProps {
@@ -157,6 +160,7 @@ export function AdminTrendAndFunnelSection({
   modelMix,
   loginMethodMix,
   aiCostEstimate,
+  aiCostActualSlot,
 }: AdminTrendAndFunnelSectionProps) {
   const trendCsv = buildDashboardTrendCsv(trend);
   const trendCsvFilename = `dashboard-trend-${csvDateSpanSuffix(
@@ -226,7 +230,10 @@ export function AdminTrendAndFunnelSection({
         </Card>
       </section>
 
-      <AdminAiCostCardPanel estimate={aiCostEstimate} />
+      <AdminAiCostCardPanel
+        estimate={aiCostEstimate}
+        actualSlot={aiCostActualSlot}
+      />
     </section>
   );
 }

--- a/features/admin-dashboard/components/AdminPageAnalyticsSection.tsx
+++ b/features/admin-dashboard/components/AdminPageAnalyticsSection.tsx
@@ -1,6 +1,7 @@
 import { Activity, AlertTriangle, ArrowRightLeft, Info } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type {
+  DashboardAiCostEstimate,
   DashboardFunnelStep,
   DashboardLoginMethodMixItem,
   DashboardModelMixItem,
@@ -13,6 +14,7 @@ import { AdminEntryAccessStackedCard } from "./AdminEntryAccessStackedCard";
 import { AdminExternalAccessStackedCard } from "./AdminExternalAccessStackedCard";
 import { AdminDropoffPagesCard } from "./AdminDropoffPagesCard";
 import { AdminFunnelCard } from "./AdminFunnelCard";
+import { AdminAiCostCardPanel } from "./AdminAiCostCardPanel";
 import { AdminLoginMethodMixChartPanel } from "./AdminLoginMethodMixChartPanel";
 import { AdminModelMixChartPanel } from "./AdminModelMixChartPanel";
 import { AdminTopLandingPagesCard } from "./AdminTopLandingPagesCard";
@@ -36,6 +38,7 @@ interface AdminTrendAndFunnelSectionProps {
   funnel: DashboardFunnelStep[];
   modelMix: DashboardModelMixItem[];
   loginMethodMix: DashboardLoginMethodMixItem[];
+  aiCostEstimate: DashboardAiCostEstimate;
 }
 
 interface AnalyticsUnavailableCardProps {
@@ -153,6 +156,7 @@ export function AdminTrendAndFunnelSection({
   funnel,
   modelMix,
   loginMethodMix,
+  aiCostEstimate,
 }: AdminTrendAndFunnelSectionProps) {
   const trendCsv = buildDashboardTrendCsv(trend);
   const trendCsvFilename = `dashboard-trend-${csvDateSpanSuffix(
@@ -221,6 +225,8 @@ export function AdminTrendAndFunnelSection({
           </CardContent>
         </Card>
       </section>
+
+      <AdminAiCostCardPanel estimate={aiCostEstimate} />
     </section>
   );
 }

--- a/features/admin-dashboard/components/AdminPageAnalyticsSectionServer.tsx
+++ b/features/admin-dashboard/components/AdminPageAnalyticsSectionServer.tsx
@@ -1,5 +1,7 @@
 import { Suspense } from "react";
 import type { Ga4DashboardData } from "@/features/analytics/lib/ga4-types";
+import type { AiCostActuals } from "../lib/ai-cost-actual-types";
+import { AdminAiCostActualRow } from "./AdminAiCostActualRow";
 import type {
   DashboardAiCostEstimate,
   DashboardFunnelStep,
@@ -24,10 +26,20 @@ interface AdminPageAnalyticsSectionServerProps {
   modelMix: DashboardModelMixItem[];
   loginMethodMix: DashboardLoginMethodMixItem[];
   aiCostEstimate: DashboardAiCostEstimate;
+  aiCostActualsPromise: Promise<AiCostActuals>;
 }
 
 interface AdminGa4SectionLoaderProps {
   ga4Promise: Promise<Ga4DashboardData>;
+}
+
+async function AdminAiCostActualLoader({
+  actualsPromise,
+}: {
+  actualsPromise: Promise<AiCostActuals>;
+}) {
+  const actuals = await actualsPromise;
+  return <AdminAiCostActualRow actuals={actuals} />;
 }
 
 async function AdminPageAnalyticsAccessSectionLoader({
@@ -52,6 +64,7 @@ export function AdminPageAnalyticsSectionServer({
   modelMix,
   loginMethodMix,
   aiCostEstimate,
+  aiCostActualsPromise,
 }: AdminPageAnalyticsSectionServerProps) {
   return (
     <section className="space-y-4">
@@ -65,6 +78,11 @@ export function AdminPageAnalyticsSectionServer({
         modelMix={modelMix}
         loginMethodMix={loginMethodMix}
         aiCostEstimate={aiCostEstimate}
+        aiCostActualSlot={
+          <Suspense fallback={null}>
+            <AdminAiCostActualLoader actualsPromise={aiCostActualsPromise} />
+          </Suspense>
+        }
       />
       <Suspense fallback={<AdminPageAnalyticsDetailsSectionSkeleton />}>
         <AdminPageAnalyticsDetailsSectionLoader ga4Promise={ga4Promise} />

--- a/features/admin-dashboard/components/AdminPageAnalyticsSectionServer.tsx
+++ b/features/admin-dashboard/components/AdminPageAnalyticsSectionServer.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 import type { Ga4DashboardData } from "@/features/analytics/lib/ga4-types";
 import type {
+  DashboardAiCostEstimate,
   DashboardFunnelStep,
   DashboardLoginMethodMixItem,
   DashboardModelMixItem,
@@ -22,6 +23,7 @@ interface AdminPageAnalyticsSectionServerProps {
   funnel: DashboardFunnelStep[];
   modelMix: DashboardModelMixItem[];
   loginMethodMix: DashboardLoginMethodMixItem[];
+  aiCostEstimate: DashboardAiCostEstimate;
 }
 
 interface AdminGa4SectionLoaderProps {
@@ -49,6 +51,7 @@ export function AdminPageAnalyticsSectionServer({
   funnel,
   modelMix,
   loginMethodMix,
+  aiCostEstimate,
 }: AdminPageAnalyticsSectionServerProps) {
   return (
     <section className="space-y-4">
@@ -61,6 +64,7 @@ export function AdminPageAnalyticsSectionServer({
         funnel={funnel}
         modelMix={modelMix}
         loginMethodMix={loginMethodMix}
+        aiCostEstimate={aiCostEstimate}
       />
       <Suspense fallback={<AdminPageAnalyticsDetailsSectionSkeleton />}>
         <AdminPageAnalyticsDetailsSectionLoader ga4Promise={ga4Promise} />

--- a/features/admin-dashboard/lib/ai-cost-actual-types.ts
+++ b/features/admin-dashboard/lib/ai-cost-actual-types.ts
@@ -1,0 +1,26 @@
+/**
+ * AI 原価カードに併記する「実額」の型（ADR-002 / ADR-004）。
+ *
+ * 実額は各プラットフォームの請求データが出典で、DB には保存しない。
+ * 未設定(not_configured)・失敗(error)でも推定表示は維持する。
+ */
+
+export type AiCostActualStatus = "ready" | "not_configured" | "error";
+
+export interface AiCostActualEntry {
+  provider: "openai" | "google";
+  providerLabel: string;
+  status: AiCostActualStatus;
+  /** status=ready のときの期間内合計（円換算後） */
+  totalJpy: number | null;
+  /** 元通貨の合計（USD 建てなら USD、円請求ならそのまま円） */
+  totalOriginal: number | null;
+  originalCurrency: string | null;
+  message: string | null;
+}
+
+export interface AiCostActuals {
+  entries: AiCostActualEntry[];
+  /** すべて not_configured のときは実額行自体を表示しない */
+  hasAnyConfigured: boolean;
+}

--- a/features/admin-dashboard/lib/ai-cost-rates.ts
+++ b/features/admin-dashboard/lib/ai-cost-rates.ts
@@ -1,0 +1,72 @@
+/**
+ * AI 画像生成の推定原価に使う単価表と換算レート（ADR-001 / ADR-003）。
+ *
+ * 単価は各社の公式料金ページから転記した「1生成あたりの USD」。
+ * 単価改定・モデル追加時はここを更新して PR を出す（DB や管理画面では持たない）。
+ *
+ * 出典（2026-07-26 取得）:
+ * - OpenAI: https://developers.openai.com/api/docs/guides/image-generation
+ *   gpt-image-2 1024x1024 → low $0.006 / medium $0.053 / high $0.211
+ * - Google: https://ai.google.dev/gemini-api/docs/pricing
+ *   gemini-3.1-flash-image $0.067 / 1K image、gemini-3-pro-image $0.134 / 1K・2K image、
+ *   gemini-3.1-flash-lite-image $0.0336 / 1K image
+ */
+
+export type AiCostProvider = "openai" | "google";
+
+export interface AiModelRate {
+  /** 1生成あたりの USD 単価 */
+  unitCostUsd: number;
+  provider: AiCostProvider;
+}
+
+/**
+ * generated_images.model に記録される値をキーにした単価表。
+ * 実データに存在する値を基準に定義し、未知のキーは「単価未設定」として金額に含めない。
+ */
+export const MODEL_COST_RATES: Record<string, AiModelRate> = {
+  "gpt-image-2-low-1k": { unitCostUsd: 0.006, provider: "openai" },
+  "gpt-image-2-medium-1k": { unitCostUsd: 0.053, provider: "openai" },
+  "gpt-image-2-high-1k": { unitCostUsd: 0.211, provider: "openai" },
+  "gemini-3.1-flash-image-preview-1024": {
+    unitCostUsd: 0.067,
+    provider: "google",
+  },
+  "gemini-3.1-flash-lite-image-1024": {
+    unitCostUsd: 0.0336,
+    provider: "google",
+  },
+  "gemini-3-pro-image-1k": { unitCostUsd: 0.134, provider: "google" },
+};
+
+/**
+ * USD→JPY の固定換算レート（ADR-003）。
+ * 原価把握が用途のため為替 API には依存せず、注記付きで固定値を使う。
+ */
+export const USD_JPY_RATE = 155;
+
+/** カードに表示する換算レートの注記 */
+export const USD_JPY_RATE_NOTE = `$1=¥${USD_JPY_RATE} 固定換算`;
+
+export const PROVIDER_LABELS: Record<AiCostProvider, string> = {
+  openai: "OpenAI",
+  google: "Google",
+};
+
+/**
+ * 色はプロバイダ（エンティティ）に固定で割り当てる。系列数や並び順で色を回さない。
+ * 隣接ペアの CVD 分離を検証済みの組み合わせ。
+ */
+export const PROVIDER_CHART_COLORS: Record<AiCostProvider, string> = {
+  openai: "#3B82F6",
+  google: "#EC4899",
+};
+
+export function getModelRate(model: string | null): AiModelRate | null {
+  if (!model) return null;
+  return MODEL_COST_RATES[model] ?? null;
+}
+
+export function usdToJpy(usd: number): number {
+  return usd * USD_JPY_RATE;
+}

--- a/features/admin-dashboard/lib/billing-bigquery-query.ts
+++ b/features/admin-dashboard/lib/billing-bigquery-query.ts
@@ -1,0 +1,74 @@
+/**
+ * Cloud Billing の BigQuery エクスポートから Gemini(Generative Language API)の
+ * 実請求額を集計するクエリビルダー(純粋・I/O なし)。
+ *
+ * 課金エクスポートの標準テーブルは `gcp_billing_export_v1_<BILLING_ACCOUNT_ID>` で、
+ * 1行が「サービス×SKU×利用日×プロジェクト」の課金明細。cost は請求通貨建て。
+ * credits は割引・無料枠で、実支払額は cost + SUM(credits.amount)。
+ *
+ * 参考: https://cloud.google.com/billing/docs/how-to/bq-examples
+ */
+
+/** Gemini API の課金サービス名（実データの表記に合わせて調整可能） */
+export const GEMINI_SERVICE_DESCRIPTIONS = [
+  "Generative Language API",
+  "Gemini API",
+];
+
+/**
+ * 期間内の Gemini 実額合計を返すクエリ。
+ * `usage_start_time` で期間を絞り、credits を差し引いた実支払額を通貨ごとに返す。
+ */
+export function buildGeminiBillingCostQuery(
+  projectId: string,
+  datasetId: string,
+  tableName: string
+): string {
+  return `
+    SELECT
+      currency,
+      SUM(cost + IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0)) AS totalCost
+    FROM \`${projectId}.${datasetId}.${tableName}\`
+    WHERE usage_start_time >= TIMESTAMP(@startTimestamp)
+      AND usage_start_time < TIMESTAMP(@endTimestamp)
+      AND service.description IN UNNEST(@serviceDescriptions)
+    GROUP BY currency
+  `;
+}
+
+/**
+ * 課金エクスポートのテーブル名を探すクエリ。
+ * テーブル名に請求先アカウント ID が含まれるため、固定名で決め打ちしない。
+ */
+export function buildBillingTableLookupQuery(
+  projectId: string,
+  datasetId: string
+): string {
+  return `
+    SELECT table_name
+    FROM \`${projectId}.${datasetId}.INFORMATION_SCHEMA.TABLES\`
+    WHERE table_name LIKE 'gcp_billing_export_v1_%'
+    ORDER BY table_name
+    LIMIT 1
+  `;
+}
+
+/**
+ * BigQuery の数値カラム（BigQueryNumeric や文字列で返ることがある）を数値化する。
+ */
+export function parseBillingCost(value: unknown): number {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : 0;
+  }
+
+  if (value && typeof value === "object" && "value" in value) {
+    return parseBillingCost((value as { value: unknown }).value);
+  }
+
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+
+  return 0;
+}

--- a/features/admin-dashboard/lib/build-ai-cost.ts
+++ b/features/admin-dashboard/lib/build-ai-cost.ts
@@ -1,0 +1,129 @@
+import {
+  enumerateJstDateKeys,
+  formatJstDateLabel,
+  isWithinDateRange,
+  toJstDateKey,
+} from "./dashboard-range";
+import {
+  getModelRate,
+  PROVIDER_LABELS,
+  USD_JPY_RATE_NOTE,
+  usdToJpy,
+  type AiCostProvider,
+} from "./ai-cost-rates";
+import type {
+  DashboardAiCostEstimate,
+  DashboardAiCostDayPoint,
+  DashboardAiCostModelItem,
+} from "./dashboard-types";
+
+type GenerationLike = {
+  model: string | null;
+  created_at: string;
+};
+
+/**
+ * 期間内の生成記録から推定 AI 原価を集計する（ADR-001）。
+ *
+ * 日別バケットは JST。単価表に無いモデル（旧データの null を含む）は
+ * 金額に含めず件数だけ返し、カード側で「単価未設定」として明示する。
+ */
+export function buildAiCostEstimate(
+  generations: GenerationLike[],
+  currentStart: Date,
+  now: Date
+): DashboardAiCostEstimate {
+  const dayKeys = enumerateJstDateKeys(currentStart, now);
+  const dayMap = new Map<string, DashboardAiCostDayPoint>(
+    dayKeys.map((key) => [
+      key,
+      {
+        bucket: key,
+        label: formatJstDateLabel(key),
+        openaiJpy: 0,
+        googleJpy: 0,
+        totalJpy: 0,
+      },
+    ])
+  );
+
+  const modelUsdTotals = new Map<
+    string,
+    { provider: AiCostProvider; count: number; usd: number }
+  >();
+
+  let totalUsd = 0;
+  let unknownModelCount = 0;
+
+  for (const generation of generations) {
+    if (!isWithinDateRange(generation.created_at, currentStart, now)) {
+      continue;
+    }
+
+    const rate = getModelRate(generation.model);
+
+    if (!rate) {
+      unknownModelCount += 1;
+      continue;
+    }
+
+    totalUsd += rate.unitCostUsd;
+
+    const modelKey = generation.model as string;
+    const modelTotal = modelUsdTotals.get(modelKey) ?? {
+      provider: rate.provider,
+      count: 0,
+      usd: 0,
+    };
+    modelTotal.count += 1;
+    modelTotal.usd += rate.unitCostUsd;
+    modelUsdTotals.set(modelKey, modelTotal);
+
+    const bucket = dayMap.get(toJstDateKey(generation.created_at));
+    if (bucket) {
+      const jpy = usdToJpy(rate.unitCostUsd);
+      if (rate.provider === "openai") {
+        bucket.openaiJpy += jpy;
+      } else {
+        bucket.googleJpy += jpy;
+      }
+      bucket.totalJpy += jpy;
+    }
+  }
+
+  const days = dayKeys.map((key) => {
+    const point = dayMap.get(key)!;
+    return {
+      ...point,
+      openaiJpy: roundJpy(point.openaiJpy),
+      googleJpy: roundJpy(point.googleJpy),
+      totalJpy: roundJpy(point.totalJpy),
+    };
+  });
+
+  const byModel: DashboardAiCostModelItem[] = Array.from(
+    modelUsdTotals.entries()
+  )
+    .map(([model, total]) => ({
+      model,
+      provider: total.provider,
+      providerLabel: PROVIDER_LABELS[total.provider],
+      count: total.count,
+      totalUsd: Number(total.usd.toFixed(4)),
+      totalJpy: roundJpy(usdToJpy(total.usd)),
+    }))
+    .sort((a, b) => b.totalUsd - a.totalUsd);
+
+  return {
+    totalUsd: Number(totalUsd.toFixed(4)),
+    totalJpy: roundJpy(usdToJpy(totalUsd)),
+    days,
+    byModel,
+    unknownModelCount,
+    rateNote: USD_JPY_RATE_NOTE,
+  };
+}
+
+function roundJpy(value: number): number {
+  return Math.round(value * 10) / 10;
+}

--- a/features/admin-dashboard/lib/dashboard-types.ts
+++ b/features/admin-dashboard/lib/dashboard-types.ts
@@ -53,6 +53,32 @@ export interface DashboardModelMixItem {
   sharePct: number;
 }
 
+export interface DashboardAiCostDayPoint {
+  bucket: string;
+  label: string;
+  openaiJpy: number;
+  googleJpy: number;
+  totalJpy: number;
+}
+
+export interface DashboardAiCostModelItem {
+  model: string;
+  provider: "openai" | "google";
+  providerLabel: string;
+  count: number;
+  totalUsd: number;
+  totalJpy: number;
+}
+
+export interface DashboardAiCostEstimate {
+  totalUsd: number;
+  totalJpy: number;
+  days: DashboardAiCostDayPoint[];
+  byModel: DashboardAiCostModelItem[];
+  unknownModelCount: number;
+  rateNote: string;
+}
+
 export interface DashboardLoginMethodMixItem {
   provider: string;
   label: string;
@@ -241,6 +267,7 @@ export interface AdminDashboardData {
   funnel: DashboardFunnelStep[];
   modelMix: DashboardModelMixItem[];
   loginMethodMix: DashboardLoginMethodMixItem[];
+  aiCostEstimate: DashboardAiCostEstimate;
   recentPurchases: DashboardPurchaseRow[];
   alerts: DashboardAlertRow[];
   quickActions: DashboardQuickAction[];

--- a/features/admin-dashboard/lib/gemini-billing-client.ts
+++ b/features/admin-dashboard/lib/gemini-billing-client.ts
@@ -1,0 +1,130 @@
+import "server-only";
+
+import { env } from "@/lib/env";
+import { getGa4BigQueryClient } from "@/features/analytics/lib/ga4-bigquery-client";
+import { usdToJpy } from "./ai-cost-rates";
+import {
+  buildBillingTableLookupQuery,
+  buildGeminiBillingCostQuery,
+  GEMINI_SERVICE_DESCRIPTIONS,
+  parseBillingCost,
+} from "./billing-bigquery-query";
+import type { AiCostActualEntry } from "./ai-cost-actual-types";
+
+interface BillingCostRow {
+  currency?: string | null;
+  totalCost?: unknown;
+}
+
+export function isGeminiBillingConfigured(): boolean {
+  return Boolean(
+    env.BILLING_BIGQUERY_DATASET &&
+      env.GA4_BIGQUERY_PROJECT_ID &&
+      env.GA4_SERVICE_ACCOUNT_JSON_BASE64
+  );
+}
+
+/**
+ * Cloud Billing の BigQuery エクスポートから Gemini の実請求額を取得する。
+ *
+ * 課金エクスポートは有効化以降のデータしか存在せず、反映も数時間〜1日遅れる。
+ * 未設定・失敗時は推定表示を壊さないよう status で返す（ADR-004）。
+ */
+export async function fetchGeminiActualCost(
+  start: Date,
+  end: Date
+): Promise<AiCostActualEntry> {
+  const base: Omit<AiCostActualEntry, "status" | "message"> = {
+    provider: "google",
+    providerLabel: "Google",
+    totalJpy: null,
+    totalOriginal: null,
+    originalCurrency: null,
+  };
+
+  if (!isGeminiBillingConfigured()) {
+    return { ...base, status: "not_configured", message: null };
+  }
+
+  try {
+    const client = getGa4BigQueryClient();
+    const projectId = env.GA4_BIGQUERY_PROJECT_ID;
+    const datasetId = env.BILLING_BIGQUERY_DATASET;
+
+    const [tableRows] = await client.query({
+      query: buildBillingTableLookupQuery(projectId, datasetId),
+      location: env.GA4_BIGQUERY_LOCATION,
+    });
+
+    const tableName = (tableRows as Array<{ table_name?: string }>)[0]
+      ?.table_name;
+
+    if (!tableName) {
+      return {
+        ...base,
+        status: "error",
+        message: "課金エクスポートのテーブルが見つかりません",
+      };
+    }
+
+    const [costRows] = await client.query({
+      query: buildGeminiBillingCostQuery(projectId, datasetId, tableName),
+      location: env.GA4_BIGQUERY_LOCATION,
+      params: {
+        startTimestamp: start.toISOString(),
+        endTimestamp: end.toISOString(),
+        serviceDescriptions: GEMINI_SERVICE_DESCRIPTIONS,
+      },
+    });
+
+    return summarizeGeminiBillingRows(costRows as BillingCostRow[], base);
+  } catch (error) {
+    console.error("Gemini billing fetch error:", error);
+    return {
+      ...base,
+      status: "error",
+      message: "Google の実額を取得できませんでした",
+    };
+  }
+}
+
+/**
+ * 通貨ごとの行を合計する。JPY 請求はそのまま、USD 請求は固定レートで換算（ADR-003）。
+ */
+export function summarizeGeminiBillingRows(
+  rows: BillingCostRow[],
+  base: Omit<AiCostActualEntry, "status" | "message">
+): AiCostActualEntry {
+  if (rows.length === 0) {
+    return {
+      ...base,
+      status: "ready",
+      message: null,
+      totalOriginal: 0,
+      originalCurrency: null,
+      totalJpy: 0,
+    };
+  }
+
+  let totalJpy = 0;
+  let totalOriginal = 0;
+  let currency: string | null = null;
+
+  for (const row of rows) {
+    const cost = parseBillingCost(row.totalCost);
+    const rowCurrency = (row.currency ?? "").toUpperCase();
+
+    totalOriginal += cost;
+    currency = currency ?? rowCurrency ?? null;
+    totalJpy += rowCurrency === "JPY" ? cost : usdToJpy(cost);
+  }
+
+  return {
+    ...base,
+    status: "ready",
+    message: null,
+    totalOriginal: Number(totalOriginal.toFixed(4)),
+    originalCurrency: currency,
+    totalJpy: Math.round(totalJpy * 10) / 10,
+  };
+}

--- a/features/admin-dashboard/lib/gemini-billing-client.ts
+++ b/features/admin-dashboard/lib/gemini-billing-client.ts
@@ -16,10 +16,18 @@ interface BillingCostRow {
   totalCost?: unknown;
 }
 
+/**
+ * 課金エクスポートが置かれている GCP プロジェクト。
+ * 別プロジェクトに作った場合のみ BILLING_BIGQUERY_PROJECT_ID で上書きする。
+ */
+export function getBillingProjectId(): string {
+  return env.BILLING_BIGQUERY_PROJECT_ID || env.GA4_BIGQUERY_PROJECT_ID;
+}
+
 export function isGeminiBillingConfigured(): boolean {
   return Boolean(
     env.BILLING_BIGQUERY_DATASET &&
-      env.GA4_BIGQUERY_PROJECT_ID &&
+      getBillingProjectId() &&
       env.GA4_SERVICE_ACCOUNT_JSON_BASE64
   );
 }
@@ -48,7 +56,7 @@ export async function fetchGeminiActualCost(
 
   try {
     const client = getGa4BigQueryClient();
-    const projectId = env.GA4_BIGQUERY_PROJECT_ID;
+    const projectId = getBillingProjectId();
     const datasetId = env.BILLING_BIGQUERY_DATASET;
 
     const [tableRows] = await client.query({

--- a/features/admin-dashboard/lib/get-admin-dashboard-data.ts
+++ b/features/admin-dashboard/lib/get-admin-dashboard-data.ts
@@ -23,6 +23,7 @@ import {
   type StyleGuestGenerateAttemptRow,
   type StylePresetDashboardRow,
 } from "./build-one-tap-style-detailed";
+import { buildAiCostEstimate } from "./build-ai-cost";
 import type {
   AdminDashboardData,
   AdminDashboardKpi,
@@ -951,6 +952,7 @@ export async function getAdminDashboardData(
     funnel,
     modelMix,
     loginMethodMix: buildLoginMethodMix(authProviderSignups, currentStart, now),
+    aiCostEstimate: buildAiCostEstimate(generatedImages, currentStart, now),
     recentPurchases,
     alerts,
     quickActions: adminQuickActionItems.map((item) => ({

--- a/features/admin-dashboard/lib/get-ai-cost-actuals.ts
+++ b/features/admin-dashboard/lib/get-ai-cost-actuals.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { getRangeBounds } from "./dashboard-range";
 import type { DashboardRange } from "./dashboard-range";
 import { fetchOpenAiActualCost } from "./openai-costs-client";
+import { fetchGeminiActualCost } from "./gemini-billing-client";
 import type { AiCostActualEntry, AiCostActuals } from "./ai-cost-actual-types";
 
 /**
@@ -18,6 +19,7 @@ export async function getAiCostActuals(
 
   const results = await Promise.allSettled([
     fetchOpenAiActualCost(currentStart, now),
+    fetchGeminiActualCost(currentStart, now),
   ]);
 
   const entries: AiCostActualEntry[] = results.map((result, index) => {

--- a/features/admin-dashboard/lib/get-ai-cost-actuals.ts
+++ b/features/admin-dashboard/lib/get-ai-cost-actuals.ts
@@ -1,0 +1,45 @@
+import "server-only";
+
+import { getRangeBounds } from "./dashboard-range";
+import type { DashboardRange } from "./dashboard-range";
+import { fetchOpenAiActualCost } from "./openai-costs-client";
+import type { AiCostActualEntry, AiCostActuals } from "./ai-cost-actual-types";
+
+/**
+ * 各プロバイダの実請求額をまとめて取得する（ADR-004）。
+ *
+ * プロバイダごとに独立して成功/失敗できるよう allSettled を使い、
+ * 片方が落ちてももう片方と推定表示は生き残る。
+ */
+export async function getAiCostActuals(
+  range: DashboardRange
+): Promise<AiCostActuals> {
+  const { currentStart, now } = getRangeBounds(range);
+
+  const results = await Promise.allSettled([
+    fetchOpenAiActualCost(currentStart, now),
+  ]);
+
+  const entries: AiCostActualEntry[] = results.map((result, index) => {
+    if (result.status === "fulfilled") {
+      return result.value;
+    }
+
+    console.error("AI cost actual fetch rejected:", result.reason);
+
+    return {
+      provider: index === 0 ? "openai" : "google",
+      providerLabel: index === 0 ? "OpenAI" : "Google",
+      status: "error" as const,
+      totalJpy: null,
+      totalOriginal: null,
+      originalCurrency: null,
+      message: "実額を取得できませんでした",
+    };
+  });
+
+  return {
+    entries,
+    hasAnyConfigured: entries.some((entry) => entry.status !== "not_configured"),
+  };
+}

--- a/features/admin-dashboard/lib/openai-costs-client.ts
+++ b/features/admin-dashboard/lib/openai-costs-client.ts
@@ -1,0 +1,121 @@
+import "server-only";
+
+import { env } from "@/lib/env";
+import { usdToJpy } from "./ai-cost-rates";
+import type { AiCostActualEntry } from "./ai-cost-actual-types";
+
+const COSTS_ENDPOINT = "https://api.openai.com/v1/organization/costs";
+const REQUEST_TIMEOUT_MS = 10_000;
+/** バケットは 1 日単位。API 上限は 180 */
+const MAX_BUCKETS = 180;
+
+interface OpenAiCostsBucketResult {
+  amount?: { value?: number; currency?: string };
+}
+
+interface OpenAiCostsBucket {
+  results?: OpenAiCostsBucketResult[];
+}
+
+interface OpenAiCostsResponse {
+  data?: OpenAiCostsBucket[];
+  has_more?: boolean;
+  next_page?: string | null;
+}
+
+export function isOpenAiCostsConfigured(): boolean {
+  return Boolean(env.OPENAI_ADMIN_API_KEY);
+}
+
+/**
+ * OpenAI Costs API から期間内の実請求額を取得する。
+ *
+ * 画像生成以外の API 利用も含む「組織全体の課金額」である点に注意
+ * （推定＝画像のみ、実額＝全用途。カード側で注記する）。
+ */
+export async function fetchOpenAiActualCost(
+  start: Date,
+  end: Date
+): Promise<AiCostActualEntry> {
+  const base: Omit<AiCostActualEntry, "status" | "message"> = {
+    provider: "openai",
+    providerLabel: "OpenAI",
+    totalJpy: null,
+    totalOriginal: null,
+    originalCurrency: null,
+  };
+
+  if (!isOpenAiCostsConfigured()) {
+    return { ...base, status: "not_configured", message: null };
+  }
+
+  const params = new URLSearchParams({
+    start_time: String(Math.floor(start.getTime() / 1000)),
+    end_time: String(Math.floor(end.getTime() / 1000)),
+    bucket_width: "1d",
+    limit: String(MAX_BUCKETS),
+  });
+
+  try {
+    const response = await fetch(`${COSTS_ENDPOINT}?${params.toString()}`, {
+      headers: {
+        Authorization: `Bearer ${env.OPENAI_ADMIN_API_KEY}`,
+      },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      cache: "no-store",
+    });
+
+    if (!response.ok) {
+      // キー自体はログにも表示にも載せない
+      return {
+        ...base,
+        status: "error",
+        message: `OpenAI Costs API エラー (${response.status})`,
+      };
+    }
+
+    const payload = (await response.json()) as OpenAiCostsResponse;
+    const { totalUsd, currency } = sumOpenAiCosts(payload);
+
+    return {
+      ...base,
+      status: "ready",
+      message: null,
+      totalOriginal: Number(totalUsd.toFixed(4)),
+      originalCurrency: currency,
+      totalJpy: Math.round(usdToJpy(totalUsd) * 10) / 10,
+    };
+  } catch (error) {
+    console.error("OpenAI costs fetch error:", error);
+    return {
+      ...base,
+      status: "error",
+      message: "OpenAI の実額を取得できませんでした",
+    };
+  }
+}
+
+/**
+ * バケット配列を合計する。通貨は最初に見つかったものを採用（通常 usd 固定）。
+ */
+export function sumOpenAiCosts(payload: OpenAiCostsResponse): {
+  totalUsd: number;
+  currency: string;
+} {
+  let totalUsd = 0;
+  let currency = "usd";
+
+  for (const bucket of payload.data ?? []) {
+    for (const result of bucket.results ?? []) {
+      const value = result.amount?.value;
+      if (typeof value === "number" && Number.isFinite(value)) {
+        totalUsd += value;
+      }
+      if (result.amount?.currency) {
+        currency = result.amount.currency;
+      }
+    }
+  }
+
+  return { totalUsd, currency };
+}

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -52,8 +52,10 @@ const envSchema = {
   // AI 原価ダッシュボード(任意。未設定なら実額表示を出さず推定のみ)
   // OpenAI Costs API 用の Admin API キー(platform.openai.com の Admin Keys)
   OPENAI_ADMIN_API_KEY: process.env.OPENAI_ADMIN_API_KEY,
-  // Cloud Billing の BigQuery エクスポート先データセット(GA4 と同じプロジェクト想定)
+  // Cloud Billing の BigQuery エクスポート先データセット
   BILLING_BIGQUERY_DATASET: process.env.BILLING_BIGQUERY_DATASET,
+  // エクスポート先が GA4 と別プロジェクトの場合のみ指定(未設定なら GA4 と同じプロジェクト)
+  BILLING_BIGQUERY_PROJECT_ID: process.env.BILLING_BIGQUERY_PROJECT_ID,
 
   // Admin
   ADMIN_USER_IDS: process.env.ADMIN_USER_IDS,
@@ -177,6 +179,7 @@ function getEnv() {
     GA4_BIGQUERY_LOCATION: envSchema.GA4_BIGQUERY_LOCATION || "",
     OPENAI_ADMIN_API_KEY: envSchema.OPENAI_ADMIN_API_KEY || "",
     BILLING_BIGQUERY_DATASET: envSchema.BILLING_BIGQUERY_DATASET || "",
+    BILLING_BIGQUERY_PROJECT_ID: envSchema.BILLING_BIGQUERY_PROJECT_ID || "",
     ADMIN_USER_IDS: envSchema.ADMIN_USER_IDS || "",
     ADMIN_PREVIEW_USER_IDS: envSchema.ADMIN_PREVIEW_USER_IDS || "",
     ACCOUNT_PURGE_CRON_SECRET:

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -49,6 +49,12 @@ const envSchema = {
   GA4_BIGQUERY_DATASET: process.env.GA4_BIGQUERY_DATASET,
   GA4_BIGQUERY_LOCATION: process.env.GA4_BIGQUERY_LOCATION,
 
+  // AI 原価ダッシュボード(任意。未設定なら実額表示を出さず推定のみ)
+  // OpenAI Costs API 用の Admin API キー(platform.openai.com の Admin Keys)
+  OPENAI_ADMIN_API_KEY: process.env.OPENAI_ADMIN_API_KEY,
+  // Cloud Billing の BigQuery エクスポート先データセット(GA4 と同じプロジェクト想定)
+  BILLING_BIGQUERY_DATASET: process.env.BILLING_BIGQUERY_DATASET,
+
   // Admin
   ADMIN_USER_IDS: process.env.ADMIN_USER_IDS,
   // 「admin 公開コンテンツ閲覧のみ」を許可するプレビュー権限ユーザー(任意, csv)。
@@ -169,6 +175,8 @@ function getEnv() {
     GA4_BIGQUERY_PROJECT_ID: envSchema.GA4_BIGQUERY_PROJECT_ID || "",
     GA4_BIGQUERY_DATASET: envSchema.GA4_BIGQUERY_DATASET || "",
     GA4_BIGQUERY_LOCATION: envSchema.GA4_BIGQUERY_LOCATION || "",
+    OPENAI_ADMIN_API_KEY: envSchema.OPENAI_ADMIN_API_KEY || "",
+    BILLING_BIGQUERY_DATASET: envSchema.BILLING_BIGQUERY_DATASET || "",
     ADMIN_USER_IDS: envSchema.ADMIN_USER_IDS || "",
     ADMIN_PREVIEW_USER_IDS: envSchema.ADMIN_PREVIEW_USER_IDS || "",
     ACCOUNT_PURGE_CRON_SECRET:

--- a/tests/unit/features/admin-dashboard/billing-bigquery-query.test.ts
+++ b/tests/unit/features/admin-dashboard/billing-bigquery-query.test.ts
@@ -1,0 +1,71 @@
+import {
+  buildBillingTableLookupQuery,
+  buildGeminiBillingCostQuery,
+  GEMINI_SERVICE_DESCRIPTIONS,
+  parseBillingCost,
+} from "@/features/admin-dashboard/lib/billing-bigquery-query";
+
+describe("buildGeminiBillingCostQuery", () => {
+  const query = buildGeminiBillingCostQuery(
+    "my-project",
+    "billing_export",
+    "gcp_billing_export_v1_ABC123"
+  );
+
+  it("完全修飾のテーブル参照を組み立てる", () => {
+    expect(query).toContain(
+      "`my-project.billing_export.gcp_billing_export_v1_ABC123`"
+    );
+  });
+
+  it("期間とサービス名を名前付きパラメータで受け取る", () => {
+    expect(query).toContain("@startTimestamp");
+    expect(query).toContain("@endTimestamp");
+    expect(query).toContain("@serviceDescriptions");
+  });
+
+  it("credits を差し引いた実支払額を集計する", () => {
+    expect(query).toContain("SUM(cost +");
+    expect(query).toContain("UNNEST(credits)");
+  });
+
+  it("通貨ごとに集計する", () => {
+    expect(query).toContain("GROUP BY currency");
+  });
+});
+
+describe("buildBillingTableLookupQuery", () => {
+  it("課金エクスポートのテーブル名を検索する", () => {
+    const query = buildBillingTableLookupQuery("my-project", "billing_export");
+
+    expect(query).toContain("INFORMATION_SCHEMA.TABLES");
+    expect(query).toContain("gcp_billing_export_v1_%");
+  });
+});
+
+describe("GEMINI_SERVICE_DESCRIPTIONS", () => {
+  it("Generative Language API を含む", () => {
+    expect(GEMINI_SERVICE_DESCRIPTIONS).toContain("Generative Language API");
+  });
+});
+
+describe("parseBillingCost", () => {
+  it("数値をそのまま返す", () => {
+    expect(parseBillingCost(12.34)).toBeCloseTo(12.34, 4);
+  });
+
+  it("BigQuery の数値ラッパー(valueプロパティ)を展開する", () => {
+    expect(parseBillingCost({ value: "5.5" })).toBeCloseTo(5.5, 4);
+  });
+
+  it("数値文字列をパースする", () => {
+    expect(parseBillingCost("3.25")).toBeCloseTo(3.25, 4);
+  });
+
+  it("null・undefined・非数値は0にする", () => {
+    expect(parseBillingCost(null)).toBe(0);
+    expect(parseBillingCost(undefined)).toBe(0);
+    expect(parseBillingCost("abc")).toBe(0);
+    expect(parseBillingCost(Number.NaN)).toBe(0);
+  });
+});

--- a/tests/unit/features/admin-dashboard/build-ai-cost.test.ts
+++ b/tests/unit/features/admin-dashboard/build-ai-cost.test.ts
@@ -1,0 +1,142 @@
+import { buildAiCostEstimate } from "@/features/admin-dashboard/lib/build-ai-cost";
+import { USD_JPY_RATE } from "@/features/admin-dashboard/lib/ai-cost-rates";
+
+// 固定ウィンドウ(3日): current=[07-24T00:00Z, 07-26T12:00Z]
+const NOW = new Date("2026-07-26T12:00:00.000Z");
+const CURRENT_START = new Date("2026-07-24T00:00:00.000Z");
+
+const GPT_LOW_USD = 0.006;
+const GEMINI_FLASH_USD = 0.067;
+
+describe("buildAiCostEstimate", () => {
+  it("生成がなくても期間分の日別バケットを埋めて0円を返す", () => {
+    const result = buildAiCostEstimate([], CURRENT_START, NOW);
+
+    expect(result.totalUsd).toBe(0);
+    expect(result.totalJpy).toBe(0);
+    expect(result.byModel).toEqual([]);
+    expect(result.unknownModelCount).toBe(0);
+    expect(result.days.map((day) => day.bucket)).toEqual([
+      "2026-07-24",
+      "2026-07-25",
+      "2026-07-26",
+    ]);
+    expect(result.days.every((day) => day.totalJpy === 0)).toBe(true);
+  });
+
+  it("モデル別単価で合計USDと円換算を算出する", () => {
+    const result = buildAiCostEstimate(
+      [
+        { model: "gpt-image-2-low-1k", created_at: "2026-07-25T01:00:00.000Z" },
+        { model: "gpt-image-2-low-1k", created_at: "2026-07-25T02:00:00.000Z" },
+        {
+          model: "gemini-3.1-flash-image-preview-1024",
+          created_at: "2026-07-25T03:00:00.000Z",
+        },
+      ],
+      CURRENT_START,
+      NOW
+    );
+
+    const expectedUsd = GPT_LOW_USD * 2 + GEMINI_FLASH_USD;
+    expect(result.totalUsd).toBeCloseTo(expectedUsd, 4);
+    expect(result.totalJpy).toBeCloseTo(expectedUsd * USD_JPY_RATE, 1);
+  });
+
+  it("日別バケットをプロバイダ別に分けて積み上げる", () => {
+    const result = buildAiCostEstimate(
+      [
+        { model: "gpt-image-2-low-1k", created_at: "2026-07-24T05:00:00.000Z" },
+        {
+          model: "gemini-3.1-flash-image-preview-1024",
+          created_at: "2026-07-26T05:00:00.000Z",
+        },
+      ],
+      CURRENT_START,
+      NOW
+    );
+
+    const [first, , last] = result.days;
+
+    expect(first.openaiJpy).toBeCloseTo(GPT_LOW_USD * USD_JPY_RATE, 1);
+    expect(first.googleJpy).toBe(0);
+    expect(last.googleJpy).toBeCloseTo(GEMINI_FLASH_USD * USD_JPY_RATE, 1);
+    expect(last.openaiJpy).toBe(0);
+    expect(last.totalJpy).toBeCloseTo(last.googleJpy, 1);
+  });
+
+  it("JST日付でバケットを決める(UTC 15時は翌日のJST扱い)", () => {
+    const result = buildAiCostEstimate(
+      [
+        // 2026-07-24T15:00Z = 2026-07-25 00:00 JST
+        { model: "gpt-image-2-low-1k", created_at: "2026-07-24T15:00:00.000Z" },
+      ],
+      CURRENT_START,
+      NOW
+    );
+
+    const jul24 = result.days.find((day) => day.bucket === "2026-07-24");
+    const jul25 = result.days.find((day) => day.bucket === "2026-07-25");
+
+    expect(jul24?.totalJpy).toBe(0);
+    expect(jul25?.totalJpy).toBeCloseTo(GPT_LOW_USD * USD_JPY_RATE, 1);
+  });
+
+  it("期間外の生成は集計しない", () => {
+    const result = buildAiCostEstimate(
+      [
+        { model: "gpt-image-2-low-1k", created_at: "2026-07-01T00:00:00.000Z" },
+        { model: "gpt-image-2-low-1k", created_at: "2026-07-25T00:00:00.000Z" },
+      ],
+      CURRENT_START,
+      NOW
+    );
+
+    expect(result.totalUsd).toBeCloseTo(GPT_LOW_USD, 4);
+    expect(result.byModel[0]?.count).toBe(1);
+  });
+
+  it("単価未設定(nullと未知モデル)は金額に含めず件数だけ返す", () => {
+    const result = buildAiCostEstimate(
+      [
+        { model: null, created_at: "2026-07-25T00:00:00.000Z" },
+        { model: "unknown-model-x", created_at: "2026-07-25T00:00:00.000Z" },
+        { model: "gpt-image-2-low-1k", created_at: "2026-07-25T00:00:00.000Z" },
+      ],
+      CURRENT_START,
+      NOW
+    );
+
+    expect(result.unknownModelCount).toBe(2);
+    expect(result.totalUsd).toBeCloseTo(GPT_LOW_USD, 4);
+    expect(result.byModel).toHaveLength(1);
+    expect(result.byModel[0]?.model).toBe("gpt-image-2-low-1k");
+  });
+
+  it("モデル別内訳は金額降順で、プロバイダラベルを持つ", () => {
+    const result = buildAiCostEstimate(
+      [
+        { model: "gpt-image-2-low-1k", created_at: "2026-07-25T00:00:00.000Z" },
+        {
+          model: "gemini-3.1-flash-image-preview-1024",
+          created_at: "2026-07-25T00:00:00.000Z",
+        },
+      ],
+      CURRENT_START,
+      NOW
+    );
+
+    expect(result.byModel.map((item) => item.model)).toEqual([
+      "gemini-3.1-flash-image-preview-1024",
+      "gpt-image-2-low-1k",
+    ]);
+    expect(result.byModel[0]?.providerLabel).toBe("Google");
+    expect(result.byModel[1]?.providerLabel).toBe("OpenAI");
+    expect(result.byModel[1]?.count).toBe(1);
+  });
+
+  it("換算レートの注記を返す", () => {
+    const result = buildAiCostEstimate([], CURRENT_START, NOW);
+    expect(result.rateNote).toContain(String(USD_JPY_RATE));
+  });
+});

--- a/tests/unit/features/admin-dashboard/gemini-billing-summary.test.ts
+++ b/tests/unit/features/admin-dashboard/gemini-billing-summary.test.ts
@@ -1,0 +1,72 @@
+import { summarizeGeminiBillingRows } from "@/features/admin-dashboard/lib/gemini-billing-client";
+import { USD_JPY_RATE } from "@/features/admin-dashboard/lib/ai-cost-rates";
+
+jest.mock("server-only", () => ({}));
+
+const BASE = {
+  provider: "google" as const,
+  providerLabel: "Google",
+  totalJpy: null,
+  totalOriginal: null,
+  originalCurrency: null,
+};
+
+describe("summarizeGeminiBillingRows", () => {
+  it("行がなければ0円のreadyを返す(課金なしと請求データなしを区別しない)", () => {
+    const result = summarizeGeminiBillingRows([], BASE);
+
+    expect(result.status).toBe("ready");
+    expect(result.totalJpy).toBe(0);
+    expect(result.totalOriginal).toBe(0);
+  });
+
+  it("JPY請求はそのまま円として扱う", () => {
+    const result = summarizeGeminiBillingRows(
+      [{ currency: "JPY", totalCost: 1234.5 }],
+      BASE
+    );
+
+    expect(result.totalJpy).toBeCloseTo(1234.5, 1);
+    expect(result.originalCurrency).toBe("JPY");
+  });
+
+  it("USD請求は固定レートで円換算する", () => {
+    const result = summarizeGeminiBillingRows(
+      [{ currency: "USD", totalCost: 2 }],
+      BASE
+    );
+
+    expect(result.totalJpy).toBeCloseTo(2 * USD_JPY_RATE, 1);
+    expect(result.totalOriginal).toBeCloseTo(2, 4);
+  });
+
+  it("複数通貨の行を円ベースで合算する", () => {
+    const result = summarizeGeminiBillingRows(
+      [
+        { currency: "JPY", totalCost: 100 },
+        { currency: "USD", totalCost: 1 },
+      ],
+      BASE
+    );
+
+    expect(result.totalJpy).toBeCloseTo(100 + USD_JPY_RATE, 1);
+  });
+
+  it("BigQueryの数値ラッパーを解釈する", () => {
+    const result = summarizeGeminiBillingRows(
+      [{ currency: "JPY", totalCost: { value: "500" } }],
+      BASE
+    );
+
+    expect(result.totalJpy).toBeCloseTo(500, 1);
+  });
+
+  it("小文字の通貨コードも大文字として判定する", () => {
+    const result = summarizeGeminiBillingRows(
+      [{ currency: "jpy", totalCost: 300 }],
+      BASE
+    );
+
+    expect(result.totalJpy).toBeCloseTo(300, 1);
+  });
+});

--- a/tests/unit/features/admin-dashboard/openai-costs-client.test.ts
+++ b/tests/unit/features/admin-dashboard/openai-costs-client.test.ts
@@ -1,0 +1,66 @@
+import { sumOpenAiCosts } from "@/features/admin-dashboard/lib/openai-costs-client";
+
+jest.mock("server-only", () => ({}));
+
+describe("sumOpenAiCosts", () => {
+  it("空レスポンスは0で既定通貨を返す", () => {
+    expect(sumOpenAiCosts({})).toEqual({ totalUsd: 0, currency: "usd" });
+    expect(sumOpenAiCosts({ data: [] })).toEqual({
+      totalUsd: 0,
+      currency: "usd",
+    });
+  });
+
+  it("全バケット・全resultsを合計する", () => {
+    const result = sumOpenAiCosts({
+      data: [
+        {
+          results: [
+            { amount: { value: 1.5, currency: "usd" } },
+            { amount: { value: 0.25, currency: "usd" } },
+          ],
+        },
+        { results: [{ amount: { value: 2, currency: "usd" } }] },
+      ],
+    });
+
+    expect(result.totalUsd).toBeCloseTo(3.75, 4);
+    expect(result.currency).toBe("usd");
+  });
+
+  it("results が空・amount 欠落のバケットを飛ばす", () => {
+    const result = sumOpenAiCosts({
+      data: [
+        { results: [] },
+        {},
+        { results: [{}, { amount: {} }] },
+        { results: [{ amount: { value: 1, currency: "usd" } }] },
+      ],
+    });
+
+    expect(result.totalUsd).toBeCloseTo(1, 4);
+  });
+
+  it("数値でない値やNaNは無視する", () => {
+    const result = sumOpenAiCosts({
+      data: [
+        {
+          results: [
+            { amount: { value: Number.NaN, currency: "usd" } },
+            { amount: { value: 2, currency: "usd" } },
+          ],
+        },
+      ],
+    });
+
+    expect(result.totalUsd).toBeCloseTo(2, 4);
+  });
+
+  it("レスポンスの通貨を採用する", () => {
+    const result = sumOpenAiCosts({
+      data: [{ results: [{ amount: { value: 1, currency: "eur" } }] }],
+    });
+
+    expect(result.currency).toBe("eur");
+  });
+});


### PR DESCRIPTION
### 概要

AI 画像生成の外部 API 費用（OpenAI / Google Gemini）を、platform.openai.com や aistudio.google.com を都度開かずに /admin で確認できるようにします。計画書は `docs/planning/ai-cost-dashboard-implementation-plan.md`。

3段構成で、Phase 1（推定）は外部依存なしで動作し、Phase 2/3（実額）は環境変数が設定されている場合のみ併記されます。**未設定でも壊れません**（実額行が出ないだけ）。

### 変更内容

**Phase 1: 推定コスト（DB 変更なし・外部依存なし）**
- `ai-cost-rates.ts`: モデル別単価と固定換算レートの定数（出典 URL と取得日をコメントに記載）
  - gpt-image-2 low/medium/high 1k = $0.006 / $0.053 / $0.211
  - gemini-3.1-flash-image = $0.067、gemini-3-pro-image = $0.134、flash-lite = $0.0336
- `build-ai-cost.ts`: 既存の `generated_images` 取得を流用し、JST 日別 × プロバイダ別に集計（新規クエリなし）
- `AdminAiCostCard`: 期間内合計（円・USD 併記）＋ 日別積み上げバー ＋ モデル別内訳
- 単価未設定モデル（旧データの `model=null` 等）は金額に含めず件数のみ表示

**Phase 2: OpenAI 実額（`OPENAI_ADMIN_API_KEY` 設定時のみ）**
- Costs API から期間内の実請求額を取得し、円換算して KPI 行に併記
- タイムアウト 10 秒。キーは `server-only` でサーバー限定、ログ・表示に載せない

**Phase 3: Gemini 実額（`BILLING_BIGQUERY_DATASET` 設定時のみ）**
- Cloud Billing の BigQuery エクスポートから credits 控除後の実支払額を集計
- 既存の GA4 BigQuery クライアント・サービスアカウントを流用
- 別プロジェクトにエクスポートした場合は `BILLING_BIGQUERY_PROJECT_ID` で上書き可

### 設計判断（詳細は計画書の ADR）

- **単価はコード定数**（DB テーブル・管理画面編集は作らない）。改定頻度が低く、git 履歴とレビューが効くため
- **日別バーは常に推定ベースで統一**し、実額は期間合計の併記のみ。実額は反映が最大1日遅れるため、1つのグラフに混ぜると急増検知の基準がブレる
- **実額は DB に保存せず都度フェッチ**（GA4 と同じ Promise + Suspense パターン）。プロバイダごとに `allSettled` で独立して劣化する
- 粗利・収益対比は今回のスコープ外

### 実機テスト

- [ ] /admin の「AI 原価（推定）」カードの表示確認
- [ ] 期間タブ（24h/7d/30d/90d）切替で数値・バーが変わること
- [ ] モバイル幅でレイアウト崩れがないこと
- [ ] （Phase 2 有効化後）実額行が表示され、推定と大きく乖離しないこと

### テスト方法

- `npm run test`（270 suites / 2595 tests パス。新規 23 件: `build-ai-cost` 8 / `openai-costs-client` 5 / `billing-bigquery-query` 6+4 / `gemini-billing-summary` 6）
- `npm run typecheck`（アプリコードのエラー 0。tests/** の既存型エラーは main と同一）
- `npm run lint`（新規・変更ファイルへの指摘 0。既存 23 errors / 57 warnings は main と同一のベースライン）
- `npm run build -- --webpack`（成功）
- 実データ健全性: 直近30日 = gpt-image-2-low-1k 1,040件 / gemini 7件 / 単価未設定 38件 → 推定 約 $6.8（≒¥1,050）

### DB 変更

なし（マイグレーション不要・revert のみで完全に戻せます）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZvJpKb6xWibF4KdiryaJt
