### PR TITLE
fix(prompt-secrets): 完了RPCの切替漏れを直し読み取り経路を全件移行する

### DIFF
--- a/features/event/lib/database.ts
+++ b/features/event/lib/database.ts
@@ -1,6 +1,7 @@
 import { createClient as createBrowserClient } from "@/lib/supabase/client";
 import { env } from "@/lib/env";
 import type { GeneratedImageRecord } from "@/features/generation/lib/database";
+import { resolveOwnVisiblePrompts } from "@/features/generation/lib/prompt-secrets-client";
 
 /**
  * イベント画像取得関数（クライアント側）
@@ -32,5 +33,7 @@ export async function getEventImages(
     throw new Error(`イベント画像の取得に失敗しました: ${error.message}`);
   }
 
-  return data || [];
+  // プロンプトの正本は author secret。generated_images.prompt は
+  // 移行期間の互換用にすぎず、Phase 0C で空になる（ADR-001）。
+  return await resolveOwnVisiblePrompts(data || []);
 }

--- a/features/event/lib/server-api.ts
+++ b/features/event/lib/server-api.ts
@@ -2,6 +2,7 @@ import { cache } from "react";
 import { createClient } from "@/lib/supabase/server";
 import { env } from "@/lib/env";
 import type { GeneratedImageRecord } from "@/features/generation/lib/database";
+import { resolveVisiblePrompts } from "@/features/generation/lib/prompt-secrets";
 
 /**
  * イベント画像取得関数（サーバー側）
@@ -34,5 +35,7 @@ export const getEventImagesServer = cache(async (
     throw new Error(`イベント画像の取得に失敗しました: ${error.message}`);
   }
 
-  return data || [];
+  // プロンプトの正本は author secret。generated_images.prompt は
+  // 移行期間の互換用にすぎず、Phase 0C で空になる（ADR-001）。
+  return await resolveVisiblePrompts(data || []);
 });

--- a/features/generation/lib/database.ts
+++ b/features/generation/lib/database.ts
@@ -1,4 +1,5 @@
 import { createClient as createBrowserClient } from "@/lib/supabase/client";
+import { resolveOwnVisiblePrompts } from "./prompt-secrets-client";
 import { COORDINATE_STOCKS_LINK_MAX_JOBS } from "./coordinate-stocks-constants";
 import type { BackgroundMode, GeminiModel, GenerationType } from "../types";
 
@@ -137,7 +138,9 @@ export async function getGeneratedImages(
     throw new Error(`画像の取得に失敗しました: ${error.message}`);
   }
 
-  return data || [];
+  // プロンプトの正本は author secret。generated_images.prompt は移行期間の
+  // 互換用にすぎず、Phase 0C で空になる（ADR-001）。
+  return await resolveOwnVisiblePrompts(data || []);
 }
 
 /**
@@ -451,7 +454,9 @@ export async function getGeneratedImagesBySourceImage(
     throw new Error(`生成画像の取得に失敗しました: ${error.message}`);
   }
 
-  return data || [];
+  // プロンプトの正本は author secret。generated_images.prompt は移行期間の
+  // 互換用にすぎず、Phase 0C で空になる（ADR-001）。
+  return await resolveOwnVisiblePrompts(data || []);
 }
 
 /**

--- a/features/generation/lib/server-database.ts
+++ b/features/generation/lib/server-database.ts
@@ -3,6 +3,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { GenerationType } from "../types";
 import { createClient } from "@/lib/supabase/server";
 import type { SourceImageStock, GeneratedImageRecord } from "./database";
+import { resolveVisiblePrompts } from "@/features/generation/lib/prompt-secrets";
 
 /**
  * サーバーサイドでストック画像一覧を取得
@@ -102,7 +103,9 @@ export const getGeneratedImagesServer = cache(async (
     throw new Error(`画像の取得に失敗しました: ${error.message}`);
   }
 
-  return data || [];
+  // プロンプトの正本は author secret。generated_images.prompt は
+  // 移行期間の互換用にすぎず、Phase 0C で空になる（ADR-001）。
+  return await resolveVisiblePrompts(data || []);
 });
 
 /**

--- a/supabase/functions/image-gen-worker/index.ts
+++ b/supabase/functions/image-gen-worker/index.ts
@@ -2702,7 +2702,11 @@ Deno.serve(async () => {
 
               if (isOpenAIImageModel(dbModel)) {
                 const { data: imageRecords, error: completeJobError } = await supabase.rpc(
-                  "complete_image_job_with_generated_images",
+                  // 画像行・author secret・job 成功更新を同一トランザクションで
+                  // 確定する。旧 complete_image_job_with_generated_images は
+                  // 空になった prompt_text をコピーするだけで author secret を
+                  // 作らないため、生成した本人が自分のプロンプトを参照できなくなる。
+                  "complete_image_job_with_prompt_secrets",
                   {
                     p_job_id: jobId,
                     p_images: uploadedImages.map((image) => ({

--- a/supabase/migrations/20260729150000_recover_missing_prompt_secrets.sql
+++ b/supabase/migrations/20260729150000_recover_missing_prompt_secrets.sql
@@ -1,0 +1,83 @@
+-- ===============================================
+-- 障害復旧: 完了 RPC の切り替え漏れで失われた author secret を復元する
+-- ===============================================
+-- Worker は complete_image_job_with_prompt_secrets へ切り替えるはずだったが、
+-- 呼び出し側を更新し忘れており、旧 complete_image_job_with_generated_images を
+-- 呼び続けていた。
+--
+-- 旧 RPC は image_jobs.prompt_text を generated_images.prompt へコピーするが、
+-- 新 Next.js は prompt_text を空にするようになったため、
+--   - generated_images.prompt は空
+--   - author secret も作られない
+-- となり、生成した本人が自分のプロンプトを参照できなくなっていた。
+--
+-- 本文は generation_prompt_snapshots.author_input に残っているため復元できる。
+-- One-Tap Style は provider_prompt しか持たず author secret を作らない仕様
+-- なので、ここでも対象外である。
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+
+INSERT INTO public.generated_image_prompt_secrets (
+  image_id,
+  prompt,
+  prompt_owner_id,
+  source_kind,
+  created_at
+)
+SELECT
+  gi.id,
+  sn.author_input,
+  sn.author_input_owner_id,
+  'author_input',
+  gi.created_at
+FROM public.generated_images AS gi
+JOIN public.generation_prompt_snapshots AS sn
+  ON sn.image_job_id = gi.image_job_id
+WHERE sn.snapshot_kind = 'materialized'
+  AND sn.author_input IS NOT NULL
+  AND sn.author_input_owner_id IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM public.generated_image_prompt_secrets AS s
+    WHERE s.image_id = gi.id
+  )
+ON CONFLICT (image_id) DO NOTHING;
+
+DO $$
+DECLARE
+  v_orphan integer;
+  v_leaked integer;
+BEGIN
+  -- 実行入力に本文があるのに secret が無い行が残っていないこと
+  SELECT count(*)
+  INTO v_orphan
+  FROM public.generated_images AS gi
+  JOIN public.generation_prompt_snapshots AS sn
+    ON sn.image_job_id = gi.image_job_id
+  WHERE sn.author_input IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1
+      FROM public.generated_image_prompt_secrets AS s
+      WHERE s.image_id = gi.id
+    );
+
+  IF v_orphan > 0 THEN
+    RAISE EXCEPTION '復元漏れが % 件', v_orphan;
+  END IF;
+
+  -- 運営資産が author secret へ紛れ込んでいないこと
+  SELECT count(*)
+  INTO v_leaked
+  FROM public.generated_image_prompt_secrets AS s
+  JOIN public.generated_images AS gi ON gi.id = s.image_id
+  WHERE gi.generation_type IN ('one_tap_style', 'inspire');
+
+  IF v_leaked > 0 THEN
+    RAISE EXCEPTION '運営資産が author secret に % 件混入している', v_leaked;
+  END IF;
+END;
+$$;
+
+COMMIT;

--- a/supabase/migrations/20260729160000_restore_empty_legacy_prompts.sql
+++ b/supabase/migrations/20260729160000_restore_empty_legacy_prompts.sql
@@ -1,0 +1,63 @@
+-- ===============================================
+-- 障害復旧(2): 空になってしまった legacy prompt を secret から書き戻す
+-- ===============================================
+-- Worker が旧完了 RPC を呼んでいた間に作られた行は、
+--   generated_images.prompt = ''（空になった prompt_text をコピーしたため）
+--   generated_image_prompt_secrets = 復旧マイグレーションで復元済み
+-- という状態になっている。
+--
+-- 生成一覧などブラウザ側の画面はまだ author secret を読んでおらず、
+-- generated_images.prompt を直接表示するため「プロンプト情報がありません」と
+-- 出てしまう。移行期間中は legacy 列にも値がある前提なので、secret から
+-- 書き戻して整合させる。
+--
+-- 対象は「secret があるのに legacy 列が空」の行だけ。運営資産(one_tap_style /
+-- inspire)は secret を持たないため、この条件に一致しない。
+--
+-- Phase 0C で legacy 列を空化する前に、ブラウザ側の読み取り経路を
+-- author secret へ移す必要がある。これはその移行までの暫定復旧である。
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+
+UPDATE public.generated_images AS gi
+SET prompt = s.prompt
+FROM public.generated_image_prompt_secrets AS s
+WHERE s.image_id = gi.id
+  AND gi.prompt = ''
+  AND s.prompt <> '';
+
+DO $$
+DECLARE
+  v_remaining integer;
+  v_leaked integer;
+BEGIN
+  -- secret があるのに legacy 列が空の行が残っていないこと
+  SELECT count(*)
+  INTO v_remaining
+  FROM public.generated_images AS gi
+  JOIN public.generated_image_prompt_secrets AS s ON s.image_id = gi.id
+  WHERE gi.prompt = ''
+    AND s.prompt <> '';
+
+  IF v_remaining > 0 THEN
+    RAISE EXCEPTION '書き戻し漏れが % 件', v_remaining;
+  END IF;
+
+  -- 運営資産を legacy 列へ書き戻していないこと。
+  -- one_tap_style / inspire は secret を持たないので 0 のはずだが、
+  -- 条件を取り違えた場合にここで止める。
+  SELECT count(*)
+  INTO v_leaked
+  FROM public.generated_image_prompt_secrets AS s
+  JOIN public.generated_images AS gi ON gi.id = s.image_id
+  WHERE gi.generation_type IN ('one_tap_style', 'inspire');
+
+  IF v_leaked > 0 THEN
+    RAISE EXCEPTION '運営資産が author secret に % 件混入している', v_leaked;
+  END IF;
+END;
+$$;
+
+COMMIT;

--- a/tests/unit/features/generation/gallery-prompt-resolution.test.ts
+++ b/tests/unit/features/generation/gallery-prompt-resolution.test.ts
@@ -1,0 +1,194 @@
+/** @jest-environment node */
+
+/**
+ * 生成一覧・イベントギャラリーが author secret を通すことのテスト。
+ *
+ * これらの経路は当初 generated_images.prompt を直接表示しており、
+ * 新 Next.js が prompt_text を空にした結果「プロンプト情報がありません」と
+ * 出る障害になった。Phase 0C で legacy 列を空化すると同じことが全件で起きる。
+ *
+ * ここでは各関数が secret 側の値を返すことを固定し、経路が戻ってしまったら
+ * 落ちるようにする（ADR-001）。
+ */
+
+const secretRows: Array<{ image_id: string; prompt: string }> = [];
+
+/** author secret の一括取得だけを差し替える最小のクライアント。 */
+function createSecretClient() {
+  return {
+    from: () => ({
+      select: () => ({
+        in: () => Promise.resolve({ data: secretRows, error: null }),
+      }),
+    }),
+  };
+}
+
+/** generated_images 側の応答を差し替えるための可変ハンドル。 */
+const imageRows: { data: unknown; error: unknown } = { data: [], error: null };
+
+/**
+ * PostgREST のビルダーは呼び出し順が経路ごとに違うため、
+ * どのメソッドを呼んでも自分自身を返し、await で結果を返す thenable にする。
+ */
+function createImageQueryBuilder() {
+  const builder: Record<string, unknown> = {};
+  const passthrough = () => builder;
+  for (const method of [
+    "select",
+    "eq",
+    "neq",
+    "in",
+    "is",
+    "not",
+    "gt",
+    "gte",
+    "lt",
+    "lte",
+    "order",
+    "range",
+    "limit",
+  ]) {
+    builder[method] = passthrough;
+  }
+  builder.then = (
+    resolve: (value: typeof imageRows) => unknown
+  ): unknown => resolve(imageRows);
+  return builder;
+}
+
+const browserFrom = jest.fn(() => createImageQueryBuilder());
+
+jest.mock("@/lib/supabase/client", () => ({
+  createClient: jest.fn(() => {
+    // 秘密テーブルと画像テーブルで返すビルダーを変える
+    return {
+      from: (table: string) =>
+        table === "generated_image_prompt_secrets"
+          ? createSecretClient().from()
+          : browserFrom(),
+    };
+  }),
+}));
+
+jest.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: jest.fn(() => createSecretClient()),
+}));
+
+jest.mock("@/lib/supabase/server", () => ({
+  createClient: jest.fn(async () => ({
+    from: (table: string) =>
+      table === "generated_image_prompt_secrets"
+        ? createSecretClient().from()
+        : browserFrom(),
+  })),
+}));
+
+jest.mock("react", () => {
+  const actual = jest.requireActual("react");
+  return { ...actual, cache: <T,>(fn: T) => fn };
+});
+
+jest.mock("@/lib/env", () => ({
+  env: { NEXT_PUBLIC_EVENT_USER_ID: "event-user" },
+}));
+
+import {
+  getGeneratedImages,
+  getGeneratedImagesBySourceImage,
+} from "@/features/generation/lib/database";
+import { getGeneratedImagesServer } from "@/features/generation/lib/server-database";
+import { getEventImages } from "@/features/event/lib/database";
+
+function setImages(rows: unknown[]) {
+  imageRows.data = rows;
+  imageRows.error = null;
+}
+
+function setSecrets(rows: Array<{ image_id: string; prompt: string }>) {
+  secretRows.length = 0;
+  secretRows.push(...rows);
+}
+
+beforeEach(() => {
+  browserFrom.mockClear();
+  setImages([]);
+  setSecrets([]);
+});
+
+/** 障害当時の状態: legacy 列が空で secret にだけ本文がある行。 */
+const ROW_WITH_EMPTY_LEGACY = {
+  id: "img-1",
+  prompt: "",
+  generation_type: "coordinate" as const,
+};
+
+const SECRET_FOR_ROW = [{ image_id: "img-1", prompt: "ネコをイヌにして" }];
+
+describe("生成一覧が author secret を通す", () => {
+  it("getGeneratedImages は secret の本文を返す", async () => {
+    setImages([ROW_WITH_EMPTY_LEGACY]);
+    setSecrets(SECRET_FOR_ROW);
+
+    const result = await getGeneratedImages("user-1");
+
+    expect(result[0].prompt).toBe("ネコをイヌにして");
+  });
+
+  it("getGeneratedImagesBySourceImage は secret の本文を返す", async () => {
+    setImages([ROW_WITH_EMPTY_LEGACY]);
+    setSecrets(SECRET_FOR_ROW);
+
+    const result = await getGeneratedImagesBySourceImage("stock-1", null);
+
+    expect(result[0].prompt).toBe("ネコをイヌにして");
+  });
+
+  it("getGeneratedImagesServer は secret の本文を返す", async () => {
+    setImages([ROW_WITH_EMPTY_LEGACY]);
+    setSecrets(SECRET_FOR_ROW);
+
+    const result = await getGeneratedImagesServer("user-1");
+
+    expect(result[0].prompt).toBe("ネコをイヌにして");
+  });
+
+  it("getEventImages は secret の本文を返す", async () => {
+    setImages([ROW_WITH_EMPTY_LEGACY]);
+    setSecrets(SECRET_FOR_ROW);
+
+    const result = await getEventImages();
+
+    expect(result[0].prompt).toBe("ネコをイヌにして");
+  });
+});
+
+describe("開示できない種別の扱い", () => {
+  it("One-Tap Style は secret が無くても legacy 列へ落とさない", async () => {
+    // 運営が組み立てたプリセット全文。生成した本人にも開示しない。
+    setImages([
+      {
+        id: "img-2",
+        prompt: "CRITICAL INSTRUCTION: ...",
+        generation_type: "one_tap_style",
+      },
+    ]);
+
+    const result = await getGeneratedImages("user-1");
+
+    expect(result[0].prompt).toBe("");
+  });
+});
+
+describe("移行前の行", () => {
+  it("secret が無ければ legacy 列を返す", async () => {
+    // backfill 前の既存行。Phase 0C までは legacy 列に値がある。
+    setImages([
+      { id: "img-3", prompt: "むかしの入力", generation_type: "coordinate" },
+    ]);
+
+    const result = await getGeneratedImages("user-1");
+
+    expect(result[0].prompt).toBe("むかしの入力");
+  });
+});

