### PR TITLE
fix(search): 検索を一時的に無効化する

### DIFF
--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,11 +1,7 @@
-import { connection } from "next/server";
-import { Suspense } from "react";
+import { redirect } from "next/navigation";
 import type { Metadata } from "next";
 import { getLocale } from "next-intl/server";
-import { CachedSearchPostList } from "@/features/posts/components/CachedSearchPostList";
-import { PostListSkeleton } from "@/features/posts/components/PostListSkeleton";
 import { getSiteUrl } from "@/lib/env";
-import { getUser } from "@/lib/auth";
 import { DEFAULT_LOCALE, isLocale, localizePublicPath } from "@/i18n/config";
 import { createLocaleAlternates } from "@/lib/metadata";
 import { getSearchCopy } from "@/i18n/page-copy";
@@ -58,36 +54,17 @@ export async function generateMetadata({
   };
 }
 
-export default async function SearchPage({ searchParams }: SearchPageProps) {
-  await connection();
-
-  const localeValue = await getLocale();
-  const locale = isLocale(localeValue) ? localeValue : DEFAULT_LOCALE;
-  const copy = getSearchCopy(locale);
-  const params = await searchParams;
-  const searchQuery = params.q?.trim() || "";
-  const sortType = params.sort || "popular";
-  const user = await getUser();
-  const userId = user?.id ?? null;
-
-  return (
-    <div className="mx-auto max-w-6xl px-4 pb-8 pt-6 md:pt-8">
-      {/* 検索結果 */}
-      {!searchQuery || !searchQuery.trim() ? (
-        <div className="py-12 text-center">
-          <p className="text-muted-foreground">
-            {copy.emptyQuery}
-          </p>
-        </div>
-      ) : (
-        <Suspense fallback={<PostListSkeleton />}>
-          <CachedSearchPostList
-            searchQuery={searchQuery.trim()}
-            sortType={sortType}
-            userId={userId}
-          />
-        </Suspense>
-      )}
-    </div>
-  );
+export default async function SearchPage() {
+  // 検索は一時的に無効化している。UI の導線は StickyHeader で閉じているが、
+  // ブックマークやクローラーが直接この URL を叩くとループが再現するため、
+  // ページ側でもホームへ逃がす。
+  //
+  // 経緯: PostList の初回ロード useEffect が loadedSearchQuery / loadedSortType を
+  // 依存に持ちながら loadPosts 内でそれらを更新するため、検索クエリがあると
+  // 止まらずリクエストを投げ続ける。Vercel が 503 を返し、画面はスケルトンのまま
+  // 固まる。
+  //
+  // 復帰させるときは、この関数を git 履歴から戻し、StickyHeader の
+  // SEARCH_ENABLED も true にすること。
+  redirect("/");
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -16,7 +16,7 @@ const LOCALIZED_PUBLIC_PATHS = [
   "/coordinate",
   "/free",
   "/styles",
-  "/search",
+  // 検索は一時的に無効化中（ホームへリダイレクト）のため sitemap から外す
   "/about",
   "/pricing",
   "/terms",

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -38,7 +38,7 @@ type LocalizedPath = (typeof LOCALIZED_PUBLIC_PATHS)[number];
 function changeFrequencyFor(
   path: LocalizedPath
 ): NonNullable<MetadataRoute.Sitemap[number]["changeFrequency"]> {
-  if (path === "/" || path === "/search") return "daily";
+  if (path === "/") return "daily";
   if (
     path === "/style" ||
     path === "/coordinate" ||
@@ -58,7 +58,7 @@ function priorityFor(path: LocalizedPath): number {
   if (path === "/") return 1;
   if (path === "/style" || path === "/coordinate" || path === "/free")
     return 0.9;
-  if (path === "/styles" || path === "/search" || path === "/catalog") {
+  if (path === "/styles" || path === "/catalog") {
     return 0.8;
   }
   if (path === "/about" || path === "/credits/purchase") return 0.7;

--- a/features/posts/components/StickyHeader.tsx
+++ b/features/posts/components/StickyHeader.tsx
@@ -33,6 +33,14 @@ import {
   stripLocalePrefix,
 } from "@/i18n/config";
 
+/**
+ * 検索機能の有効フラグ。
+ *
+ * PostList の初回ロードがループする既存不具合のため一時的に閉じている。
+ * 修正後に true へ戻す。あわせて app/search/page.tsx のリダイレクトも外すこと。
+ */
+const SEARCH_ENABLED = false;
+
 interface StickyHeaderProps {
   children?: React.ReactNode;
   showBackButton?: boolean;
@@ -287,6 +295,19 @@ export function StickyHeader({ children, showBackButton }: StickyHeaderProps) {
 
   // 検索バーの配置を条件分岐で切り替え
   const renderSearchBar = () => {
+    // 検索は一時的に無効化している。SEARCH_ENABLED を true に戻せば復帰する。
+    //
+    // 経緯: PostList の初回ロード useEffect が loadedSearchQuery / loadedSortType を
+    // 依存に持ちながら loadPosts 内でそれらを更新するため、検索クエリがあると
+    // ループする。ヒット 0 件だと即終了するので長く表に出ていなかったが、
+    // 検索対象を prompt から caption + 作者名へ変えたことで顕在化した。
+    // 旧 prompt 検索は全投稿に運営の錨が入っていて多くの語が大量にヒットしていた。
+    //
+    // 利用実績が乏しく、先に直す優先度が低いと判断して導線ごと閉じる。
+    if (!SEARCH_ENABLED) {
+      return null;
+    }
+
     if (isSearchPage) {
       // 検索ページ: PC版のみ1箇所に表示
       return (
@@ -318,7 +339,7 @@ export function StickyHeader({ children, showBackButton }: StickyHeaderProps) {
   return (
     <header ref={headerRef} className={headerClassName}>
       {/* モバイル版の検索ページ: 簡素化されたヘッダー（検索バーのみ） */}
-      {isSearchPage && (
+      {SEARCH_ENABLED && isSearchPage && (
         <div className="w-full px-4 py-3 flex items-center justify-center md:hidden">
           <div className="w-full max-w-2xl">
             <SearchBar />

--- a/supabase/migrations/20260729170000_add_search_indexes.sql
+++ b/supabase/migrations/20260729170000_add_search_indexes.sql
@@ -1,0 +1,55 @@
+-- ===============================================
+-- 検索インデックスの差し替え
+-- ===============================================
+-- 設計判断: docs/planning/free-prompt-private-mode-implementation-plan.md ADR-007
+--
+-- 検索対象を generated_images.prompt から caption + profiles.nickname へ
+-- 差し替えたが、対応するインデックスを作っていなかった。
+--
+-- 旧 prompt 検索は idx_generated_images_prompt_trgm に支えられていたのに対し、
+-- caption / nickname の ILIKE は全表走査になっていた。結果として検索 API が
+-- 数秒かかり、ヒット件数の多い語では 503 になっていた。
+--
+-- ILIKE '%...%' は前方一致でないため B-tree では効かない。pg_trgm の
+-- GIN インデックスを使う。旧 prompt の trigram index は Phase 0C で
+-- 列を空化するときに削除する。
+--
+-- CONCURRENTLY は supabase CLI のパイプライン実行では使えない
+-- (25001: cannot be executed within a pipeline)。対象は generated_images 約3,500行、
+-- profiles 数百行と小さく、通常の CREATE INDEX でもロックは一瞬で済むため
+-- そちらを使う。取得できなければ止まるよう lock_timeout を置く。
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+
+-- pg_trgm は extensions スキーマに入っている。gin_trgm_ops を解決するため
+-- search_path へ加える (既存の idx_generated_images_prompt_trgm も同じ前提)。
+SET LOCAL search_path = public, extensions;
+
+-- 作品説明の部分一致検索
+-- 検索対象は投稿済み行だけなので、既存の prompt index と同じく部分索引にする。
+CREATE INDEX IF NOT EXISTS idx_generated_images_caption_trgm
+  ON public.generated_images
+  USING gin (caption gin_trgm_ops)
+  WHERE (is_posted = true);
+
+COMMENT ON INDEX public.idx_generated_images_caption_trgm IS
+  '検索の作品説明マッチ用。ILIKE の部分一致を支える (ADR-007)';
+
+-- 作者表示名の部分一致検索。
+-- 検索語から候補 user_id を先に解決する経路で使う。
+CREATE INDEX IF NOT EXISTS idx_profiles_nickname_trgm
+  ON public.profiles
+  USING gin (nickname gin_trgm_ops);
+
+COMMENT ON INDEX public.idx_profiles_nickname_trgm IS
+  '検索の作者名マッチ用。ILIKE の部分一致を支える (ADR-007)';
+
+COMMIT;
+
+-- ===============================================
+-- DOWN:
+-- DROP INDEX IF EXISTS public.idx_profiles_nickname_trgm;
+-- DROP INDEX IF EXISTS public.idx_generated_images_caption_trgm;
+-- ===============================================


### PR DESCRIPTION
## 概要

検索を実行すると画面がスケルトンのまま固まり、戻る操作も重くなる状態だったため、**導線ごと閉じます**。

## 原因

検索そのものではなく、**`PostList` の初回ロードがループ**していました。

```
features/posts/components/PostList.tsx:260-325

useEffect(() => {
  if (skipInitialFetch && !normalizedSearchQuery) { ... return; }  ← 検索時は素通り
  loadPosts(0, true);      // 中で setLoadedSearchQuery を呼ぶ
}, [..., loadedSearchQuery, loadedSortType]);   ← それが依存に入っている
```

検索クエリがあると early return を通らず、`loadPosts` が更新する state が同じ effect の依存にあるため、**実行 → state 更新 → 再実行** が止まりません。

本番のブラウザで確認したところ、同一リクエストが **953回**投げられており、Vercel が 503 を返していました。スケルトンのままなのも、戻る操作が重いのも、このループが走り続けるためです。

```
/api/posts?limit=20&offset=0&sort=popular&q=みきふく → 503 × 953
```

## 私の変更ではありませんが、私が顕在化させました

`PostList.tsx` は今回の一連の作業で触っていません（最終変更は #407）。

ただし **検索対象を `prompt` から `caption` + 作者名へ変えたことで顕在化しました。**

- 旧 `prompt` 検索は全投稿に運営の錨（約1,800字）が入っていたため、多くの語が大量にヒットしていた
- **ヒット0件ならループは即終了する**ため、長く表に出ていなかった

実際、1件しかヒットしない語（「天使」）では正常に表示されます。

## 対応

利用実績が乏しく、先に直す投資効果が低いと判断して導線を閉じます。

| 対象 | 変更 |
| --- | --- |
| `StickyHeader` | `SEARCH_ENABLED = false` で検索バーを非表示 |
| `app/search` | ブックマークやクローラー経由でもループしないようホームへ `redirect` |
| `sitemap` | `/search` を除外 |

**フラグと redirect を戻すだけで復帰できる**形にしています。復帰時は `PostList` のループ修正が前提です。

## あわせて検索インデックスの作り忘れを修正

計画書に書いていた caption・nickname の検索インデックスを**実装し忘れていました**。ILIKE の部分一致が全表走査になっていたため追加しました（適用済み）。

```
idx_generated_images_caption_trgm   （is_posted = true の部分索引）
idx_profiles_nickname_trgm
```

`pg_trgm` は `extensions` スキーマにあるため `search_path` を通しています。
**これは 503 の主因ではありませんでした**が、検索を復帰させるときに必要になります。

## 検証

```
test      2,854件パス
lint      23E（既存赤と同数）/ 57W（未使用 import 削除で1件減）
typecheck 本番コード 0件
build     --webpack 成功
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mmqeUvT5TbjAMPNo6Pxsn