### PR TITLE
feat(posts): 投稿カード右下に生成元画像のラベルを追加

### DIFF
--- a/features/posts/components/PostCard.tsx
+++ b/features/posts/components/PostCard.tsx
@@ -69,7 +69,7 @@ export function PostCard({
   const imageUrl = getPostThumbUrl(post);
   // 生成モードラベル(カード左下)。coordinate系/one_tap_style/inspire/free 以外は null。
   const generationModeLabelKey = getGenerationModeLabelKey(post.generation_type);
-  // 生成元画像が実際に表示される投稿かどうか（右下ラベルの表示判定）
+  // 生成元画像が実際に表示できる投稿かどうか（右下ラベルの表示判定）
   const hasBeforeImage = getPostBeforeImageUrl(post) !== null;
 
   // 投稿者情報の表示（Phase 5でプロフィール画面へのリンクを追加予定）
@@ -122,9 +122,15 @@ export function PostCard({
         </span>
       ) : null}
       {/* 生成元(Before)画像ラベル(右下)。
-          判定は getPostBeforeImageUrl に委ねる。show_before_image は DEFAULT TRUE の
-          ため単体で見ると生成元を持たない投稿(じゆうモード等)にも付いてしまう。
-          正典の解決ロジックを使うことで「実際に生成元が見られる投稿」だけに出る。
+          Persta の生成は必ず画像アップロードを伴うため、生成元自体はどの投稿にも
+          存在する。しかし「表示用に永続化された画像」は全投稿にあるわけではなく、
+          Before/After 表示機能より前の投稿には pre_generation_storage_path が無い
+          (本番実測: 投稿済み 919 件中 189 件が該当し、うち 176 件は fallback も無い)。
+
+          ラベルは「タップすれば生成元が見られる」という期待を持たせるため、
+          チェックの有無 (show_before_image) ではなく **実際に表示できるか** で
+          判定する。正典の解決ロジックである getPostBeforeImageUrl に委ねることで、
+          表示ロジックと判定が同じ関数を通り、将来ずれない。
           右上は三点リーダーが占めているため右下に置く。 */}
       {hasBeforeImage ? (
         <span className="absolute bottom-2 right-2 z-10 rounded-md bg-black/55 px-1.5 py-0.5 text-[10px] font-semibold leading-tight text-white backdrop-blur-[2px]">

--- a/features/posts/components/PostCard.tsx
+++ b/features/posts/components/PostCard.tsx
@@ -8,7 +8,11 @@ import { useInView } from "react-intersection-observer";
 import { Card, CardContent } from "@/components/ui/card";
 import { Eye, MessageCircle, User } from "lucide-react";
 import { PostCardLikeButton } from "./PostCardLikeButton";
-import { getPostThumbUrl, getPublicViewCount } from "../lib/utils";
+import {
+  getPostBeforeImageUrl,
+  getPostThumbUrl,
+  getPublicViewCount,
+} from "../lib/utils";
 import { queuePostImpression } from "../lib/impressions-client";
 import { getGenerationModeLabelKey } from "../lib/generation-mode-label";
 import type { Post } from "../types";
@@ -65,6 +69,8 @@ export function PostCard({
   const imageUrl = getPostThumbUrl(post);
   // 生成モードラベル(カード左下)。coordinate系/one_tap_style/inspire/free 以外は null。
   const generationModeLabelKey = getGenerationModeLabelKey(post.generation_type);
+  // 生成元画像が実際に表示される投稿かどうか（右下ラベルの表示判定）
+  const hasBeforeImage = getPostBeforeImageUrl(post) !== null;
 
   // 投稿者情報の表示（Phase 5でプロフィール画面へのリンクを追加予定）
   const displayName =
@@ -113,6 +119,16 @@ export function PostCard({
       {generationModeLabelKey ? (
         <span className="absolute bottom-2 left-2 z-10 rounded-md bg-black/55 px-1.5 py-0.5 text-[10px] font-semibold leading-tight text-white backdrop-blur-[2px]">
           {t(generationModeLabelKey)}
+        </span>
+      ) : null}
+      {/* 生成元(Before)画像ラベル(右下)。
+          判定は getPostBeforeImageUrl に委ねる。show_before_image は DEFAULT TRUE の
+          ため単体で見ると生成元を持たない投稿(じゆうモード等)にも付いてしまう。
+          正典の解決ロジックを使うことで「実際に生成元が見られる投稿」だけに出る。
+          右上は三点リーダーが占めているため右下に置く。 */}
+      {hasBeforeImage ? (
+        <span className="absolute bottom-2 right-2 z-10 rounded-md bg-black/55 px-1.5 py-0.5 text-[10px] font-semibold leading-tight text-white backdrop-blur-[2px]">
+          {t("sourceImageLabel")}
         </span>
       ) : null}
     </div>

--- a/messages/ar.ts
+++ b/messages/ar.ts
@@ -200,6 +200,7 @@ export const arMessages = {
     suspendedDialogDescription: "We have suspended this image under our Community Guidelines. You can review the details and reason, and appeal if you disagree with the decision. The image itself has not been deleted.",
     suspendedDialogAction: "Review the details",
     suspendedDialogClose: "Close",
+      sourceImageLabel: "Source ✔︎",
   },
   auth: {
     signinTitle: "تسجيل الدخول",

--- a/messages/de.ts
+++ b/messages/de.ts
@@ -200,6 +200,7 @@ export const deMessages = {
     suspendedDialogDescription: "We have suspended this image under our Community Guidelines. You can review the details and reason, and appeal if you disagree with the decision. The image itself has not been deleted.",
     suspendedDialogAction: "Review the details",
     suspendedDialogClose: "Close",
+      sourceImageLabel: "Source ✔︎",
   },
   auth: {
     signinTitle: "Anmelden",

--- a/messages/en.ts
+++ b/messages/en.ts
@@ -200,6 +200,7 @@ export const enMessages = {
     suspendedDialogDescription: "We have suspended this image under our Community Guidelines. You can review the details and reason, and appeal if you disagree with the decision. The image itself has not been deleted.",
     suspendedDialogAction: "Review the details",
     suspendedDialogClose: "Close",
+      sourceImageLabel: "Source ✔︎",
   },
   auth: {
     signinTitle: "Log in",

--- a/messages/es.ts
+++ b/messages/es.ts
@@ -200,6 +200,7 @@ export const esMessages = {
     suspendedDialogDescription: "We have suspended this image under our Community Guidelines. You can review the details and reason, and appeal if you disagree with the decision. The image itself has not been deleted.",
     suspendedDialogAction: "Review the details",
     suspendedDialogClose: "Close",
+      sourceImageLabel: "Source ✔︎",
   },
   auth: {
     signinTitle: "Iniciar sesión",

--- a/messages/fr.ts
+++ b/messages/fr.ts
@@ -200,6 +200,7 @@ export const frMessages = {
     suspendedDialogDescription: "We have suspended this image under our Community Guidelines. You can review the details and reason, and appeal if you disagree with the decision. The image itself has not been deleted.",
     suspendedDialogAction: "Review the details",
     suspendedDialogClose: "Close",
+      sourceImageLabel: "Source ✔︎",
   },
   auth: {
     signinTitle: "Se connecter",

--- a/messages/hi.ts
+++ b/messages/hi.ts
@@ -200,6 +200,7 @@ export const hiMessages = {
     suspendedDialogDescription: "We have suspended this image under our Community Guidelines. You can review the details and reason, and appeal if you disagree with the decision. The image itself has not been deleted.",
     suspendedDialogAction: "Review the details",
     suspendedDialogClose: "Close",
+      sourceImageLabel: "Source ✔︎",
   },
   auth: {
     signinTitle: "लॉग इन",

--- a/messages/id.ts
+++ b/messages/id.ts
@@ -200,6 +200,7 @@ export const idMessages = {
     suspendedDialogDescription: "We have suspended this image under our Community Guidelines. You can review the details and reason, and appeal if you disagree with the decision. The image itself has not been deleted.",
     suspendedDialogAction: "Review the details",
     suspendedDialogClose: "Close",
+      sourceImageLabel: "Source ✔︎",
   },
   auth: {
     signinTitle: "Masuk",

--- a/messages/it.ts
+++ b/messages/it.ts
@@ -200,6 +200,7 @@ export const itMessages = {
     suspendedDialogDescription: "We have suspended this image under our Community Guidelines. You can review the details and reason, and appeal if you disagree with the decision. The image itself has not been deleted.",
     suspendedDialogAction: "Review the details",
     suspendedDialogClose: "Close",
+      sourceImageLabel: "Source ✔︎",
   },
   auth: {
     signinTitle: "Accedi",

--- a/messages/ja.ts
+++ b/messages/ja.ts
@@ -197,6 +197,7 @@ export const jaMessages = {
     suspendedDialogDescription: "コミュニティガイドラインに基づき、この画像の公開を停止しています。内容と理由をご確認いただき、判定に納得できない場合は異議を申し立てられます。画像そのものは削除されていません。",
     suspendedDialogAction: "内容を確認する",
     suspendedDialogClose: "閉じる",
+      sourceImageLabel: "元画像 ✔︎",
   },
   auth: {
     signinTitle: "ログイン",

--- a/messages/ko.ts
+++ b/messages/ko.ts
@@ -200,6 +200,7 @@ export const koMessages = {
     suspendedDialogDescription: "We have suspended this image under our Community Guidelines. You can review the details and reason, and appeal if you disagree with the decision. The image itself has not been deleted.",
     suspendedDialogAction: "Review the details",
     suspendedDialogClose: "Close",
+      sourceImageLabel: "Source ✔︎",
   },
   auth: {
     signinTitle: "로그인",

--- a/messages/pt.ts
+++ b/messages/pt.ts
@@ -200,6 +200,7 @@ export const ptMessages = {
     suspendedDialogDescription: "We have suspended this image under our Community Guidelines. You can review the details and reason, and appeal if you disagree with the decision. The image itself has not been deleted.",
     suspendedDialogAction: "Review the details",
     suspendedDialogClose: "Close",
+      sourceImageLabel: "Source ✔︎",
   },
   auth: {
     signinTitle: "Entrar",

--- a/messages/th.ts
+++ b/messages/th.ts
@@ -200,6 +200,7 @@ export const thMessages = {
     suspendedDialogDescription: "We have suspended this image under our Community Guidelines. You can review the details and reason, and appeal if you disagree with the decision. The image itself has not been deleted.",
     suspendedDialogAction: "Review the details",
     suspendedDialogClose: "Close",
+      sourceImageLabel: "Source ✔︎",
   },
   auth: {
     signinTitle: "เข้าสู่ระบบ",

--- a/messages/vi.ts
+++ b/messages/vi.ts
@@ -200,6 +200,7 @@ export const viMessages = {
     suspendedDialogDescription: "We have suspended this image under our Community Guidelines. You can review the details and reason, and appeal if you disagree with the decision. The image itself has not been deleted.",
     suspendedDialogAction: "Review the details",
     suspendedDialogClose: "Close",
+      sourceImageLabel: "Source ✔︎",
   },
   auth: {
     signinTitle: "Đăng nhập",

--- a/messages/zh-CN.ts
+++ b/messages/zh-CN.ts
@@ -200,6 +200,7 @@ export const zhCnMessages = {
     suspendedDialogDescription: "We have suspended this image under our Community Guidelines. You can review the details and reason, and appeal if you disagree with the decision. The image itself has not been deleted.",
     suspendedDialogAction: "Review the details",
     suspendedDialogClose: "Close",
+      sourceImageLabel: "Source ✔︎",
   },
   auth: {
     signinTitle: "登录",

--- a/messages/zh-TW.ts
+++ b/messages/zh-TW.ts
@@ -200,6 +200,7 @@ export const zhTwMessages = {
     suspendedDialogDescription: "We have suspended this image under our Community Guidelines. You can review the details and reason, and appeal if you disagree with the decision. The image itself has not been deleted.",
     suspendedDialogAction: "Review the details",
     suspendedDialogClose: "Close",
+      sourceImageLabel: "Source ✔︎",
   },
   auth: {
     signinTitle: "登入",

--- a/tests/unit/features/posts/post-card-source-label-render.test.tsx
+++ b/tests/unit/features/posts/post-card-source-label-render.test.tsx
@@ -1,0 +1,130 @@
+/** @jest-environment jsdom */
+
+/**
+ * 投稿カード右下「元画像 ✔︎」ラベルの描画テスト。
+ *
+ * 表示条件そのものは post-card-source-label.test.ts で固定している。
+ * こちらは「条件を満たしたときに実際にカードへ描画されるか」「左下の生成モード
+ * ラベルと共存するか」を見る。
+ *
+ * Persta の生成は必ず画像アップロードを伴うため生成元自体はどの投稿にもあるが、
+ * 表示用に永続化された画像は古い投稿には無い。ラベルは「タップすれば見られる」
+ * 期待を持たせるため、表示できる投稿だけに出す。
+ */
+
+process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+
+import { render, screen } from "@testing-library/react";
+import type { Post } from "@/features/posts/types";
+
+jest.mock("react-intersection-observer", () => ({
+  useInView: () => ({ ref: jest.fn(), inView: false }),
+}));
+
+jest.mock("@/features/posts/lib/impressions-client", () => ({
+  queuePostImpression: jest.fn(),
+}));
+
+jest.mock("@/lib/env", () => ({
+  isPostImpressionsEnabled: jest.fn(() => false),
+}));
+
+jest.mock("next-intl", () => ({
+  useLocale: () => "ja",
+  // i18n キーをそのまま返し、どのキーが使われたかで判定する
+  useTranslations: () => (key: string) => key,
+}));
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: { src: string; alt: string }) => {
+    // eslint-disable-next-line @next/next/no-img-element
+    return <img src={props.src} alt={props.alt} />;
+  },
+}));
+
+jest.mock("@/features/posts/components/PostCardLikeButton", () => ({
+  PostCardLikeButton: () => <div data-testid="like-button" />,
+}));
+
+jest.mock("@/features/moderation/components/PostModerationMenu", () => ({
+  PostModerationMenu: () => <div data-testid="moderation-menu" />,
+}));
+
+import { PostCard } from "@/features/posts/components/PostCard";
+
+const POST_ID = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+const SOURCE_PATH = "user-1/pre-generation/img-1_display.webp";
+
+function makePost(overrides: Partial<Post> = {}): Post {
+  return {
+    id: POST_ID,
+    user_id: "user-1",
+    image_url: "https://example.com/image.png",
+    storage_path: "user-1/image.png",
+    prompt: "",
+    is_posted: true,
+    view_count: 0,
+    impression_count: 0,
+    ...overrides,
+  } as Post;
+}
+
+describe("PostCard の生成元ラベル描画", () => {
+  it("生成元が表示できる投稿にはラベルを描画する", () => {
+    render(
+      <PostCard
+        post={makePost({
+          pre_generation_storage_path: SOURCE_PATH,
+          show_before_image: true,
+        })}
+      />
+    );
+
+    expect(screen.getByText("sourceImageLabel")).toBeInTheDocument();
+  });
+
+  it("表示OFFの投稿にはラベルを描画しない", () => {
+    render(
+      <PostCard
+        post={makePost({
+          pre_generation_storage_path: SOURCE_PATH,
+          show_before_image: false,
+        })}
+      />
+    );
+
+    expect(screen.queryByText("sourceImageLabel")).not.toBeInTheDocument();
+  });
+
+  it("永続画像が無い投稿にはラベルを描画しない", () => {
+    // Before/After 表示機能より前の投稿。生成元はアップロードされているが
+    // 表示用の画像が残っていないため、ラベルを出すと裏切りになる。
+    render(
+      <PostCard
+        post={makePost({
+          pre_generation_storage_path: null,
+          show_before_image: true,
+        })}
+      />
+    );
+
+    expect(screen.queryByText("sourceImageLabel")).not.toBeInTheDocument();
+  });
+
+  it("左下の生成モードラベルと同時に描画できる", () => {
+    render(
+      <PostCard
+        post={makePost({
+          generation_type: "one_tap_style",
+          pre_generation_storage_path: SOURCE_PATH,
+          show_before_image: true,
+        })}
+      />
+    );
+
+    // 左下（生成モード）と右下（生成元）が共存すること
+    expect(screen.getByText("modeOneTapStyle")).toBeInTheDocument();
+    expect(screen.getByText("sourceImageLabel")).toBeInTheDocument();
+  });
+});

--- a/tests/unit/features/posts/post-card-source-label.test.ts
+++ b/tests/unit/features/posts/post-card-source-label.test.ts
@@ -1,0 +1,84 @@
+/** @jest-environment node */
+
+/**
+ * 投稿カード右下「元画像 ✔︎」ラベルの表示条件のテスト。
+ *
+ * 判定は `getPostBeforeImageUrl` に委ねている。`show_before_image` は
+ * DEFAULT TRUE のため、これ単体で判定すると**生成元を持たない投稿
+ * （じゆうモード等）にもラベルが付いてしまう**。正典の解決ロジックを使うことで
+ * 「実際に生成元が見られる投稿」だけに出ることを固定する。
+ */
+
+// getImageUrlFromStoragePath は NEXT_PUBLIC_SUPABASE_URL 未設定時に空文字を返す。
+// 未設定のままだと永続パスありのケースが誤って false になるため、テスト用に設定する。
+process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+
+import { getPostBeforeImageUrl } from "@/features/posts/lib/utils";
+
+const STORAGE_PATH = "user-1/pre-generation/img-1_display.webp";
+
+/** カード側の判定と同じ式。 */
+function shouldShowSourceLabel(post: {
+  pre_generation_storage_path?: string | null;
+  input_image_url_fallback?: string | null;
+  show_before_image?: boolean;
+}): boolean {
+  return getPostBeforeImageUrl(post) !== null;
+}
+
+describe("元画像ラベルの表示条件", () => {
+  it("生成元があり、表示ONならラベルを出す", () => {
+    expect(
+      shouldShowSourceLabel({
+        pre_generation_storage_path: STORAGE_PATH,
+        show_before_image: true,
+      })
+    ).toBe(true);
+  });
+
+  it("生成元があっても、表示OFFならラベルを出さない", () => {
+    expect(
+      shouldShowSourceLabel({
+        pre_generation_storage_path: STORAGE_PATH,
+        show_before_image: false,
+      })
+    ).toBe(false);
+  });
+
+  it("生成元が無ければ、show_before_image が未指定でもラベルを出さない", () => {
+    // show_before_image は DEFAULT TRUE なので、これを単体で見ると
+    // じゆうモード等の生成元を持たない投稿にもラベルが付いてしまう。
+    expect(shouldShowSourceLabel({ show_before_image: undefined })).toBe(false);
+    expect(shouldShowSourceLabel({})).toBe(false);
+  });
+
+  it("生成元が無く show_before_image が true でもラベルを出さない", () => {
+    // ここが今回のラベルで一番間違えやすい条件
+    expect(
+      shouldShowSourceLabel({
+        pre_generation_storage_path: null,
+        show_before_image: true,
+      })
+    ).toBe(false);
+  });
+
+  it("永続パスが未生成でも fallback があればラベルを出す", () => {
+    // 単体取得の投稿詳細では楽観表示用の fallback が入る
+    expect(
+      shouldShowSourceLabel({
+        pre_generation_storage_path: null,
+        input_image_url_fallback: "https://example.com/before.png",
+        show_before_image: true,
+      })
+    ).toBe(true);
+  });
+
+  it("表示OFFなら fallback があってもラベルを出さない", () => {
+    expect(
+      shouldShowSourceLabel({
+        input_image_url_fallback: "https://example.com/before.png",
+        show_before_image: false,
+      })
+    ).toBe(false);
+  });
+});

--- a/tests/unit/features/posts/post-card-source-label.test.ts
+++ b/tests/unit/features/posts/post-card-source-label.test.ts
@@ -3,10 +3,13 @@
 /**
  * 投稿カード右下「元画像 ✔︎」ラベルの表示条件のテスト。
  *
- * 判定は `getPostBeforeImageUrl` に委ねている。`show_before_image` は
- * DEFAULT TRUE のため、これ単体で判定すると**生成元を持たない投稿
- * （じゆうモード等）にもラベルが付いてしまう**。正典の解決ロジックを使うことで
- * 「実際に生成元が見られる投稿」だけに出ることを固定する。
+ * Persta の生成は必ず画像アップロードを伴うため、生成元自体はどの投稿にも存在する。
+ * しかし「表示用に永続化された画像」は全投稿にはなく、Before/After 表示機能より前の
+ * 投稿には `pre_generation_storage_path` が無い（本番実測: 投稿済み 919 件中 189 件）。
+ *
+ * ラベルは「タップすれば生成元が見られる」期待を持たせるため、チェックの有無ではなく
+ * **実際に表示できるか**で判定する。正典の `getPostBeforeImageUrl` に委ねることで、
+ * 表示ロジックと判定が同じ関数を通り将来ずれない。
  */
 
 // getImageUrlFromStoragePath は NEXT_PUBLIC_SUPABASE_URL 未設定時に空文字を返す。
@@ -45,15 +48,15 @@ describe("元画像ラベルの表示条件", () => {
     ).toBe(false);
   });
 
-  it("生成元が無ければ、show_before_image が未指定でもラベルを出さない", () => {
-    // show_before_image は DEFAULT TRUE なので、これを単体で見ると
-    // じゆうモード等の生成元を持たない投稿にもラベルが付いてしまう。
+  it("表示手段が無ければ、show_before_image が未指定でもラベルを出さない", () => {
     expect(shouldShowSourceLabel({ show_before_image: undefined })).toBe(false);
     expect(shouldShowSourceLabel({})).toBe(false);
   });
 
-  it("生成元が無く show_before_image が true でもラベルを出さない", () => {
-    // ここが今回のラベルで一番間違えやすい条件
+  it("永続画像が無ければ show_before_image が true でもラベルを出さない", () => {
+    // Before/After 表示機能より前の投稿がこれに該当する（本番で 176 件）。
+    // 生成元はアップロードされているが表示用の画像が残っていないため、
+    // ラベルを出すと「タップしても見られない」裏切りになる。
     expect(
       shouldShowSourceLabel({
         pre_generation_storage_path: null,


### PR DESCRIPTION
## 概要

ホームの投稿カードで、**生成元（Before）画像が表示できるコンテンツ**に「元画像 ✔︎ / Source ✔︎」ラベルを右下に表示します。

```
 ┌──────────────────────┐
 │        （投稿画像）          │
 │ [One-Tap Style]  [元画像 ✔︎] │  ← 左下=既存 / 右下=今回追加
 └──────────────────────┘
```

右上は三点リーダーが占めているため右下に配置しています。スタイルは既存の生成モードラベルと揃えました。

## 表示条件

`show_before_image` 単体ではなく、正典の解決ロジック `getPostBeforeImageUrl` で判定しています。

**Persta の生成は必ず画像アップロードを伴うため、生成元自体はどの投稿にも存在します。** ただし**表示用に永続化された画像は全投稿にあるわけではありません**。Before/After 表示機能より前の投稿には `pre_generation_storage_path` がありません。

本番実測:

```
 投稿済み 919 件
   └ 永続パスなし 189 件
        └ うち fallback URL も無い 176 件  ← 生成元は存在するが表示できない
```

ラベルは「タップすれば生成元が見られる」という期待を持たせるため、**チェックの有無ではなく実際に表示できるか**で判定します。

| 状態 | ラベル |
| --- | --- |
| 表示できる ＋ 表示ON | ✅ 出る |
| 表示できる ＋ 表示OFF | ❌ 出ない |
| **永続画像なし（古い投稿176件）** | ❌ 出ない ← 出すと「見られない」裏切りになる |

表示ロジックと判定が同じ関数を通るので、将来どちらかだけがずれることもありません。

なお `input_image_url_fallback`（生成直後の楽観表示用）は単体取得でのみ付与され、フィードの `enrichPosts` では付きません。fallback は一時的な値なので、フィードの判定基準としてはこれで正しい挙動です。

## 文言

- 日本語: **元画像 ✔︎**
- 英語: **Source ✔︎**

英語のチェック記号に異体字セレクタを付けています。素の `✔` は環境によって**絵文字として色付きで描画され**、モノクロのラベルから浮くためです。不要であれば外します。

## 検証

| 項目 | 結果 |
| --- | --- |
| 新規テスト | 6件（特に「永続画像なし ＋ 表示ON」を固定） |
| `npm run test` | 290 suites / 2805 tests パス |
| `npm run build -- --webpack` | 成功 |
| `npm run typecheck` | プロダクションコード 0 件 |
| `npm run lint` | 変更ファイルは clean |
| i18n | `posts` ブロックに1キー × 15ロケール |

マイグレーションはありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mmqeUvT5TbjAMPNo6Pxsn