### PR TITLE
refactor(moderation): 通報の pending 化を service_role クライアント経由に変更

### DIFF
--- a/app/api/reports/posts/route.ts
+++ b/app/api/reports/posts/route.ts
@@ -107,8 +107,15 @@ async function calculatePendingMetrics(
   };
 }
 
+/**
+ * pending 化 RPC を呼ぶ。
+ *
+ * ADR-010: `mark_post_pending_by_report` は service_role 専用に是正したため、
+ * 必ず `createAdminClient()` 由来のクライアントを渡すこと。セッションクライアントを
+ * 渡すと権限エラーになり、通報起因の自動非表示が停止する。
+ */
 async function setPendingWithRpc(
-  supabase: Awaited<ReturnType<typeof createClient>>,
+  supabase: ReturnType<typeof createAdminClient>,
   context: PendingContext
 ): Promise<{ ok: boolean; reason: string }> {
   const reasonCode =
@@ -143,8 +150,12 @@ async function setPendingWithRpc(
   return { ok: true, reason: "rpc_success" };
 }
 
+/**
+ * ADR-010: pending 判定の確認も admin クライアントに揃える。
+ * RLS 依存で「見えないから pending ではない」と誤判定するのを避ける。
+ */
 async function isPostAlreadyPending(
-  supabase: Awaited<ReturnType<typeof createClient>>,
+  supabase: ReturnType<typeof createAdminClient>,
   postId: string
 ): Promise<boolean> {
   const { data: currentPost, error } = await supabase
@@ -283,6 +294,11 @@ export async function POST(request: NextRequest) {
     let postModerationStatus: "visible" | "pending" | "removed" = post.moderation_status || "visible";
     const pendingMode: PendingMode = isReporterAdmin ? "admin_immediate" : "primary";
 
+    // ADR-010: pending 化 RPC と状態確認は service_role 専用に是正したため、
+    // admin 通報 (閾値判定をスキップする経路) でも admin クライアントが要る。
+    // 従来は非 admin 経路の集計内でのみ生成していたのでスコープを引き上げる。
+    const adminClient = createAdminClient();
+
     if (isReporterAdmin) {
       // admin による通報は閾値判定をスキップして即時 pending 化する
       metrics = {
@@ -294,7 +310,6 @@ export async function POST(request: NextRequest) {
       };
     } else {
       try {
-        const adminClient = createAdminClient();
         metrics = await calculatePendingMetrics(adminClient, postId, baselineTime);
 
         // 並行通報で集計タイミングが競合した場合に取りこぼしやすいため、短時間だけ再評価する
@@ -326,10 +341,10 @@ export async function POST(request: NextRequest) {
         mode: pendingMode,
       };
 
-      const rpcResult = await setPendingWithRpc(supabase, context);
+      const rpcResult = await setPendingWithRpc(adminClient, context);
       let pendingApplied = rpcResult.ok;
       if (!pendingApplied) {
-        const alreadyPending = await isPostAlreadyPending(supabase, postId);
+        const alreadyPending = await isPostAlreadyPending(adminClient, postId);
         if (!alreadyPending) {
           console.error("[Moderation] Pending update failed:", {
             context,

--- a/tests/unit/app/api/reports/posts-route-pending-client.test.ts
+++ b/tests/unit/app/api/reports/posts-route-pending-client.test.ts
@@ -1,0 +1,274 @@
+/** @jest-environment node */
+
+/**
+ * POST /api/reports/posts の pending 化経路が service_role クライアントを使うことの回帰テスト。
+ *
+ * 設計判断: docs/planning/post-moderation-notification-implementation-plan.md ADR-010 / REQ-020
+ *
+ * `mark_post_pending_by_report` は anon / authenticated から EXECUTE を剥奪し
+ * service_role 専用にした。そのためルート側は必ず `createAdminClient()` 由来の
+ * クライアントから RPC を呼ぶ必要がある。セッションクライアントに戻ると本番で
+ * 権限エラーになり、通報起因の自動非表示が無言で停止するため、ここを固定する。
+ */
+
+jest.mock("next/cache", () => ({
+  revalidateTag: jest.fn(),
+}));
+
+jest.mock("@/lib/supabase/server", () => ({
+  createClient: jest.fn(),
+}));
+
+jest.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: jest.fn(),
+}));
+
+jest.mock("@/lib/env", () => ({
+  getAdminUserIds: jest.fn(() => []),
+}));
+
+jest.mock("@/lib/security/same-origin", () => ({
+  ensureSameOrigin: jest.fn(() => null),
+}));
+
+jest.mock("@/lib/api/route-locale", () => ({
+  getRouteLocale: jest.fn(() => "ja"),
+}));
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/reports/posts/route";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getAdminUserIds } from "@/lib/env";
+
+const mockCreateClient = createClient as jest.MockedFunction<typeof createClient>;
+const mockCreateAdminClient = createAdminClient as jest.MockedFunction<
+  typeof createAdminClient
+>;
+const mockGetAdminUserIds = getAdminUserIds as jest.MockedFunction<
+  typeof getAdminUserIds
+>;
+
+const POST_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const REPORTER_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const AUTHOR_ID = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+const REPORT_ROW_ID = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+
+type QueryResult = Record<string, unknown>;
+
+/**
+ * PostgREST のチェーン呼び出しを受け流し、テーブルごとに用意した結果を順に返すビルダ。
+ * `await builder` と `builder.maybeSingle()` の両方で解決できるよう thenable にしている。
+ */
+function createChainMock(resultsByTable: Record<string, QueryResult[]>) {
+  const cursors: Record<string, number> = {};
+
+  const nextResult = (table: string): QueryResult => {
+    const queue = resultsByTable[table] ?? [];
+    const index = cursors[table] ?? 0;
+    cursors[table] = index + 1;
+    return queue[index] ?? { data: null, error: null, count: 0 };
+  };
+
+  const makeBuilder = (table: string) => {
+    const resolve = () => Promise.resolve(nextResult(table));
+    const builder: Record<string, unknown> = {
+      then: (onFulfilled: (value: QueryResult) => unknown) =>
+        resolve().then(onFulfilled),
+      maybeSingle: () => resolve(),
+      single: () => resolve(),
+    };
+    for (const method of [
+      "select",
+      "insert",
+      "update",
+      "delete",
+      "eq",
+      "gt",
+      "gte",
+      "lt",
+      "lte",
+      "not",
+      "in",
+      "is",
+      "or",
+      "order",
+      "range",
+      "limit",
+    ]) {
+      builder[method] = jest.fn(() => builder);
+    }
+    return builder;
+  };
+
+  return {
+    from: jest.fn((table: string) => makeBuilder(table)),
+  };
+}
+
+function buildSessionClient() {
+  const client = createChainMock({
+    // 1,2回目: レート制限カウント / 3回目: 通報行の INSERT
+    post_reports: [
+      { count: 0, error: null },
+      { count: 0, error: null },
+      { data: { id: REPORT_ROW_ID }, error: null },
+    ],
+    // 1回目: 対象投稿の取得 / 2回目: 通報者の投稿数カウント
+    generated_images: [
+      {
+        data: {
+          id: POST_ID,
+          user_id: AUTHOR_ID,
+          is_posted: true,
+          moderation_status: "visible",
+          moderation_approved_at: null,
+        },
+        error: null,
+      },
+      { count: 3, error: null },
+    ],
+  });
+
+  return {
+    ...client,
+    auth: {
+      getUser: jest.fn(async () => ({
+        data: { user: { id: REPORTER_ID, created_at: "2020-01-01T00:00:00.000Z" } },
+        error: null,
+      })),
+    },
+    // セッションクライアントから RPC を呼んでいないことを検証するために生やす
+    rpc: jest.fn(async () => ({ data: true, error: null })),
+  };
+}
+
+function buildRequest() {
+  return new NextRequest("https://example.com/api/reports/posts", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      postId: POST_ID,
+      categoryId: "rights",
+      subcategoryId: "copyright",
+    }),
+  });
+}
+
+describe("POST /api/reports/posts の pending 化クライアント (ADR-010)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("運営通報では admin クライアントから pending RPC を呼び、セッションクライアントは使わない", async () => {
+    mockGetAdminUserIds.mockReturnValue([REPORTER_ID]);
+
+    const sessionClient = buildSessionClient();
+    mockCreateClient.mockResolvedValue(
+      sessionClient as unknown as Awaited<ReturnType<typeof createClient>>
+    );
+
+    const adminRpc = jest.fn(async () => ({ data: true, error: null }));
+    const adminClient = {
+      ...createChainMock({}),
+      rpc: adminRpc,
+    };
+    mockCreateAdminClient.mockReturnValue(
+      adminClient as unknown as ReturnType<typeof createAdminClient>
+    );
+
+    const response = await POST(buildRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.postModerationStatus).toBe("pending");
+
+    // service_role 側で呼ばれていること
+    expect(adminRpc).toHaveBeenCalledTimes(1);
+    expect(adminRpc).toHaveBeenCalledWith(
+      "mark_post_pending_by_report",
+      expect.objectContaining({
+        p_post_id: POST_ID,
+        p_actor_id: REPORTER_ID,
+        p_reason: "admin_immediate",
+      })
+    );
+
+    // セッションクライアントからは RPC を呼ばないこと (ここが退行すると本番で権限エラーになる)
+    expect(sessionClient.rpc).not.toHaveBeenCalled();
+  });
+
+  it("一般ユーザーの通報がしきい値に達した場合も admin クライアントから pending RPC を呼ぶ", async () => {
+    mockGetAdminUserIds.mockReturnValue([]);
+
+    const sessionClient = buildSessionClient();
+    mockCreateClient.mockResolvedValue(
+      sessionClient as unknown as Awaited<ReturnType<typeof createClient>>
+    );
+
+    const adminRpc = jest.fn(async () => ({ data: true, error: null }));
+    const adminClient = {
+      ...createChainMock({
+        // calculatePendingMetrics: 通報行 (加重合計 3.0 でしきい値到達)
+        post_reports: [
+          {
+            data: [
+              { weight: 1, created_at: new Date().toISOString() },
+              { weight: 1, created_at: new Date().toISOString() },
+              { weight: 1, created_at: new Date().toISOString() },
+            ],
+            error: null,
+          },
+        ],
+        // アクティブユーザー算出用
+        generated_images: [{ data: [{ user_id: AUTHOR_ID }], error: null }],
+      }),
+      rpc: adminRpc,
+    };
+    mockCreateAdminClient.mockReturnValue(
+      adminClient as unknown as ReturnType<typeof createAdminClient>
+    );
+
+    const response = await POST(buildRequest());
+
+    expect(response.status).toBe(200);
+    expect(adminRpc).toHaveBeenCalledWith(
+      "mark_post_pending_by_report",
+      expect.objectContaining({
+        p_post_id: POST_ID,
+        p_reason: "report_threshold",
+      })
+    );
+    expect(sessionClient.rpc).not.toHaveBeenCalled();
+  });
+
+  it("RPC が失敗したときの pending 再確認も admin クライアントで行う", async () => {
+    mockGetAdminUserIds.mockReturnValue([REPORTER_ID]);
+
+    const sessionClient = buildSessionClient();
+    mockCreateClient.mockResolvedValue(
+      sessionClient as unknown as Awaited<ReturnType<typeof createClient>>
+    );
+
+    const adminChain = createChainMock({
+      // isPostAlreadyPending: 既に pending だった、を返す
+      generated_images: [{ data: { moderation_status: "pending" }, error: null }],
+    });
+    const adminClient = {
+      ...adminChain,
+      rpc: jest.fn(async () => ({
+        data: null,
+        error: { message: "permission denied" },
+      })),
+    };
+    mockCreateAdminClient.mockReturnValue(
+      adminClient as unknown as ReturnType<typeof createAdminClient>
+    );
+
+    const response = await POST(buildRequest());
+
+    expect(response.status).toBe(200);
+    // 再確認のクエリが admin クライアント側に来ていること
+    expect(adminChain.from).toHaveBeenCalledWith("generated_images");
+  });
+});


### PR DESCRIPTION
## 概要

通報による pending 化 RPC の呼び出しを、セッションクライアントから **admin（service_role）クライアント**に差し替えます。

セキュリティ修正の **1本目**です。権限の REVOKE は #457 で行います。

（#456 を分割作業でプレビューDBの履歴と齟齬が出たため、クリーンなブランチで作り直したPRです）

## 背景

`mark_post_pending_by_report` は本番の ACL 実測で **anon / authenticated に EXECUTE が付いています**。

```
mark_post_pending_by_report:  anon=X | authenticated=X | service_role=X  (SECURITY DEFINER)
```

マイグレーションには `GRANT EXECUTE TO authenticated` しか書かれていませんが、Supabase の default privileges により anon にも付与されています。関数は `auth.uid()` を参照せず、`p_actor_id` / `p_reason` が呼出者任せで、`post_reports` の存在確認もありません。更新条件は `is_posted = true AND moderation_status = 'visible'` のみです。

このため **公開 anon キーだけで任意の公開投稿を pending（全ユーザーから非表示）にでき**、偽の監査ログも作れる状態です。anon キーはクライアントバンドルに含まれる公開値で、PostgREST の `/rest/v1/rpc/` に直接到達できます。

## なぜ2本に分けるか

このリポジトリでは main へのマージ時点で Supabase の GitHub 連携がマイグレーションを**本番へ自動適用**します（= マージ = 適用）。REVOKE を同一PRに含めると、

```
マージ → REVOKE が即適用 → Vercel はまだビルド中（数分）→ 旧コードが権限エラー
```

となり、その間は運営通報としきい値到達通報が 500 になります。

そこで本PRでは**コード側だけ**を先に反映します。admin クライアントは REVOKE 前でも実行できるため、単独マージで機能は一切変わらず安全です。

## 変更内容

- `setPendingWithRpc` / `isPostAlreadyPending` の引数型を `createAdminClient()` の戻り値に変更
- admin クライアントの生成箇所を、非 admin 経路の内側から関数スコープへ引き上げ（運営通報の経路でも必要になったため）
- 引数シグネチャは変更していないため、RPC 側の変更は不要

## マージ後の手順

1. 本PRをマージ
2. **Vercel のデプロイ完了を確認**
3. #457（REVOKE マイグレーション・現在 Draft）を Ready にしてマージ

## 検証

| 項目 | 結果 |
| --- | --- |
| 新規テスト | 3件追加・パス（運営通報 / 一般通報しきい値到達 / RPC失敗時の再確認、いずれも admin クライアント経由でセッションクライアントは未使用） |
| `npm run test` | 274 suites / 2636 tests パス |
| `npm run build -- --webpack` | 成功 |
| `npm run typecheck` | origin/main と完全一致で新規エラー0件（既存赤540件は main 由来） |
| `npm run lint` | 変更ファイル単体で警告0件 |

設計判断: `docs/planning/post-moderation-notification-implementation-plan.md` ADR-010 / REQ-020

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mmqeUvT5TbjAMPNo6Pxsn