--- a/tests/unit/features/generation/prompt-read-paths.test.ts
+++ b/tests/unit/features/generation/prompt-read-paths.test.ts
@@ -1,0 +1,151 @@
+/** @jest-environment node */
+
+/**
+ * プロンプト読み取り経路の網羅チェック。
+ *
+ * このテストは実装ではなく「見落とし」を検出するために書いている。
+ *
+ * 秘匿境界の移行では、同じ性質のミスを 3 度繰り返した。
+ *   1. 列を削除したが、その列を参照する RPC を直し忘れた
+ *   2. 新しい完了 RPC を作ったが、Worker の呼び出しを切り替え忘れた
+ *   3. 読み取り経路を移行したが、生成一覧の経路を見落とした
+ *
+ * いずれも「対の片方を忘れる」型で、目視レビューでは繰り返し漏れた。
+ * Phase 0C で generated_images.prompt を空にすると、移行し忘れた経路は
+ * 「プロンプトが表示されない」形で初めて露見する。空化は実質不可逆なので、
+ * 事前に機械的に潰す。
+ *
+ * 判定方法: generated_images から prompt を返しうるクエリを列挙し、
+ * それぞれが author secret の解決を通っているかを検査する。
+ * 新しい読み取り経路を足したときは、このテストが落ちて気づける。
+ */
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOTS = ["app", "features", "lib"];
+const RESOLVERS = ["resolveVisiblePrompts", "resolveOwnVisiblePrompts"];
+
+/**
+ * 解決を通さなくてよい経路。
+ *
+ * 除外は「なぜ安全か」を必ず書く。理由を書けないものは除外しない。
+ */
+const ALLOWED_WITHOUT_RESOLUTION: Array<{ file: string; reason: string }> = [
+  {
+    file: "app/api/admin/generate-webp/route.ts",
+    reason:
+      "WebP 変換のバッチ。storage path しか使わず prompt を参照も返却もしない",
+  },
+  {
+    file: "app/api/reports/posts/route.ts",
+    reason: "通報の受付。通報対象の存在確認のみで prompt を参照も返却もしない",
+  },
+  {
+    file: "features/posts/lib/server-api.ts",
+    reason:
+      "enrichPosts / getPost が resolveVisiblePrompts を通す。getPostedImages は未使用",
+  },
+  {
+    file: "features/my-page/lib/server-api.ts",
+    reason:
+      "一覧2経路は resolveVisiblePrompts を通す。getUserStatsServer は head:true で行を返さない",
+  },
+  {
+    file: "features/my-page/lib/api.ts",
+    reason: "resolveOwnVisiblePrompts を通す",
+  },
+  {
+    file: "features/generation/lib/database.ts",
+    reason:
+      "取得2経路は resolveOwnVisiblePrompts を通す。saveGeneratedImages は書き込み、listCoordinateImagesCreatedAfter は未使用",
+  },
+];
+
+function listSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules" || entry.startsWith(".")) continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...listSourceFiles(full));
+    } else if (/\.(ts|tsx)$/.test(entry)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/** generated_images から prompt を返しうるクエリを持つファイルを抽出する。 */
+function findPromptReadingFiles(): string[] {
+  const found = new Set<string>();
+
+  for (const root of ROOTS) {
+    for (const file of listSourceFiles(root)) {
+      const src = readFileSync(file, "utf-8");
+      if (!src.includes('from("generated_images")')) continue;
+
+      const lines = src.split("\n");
+      for (let i = 0; i < lines.length; i++) {
+        if (!lines[i].includes('from("generated_images")')) continue;
+
+        // クエリの直後 30 行から select を探す
+        const window = lines.slice(i, i + 30).join("\n");
+        const match = window.match(/\.select\(\s*("[^"]*"|'[^']*'|`[^`]*`)/);
+        if (!match) continue;
+
+        const selection = match[1];
+        // head:true は件数のみで行を返さない
+        if (/head:\s*true/.test(window)) continue;
+
+        const returnsPrompt =
+          selection.includes("*") || /\bprompt\b/.test(selection);
+        if (returnsPrompt) {
+          found.add(file);
+          break;
+        }
+      }
+    }
+  }
+
+  return Array.from(found).sort();
+}
+
+describe("プロンプト読み取り経路", () => {
+  it("prompt を返すクエリを持つファイルは author secret の解決を通す", () => {
+    const allowed = new Set(ALLOWED_WITHOUT_RESOLUTION.map((e) => e.file));
+    const unresolved: string[] = [];
+
+    for (const file of findPromptReadingFiles()) {
+      const src = readFileSync(file, "utf-8");
+      const resolves = RESOLVERS.some((r) => src.includes(r));
+      if (!resolves && !allowed.has(file)) {
+        unresolved.push(file);
+      }
+    }
+
+    expect(unresolved).toEqual([]);
+  });
+
+  it("除外リストは実在するファイルだけを指す", () => {
+    // ファイル移動やリネームで除外が空振りし、検査が骨抜きになるのを防ぐ
+    const stale = ALLOWED_WITHOUT_RESOLUTION.filter((entry) => {
+      try {
+        statSync(entry.file);
+        return false;
+      } catch {
+        return true;
+      }
+    }).map((entry) => entry.file);
+
+    expect(stale).toEqual([]);
+  });
+
+  it("除外には理由が書かれている", () => {
+    const missing = ALLOWED_WITHOUT_RESOLUTION.filter(
+      (entry) => entry.reason.trim().length === 0
+    ).map((entry) => entry.file);
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/tests/unit/lib/event-server-api.test.ts
+++ b/tests/unit/lib/event-server-api.test.ts
@@ -8,6 +8,21 @@ jest.mock("react", () => {
   };
 });
 
+/**
+ * プロンプトの正本を service-only の generated_image_prompt_secrets へ移した
+ * ため、読み取り経路が service role の参照を持つようになった（ADR-001）。
+ * ここでは secret 未作成を再現し、legacy 列へのフォールバックを前提にする。
+ */
+jest.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    from: () => ({
+      select: () => ({
+        in: () => Promise.resolve({ data: [], error: null }),
+      }),
+    }),
+  }),
+}));
+
 jest.mock("@/lib/supabase/server", () => ({
   createClient: jest.fn(),
 }));


### PR DESCRIPTION
## 概要

生成した本人が自分のプロンプトを参照できなくなっていた障害の修正と、同じ見落としが Phase 0C で再発しないための網羅チェックです。
本番へは適用・デプロイ済みで、復旧を確認しています。

## 障害の原因

`complete_image_job_with_prompt_secrets` を作ったのに、**Worker の呼び出しを切り替え忘れていました。**

旧 `complete_image_job_with_generated_images` は `image_jobs.prompt_text` を `generated_images.prompt` へコピーするだけで author secret を作りません。新 Next.js は `prompt_text` を空にするため、結果として次の状態になっていました。

```
generated_images.prompt = ''
author secret           なし
→ プロンプトがどこにも残らない
```

本文は `generation_prompt_snapshots.author_input` に残っていたため**全件復元できました**。

## 復旧

| マイグレーション | 内容 |
| --- | --- |
| `20260729150000` | snapshot の `author_input` から失われた secret を復元 |
| `20260729160000` | secret から legacy 列へ書き戻し（対象3件） |

どちらも検証を組み込み、復元漏れか運営資産の混入があれば巻き戻ります。

## 読み取り経路の全件移行

**生成一覧の画面が author secret を読んでいませんでした。** `generated_images.prompt` だけを見ています。
Phase 0C で legacy 列を空にすると、この画面のプロンプトが全件消えます。

`generated_images` から `prompt` を返しうるクエリを機械的に列挙し、18箇所を特定して判定しました。移行が必要だったのは4関数です。

| 関数 | 画面 |
| --- | --- |
| `getGeneratedImages` | 生成一覧（ブラウザ） |
| `getGeneratedImagesBySourceImage` | 元画像からの一覧（ブラウザ） |
| `getGeneratedImagesServer` | 生成一覧（サーバー） |
| `getEventImages` / `getEventImagesServer` | イベントギャラリー |

管理系2件（`generate-webp` / `reports/posts`）は `prompt` を参照も返却もしないため対象外としました。

## 再発防止

**同じ性質のミスを3度繰り返しました。**

1. 列を削除したが、その列を参照する RPC を直し忘れた
2. 新しい完了 RPC を作ったが、Worker の呼び出しを切り替え忘れた
3. 読み取り経路を移行したが、生成一覧の経路を見落とした

いずれも「対の片方を忘れる」型で、**目視レビューでは繰り返し漏れました。**

`prompt` を返すクエリを持つファイルが author secret の解決を通しているかを検査するテストを追加しました。除外は理由の記載を必須とし、ファイル移動で除外が空振りしないことも検査します。

実際に経路を1つ壊してテストが落ちることを確認済みです。

## Phase 0C の前提

このPRで「`generated_images.prompt` を空にしても表示が壊れない」状態になります。
空化は実質不可逆なので、**しばらく新経路で安定稼働することを確認してから** Phase 0C へ進む想定です。

## 検証

```
test      2,848件パス
lint      23E/58W（main の既存赤と一致）
typecheck 本番コード 0件
build     --webpack 成功
Worker    deno check 29件（変更前と同数）
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mmqeUvT5TbjAMPNo6Pxsn