### PR TITLE
feat(prompt-secrets): 公開列からプロンプトを消しDBで再発を拒否する (Phase 0C)

### DIFF
--- a/.cursor/rules/database-design.mdc
+++ b/.cursor/rules/database-design.mdc
@@ -531,7 +531,7 @@ alwaysApply: false
 - 画像関連: `increment_view_count`, `insert_source_image_stock`, `update_stock_image_last_used`, `get_stock_image_limit`, `get_stock_image_usage_count`, `complete_image_job_with_generated_images`
 - プロンプト秘匿境界（`service_role` のみ EXECUTE 可）:
   - `create_image_job_with_prompt_execution(p_job jsonb, p_prompt_execution jsonb)` — job と `generation_prompt_snapshots` を同一トランザクションで作成し、execution record を持たない job を作らせない。`prompt_text` は常に空へ正規化する
-  - `complete_image_job_with_prompt_secrets(p_job_id uuid, p_images jsonb, p_generation_metadata jsonb, p_result_image_url text)` — 生成画像・author secret・job 成功更新を同一トランザクションで確定する。author secret は `snapshot_kind = 'materialized'` かつ `author_input` / owner が揃うときだけ作るため、派生 job には作られない
+  - `complete_image_job_with_prompt_secrets(p_job_id uuid, p_images jsonb, p_generation_metadata jsonb DEFAULT NULL, p_result_image_url text DEFAULT NULL, p_model text DEFAULT NULL, p_background_mode text DEFAULT NULL)` — 生成画像・author secret・job 成功更新・`credit_transactions.related_generation_id` 更新を同一トランザクションで確定する。末尾2引数はWorkerが正規化済みの値を渡すために使い、NULL時だけjobの値へfallbackする。author secret は `snapshot_kind = 'materialized'` かつ `author_input` / owner が揃うときだけ作るため、派生 job には作られない
 
 ### trigger / helper / 運用関数
 - 通知連動: `notify_on_like`, `notify_on_comment`, `notify_on_follow`, `delete_notification_on_like_removal`, `delete_notification_on_comment_deletion`, `delete_notification_on_follow_removal`

--- a/.cursor/rules/database-design.mdc
+++ b/.cursor/rules/database-design.mdc
@@ -132,6 +132,7 @@ alwaysApply: false
 - 主要カラム: `user_id`, `prompt_text`, `input_image_url`, `source_image_stock_id`, `generation_type`, `generation_metadata`, `model`, `status`, `processing_stage`, `requested_image_count`, `result_image_url`, `error_message`, `attempts`, `created_at`, `updated_at`, `started_at`, `completed_at`, `background_mode`, `source_image_type`, `style_template_id`, `style_reference_image_url`, `style_reference_image_bucket`, `style_preset_category_key`
 - 外部キー: `user_id -> auth.users.id`, `source_image_stock_id -> source_image_stocks.id`
 - 備考: `status` は `queued/processing/succeeded/failed`、`processing_stage` は `queued/processing/charging/generating/uploading/persisting/completed/failed`、`requested_image_count` は `1..4`（OpenAI batched edit の受理枚数）、`generation_type` は `coordinate/specified_coordinate/full_body/chibi/one_tap_style/inspire/free`（`specified_coordinate/full_body/chibi` は歴史的経緯で CHECK に残るが新規未使用）、`source_image_type` は `illustration/real`、`background_mode` は `keep/ai_auto/include_in_prompt`、`model` は `gemini-2.5-flash-image` の履歴値に加えて `gemini-3.1-flash-image-preview-512` / `gemini-3.1-flash-image-preview-1024` / `gemini-3-pro-image-1k` / `gemini-3-pro-image-2k` / `gemini-3-pro-image-4k` / `gpt-image-2-low-1k` / `gpt-image-2-low-2k` / `gpt-image-2-low-4k` / `gpt-image-2-medium-1k` / `gpt-image-2-medium-2k` / `gpt-image-2-medium-4k` / `gpt-image-2-high-1k` / `gpt-image-2-high-2k` / `gpt-image-2-high-4k`（旧 `gpt-image-2-low` も履歴互換で許可）を保持する
+- 備考(秘匿): `prompt_text` は常に空。本文は `generation_prompt_snapshots` にのみ存在する。SELECT RLS が本人開放のため、ここへ書くと One-Tap Style の運営プリセットが生成者本人から読めてしまう（REQ-019）
 - RLS: 本人のみ `SELECT/INSERT/UPDATE/DELETE`
 
 #### `generated_images`
@@ -139,6 +140,7 @@ alwaysApply: false
 - 主要カラム: `user_id`, `image_url`, `storage_path`, `prompt`, `is_posted`, `caption`, `posted_at`, `created_at`, `view_count`, `generation_type`, `input_images`, `generation_metadata`, `source_image_stock_id`, `image_job_id`, `image_job_result_index`, `width`, `height`, `model`, `storage_path_display`, `storage_path_thumb`, `moderation_status`, `moderation_reason`, `moderation_updated_at`, `moderation_approved_at`, `background_mode`
 - 外部キー: `user_id -> auth.users.id`, `source_image_stock_id -> source_image_stocks.id`, `image_job_id -> image_jobs.id`
 - 備考: `generation_type` は `coordinate/specified_coordinate/full_body/chibi/one_tap_style/inspire/free`（`specified_coordinate/full_body/chibi` は歴史的経緯で CHECK に残るが新規未使用）、`moderation_status` は `visible/pending/removed`、`background_mode` は `keep/ai_auto/include_in_prompt`、`image_job_id` / `image_job_result_index` は OpenAI batched edit の 1 job 複数結果を OpenAI response `data[]` 順で紐づける。`model` は `gemini-2.5-flash-image` の履歴値に加えて `gemini-3.1-flash-image-preview-512` / `gemini-3.1-flash-image-preview-1024` / `gemini-3-pro-image-1k` / `gemini-3-pro-image-2k` / `gemini-3-pro-image-4k` / `gpt-image-2-low-1k` / `gpt-image-2-low-2k` / `gpt-image-2-low-4k` / `gpt-image-2-medium-1k` / `gpt-image-2-medium-2k` / `gpt-image-2-medium-4k` / `gpt-image-2-high-1k` / `gpt-image-2-high-2k` / `gpt-image-2-high-4k`（旧 `gpt-image-2-low` も履歴互換で許可）を保持する。`width` / `height` は画像実寸（INT、`> 0` の CHECK 制約、NULL 許容）で、Post 詳細画面のサイズ表示と画像向き判定用に server-api の lazy compute で fetch 時に保存される
+- 制約: `prompt` は `CHECK (prompt = '')` + `DEFAULT ''`。本文は `generated_image_prompt_secrets`（原作者入力）と `generation_prompt_snapshots`（生成実行入力）にのみ存在し、この列は `select("*")` 互換のために残している空列（ADR-001 / REQ-020）
 - RLS: 投稿済みかつ `visible` の画像は公開、それ以外は本人のみ。`INSERT/UPDATE/DELETE` は本人のみ
 
 #### `generated_image_prompt_secrets`
@@ -446,7 +448,9 @@ alwaysApply: false
 - `idx_generated_images_image_job_id`
 - `idx_generated_images_job_result_unique`（`image_job_id IS NOT NULL AND image_job_result_index IS NOT NULL` の部分 UNIQUE）
 - `idx_generated_images_moderation_approved_at`
-- `idx_generated_images_prompt_trgm`（`prompt` の trigram 検索用）
+- ~~`idx_generated_images_prompt_trgm`~~（Phase 0C で削除。prompt 列は常に空）
+- `idx_generated_images_caption_trgm`（`is_posted = true` 部分索引・検索の作品説明マッチ用）
+- `idx_profiles_nickname_trgm`（検索の作者名マッチ用）（`prompt` の trigram 検索用）
 - `idx_image_jobs_user_id_status`
 - `idx_image_jobs_created_at`
 - `idx_image_jobs_user_id`

--- a/docs/architecture/data.en.md
+++ b/docs/architecture/data.en.md
@@ -195,16 +195,15 @@ This matches Supabase/Postgres best practices used in this repo:
    - switches to `processing_stage = charging` and calls `deduct_free_percoins` only for paid jobs
    - switches to `processing_stage = generating` and calls Gemini or the OpenAI Images Edit API. OpenAI batch generation sends `n=requested_image_count` in one upstream API call
    - switches to `processing_stage = uploading` and uploads the result images to Storage. OpenAI batch results use file names under the same `jobId` with a result index
-   - switches to `processing_stage = persisting` and inserts rows in `generated_images`, carrying forward `generation_metadata` when needed by later detail views. OpenAI batch generation uses the `complete_image_job_with_generated_images` RPC so multiple inserts, the `image_jobs` success update, and legacy `credit_transactions.related_generation_id` backfill happen in one transaction
-   - updates `image_jobs` to `status = succeeded` and `processing_stage = completed`
-   - backfills `credit_transactions.related_generation_id`
-7. If generation reaches terminal failure, the worker stores `processing_stage = failed` and calls `refund_percoins` exactly once.
+   - switches to `processing_stage = persisting` and completes both Gemini and OpenAI jobs through `complete_image_job_with_prompt_secrets`. The RPC creates `generated_images` rows and author secrets, marks `image_jobs` successful, and links `credit_transactions.related_generation_id` in one transaction. If a competing worker's result wins, uploads absent from the RPC's returned `storage_path` set are removed
+7. If generation reaches terminal failure, the worker stores `processing_stage = failed` and idempotently runs `refund_percoins` or releases the free attempt using the recorded consumption amount. A billing failure leaves the queue message unacknowledged so terminal-failed redelivery reconciles it.
 
 ### Why the design looks this way
 
 - The route handler checks balance early for user feedback
 - The worker owns the real deduction so billing happens close to the external side effect
 - Refund logic is also centralized in SQL to keep allocation bookkeeping consistent
+- Reconciliation uses the original `credit_transactions.amount` rather than recalculating from the current model price table
 - OpenAI batch generation is all-or-nothing. A returned image count mismatch or persistence failure marks the job failed and refunds the full amount; partial success is not saved or billed.
 
 ## Core flow 4: Posting, likes, comments, follows, and notifications

--- a/docs/architecture/data.ja.md
+++ b/docs/architecture/data.ja.md
@@ -205,16 +205,15 @@ RLS をバイパスする必要があるサーバー処理では `createAdminCli
    - `processing_stage = charging` にして、課金が必要なジョブのみ `deduct_free_percoins` を実行
    - `processing_stage = generating` にして Gemini または OpenAI Images Edit API を呼ぶ。OpenAI バッチでは 1 回の API 呼び出しに `n=requested_image_count` を渡す
    - `processing_stage = uploading` にして生成画像を Storage に保存する。OpenAI バッチでは同一 `jobId` 配下に result index 付きのファイル名で複数保存する
-   - `processing_stage = persisting` にして `generated_images` を INSERT し、必要に応じて `generation_metadata` も引き継ぐ。OpenAI バッチでは `complete_image_job_with_generated_images` RPC が複数行 INSERT、`image_jobs` 成功更新、`credit_transactions.related_generation_id` の legacy backfill を 1 transaction に閉じる
-   - `image_jobs` を `status = succeeded`, `processing_stage = completed` に更新
-   - `credit_transactions.related_generation_id` を後で埋める
-7. 終端失敗になった場合は `processing_stage = failed` を保存し、`refund_percoins` を 1 回だけ呼ぶ
+   - `processing_stage = persisting` にして、Gemini / OpenAIの両方を `complete_image_job_with_prompt_secrets` RPC で確定する。同RPCが `generated_images` とauthor secretの作成、`image_jobs` 成功更新、`credit_transactions.related_generation_id` の更新を 1 transaction に閉じる。競合で今回のStorage uploadが採用されなかった場合は、RPCが返した `storage_path` との差分を削除する
+7. 終端失敗になった場合は `processing_stage = failed` を保存し、記録済み消費トランザクションの金額で冪等な `refund_percoins` または無料枠releaseを実行する。課金後処理が失敗した場合はqueue messageを残し、failed再配送をreconciliationとして同じ処理を繰り返す
 
 ### 重要な点
 
 - route handler 側の残高チェックは、ユーザーへの早いフィードバックが目的
 - 実際の減算は外部副作用に最も近い worker 側が担う
 - 返金ロジックも SQL に寄せているため、配分の整合性が保たれる
+- reconciliation時も現在のモデル料金表から再計算せず、減算時の`credit_transactions.amount`を返金額の正本にする
 - OpenAI バッチは all-or-nothing。返却枚数不足や永続化失敗は job 失敗 + 全額返金扱いにし、部分成功の保存・課金はしない
 
 ## 主要フロー 4: 投稿、いいね、コメント、フォロー、通知

--- a/docs/planning/free-prompt-private-mode-implementation-plan.md
+++ b/docs/planning/free-prompt-private-mode-implementation-plan.md
@@ -553,9 +553,9 @@ Workerは課金前とprovider呼び出し直前に認可を検証する。課金
 ### ADR-009: Phase 0 は expand・backfill・contract の複数デプロイに分ける
 
 - **Context**: Vercel デプロイと `supabase db push`、Edge Function deploy は別操作である。単一PRに additive migration と空化 migration を同梱すると、旧コード停止・テーブル未作成・backfill後の新規行取りこぼしのいずれかが起こる。
-- **Decision**: 既存漏洩修正は3段階に分ける。Phase 0A で additive schema、Phase 0B で互換コード・dual-write・backfill・検証、Phase 0C で旧fallback撤去・空化・DB invariantを適用する。各段階を別PR・別デプロイとし、新機能UIより先に完了させる。
+- **Decision**: 既存漏洩修正は3段階に分ける。Phase 0A で additive schema、Phase 0B で互換コード・dual-write・backfill・検証、Phase 0C で旧fallback撤去・空化・DB invariantを適用する。各段階を別PR・別デプロイとし、新機能UIより先に完了させる。さらに Phase 0C で必要になった完了RPCの6引数化は、contractと同じ未適用migration群へ入れず、**先行expand PRとして単独でマージ・適用**する。`supabase db push` は特定migrationで停止できないため、expandとcontractの間へWorkerデプロイを挟むにはPR自体を分ける。
 - **Reason**: 時間ではなく、dual-write 稼働中の行単位検証を contract の前提にする必要がある。未使用の additive table が一時的に残ることは、データ欠損や漏洩より安全である。
-- **Consequence**: 当初の「Phase 0〜5を単一PR」は撤回する。移行中だけ新→旧の dual-read を許すが、secret取得エラー時の無条件fallbackは禁止する。fallbackには期限・観測・撤去PRを必須とする。
+- **Consequence**: 当初の「Phase 0〜5を単一PR」は撤回する。移行中だけ新→旧の dual-read を許すが、secret取得エラー時の無条件fallbackは禁止する。fallbackには期限・観測・撤去PRを必須とする。Phase 0C expand適用後はPostgRESTのschema cacheを明示reloadし、旧4引数・新6引数の両呼び出しが解決できることを確認してからWorkerを切り替える。
 
 ### ADR-010: provider error と公開画像メタデータを秘密の出口として扱う
 
@@ -598,8 +598,9 @@ Workerは課金前とprovider呼び出し直前に認可を検証する。課金
 ```mermaid
 flowchart LR
     P0A["Phase 0A PR1: Expand"] --> P0B["Phase 0B PR2: Dual write と検索と Backfill"]
-    P0B --> P0C["Phase 0C PR3: Contract"]
-    P0C --> P1["Phase 1 PR4: 非公開モードDBとAPI"]
+    P0B --> P0CE["Phase 0C PR3a: 完了RPC Expand"]
+    P0CE --> P0CC["Phase 0C PR3b: Contract"]
+    P0CC --> P1["Phase 1 PR4: 非公開モードDBとAPI"]
     P1 --> P2["Phase 2 PR5: 投稿と閲覧UI"]
     P2 --> P3["Phase 3 PR6: Adminと仕上げ"]
 ```
@@ -612,10 +613,35 @@ flowchart LR
 | 2 | PR2のbackward-compatible Worker | legacy jobは従来どおり、materialized execution recordを持つjobも処理可能 |
 | 3 | PR2のNext.js | `createImageJob(jobData, promptExecution)` が必須で、新規jobの `prompt_text` が全種別で空。検索がcaption + 作者名へ移行済み |
 | 4 | backfill + 検証SQL | 種別件数・行digest・owner・orphan・dual-write後の差分がすべて0 |
-| 5 | PR3直前の本番ゲート | user retryが新規jobを作ること、**PR2デプロイ時刻より前に作られたqueued / processing jobが0件**であること、PR2以後のjobが全件execution recordを持つこと、既知caption・nickname検索が結果を返すことを記録 |
-| 6 | PR3のfallbackなしNext.js / Worker | secret読み取りエラーがfail closed。既存表示・生成が正常 |
-| 7 | PR3のcontract migration | 公開列と終端jobを空化し、DB invariantをVALIDATE。直後に同じcaption・nickname検索が0件固定でないことを確認 |
-| 8 | PR4以降 | private prompt新機能を初めて有効化 |
+| 5 | Phase 0C先行expand PR | `20260730090000` **だけ**を含むPRをマージする。`supabase db push --dry-run` が1本だけを示すことを確認して適用 |
+| 6 | PostgREST互換ゲート | schema reload後、旧4引数・新6引数の双方がPGRST202ではなく関数本体の応答へ到達することをservice roleで確認 |
+| 7 | Phase 0C contract PRのNext.js / Worker | 先行expandを含むmainと同期してからデプロイ。secret読み取りエラーがfail closedで、Gemini / OpenAI双方の生成・表示が正常 |
+| 8 | contract直前のdrain | 生成受付を止め、Worker cronを動かしたまま`queued / processing = 0`までdrain。その後cronを止め、active=0を再確認 |
+| 9 | Phase 0C contract migration | `supabase db push --dry-run` が`20260730100000`だけを示すことを確認。公開列と**全job**を空化し、DB invariantを追加 |
+| 10 | 再開・受け入れ確認 | Worker cronを戻して生成受付を再開。Gemini / OpenAI生成、表示、anon公開列、Storage孤児、課金reconciliationを確認 |
+| 11 | PR4以降 | private prompt新機能を初めて有効化 |
+
+expand適用後のPostgREST疎通は、実在しないjob IDを使って関数解決だけを確認する。
+service role keyはシェル履歴・ログへ出さず、次の旧4引数 / 新6引数リクエストが
+どちらも `PGRST202` ではなく関数本体の `image job not found` へ到達することを確認する。
+
+```bash
+curl -sS "${SUPABASE_URL}/rest/v1/rpc/complete_image_job_with_prompt_secrets" \
+  -H "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
+  -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"p_job_id":"00000000-0000-4000-8000-000000000000","p_images":[],"p_generation_metadata":null,"p_result_image_url":null}'
+
+curl -sS "${SUPABASE_URL}/rest/v1/rpc/complete_image_job_with_prompt_secrets" \
+  -H "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
+  -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"p_job_id":"00000000-0000-4000-8000-000000000000","p_images":[],"p_generation_metadata":null,"p_result_image_url":null,"p_model":null,"p_background_mode":null}'
+```
+
+生成受付を一時停止する運用手段が用意できない場合はcontractを適用しない。
+受付を止めずにactive=0の瞬間を狙う運用は、migration内部ゲートによりfail closedには
+なるが、再試行回数と停止時間を予測できず、本ランブックの正式手順とはしない。
 
 各段階でロールバック先は「直前の互換バージョン」とする。順序を飛ばさず、Vercel・DB・Workerのどれが現在の本番バージョンかをリリース記録へ残す。
 
@@ -694,12 +720,16 @@ flowchart LR
   - owner/source_kind不整合、orphan、移行漏れが0件
   - dual-write開始後に作られた行も差分0件
 
-### Phase 0C: Contract・既存漏洩の閉鎖（PR3）
+### Phase 0C: Contract・既存漏洩の閉鎖（先行expand PR + contract PR3）
 
 **目的**: 公開列・ユーザー所有ジョブ・fallbackを完全に閉じ、再発をDBで拒否する
-**開始条件**: Phase 0Bが本番稼働し、検索がprompt列へ依存せず、検証SQLが連続して差分0件。**PR2デプロイ時刻より前に作られたqueued / processing jobが残っていない**。PR2以後のjobは作成RPCにより全件execution recordを持つ。ユーザー向け再試行が新規job作成であることを確認。日次物理バックアップが直近分まで `COMPLETED` であることを確認（PITRは不要）。
+**開始条件**: Phase 0Bが本番稼働し、検索がprompt列へ依存せず、検証SQLが連続して差分0件。Phase 0C先行expand PRの `20260730090000` が本番migration historyに存在し、PostgREST経由で旧4引数・新6引数の両呼び出しが解決できる。ユーザー向け再試行が新規job作成であることを確認。日次物理バックアップが直近分まで `COMPLETED` であることを確認（PITRは不要）。contract適用直前は生成受付を止め、Workerでdrainした後にcronを止め、**全queued / processing jobが0件**であることをSQLとmigration内部ゲートの両方で確認する。
 あわせて author secret 側の完全性を再検証する（件数・行ごとのmd5・所有者・運営資産の非混入）
 
+- [ ] `20260730090000_expand_complete_rpc_model_params.sql` をcontractとは別の先行PRとしてマージ・適用
+  - `supabase db push --dry-run` で対象がこの1本だけであることを確認
+  - `NOTIFY pgrst, 'reload schema'` 後、旧4引数・新6引数の双方が解決できることを確認
+  - contract PRを更新後のmainと同期し、同migrationがcontract PRの差分から消えたことを確認
 - [ ] secret→legacyの読み取りfallbackを削除してデプロイし、読み取りエラー率を監視
 - [ ] `generated_images.prompt` を空文字へ更新
 - [ ] `ALTER COLUMN prompt SET DEFAULT ''` を適用
@@ -708,10 +738,11 @@ flowchart LR
   - 検索は無効化済みで、有効化しても caption / nickname の trigram index を使う
     （`20260729170000` で追加済み）。prompt の index は空化後に不要になる
 - [ ] 最新の `complete_image_job_with_generated_images` を含む全永続化経路が空文字しか書かないことを確認
-- [ ] 全生成種別の `image_jobs.prompt_text` を段階的に空化
-  - succeeded / failed / cancelled等の終端jobを対象にする
-  - PR2より前のqueued / processingは先にmaterialized recordへ移すか、完了後に空化する
-  - 適用直前にgeneration_type・status・attempts・created_at別件数を再取得する。全queued / processingが0件になるまで待つ必要はなく、記録済みPR2デプロイ時刻より前のactive jobが0件であることを停止条件にする
+- [ ] 全生成種別・全statusの `image_jobs.prompt_text` を同一transactionで空化
+  - 生成受付を一時停止し、Worker cronを動かしたまま全queued / processingをdrainする
+  - active=0になってからWorker cronを止め、直後に件数を再確認する
+  - migrationは最初に`image_jobs EXCLUSIVE → generated_images ACCESS EXCLUSIVE`の順でロックし、activeが1件でもあれば中断する
+  - 全件空化後に`DEFAULT ''`と`CHECK (prompt_text = '')`を追加し、再発をDBで拒否する
   - legacy failedは同一jobで再実行せず、ユーザー再試行は新規jobを作る
   - Workerのclaim条件を `queued` のみに変更し、終端failedを再取得しない
   - 固定件数ではなく実行時クエリ結果をgeneration_type・status別に記録
@@ -954,7 +985,7 @@ flowchart LR
 | Phase 0B dual-write | contract前は新規書き込みを旧経路へ戻せる。ただしOne-Tapの公開漏洩を再開するrevertは行わず、機能停止または固定エラーで閉じる |
 | `generated_images.prompt` の空化 | 列はDROPしないが、公開列への書き戻しは行わない。表示障害はsecret対応コードへのrollbackで復旧する。author secretへ移行しないplatform/未分類値はcanonical preset・信頼できるmaterialized execution record・DBバックアップの有無を確認してから消去する |
 | `CHECK (prompt = '')` | アプリを戻す必要がある場合も制約を先に外さず、旧コードが非空値を書かない互換版へ戻す |
-| `image_jobs.prompt_text` 空化 | 全生成種別でPR2以前のqueued / processingを先にmaterialized execution recordへ移す。終端failedは再利用せず、終端行の平文は復元しない |
+| `image_jobs.prompt_text` 空化 | contract適用前に生成受付停止・drain・cron停止で全activeを0にする。終端failedは再利用せず、空化後の平文は復元しない |
 | ログ削除 | 単独で安全。revert する理由が無い |
 | 検索対象の差し替え | 独立コミット。`caption` 検索で不評なら調整できるが、**prompt 検索へ戻してはならない**（ADR-001 と矛盾する） |
 | Phase 1 の列追加 | 既定が `public` / NULL なので、適用しても挙動は変わらない |
@@ -963,7 +994,7 @@ flowchart LR
 | Worker | backward-compatible版を先に出す。rollback時もmaterialized execution recordとlegacy active jobの両方を読める直前版へ戻す。派生実行時解決をprovider全文の永続化へ戻さない |
 | UI | PR5をrevertまたは機能導線を隠しても、DBの秘匿境界は維持する |
 
-**適用順序**: Phase 0A → 0B → 検証 → 0C を厳守する。`supabase db push` は各PRに含まれる対象migrationだけであることを `supabase migration list` で確認する。Phase 0C完了前にprivate prompt新機能を公開しない。
+**適用順序**: Phase 0A → 0B → 検証 → Phase 0C先行expand PR → PostgREST互換確認 → Phase 0C contract PR を厳守する。`supabase db push --dry-run` と `supabase migration list` の両方で各PRの対象migrationが1本だけであることを確認する。Phase 0C完了前にprivate prompt新機能を公開しない。
 
 ---
 

--- a/features/generation/lib/database.ts
+++ b/features/generation/lib/database.ts
@@ -64,49 +64,6 @@ export interface SourceImageStock {
 }
 
 /**
- * 生成画像のメタデータをデータベースに保存
- */
-export async function saveGeneratedImage(
-  data: Omit<GeneratedImageRecord, "id" | "created_at">
-): Promise<GeneratedImageRecord> {
-  const supabase = createBrowserClient();
-
-  const { data: record, error } = await supabase
-    .from("generated_images")
-    .insert([data])
-    .select()
-    .single();
-
-  if (error) {
-    console.error("Database insert error:", error);
-    throw new Error(`画像メタデータの保存に失敗しました: ${error.message}`);
-  }
-
-  return record;
-}
-
-/**
- * 複数の生成画像のメタデータを一括保存
- */
-export async function saveGeneratedImages(
-  images: Array<Omit<GeneratedImageRecord, "id" | "created_at">>
-): Promise<GeneratedImageRecord[]> {
-  const supabase = createBrowserClient();
-
-  const { data: records, error } = await supabase
-    .from("generated_images")
-    .insert(images)
-    .select();
-
-  if (error) {
-    console.error("Database insert error:", error);
-    throw new Error(`画像メタデータの保存に失敗しました: ${error.message}`);
-  }
-
-  return records;
-}
-
-/**
  * ユーザーの生成画像一覧を取得
  * generationType が指定された場合はそのタイプのみを取得し、
  * 指定されない場合は全てのタイプを取得する。

--- a/features/generation/lib/prompt-secrets-client.ts
+++ b/features/generation/lib/prompt-secrets-client.ts
@@ -39,8 +39,9 @@ function isDisclosableGenerationType(
 /**
  * 本人の author secret を一括取得して表示用プロンプトを解決する。
  *
- * 取得に失敗した場合は legacy 列へ落とさず投げる。障害時に秘匿境界が
- * 緩む方向へ倒れることを避けるため。
+ * secret が無ければ空文字（legacy 列へは落ちない）。Phase 0C 以降、
+ * 本文は secret にしか存在しないため。取得に失敗した場合も legacy 列へ
+ * 落とさず投げる。障害時に秘匿境界が緩む方向へ倒れることを避けるため。
  */
 export async function resolveOwnVisiblePrompts<
   T extends ClientPromptResolvableRecord,
@@ -78,8 +79,7 @@ export async function resolveOwnVisiblePrompts<
       return record.prompt === "" ? record : { ...record, prompt: "" };
     }
 
-    const secret = record.id ? secrets.get(record.id) : undefined;
-    const resolved = secret ?? record.prompt;
+    const resolved = (record.id ? secrets.get(record.id) : undefined) ?? "";
     return resolved === record.prompt ? record : { ...record, prompt: resolved };
   });
 }

--- a/features/generation/lib/prompt-secrets.ts
+++ b/features/generation/lib/prompt-secrets.ts
@@ -11,9 +11,11 @@ import type { GeneratedImageRecord } from "./database";
  *
  * 詳細は docs/planning/free-prompt-private-mode-implementation-plan.md ADR-001。
  *
- * 移行の段階:
- *   Phase 0B (現在) 新規行は secret、既存行は legacy 列。ここでは両方を見る
- *   Phase 0C        legacy 列を空化し、DB 制約で非空値を拒否する
+ * Phase 0C 以降、本文は secret にしか存在しない。`generated_images.prompt` は
+ * 常に空で、DB の CHECK 制約が非空値の書き込みを拒否する。
+ * legacy 列へのフォールバックは持たない（fail closed）。secret が無い行は
+ * 「開示するものが無い」行であり、障害時に古い列へ落ちて秘匿境界が緩む
+ * 経路を残さないため。
  */
 
 /** 解決に必要な最小の形。Post 型でも生の行でも受けられるようにする。 */
@@ -81,9 +83,8 @@ async function fetchPromptSecrets(
 /**
  * 複数レコードの表示用プロンプトを解決する。
  *
- * 開示不可の種別は空文字にし、それ以外は secret を優先して legacy 列へ
- * フォールバックする。フォールバックが必要なのは backfill 前の既存行だけで、
- * Phase 0C 以降は secret に一本化される。
+ * 開示不可の種別は空文字にし、それ以外は secret の値だけを使う。
+ * secret が無ければ空文字（legacy 列へは落ちない）。
  */
 export async function resolveVisiblePrompts<T extends PromptResolvableRecord>(
   records: T[]
@@ -104,8 +105,7 @@ export async function resolveVisiblePrompts<T extends PromptResolvableRecord>(
       return record.prompt === "" ? record : { ...record, prompt: "" };
     }
 
-    const secret = record.id ? secrets.get(record.id) : undefined;
-    const resolved = secret ?? record.prompt;
+    const resolved = (record.id ? secrets.get(record.id) : undefined) ?? "";
     return resolved === record.prompt ? record : { ...record, prompt: resolved };
   });
 }

--- a/supabase/functions/image-gen-worker/failed-job-billing.ts
+++ b/supabase/functions/image-gen-worker/failed-job-billing.ts
@@ -1,6 +1,25 @@
 import { isSafetyPolicyBlockedErrorMessage } from "../../../shared/generation/errors.ts";
 
 /**
+ * 消費トランザクションに記録された額から返金額を復元する。
+ *
+ * reconciliation は失敗から時間が経って実行されることがあるため、現在の
+ * モデル料金表から再計算してはならない。料金改定後に再計算値と
+ * generation_percoin_allocations の合計がずれると、refund_percoins の
+ * allocation total mismatch で永久に返金できなくなる。
+ */
+export function resolveRecordedPercoinRefundAmount(
+  consumptionAmount: unknown,
+): number {
+  const numericAmount = Number(consumptionAmount);
+  if (!Number.isSafeInteger(numericAmount) || numericAmount >= 0) {
+    throw new Error("invalid recorded consumption amount");
+  }
+
+  return Math.abs(numericAmount);
+}
+
+/**
  * 最終失敗したジョブの課金後処理。
  *
  * Worker は「failed へ更新 → 返金/release → pgmq_delete」の順で処理する。

--- a/supabase/functions/image-gen-worker/failed-job-billing.ts
+++ b/supabase/functions/image-gen-worker/failed-job-billing.ts
@@ -1,0 +1,99 @@
+import { isSafetyPolicyBlockedErrorMessage } from "../../../shared/generation/errors.ts";
+
+/**
+ * 最終失敗したジョブの課金後処理。
+ *
+ * Worker は「failed へ更新 → 返金/release → pgmq_delete」の順で処理する。
+ * この途中でクラッシュすると、再配送側が終端判定でメッセージを削除してしまい、
+ * 未実施の返金が永久に実行されない。ユーザーのペルコインが減算されたまま
+ * 確定してしまう。
+ *
+ * そこで課金後処理をここへ集約し、初回失敗時と failed 再配送時の両方から
+ * 呼ぶ。`refund_percoins` と release RPC はどちらも冪等なので、再配送を
+ * reconciliation として使える。
+ *
+ * 副作用は呼び出し側から注入する。Worker 本体は Deno/JSR に依存しており
+ * Jest から import できないため、判定と順序だけをこのモジュールへ隔離して
+ * テスト可能にしている。
+ */
+
+export interface SettleFailedJobBillingParams {
+  jobId: string;
+  /** 無料枠の One-Tap Style ジョブか */
+  isFreeOneTapStyleJob: boolean;
+  /** 予約済みの無料枠 ID。無ければ null */
+  reservedAttemptId: string | null;
+  /** 失敗理由。安全性ブロックの判定に使う */
+  errorMessage: string;
+  /** 無料枠を返す副作用 */
+  releaseFreeAttempt: (
+    reservedAttemptId: string,
+    releaseReason: "no_image_generated" | "worker_failed",
+  ) => Promise<void>;
+  /** ペルコインを返金する副作用（冪等） */
+  refundPercoins: () => Promise<void>;
+  /** ログ出力（テストでは差し替える） */
+  logInfo?: (message: string) => void;
+  logError?: (message: string, error: unknown) => void;
+}
+
+/**
+ * 課金後処理を実行する。
+ *
+ * @returns 完了したか。**false のときメッセージを ack してはならない。**
+ *          残しておけば次の配送で reconciliation として再実行される。
+ */
+export async function settleFailedJobBilling(
+  params: SettleFailedJobBillingParams,
+): Promise<boolean> {
+  const {
+    jobId,
+    isFreeOneTapStyleJob,
+    reservedAttemptId,
+    errorMessage,
+    releaseFreeAttempt,
+    refundPercoins,
+    logInfo = () => {},
+    logError = () => {},
+  } = params;
+
+  if (isFreeOneTapStyleJob) {
+    // 安全性ブロックは枠を消費させる仕様なので release しない。
+    // 予約が無い場合も返すものが無いので完了扱いにする。
+    if (
+      reservedAttemptId === null ||
+      isSafetyPolicyBlockedErrorMessage(errorMessage)
+    ) {
+      return true;
+    }
+
+    try {
+      await releaseFreeAttempt(
+        reservedAttemptId,
+        errorMessage === "No images generated"
+          ? "no_image_generated"
+          : "worker_failed",
+      );
+      logInfo(`Released free style attempt for failed job ${jobId}`);
+      return true;
+    } catch (releaseError) {
+      logError(
+        `Failed to release free style attempt; leaving message for retry: ${jobId}`,
+        releaseError,
+      );
+      return false;
+    }
+  }
+
+  try {
+    await refundPercoins();
+    logInfo(`Refunded percoins for finally failed job ${jobId}`);
+    return true;
+  } catch (refundError) {
+    logError(
+      `Failed to refund percoins; leaving message for retry: ${jobId}`,
+      refundError,
+    );
+    return false;
+  }
+}

--- a/supabase/functions/image-gen-worker/index.ts
+++ b/supabase/functions/image-gen-worker/index.ts
@@ -62,6 +62,7 @@ import {
 import { buildGeminiGenerationConfig } from "./gemini-request-config.ts";
 import { resolveAllPromptTemplatesForWorker } from "./prompt-override.ts";
 import { resolvePromptExecutionInput } from "./prompt-execution.ts";
+import { settleFailedJobBilling } from "./failed-job-billing.ts";
 
 /**
  * 画像生成ワーカー Edge Function
@@ -782,6 +783,55 @@ function getGenerationPercoinAmount(job: {
 const GENERATION_PROMPT_EXECUTION_MISSING =
   "GENERATION_PROMPT_EXECUTION_MISSING";
 
+/**
+ * 最終失敗したジョブの課金後処理を冪等に実行する。
+ *
+ * 判定と順序は failed-job-billing.ts に隔離し（Jest でテスト可能にするため）、
+ * ここでは Supabase への副作用を注入するだけにする。
+ *
+ * @returns 完了したか。false のときメッセージを ack してはならない。
+ */
+async function settleFailedJobBillingWithSupabase(
+  // deno-lint-ignore no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: any,
+  params: {
+    jobId: string;
+    // deno-lint-ignore no-explicit-any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    job: any;
+    errorMessage: string;
+    isFreeOneTapStyleJob: boolean;
+    reservedAttemptId: string | null;
+  },
+): Promise<boolean> {
+  const { jobId, job, errorMessage, isFreeOneTapStyleJob, reservedAttemptId } =
+    params;
+
+  return await settleFailedJobBilling({
+    jobId,
+    isFreeOneTapStyleJob,
+    reservedAttemptId,
+    errorMessage,
+    releaseFreeAttempt: (attemptId, releaseReason) =>
+      releaseStyleAuthenticatedGenerateAttempt(
+        supabase,
+        attemptId,
+        releaseReason,
+      ),
+    refundPercoins: () =>
+      refundPercoinsFromGeneration(
+        supabase,
+        job.user_id,
+        jobId,
+        getGenerationPercoinAmount(job),
+      ),
+    logInfo: (message) => console.log(`[Job Processing] ${message}`),
+    logError: (message, error) =>
+      console.error(`[Job Processing] ${message}`, error),
+  });
+}
+
 function isNonRetriableGenerationError(errorMessage: string): boolean {
   return (
     errorMessage === GENERATION_PROMPT_EXECUTION_MISSING ||
@@ -1479,6 +1529,37 @@ Deno.serve(async () => {
         // processing は削除しない。削除するとクラッシュ時にジョブが永続的に
         // processing のまま残る（下の stale 判定で回収する）。
         if (job.status === "succeeded" || job.status === "failed") {
+          // failed の再配送は課金後処理の reconciliation として使う。
+          // 「failed へ更新 → 返金 → pgmq_delete」の途中でクラッシュした場合、
+          // ここで無条件に削除すると未実施の返金が永久に実行されない。
+          if (job.status === "failed") {
+            const terminalOneTapMetadata =
+              job.generation_type === "one_tap_style"
+                ? getOneTapStylePresetMetadata(job)
+                : null;
+            const settled = await settleFailedJobBillingWithSupabase(supabase, {
+              jobId,
+              job,
+              errorMessage: job.error_message ?? "",
+              isFreeOneTapStyleJob:
+                job.generation_type === "one_tap_style" &&
+                terminalOneTapMetadata?.billingMode === "free",
+              reservedAttemptId:
+                job.generation_type === "one_tap_style"
+                  ? getOneTapStyleReservedAttemptId(job)
+                  : null,
+            });
+
+            if (!settled) {
+              // ack せずメッセージを残し、次の配送でもう一度試す
+              console.warn(
+                `[Job Processing] Left failed message for billing reconciliation: ${jobId}`,
+              );
+              skippedCount++;
+              continue;
+            }
+          }
+
           const { error: terminalDeleteError } = await supabase.rpc("pgmq_delete", {
             p_queue_name: QUEUE_NAME,
             p_msg_id: msgId,
@@ -2657,8 +2738,22 @@ Deno.serve(async () => {
           };
 
           const uploadedImages: UploadedGeneratedImage[] = [];
-          const cleanupUploadedImages = async (reason: string) => {
-            const uploadPaths = uploadedImages.map((image) => image.uploadPath);
+          /**
+           * アップロード済み画像のうち、DB に紐づかなかった分を削除する。
+           *
+           * 完了 RPC は冪等で、stale 競合時には別 Worker が作った既存行を返す。
+           * その場合、今回アップロードした画像は誰からも参照されない孤児になる。
+           * RPC が返した storage_path に含まれないものだけを消すことで、
+           * エラー時（persistedPaths なし = 全部消す）と競合時の両方を扱える。
+           */
+          const cleanupUploadedImages = async (
+            reason: string,
+            persistedPaths?: readonly string[],
+          ) => {
+            const keep = new Set(persistedPaths ?? []);
+            const uploadPaths = uploadedImages
+              .map((image) => image.uploadPath)
+              .filter((path) => !keep.has(path));
             if (uploadPaths.length === 0) {
               return;
             }
@@ -2672,8 +2767,22 @@ Deno.serve(async () => {
                 `[Worker] failed to cleanup uploaded images after ${reason}`,
                 cleanupError
               );
+            } else {
+              console.log(
+                `[Worker] cleaned up ${uploadPaths.length} unpersisted uploads after ${reason}`,
+              );
             }
           };
+
+          /** 完了 RPC の返り値から storage_path を取り出す。 */
+          const extractPersistedPaths = (rows: unknown): string[] =>
+            Array.isArray(rows)
+              ? (rows as Array<{ storage_path?: unknown }>)
+                  .map((row) =>
+                    typeof row?.storage_path === "string" ? row.storage_path : null
+                  )
+                  .filter((path): path is string => path !== null)
+              : [];
 
           currentStage = "uploading";
           await measureJobStage(
@@ -2795,6 +2904,13 @@ Deno.serve(async () => {
                   );
                 }
 
+                // stale 競合で別 Worker の既存行が返った場合、今回アップロードした
+                // 画像は誰からも参照されない。返却 storage_path に無い分を消す。
+                await cleanupUploadedImages(
+                  "atomic completion",
+                  extractPersistedPaths(imageRecords),
+                );
+
                 imageRecordIds.push(...rpcImageRecordIds);
                 return;
               }
@@ -2838,6 +2954,8 @@ Deno.serve(async () => {
                   "Failed to complete image job atomically:",
                   geminiCompleteError,
                 );
+                // DB に紐づかなかったアップロードを孤児にしない
+                await cleanupUploadedImages("persistence failure");
                 throw new Error(
                   `画像メタデータの保存に失敗しました: ${geminiCompleteError.message}`,
                 );
@@ -2851,8 +2969,16 @@ Deno.serve(async () => {
 
               if (geminiRecordIds.length === 0) {
                 // RPC は冪等で、既に成功済みなら既存行を返す。0 件は想定外。
+                await cleanupUploadedImages("empty persistence result");
                 throw new Error("画像メタデータの保存結果が空です");
               }
+
+              // stale 競合で別 Worker の既存行が返った場合、今回アップロードした
+              // 画像は誰からも参照されない。返却 storage_path に無い分を消す。
+              await cleanupUploadedImages(
+                "atomic completion",
+                extractPersistedPaths(geminiImageRecords),
+              );
 
               imageRecordIds.push(...geminiRecordIds);
 
@@ -2987,57 +3113,35 @@ Deno.serve(async () => {
             continue;
           }
 
-          // 最終失敗が確定した場合のみ返金または無料枠release
+          // 最終失敗が確定した場合のみ課金後処理を行う。
+          // 完了してからだけ ack する（未返金のまま捨てないため）。
           if (shouldMarkAsFailed) {
-            if (isFreeOneTapStyleJob) {
-              const shouldReleaseFreeAttempt =
-                reservedAttemptId !== null &&
-                !isSafetyPolicyBlockedErrorMessage(errorMessage);
+            const settled = await settleFailedJobBillingWithSupabase(supabase, {
+              jobId,
+              job,
+              errorMessage,
+              isFreeOneTapStyleJob,
+              reservedAttemptId,
+            });
 
-              if (shouldReleaseFreeAttempt) {
-                try {
-                  const releaseReason =
-                    errorMessage === "No images generated"
-                      ? "no_image_generated"
-                      : "worker_failed";
-                  await releaseStyleAuthenticatedGenerateAttempt(
-                    supabase,
-                    reservedAttemptId,
-                    releaseReason
-                  );
-                  console.log(
-                    `[Job Processing] Released free style attempt for failed job ${jobId}`
-                  );
-                } catch (releaseError) {
-                  console.error(
-                    "[Job Processing] Failed to release free style attempt after final generation failure:",
-                    releaseError
-                  );
-                }
+            if (settled) {
+              const { error: failDeleteError } = await supabase.rpc("pgmq_delete", {
+                p_queue_name: QUEUE_NAME,
+                p_msg_id: msgId,
+              });
+              if (failDeleteError) {
+                console.error(
+                  "Failed to delete message after final failure:",
+                  failDeleteError,
+                );
               }
             } else {
-              try {
-                const percoinCost = getGenerationPercoinAmount(job);
-                await refundPercoinsFromGeneration(
-                  supabase,
-                  job.user_id,
-                  jobId,
-                  percoinCost
-                );
-                console.log(`[Job Processing] Refunded ${percoinCost} percoins for finally failed job ${jobId}`);
-              } catch (refundError) {
-                // 返金失敗はログに記録（既に減算されているため、手動対応が必要な可能性がある）
-                console.error("[Job Processing] Failed to refund percoins after final generation failure:", refundError);
-              }
+              // メッセージを残す。可視性タイムアウト後に再配送され、
+              // 冒頭の failed 分岐が reconciliation として課金後処理を再実行する。
+              console.warn(
+                `[Job Processing] Left message for billing reconciliation: ${jobId}`,
+              );
             }
-          }
-
-          // メッセージの削除/アーカイブ（即時失敗またはattempts >= 2の場合）
-          if (shouldMarkAsFailed) {
-            await supabase.rpc("pgmq_delete", {
-              p_queue_name: QUEUE_NAME,
-              p_msg_id: msgId,
-            });
           }
         }
       } catch (error) {

--- a/supabase/functions/image-gen-worker/index.ts
+++ b/supabase/functions/image-gen-worker/index.ts
@@ -1594,7 +1594,13 @@ Deno.serve(async () => {
             started_at: new Date().toISOString(),
           })
           .eq("id", jobId)
-          .in("status", ["queued", "failed"]) // 既にprocessingの場合は更新しない
+          // claim できるのは queued のみ (ADR-012)。
+          // 以前は failed も含めていたが、終端 failed を暗黙に再実行する経路に
+          // なっており、attempts の上限(2)を超えて再試行される不具合の温床だった
+          // (本番実測: attempts=3 が 25 件)。内部リトライは status を queued に
+          // 戻して行い、終端 failed は不変とする。ユーザーの再試行は新しい
+          // ジョブ + 実行入力レコードを作る。
+          .eq("status", "queued")
           .select("id")
           .maybeSingle();
 
@@ -1778,16 +1784,17 @@ Deno.serve(async () => {
         // ===== フェーズ4-1: Gemini API呼び出しの実装 =====
         const geminiAttempts: GeminiAttemptMetadata[] = [];
         try {
-          // 生成入力の解決 (プロンプト秘匿境界の移行期)
+          // 生成入力の解決 (プロンプト秘匿境界)
           //
-          // 新規ジョブは image_jobs.prompt_text を空にし、本文を service-only の
-          // generation_prompt_snapshots へ置いている。image_jobs の SELECT RLS は
-          // auth.uid() = user_id なので、本文をそこへ残すと生成した本人が運営資産まで
-          // 読めてしまう。
+          // 本文は service-only の generation_prompt_snapshots にだけ存在する。
+          // image_jobs.prompt_text は常に空で、legacy 列へのフォールバックは
+          // 持たない (fail closed)。落ちる経路を残すと、レコードの作成漏れが
+          // 「古い列の値で生成が通ってしまう」形で隠蔽され、Phase 0C の空化後に
+          // 初めて壊れる。
           //
-          // 移行前のジョブは prompt_text に値があるため、当面は「実行入力レコードが
-          // あればそちら、無ければ prompt_text」とする。Phase 0C で prompt_text を
-          // 空化した後は、レコード欠落を固定内部コードで fail closed させる。
+          // 生成種別ごとに必要な入力が揃っていなければ、provider を呼ぶ前に
+          // 固定内部コードで終端失敗させる。課金の後だが、失敗時は既存の
+          // 冪等返金経路 (refundPercoinsFromGeneration) でペルコインが戻る。
           //
           // 生成フェーズと画像永続化フェーズの両方から参照するため、どちらの
           // コールバックよりも外側で解決しておく。
@@ -1800,7 +1807,23 @@ Deno.serve(async () => {
           const generationInput =
             promptExecution?.authorInput ??
             promptExecution?.providerPrompt ??
-            job.prompt_text;
+            "";
+
+          {
+            const requiresAuthorInput =
+              job.generation_type === "coordinate" ||
+              job.generation_type === "free";
+            const requiresProviderPrompt =
+              job.generation_type === "one_tap_style";
+
+            if (
+              (requiresAuthorInput && !promptExecution?.authorInput) ||
+              (requiresProviderPrompt && !promptExecution?.providerPrompt)
+            ) {
+              throw new Error("GENERATION_PROMPT_EXECUTION_MISSING");
+            }
+          }
+
 
           let generatedImages: GeneratedImageResult[] = [];
           currentStage = "generating";
@@ -2775,10 +2798,9 @@ Deno.serve(async () => {
                   user_id: job.user_id,
                   image_url: primaryUploadedImage.publicUrl,
                   storage_path: primaryUploadedImage.uploadPath,
-                  // 移行期の dual-write。legacy ジョブは prompt_text に、
-                  // 新規ジョブは実行入力レコードに値がある。
-                  // Phase 0C でこの列は空化し、DB 制約で非空値を拒否する。
-                  prompt: generationInput,
+                  // 本文はユーザーが読める列に置かない。表示は author secret から
+                  // 解決される。DB の CHECK 制約も非空値を拒否する (REQ-020)。
+                  prompt: "",
                   background_mode: backgroundMode,
                   is_posted: false,
                   generation_type: job.generation_type,

--- a/supabase/functions/image-gen-worker/index.ts
+++ b/supabase/functions/image-gen-worker/index.ts
@@ -773,8 +773,18 @@ function getGenerationPercoinAmount(job: {
 /**
  * 再試行不可のエラーか判定
  */
+/**
+ * 生成実行入力が欠落・不整合のときに投げる固定内部コード。
+ *
+ * 復旧不能な状態なので再試行しない。リトライすると、減算済みペルコインの
+ * 返金が次回配送まで遅れ、課金RPC・snapshot 検索・worker 起動がもう一度走る。
+ */
+const GENERATION_PROMPT_EXECUTION_MISSING =
+  "GENERATION_PROMPT_EXECUTION_MISSING";
+
 function isNonRetriableGenerationError(errorMessage: string): boolean {
   return (
+    errorMessage === GENERATION_PROMPT_EXECUTION_MISSING ||
     errorMessage === "No images generated" ||
     isInvalidGeminiArgumentErrorMessage(errorMessage) ||
     isMalformedGeminiPartsErrorMessage(errorMessage) ||
@@ -1458,12 +1468,27 @@ Deno.serve(async () => {
           continue;
         }
 
-        // 冪等性チェック: 既に完了している場合はメッセージを削除してスキップ
-        if (job.status === "succeeded") {
-          await supabase.rpc("pgmq_delete", {
+        // 冪等性チェック: 終端状態のジョブはメッセージを削除してスキップ。
+        //
+        // failed も削除対象に含める。claim を queued 限定にしたため、failed の
+        // メッセージが再配送されても UPDATE が 0 件になり、削除されないまま
+        // 残り続ける。可視性タイムアウトごとに再取得され、取得枠を占有して
+        // 新しい生成を飢餓状態にしうる。「failed 更新後・pgmq_delete 前に
+        // クラッシュ」でも再現する。
+        //
+        // processing は削除しない。削除するとクラッシュ時にジョブが永続的に
+        // processing のまま残る（下の stale 判定で回収する）。
+        if (job.status === "succeeded" || job.status === "failed") {
+          const { error: terminalDeleteError } = await supabase.rpc("pgmq_delete", {
             p_queue_name: QUEUE_NAME,
             p_msg_id: msgId,
           });
+          if (terminalDeleteError) {
+            console.error(
+              "Failed to delete terminal job message:",
+              terminalDeleteError,
+            );
+          }
           skippedCount++;
           continue;
         }
@@ -1820,7 +1845,7 @@ Deno.serve(async () => {
               (requiresAuthorInput && !promptExecution?.authorInput) ||
               (requiresProviderPrompt && !promptExecution?.providerPrompt)
             ) {
-              throw new Error("GENERATION_PROMPT_EXECUTION_MISSING");
+              throw new Error(GENERATION_PROMPT_EXECUTION_MISSING);
             }
           }
 
@@ -2699,7 +2724,13 @@ Deno.serve(async () => {
           );
 
           // ===== フェーズ4-3: generated_imagesテーブルへの保存 =====
-          let shouldSkipAfterPersist = false;
+          // 「永続化の直前に他ワーカーが状態を変えた」ケースの skip 分岐は
+          // 廃止した。両 provider が complete_image_job_with_prompt_secrets を
+          // 使うようになり、
+          //   - すでに succeeded なら RPC が既存行を返す（冪等）
+          //   - それ以外の状態遷移は RPC が例外を投げ、通常の失敗経路で
+          //     冪等返金まで進む
+          // という形で RPC 側に寄ったため。OpenAI 経路は元からこの挙動だった。
           const imageRecordIds: string[] = [];
           const primaryUploadedImage = uploadedImages[0];
           if (!primaryUploadedImage) {
@@ -2768,202 +2799,68 @@ Deno.serve(async () => {
                 return;
               }
 
-              // 生成完了直前に source_image_stock_id を再取得する。
-              // 生成中にユーザーがダイアログから元画像をストック保存した場合、
-              // link-stock API が image_jobs.source_image_stock_id を後追いで更新するため、
-              // 起動時にロードした job.source_image_stock_id では古い値（NULL）を保持している可能性がある。
-              const { data: latestJob, error: latestJobError } = await supabase
-                .from("image_jobs")
-                .select("source_image_stock_id")
-                .eq("id", jobId)
-                .maybeSingle();
-
-              if (latestJobError) {
-                console.warn(
-                  `[Worker] failed to refetch source_image_stock_id for job ${jobId}, falling back to initial value`,
-                  latestJobError
-                );
-              }
-
-              const latestSourceImageStockId =
-                latestJob?.source_image_stock_id ?? job.source_image_stock_id;
-
-              // inspire 用: generated_images_inspire_template_consistency_check
-              // (generation_type='inspire' ⇔ style_template_id IS NOT NULL) を満たすため、
-              // image_jobs から style_template_id / override_* を継承する。
-              const isInspireRecord = job.generation_type === "inspire";
-              const { data: imageRecord, error: insertError } = await supabase
-                .from("generated_images")
-                .insert({
-                  user_id: job.user_id,
-                  image_url: primaryUploadedImage.publicUrl,
-                  storage_path: primaryUploadedImage.uploadPath,
-                  // 本文はユーザーが読める列に置かない。表示は author secret から
-                  // 解決される。DB の CHECK 制約も非空値を拒否する (REQ-020)。
-                  prompt: "",
-                  background_mode: backgroundMode,
-                  is_posted: false,
-                  generation_type: job.generation_type,
-                  generation_metadata: job.generation_metadata ?? null,
-                  model: dbModel,
-                  source_image_stock_id: latestSourceImageStockId,
-                  image_job_id: jobId,
-                  image_job_result_index: 0,
-                  width: primaryUploadedImage.width,
-                  height: primaryUploadedImage.height,
-                  style_template_id: job.style_template_id ?? null,
-                  override_target: job.override_target ?? null,
-                  override_outfit: isInspireRecord ? (job.override_outfit ?? true) : null,
-                  override_angle: isInspireRecord ? (job.override_angle ?? true) : null,
-                  override_pose: isInspireRecord ? (job.override_pose ?? true) : null,
-                  override_background: isInspireRecord ? (job.override_background ?? true) : null,
-                })
-                .select()
-                .single();
-
-              if (insertError) {
-                console.error("Database insert error:", insertError);
-                throw new Error(`画像メタデータの保存に失敗しました: ${insertError.message}`);
-              }
-
-              imageRecordIds.push(imageRecord.id);
-
-              // 原作者へ開示してよい生入力だけを author secret へ転記する。
-              // one_tap_style は provider_prompt しか持たないためここへ入らず、
-              // 生成した本人が運営資産を読める状態にはならない。
-              // 派生ジョブは derived_reference で author_input を持てない
-              // (テーブル CHECK) ため、同様にここへ入らない。
-              if (
-                promptExecution?.snapshotKind === "materialized" &&
-                promptExecution.authorInput &&
-                promptExecution.authorInputOwnerId
-              ) {
-                const { error: secretError } = await supabase
-                  .from("generated_image_prompt_secrets")
-                  .upsert(
+              // Gemini 経路も OpenAI と同じ原子的 RPC で確定する。
+              //
+              // 以前は「画像を INSERT → author secret を別リクエストで upsert →
+              // job を成功更新」の3手順に分かれており、secret の失敗をログだけで
+              // 握りつぶしていた。generated_images.prompt を空にした後は、この
+              // 部分成功が「画像はあるがプロンプトが永久に空」という表示欠損として
+              // 顕在化する。ジョブは成功扱いなので再試行も返金もされない。
+              // Phase 0B で実際に起きた事故と同型なので、同一トランザクションへ
+              // 寄せる（計画書 Phase 0B「Gemini/OpenAI双方の画像永続化を新RPCへ統一」）。
+              //
+              // model と background_mode は Worker 側で正規化した値を渡す。
+              // 直接 INSERT 時代は normalizeModelName / resolveBackgroundMode の
+              // 結果を書いていたため、RPC がジョブの生値を書くと挙動が変わる。
+              //
+              // source_image_stock_id は RPC 内で FOR UPDATE 付きに読み直した
+              // ジョブの値を使う。生成中にユーザーがストック保存した場合の
+              // 後追い更新も、Worker 起動時の古い値ではなく最新が反映される。
+              const { data: geminiImageRecords, error: geminiCompleteError } =
+                await supabase.rpc("complete_image_job_with_prompt_secrets", {
+                  p_job_id: jobId,
+                  p_images: [
                     {
-                      image_id: imageRecord.id,
-                      prompt: promptExecution.authorInput,
-                      prompt_owner_id: promptExecution.authorInputOwnerId,
-                      source_kind: "author_input",
+                      image_url: primaryUploadedImage.publicUrl,
+                      storage_path: primaryUploadedImage.uploadPath,
+                      width: primaryUploadedImage.width,
+                      height: primaryUploadedImage.height,
                     },
-                    { onConflict: "image_id", ignoreDuplicates: true },
-                  );
+                  ],
+                  p_generation_metadata: successGenerationMetadata,
+                  p_result_image_url: primaryUploadedImage.publicUrl,
+                  p_model: dbModel,
+                  p_background_mode: backgroundMode,
+                });
 
-                if (secretError) {
-                  // 本文は載せない。ここで失敗しても画像自体は保存済みなので、
-                  // 生成を落とさず記録だけ残す。移行完了後は完了 RPC 経由に
-                  // 一本化されるため、この経路は縮小する。
-                  console.error(
-                    `[Worker] failed to store author prompt secret for image ${imageRecord.id}`,
-                    { code: secretError.code },
-                  );
-                }
-              }
-
-              const { data: postInsertJob, error: postInsertJobError } = await supabase
-                .from("image_jobs")
-                .select("source_image_stock_id")
-                .eq("id", jobId)
-                .maybeSingle();
-
-              if (postInsertJobError) {
-                console.warn(
-                  `[Worker] failed to post-sync source_image_stock_id for generated image ${imageRecord.id}`,
-                  postInsertJobError
+              if (geminiCompleteError) {
+                console.error(
+                  "Failed to complete image job atomically:",
+                  geminiCompleteError,
+                );
+                throw new Error(
+                  `画像メタデータの保存に失敗しました: ${geminiCompleteError.message}`,
                 );
               }
 
-              const postInsertSourceImageStockId =
-                postInsertJob?.source_image_stock_id ?? null;
+              const geminiRecordIds = Array.isArray(geminiImageRecords)
+                ? (geminiImageRecords as Array<{ id?: unknown }>)
+                    .map((row) => (typeof row?.id === "string" ? row.id : null))
+                    .filter((id): id is string => id !== null)
+                : [];
 
-              if (
-                postInsertSourceImageStockId &&
-                postInsertSourceImageStockId !== latestSourceImageStockId
-              ) {
-                const { error: syncGeneratedImageError } = await supabase
-                  .from("generated_images")
-                  .update({ source_image_stock_id: postInsertSourceImageStockId })
-                  .eq("id", imageRecord.id);
-
-                if (syncGeneratedImageError) {
-                  console.warn(
-                    `[Worker] failed to post-sync generated image ${imageRecord.id} with source image stock`,
-                    syncGeneratedImageError
-                  );
-                }
+              if (geminiRecordIds.length === 0) {
+                // RPC は冪等で、既に成功済みなら既存行を返す。0 件は想定外。
+                throw new Error("画像メタデータの保存結果が空です");
               }
 
-              // ===== フェーズ4-4: 成功時の処理 =====
-              // image_jobsテーブルを更新（成功時）
-              const { data: succeededJob, error: successUpdateError } = await supabase
-                .from("image_jobs")
-                .update({
-                  status: "succeeded",
-                  processing_stage: "completed",
-                  result_image_url: primaryUploadedImage.publicUrl,
-                  error_message: null,
-                  completed_at: new Date().toISOString(),
-                  generation_metadata: successGenerationMetadata,
-                })
-                .eq("id", jobId)
-                .eq("status", "processing")
-                .select("id")
-                .maybeSingle();
+              imageRecordIds.push(...geminiRecordIds);
 
-              if (successUpdateError) {
-                console.error("Failed to update job status to succeeded:", successUpdateError);
-                throw new Error(`ジョブステータスの更新に失敗しました: ${successUpdateError.message}`);
-              }
-
-              if (!succeededJob) {
-                console.warn(`[Job Success] Skipped succeeded update because status changed: ${jobId}`);
-                skippedCount++;
-                shouldSkipAfterPersist = true;
-                return;
-              }
-
-              // credit_transactionsのrelated_generation_idを更新
-              // 画像生成前にNULLで保存していた取引履歴を、generated_images.idに更新
-              try {
-                const { error: updateTransactionError } = await supabase
-                  .from("credit_transactions")
-                  .update({ related_generation_id: imageRecord.id })
-                  .eq("user_id", job.user_id)
-                  .is("related_generation_id", null) // NULLの取引履歴を検索
-                  .eq("transaction_type", "consumption")
-                  .eq("metadata->>job_id", jobId); // metadata内のjob_idで特定
-                
-                if (updateTransactionError) {
-                  console.error("[Job Success] Failed to update credit transaction:", updateTransactionError);
-                  // エラーはログに記録するが、処理は継続
-                } else {
-                  console.log(`[Job Success] Updated credit transaction related_generation_id to ${imageRecord.id}`);
-                }
-              } catch (updateTransactionError) {
-                console.error("[Job Success] Failed to update credit transaction:", updateTransactionError);
-                // エラーはログに記録するが、処理は継続
-              }
+              // credit_transactions.related_generation_id の更新は
+              // complete_image_job_with_prompt_secrets が同一トランザクション内で
+              // 行うため、ここでの後追い更新は不要になった。
             }
           );
-
-          if (shouldSkipAfterPersist) {
-            const skippedAtMs = Date.now();
-            const totalDurationMs =
-              createdAtMs !== null && !Number.isNaN(createdAtMs)
-                ? Math.max(skippedAtMs - createdAtMs, 0)
-                : null;
-            logJobTimingSummary({
-              jobId,
-              outcome: "ジョブスキップ",
-              queueWaitMs,
-              workerDurationMs: Math.max(skippedAtMs - workerStartedAtMs, 0),
-              totalDurationMs,
-              stageDurationsMs,
-              currentStage,
-            });
-            continue;
-	          }
 
           await deleteGeneratedImagesTempReferenceImageIfExists(
             supabase,

--- a/supabase/functions/image-gen-worker/index.ts
+++ b/supabase/functions/image-gen-worker/index.ts
@@ -62,7 +62,10 @@ import {
 import { buildGeminiGenerationConfig } from "./gemini-request-config.ts";
 import { resolveAllPromptTemplatesForWorker } from "./prompt-override.ts";
 import { resolvePromptExecutionInput } from "./prompt-execution.ts";
-import { settleFailedJobBilling } from "./failed-job-billing.ts";
+import {
+  resolveRecordedPercoinRefundAmount,
+  settleFailedJobBilling,
+} from "./failed-job-billing.ts";
 
 /**
  * 画像生成ワーカー Edge Function
@@ -824,7 +827,6 @@ async function settleFailedJobBillingWithSupabase(
         supabase,
         job.user_id,
         jobId,
-        getGenerationPercoinAmount(job),
       ),
     logInfo: (message) => console.log(`[Job Processing] ${message}`),
     logError: (message, error) =>
@@ -919,20 +921,20 @@ async function refundPercoinsFromGeneration(
   supabase: ReturnType<typeof createClient>,
   userId: string,
   jobId: string,
-  percoinAmount: number
 ): Promise<void> {
   try {
-    console.log(`[Percoin Refund] Starting refund for user ${userId}, job ${jobId}, amount ${percoinAmount}`);
-
-    // 互換性のため request値は引き続き算出するが、
-    // 実際の返金配分は DB 側 refund_percoins が allocation 明細を優先して決定する。
-    // （旧データのみ legacy fallback で request値を使用）
+    // reconciliation は価格改定後に走る可能性があるため、現在の料金表から
+    // 返金額を再計算しない。減算時の credit_transactions.amount を正本にする。
+    // allocation を持つ現行データでは、この絶対値が DB 側の allocation 合計と
+    // 一致しなければ refund_percoins が fail closed する。
     const { data: consumptionTx, error: consumptionError } = await supabase
       .from("credit_transactions")
-      .select("id, metadata")
+      .select("id, amount, metadata")
       .eq("user_id", userId)
       .eq("transaction_type", "consumption")
       .eq("metadata->>job_id", jobId)
+      .order("created_at", { ascending: false })
+      .limit(1)
       .maybeSingle();
 
     if (consumptionError) {
@@ -943,6 +945,13 @@ async function refundPercoinsFromGeneration(
       console.warn(`[Percoin Refund] Consumption transaction not found for job ${jobId}, skipping refund`);
       return;
     }
+
+    const percoinAmount = resolveRecordedPercoinRefundAmount(
+      consumptionTx.amount,
+    );
+    console.log(
+      `[Percoin Refund] Starting refund for user ${userId}, job ${jobId}, amount ${percoinAmount}`,
+    );
 
     const metadata = (consumptionTx.metadata as { from_promo?: number; from_paid?: number } | null) ?? {};
     const refundToPromo = Math.max(0, Math.min(percoinAmount, Number(metadata.from_promo ?? percoinAmount)));
@@ -1626,7 +1635,9 @@ Deno.serve(async () => {
             continue;
           }
 
-          // 最終失敗確定時のみ返金または無料枠release（未減算ジョブの過剰返金も防ぐ）
+          // 最終失敗確定時のみ返金または無料枠release。
+          // 通常失敗・failed再配送と同じ共通処理を通し、課金後処理が
+          // 完了したときだけメッセージを ack する。
           const staleOneTapStyleMetadata =
             job.generation_type === "one_tap_style"
               ? getOneTapStylePresetMetadata(job)
@@ -1636,56 +1647,37 @@ Deno.serve(async () => {
               ? getOneTapStyleReservedAttemptId(job)
               : null;
 
-          if (
-            job.generation_type === "one_tap_style" &&
-            staleOneTapStyleMetadata?.billingMode === "free" &&
-            staleReservedAttemptId
-          ) {
-            try {
-              await releaseStyleAuthenticatedGenerateAttempt(
-                supabase,
-                staleReservedAttemptId,
-                "worker_failed"
-              );
-              console.log(
-                `[Job Processing] Released free style attempt for final stale-failed job ${jobId}`
-              );
-            } catch (releaseError) {
-              console.error(
-                "[Job Processing] Failed to release free style attempt for final stale-failed job:",
-                releaseError
-              );
-            }
-          } else {
-            try {
-              const { data: consumptionTx } = await supabase
-                .from("credit_transactions")
-                .select("id")
-                .eq("user_id", job.user_id)
-                .eq("transaction_type", "consumption")
-                .eq("metadata->>job_id", jobId)
-                .maybeSingle();
+          const staleSettled = await settleFailedJobBillingWithSupabase(
+            supabase,
+            {
+              jobId,
+              job,
+              errorMessage: staleErrorMessage,
+              isFreeOneTapStyleJob:
+                job.generation_type === "one_tap_style" &&
+                staleOneTapStyleMetadata?.billingMode === "free",
+              reservedAttemptId: staleReservedAttemptId,
+            },
+          );
 
-              if (consumptionTx) {
-                const percoinCost = getGenerationPercoinAmount(job);
-                await refundPercoinsFromGeneration(
-                  supabase,
-                  job.user_id,
-                  jobId,
-                  percoinCost
-                );
-                console.log(`[Job Processing] Refunded ${percoinCost} percoins for final stale-failed job ${jobId}`);
-              }
-            } catch (refundError) {
-              console.error("[Job Processing] Failed to refund final stale-failed job:", refundError);
-            }
+          if (!staleSettled) {
+            console.warn(
+              `[Job Processing] Left stale-failed message for billing reconciliation: ${jobId}`,
+            );
+            skippedCount++;
+            continue;
           }
 
-          // 失敗確定したためメッセージを削除
-          await supabase.rpc("pgmq_delete", {
+          const { error: staleDeleteError } = await supabase.rpc("pgmq_delete", {
             p_queue_name: QUEUE_NAME,
             p_msg_id: msgId,
           });
+          if (staleDeleteError) {
+            console.error(
+              "Failed to delete message after stale final failure:",
+              staleDeleteError,
+            );
+          }
           skippedCount++;
           continue;
         }

--- a/supabase/migrations/20260730100000_contract_generated_images_prompt.sql
+++ b/supabase/migrations/20260730100000_contract_generated_images_prompt.sql
@@ -13,8 +13,19 @@
 -- ★ 適用順序が重要 ★
 -- この migration より先に、次の2つがデプロイ済みであること。
 --   1. Next.js (legacy フォールバックを外した読み取り)
---   2. Worker  (直接 INSERT が prompt='' を書く版)
--- 旧 Worker のまま適用すると、Gemini 経路の INSERT が CHECK 違反で失敗する。
+--   2. Worker  (Gemini 経路も原子的 RPC を使い、prompt_text を読まない版)
+--
+-- 旧 Worker のまま適用すると次が起きる。
+--   - Gemini 経路の直接 INSERT が generated_images.prompt の CHECK 違反で失敗
+--   - prompt_text を読む旧 Worker が、空化された active ジョブで生成入力を失う
+--
+-- さらに、in-flight の旧 revision 処理が残っていないことを確認する。
+-- 手順:
+--   a. 新 Worker をデプロイする
+--   b. image_jobs の queued / processing が 0 件になるまで待つ
+--      (0 件でなくても、全件が実行入力レコードを持つなら続行可。migration が
+--       この条件を検証し、満たさなければ中断する)
+--   c. この migration を適用する
 --
 -- 不可逆性について:
 --   この UPDATE 自体は不可逆だが、本文は secret 側に残っているため、
@@ -33,17 +44,27 @@ SET LOCAL lock_timeout = '5s';
 -- いずれも user_id IS NULL・未投稿・ジョブ紐付けなしの孤児だった。
 -- RLS 上、未投稿かつ所有者なしの行は誰にも見えないため、失っても影響がない。
 --
--- 所有者のいる行が 1 件でも混ざっていたら、backfill 漏れなので中断する。
+-- ただし「安全な孤児」の条件は人の目視ではなく SQL で強制する。
+-- 適用直前に所有者付きの行や、投稿済み・ジョブ紐付きの欠損行が増えていたら、
+-- 不可逆操作の前提が崩れているので中断する。
 
 DO $$
 DECLARE
-  v_owned_loss integer;
-  v_orphan_loss integer;
+  v_safe_orphan integer;
+  v_unsafe integer;
 BEGIN
   SELECT
-    count(*) FILTER (WHERE gi.user_id IS NOT NULL),
-    count(*) FILTER (WHERE gi.user_id IS NULL)
-  INTO v_owned_loss, v_orphan_loss
+    count(*) FILTER (
+      WHERE gi.user_id IS NULL
+        AND gi.is_posted IS NOT TRUE
+        AND gi.image_job_id IS NULL
+    ),
+    count(*) FILTER (
+      WHERE gi.user_id IS NOT NULL
+        OR gi.is_posted IS TRUE
+        OR gi.image_job_id IS NOT NULL
+    )
+  INTO v_safe_orphan, v_unsafe
   FROM public.generated_images AS gi
   WHERE gi.generation_type IN ('coordinate', 'free')
     AND gi.prompt <> ''
@@ -53,12 +74,12 @@ BEGIN
       WHERE s.image_id = gi.id
     );
 
-  IF v_owned_loss > 0 THEN
+  IF v_unsafe > 0 THEN
     RAISE EXCEPTION
-      '所有者のいる行 % 件が secret を持たないまま空化されようとしている。backfill 漏れのため中断', v_owned_loss;
+      'secret を持たない行のうち % 件が「安全な孤児」の条件を満たさない（所有者あり / 投稿済み / ジョブ紐付きのいずれか）。backfill 漏れのため中断', v_unsafe;
   END IF;
 
-  RAISE NOTICE '空化で表示を失うのは所有者なしの孤児 % 件のみ（想定どおり）', v_orphan_loss;
+  RAISE NOTICE '空化で表示を失うのは所有者なし・未投稿・ジョブ紐付けなしの孤児 % 件のみ（想定どおり）', v_safe_orphan;
 END;
 $$;
 
@@ -66,6 +87,7 @@ $$;
 DO $$
 DECLARE
   v_digest_mismatch integer;
+  v_owner_mismatch integer;
   v_platform_leak integer;
 BEGIN
   SELECT count(*)
@@ -77,6 +99,21 @@ BEGIN
 
   IF v_digest_mismatch > 0 THEN
     RAISE EXCEPTION 'legacy と secret の内容不一致が % 件。中断', v_digest_mismatch;
+  END IF;
+
+  -- 所有者の不一致。coordinate / free は本人の入力なので画像所有者と一致する。
+  -- ずれていると、本来の原作者は見られず、誤って prompt_owner_id に入った
+  -- 別ユーザーが RLS 経由で本文を直接取得できる。
+  -- backfill (20260729130000) と同じ検証を contract 直前にも実行する。
+  SELECT count(*)
+  INTO v_owner_mismatch
+  FROM public.generated_images AS gi
+  JOIN public.generated_image_prompt_secrets AS s ON s.image_id = gi.id
+  WHERE gi.generation_type IN ('coordinate', 'free')
+    AND s.prompt_owner_id IS DISTINCT FROM gi.user_id;
+
+  IF v_owner_mismatch > 0 THEN
+    RAISE EXCEPTION 'author secret の所有者不一致が % 件。中断', v_owner_mismatch;
   END IF;
 
   SELECT count(*)
@@ -98,11 +135,17 @@ $$;
 -- legacy 値を generated_images.prompt へ書いていた。以後は空文字だけを書く。
 -- author secret の作成はそのまま維持する。
 
+-- Gemini 経路も同じ RPC で確定できるよう、model と background_mode を
+-- 呼び出し側から渡せるようにする。Worker は image_jobs の生値ではなく
+-- 正規化後の値 (normalizeModelName / resolveBackgroundMode) を画像へ書いて
+-- いたため、NULL のときだけジョブの値を使う形で互換を保つ。
 CREATE OR REPLACE FUNCTION public.complete_image_job_with_prompt_secrets(
   p_job_id uuid,
   p_images jsonb,
   p_generation_metadata jsonb DEFAULT NULL::jsonb,
-  p_result_image_url text DEFAULT NULL::text
+  p_result_image_url text DEFAULT NULL::text,
+  p_model text DEFAULT NULL::text,
+  p_background_mode text DEFAULT NULL::text
 )
 RETURNS TABLE (
   id uuid,
@@ -237,11 +280,11 @@ BEGIN
       -- 本文はユーザーが読める列に置かない。表示は author secret から
       -- 解決される (REQ-020)。
       '',
-      v_job.background_mode,
+      COALESCE(p_background_mode, v_job.background_mode),
       false,
       v_job.generation_type,
       COALESCE(p_generation_metadata, v_job.generation_metadata),
-      v_job.model,
+      COALESCE(p_model, v_job.model),
       v_job.source_image_stock_id,
       p_job_id,
       v_index,
@@ -317,41 +360,56 @@ BEGIN
 END;
 $function$;
 
-REVOKE ALL ON FUNCTION public.complete_image_job_with_prompt_secrets(uuid, jsonb, jsonb, text) FROM PUBLIC;
-REVOKE ALL ON FUNCTION public.complete_image_job_with_prompt_secrets(uuid, jsonb, jsonb, text) FROM anon;
-REVOKE ALL ON FUNCTION public.complete_image_job_with_prompt_secrets(uuid, jsonb, jsonb, text) FROM authenticated;
-GRANT EXECUTE ON FUNCTION public.complete_image_job_with_prompt_secrets(uuid, jsonb, jsonb, text) TO service_role;
+-- 旧シグネチャ (4引数) は overload として残らないよう明示的に落とす。
+-- 残すと呼び出し側の引数漏れが「別の関数が呼ばれる」形で隠れる。
+DROP FUNCTION IF EXISTS public.complete_image_job_with_prompt_secrets(uuid, jsonb, jsonb, text);
 
--- 旧完了 RPC はもう呼ばれないが、定義が残っている限り「呼べば非空を書く」
--- 経路になる。CHECK 追加後は実行時エラーになるだけだが、prompt_text を
--- コピーしない版へ置き換えて無害化しておく。
--- 定義全体の置き換えはせず、INSERT の prompt だけを '' にした版を上書きする。
+REVOKE ALL ON FUNCTION public.complete_image_job_with_prompt_secrets(uuid, jsonb, jsonb, text, text, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.complete_image_job_with_prompt_secrets(uuid, jsonb, jsonb, text, text, text) FROM anon;
+REVOKE ALL ON FUNCTION public.complete_image_job_with_prompt_secrets(uuid, jsonb, jsonb, text, text, text) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.complete_image_job_with_prompt_secrets(uuid, jsonb, jsonb, text, text, text) TO service_role;
 
-DO $$
-DECLARE
-  v_def text;
-BEGIN
-  SELECT pg_get_functiondef(p.oid)
-  INTO v_def
-  FROM pg_proc AS p
-  JOIN pg_namespace AS n ON n.oid = p.pronamespace
-  WHERE n.nspname = 'public'
-    AND p.proname = 'complete_image_job_with_generated_images';
+-- 旧完了 RPC を新 RPC への forwarding wrapper に置き換える。
+--
+-- 当初は pg_get_functiondef で定義を取り出し、v_job.prompt_text を文字列置換
+-- する方式にしていた。現行定義では成立するが、overload 追加や本番 hotfix で
+-- 定義がずれると壊れる。wrapper なら 198 行の複製も文字列操作も不要で、
+-- 旧呼び出しも新しい原子的完了契約（author secret 作成を含む）へ揃う。
+--
+-- 誤って旧 RPC が使われても、prompt='' と author secret 作成が保証される。
 
-  IF v_def IS NULL THEN
-    RAISE NOTICE '旧完了RPCは存在しない。スキップ';
-    RETURN;
-  END IF;
+CREATE OR REPLACE FUNCTION public.complete_image_job_with_generated_images(
+  p_job_id uuid,
+  p_images jsonb,
+  p_generation_metadata jsonb DEFAULT NULL::jsonb,
+  p_result_image_url text DEFAULT NULL::text
+)
+RETURNS TABLE (
+  id uuid,
+  image_url text,
+  storage_path text,
+  image_job_result_index integer
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+  SELECT *
+  FROM public.complete_image_job_with_prompt_secrets(
+    p_job_id,
+    p_images,
+    p_generation_metadata,
+    p_result_image_url
+  );
+$function$;
 
-  -- v_job.prompt_text を '' に置き換えて再定義する
-  IF v_def NOT LIKE '%v_job.prompt_text,%' THEN
-    RAISE EXCEPTION '旧完了RPCの形が想定と異なる。手動確認が必要';
-  END IF;
+COMMENT ON FUNCTION public.complete_image_job_with_generated_images(uuid, jsonb, jsonb, text) IS
+  '互換用の forwarding wrapper。実体は complete_image_job_with_prompt_secrets。新規実装はこちらを呼ばないこと';
 
-  v_def := replace(v_def, 'v_job.prompt_text,', '''''::text, -- 本文は書かない (REQ-020)');
-  EXECUTE v_def;
-END;
-$$;
+REVOKE ALL ON FUNCTION public.complete_image_job_with_generated_images(uuid, jsonb, jsonb, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.complete_image_job_with_generated_images(uuid, jsonb, jsonb, text) FROM anon;
+REVOKE ALL ON FUNCTION public.complete_image_job_with_generated_images(uuid, jsonb, jsonb, text) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.complete_image_job_with_generated_images(uuid, jsonb, jsonb, text) TO service_role;
 
 -- ===============================================
 -- 2. 公開列を空にする
@@ -381,40 +439,46 @@ COMMENT ON COLUMN public.generated_images.prompt IS
   '常に空。本文は generated_image_prompt_secrets (原作者入力) と generation_prompt_snapshots (生成実行入力) にのみ存在する。列は select("*") 互換のため残している (ADR-001)';
 
 -- ===============================================
--- 4. image_jobs.prompt_text の終端ジョブを空にする
+-- 4. image_jobs.prompt_text を全件空にし、DB で固定する
 -- ===============================================
 -- SELECT RLS が auth.uid() = user_id のため、One-Tap Style の組み立て済み
 -- 全文が生成した本人から読める状態が残っていた (REQ-019)。
--- queued / processing は Worker が参照する可能性があるため対象外とするが、
--- 適用時点で 0 件であることを確認する（0 件でなければ中断して待つ）。
+--
+-- 当初は「終端ジョブのみ空化」としていたが、それでは execution record を持つ
+-- active ジョブが除外されたまま残り、後に終端へ遷移しても空化する処理も
+-- DB 制約も無いため、一部ジョブで漏洩が継続する。migration は成功 NOTICE を
+-- 出すので「閉じた」と誤認する。
+--
+-- 新 Worker は prompt_text を読まない (実行入力レコードから解決する) ため、
+-- active ジョブも空化して構わない。generated_images.prompt と同じく
+-- DEFAULT '' + CHECK で不変条件にする。
+--
+-- 競合防止: 事前チェックと UPDATE の間に旧 Worker の stale 処理が状態を
+-- 変えられないよう、テーブルロックを取ってから検証する。
+-- ロック中は image_jobs への書き込みが待たされるが、対象は約3,600行で
+-- UPDATE は一瞬である。
 
+LOCK TABLE public.image_jobs IN SHARE ROW EXCLUSIVE MODE;
+
+-- 実行入力レコードを持たない active ジョブがあれば、空化すると生成入力を
+-- 失う。1 件でもあれば中断し、完了を待ってから再適用する。
 DO $$
 DECLARE
-  v_active integer;
   v_active_without_record integer;
 BEGIN
   SELECT count(*)
-  INTO v_active
-  FROM public.image_jobs
-  WHERE status IN ('queued', 'processing');
+  INTO v_active_without_record
+  FROM public.image_jobs AS j
+  WHERE j.status IN ('queued', 'processing')
+    AND NOT EXISTS (
+      SELECT 1
+      FROM public.generation_prompt_snapshots AS s
+      WHERE s.image_job_id = j.id
+    );
 
-  IF v_active > 0 THEN
-    -- 実行入力レコードを持たない active ジョブが 1 件でもあれば、空化すると
-    -- そのジョブは生成入力を失う。全件レコード持ちなら空化しても影響がない。
-    SELECT count(*)
-    INTO v_active_without_record
-    FROM public.image_jobs AS j
-    WHERE j.status IN ('queued', 'processing')
-      AND NOT EXISTS (
-        SELECT 1
-        FROM public.generation_prompt_snapshots AS s
-        WHERE s.image_job_id = j.id
-      );
-
-    IF v_active_without_record > 0 THEN
-      RAISE EXCEPTION
-        '実行入力レコードを持たない active ジョブが % 件ある。完了を待ってから再適用すること', v_active_without_record;
-    END IF;
+  IF v_active_without_record > 0 THEN
+    RAISE EXCEPTION
+      '実行入力レコードを持たない active ジョブが % 件ある。完了を待ってから再適用すること', v_active_without_record;
   END IF;
 END;
 $$;
@@ -438,8 +502,20 @@ $$;
 
 UPDATE public.image_jobs
 SET prompt_text = ''
-WHERE prompt_text <> ''
-  AND status NOT IN ('queued', 'processing');
+WHERE prompt_text <> '';
+
+ALTER TABLE public.image_jobs
+  ALTER COLUMN prompt_text SET DEFAULT '';
+
+ALTER TABLE public.image_jobs
+  ADD CONSTRAINT image_jobs_prompt_text_must_be_empty
+  CHECK (prompt_text = '') NOT VALID;
+
+ALTER TABLE public.image_jobs
+  VALIDATE CONSTRAINT image_jobs_prompt_text_must_be_empty;
+
+COMMENT ON COLUMN public.image_jobs.prompt_text IS
+  '常に空。生成入力は generation_prompt_snapshots にのみ存在する。SELECT RLS が本人開放のため、ここへ書くと One-Tap Style の運営プリセットが生成者本人から読める (REQ-019)';
 
 -- ===============================================
 -- 5. 旧 prompt の trigram index を落とす
@@ -456,7 +532,7 @@ DROP INDEX IF EXISTS public.idx_generated_images_prompt_trgm;
 DO $$
 DECLARE
   v_nonempty_images integer;
-  v_nonempty_terminal_jobs integer;
+  v_nonempty_jobs integer;
 BEGIN
   SELECT count(*)
   INTO v_nonempty_images
@@ -468,16 +544,15 @@ BEGIN
   END IF;
 
   SELECT count(*)
-  INTO v_nonempty_terminal_jobs
+  INTO v_nonempty_jobs
   FROM public.image_jobs
-  WHERE prompt_text <> ''
-    AND status NOT IN ('queued', 'processing');
+  WHERE prompt_text <> '';
 
-  IF v_nonempty_terminal_jobs > 0 THEN
-    RAISE EXCEPTION '終端ジョブの prompt_text に非空が % 件残っている', v_nonempty_terminal_jobs;
+  IF v_nonempty_jobs > 0 THEN
+    RAISE EXCEPTION 'image_jobs.prompt_text に非空が % 件残っている', v_nonempty_jobs;
   END IF;
 
-  RAISE NOTICE 'contract 完了: 公開列と終端ジョブからプロンプトが消え、CHECK が有効';
+  RAISE NOTICE 'contract 完了: generated_images.prompt と image_jobs.prompt_text が全件空になり、両方に CHECK が有効';
 END;
 $$;
 

--- a/supabase/migrations/20260730100000_contract_generated_images_prompt.sql
+++ b/supabase/migrations/20260730100000_contract_generated_images_prompt.sql
@@ -11,21 +11,26 @@
 -- 表示・生成ともにこの列を読まなくなっている。
 --
 -- ★ 適用順序が重要 ★
--- この migration より先に、次の2つがデプロイ済みであること。
---   1. Next.js (legacy フォールバックを外した読み取り)
---   2. Worker  (Gemini 経路も原子的 RPC を使い、prompt_text を読まない版)
+-- この migration より先に、次の3つが完了していること。
+--   1. expand migration 20260730090000 (完了RPCの6引数化)
+--   2. Next.js (legacy フォールバックを外した読み取り)
+--   3. Worker  (Gemini 経路も原子的 RPC を使い、prompt_text を読まない版)
 --
 -- 旧 Worker のまま適用すると次が起きる。
 --   - Gemini 経路の直接 INSERT が generated_images.prompt の CHECK 違反で失敗
 --   - prompt_text を読む旧 Worker が、空化された active ジョブで生成入力を失う
 --
--- さらに、in-flight の旧 revision 処理が残っていないことを確認する。
+-- さらに、in-flight の処理が残っていないことを確認する。
 -- 手順:
---   a. 新 Worker をデプロイする
---   b. image_jobs の queued / processing が 0 件になるまで待つ
---      (0 件でなくても、全件が実行入力レコードを持つなら続行可。migration が
---       この条件を検証し、満たさなければ中断する)
---   c. この migration を適用する
+--   a. expand migration 20260730090000 を適用する (旧・新 Worker の両対応)
+--   b. Next.js をマージ・デプロイし、新 Worker をデプロイする
+--   c. Worker の cron を止め、image_jobs の queued / processing が 0 件になるまで待つ
+--   d. この migration を適用する
+--   e. Worker の cron を戻す
+--
+-- c で active を 0 にするのは必須である。active を許したまま強いロックを取ると
+-- Worker と互いの次処理を待つ deadlock が成立し、許さずに緩いロックにすると
+-- 空化と生成入力の読み取りが競合する。運用で止めるのが最も単純で安全。
 --
 -- 不可逆性について:
 --   この UPDATE 自体は不可逆だが、本文は secret 側に残っているため、
@@ -35,6 +40,21 @@
 BEGIN;
 
 SET LOCAL lock_timeout = '5s';
+
+-- ===============================================
+-- ロックを最初に取る（Worker と同じ順序で、完了 RPC の入口も止める強さ）
+-- ===============================================
+-- 完了 RPC は image_jobs を FOR UPDATE (ROW SHARE) で押さえてから
+-- generated_images へ INSERT する。migration がこれと逆順、または競合しない
+-- 弱いロックを取ると deadlock が成立する。
+--   migration: generated_images を保持 → image_jobs の UPDATE 待ち
+--   Worker   : image_jobs 行を保持     → generated_images の INSERT 待ち
+--
+-- そこで Worker と同じ順序 (image_jobs → generated_images) で、
+-- FOR UPDATE も INSERT も入れない強さのロックを検証より前に取得する。
+-- lock_timeout があるので、取れなければ何も適用せず巻き戻る。
+LOCK TABLE public.image_jobs IN EXCLUSIVE MODE;
+LOCK TABLE public.generated_images IN ACCESS EXCLUSIVE MODE;
 
 -- ===============================================
 -- 0. 事前検証: 空化して表示を失う行が「想定内の孤児」だけであること
@@ -135,10 +155,9 @@ $$;
 -- legacy 値を generated_images.prompt へ書いていた。以後は空文字だけを書く。
 -- author secret の作成はそのまま維持する。
 
--- Gemini 経路も同じ RPC で確定できるよう、model と background_mode を
--- 呼び出し側から渡せるようにする。Worker は image_jobs の生値ではなく
--- 正規化後の値 (normalizeModelName / resolveBackgroundMode) を画像へ書いて
--- いたため、NULL のときだけジョブの値を使う形で互換を保つ。
+-- シグネチャ拡張 (p_model / p_background_mode) は expand migration
+-- 20260730090000 で先行適用済み。ここでは dual-write を止めるためだけに
+-- 再定義する。差分は generated_images.prompt へ書く値のみ。
 CREATE OR REPLACE FUNCTION public.complete_image_job_with_prompt_secrets(
   p_job_id uuid,
   p_images jsonb,
@@ -360,10 +379,6 @@ BEGIN
 END;
 $function$;
 
--- 旧シグネチャ (4引数) は overload として残らないよう明示的に落とす。
--- 残すと呼び出し側の引数漏れが「別の関数が呼ばれる」形で隠れる。
-DROP FUNCTION IF EXISTS public.complete_image_job_with_prompt_secrets(uuid, jsonb, jsonb, text);
-
 REVOKE ALL ON FUNCTION public.complete_image_job_with_prompt_secrets(uuid, jsonb, jsonb, text, text, text) FROM PUBLIC;
 REVOKE ALL ON FUNCTION public.complete_image_job_with_prompt_secrets(uuid, jsonb, jsonb, text, text, text) FROM anon;
 REVOKE ALL ON FUNCTION public.complete_image_job_with_prompt_secrets(uuid, jsonb, jsonb, text, text, text) FROM authenticated;
@@ -453,32 +468,28 @@ COMMENT ON COLUMN public.generated_images.prompt IS
 -- active ジョブも空化して構わない。generated_images.prompt と同じく
 -- DEFAULT '' + CHECK で不変条件にする。
 --
--- 競合防止: 事前チェックと UPDATE の間に旧 Worker の stale 処理が状態を
--- 変えられないよう、テーブルロックを取ってから検証する。
--- ロック中は image_jobs への書き込みが待たされるが、対象は約3,600行で
--- UPDATE は一瞬である。
-
-LOCK TABLE public.image_jobs IN SHARE ROW EXCLUSIVE MODE;
-
--- 実行入力レコードを持たない active ジョブがあれば、空化すると生成入力を
--- 失う。1 件でもあれば中断し、完了を待ってから再適用する。
+-- active ジョブが 1 件でもあれば中断する。
+--
+-- 当初は「実行入力レコードを持つなら active でも続行可」としていたが、これは
+-- 安全ではない。active を許すと Worker と競合し、
+--   - 緩いロック (SHARE ROW EXCLUSIVE) では完了 RPC の FOR UPDATE と競合せず、
+--     空化と生成入力の読み取りがすれ違う
+--   - 強いロックを後から取ると、migration が generated_images を保持したまま
+--     image_jobs を待ち、Worker が image_jobs 行を保持したまま
+--     generated_images を待つ deadlock が成立する
+-- 運用で Worker を止めてキューを空にするのが最も単純で安全である。
 DO $$
 DECLARE
-  v_active_without_record integer;
+  v_active integer;
 BEGIN
   SELECT count(*)
-  INTO v_active_without_record
-  FROM public.image_jobs AS j
-  WHERE j.status IN ('queued', 'processing')
-    AND NOT EXISTS (
-      SELECT 1
-      FROM public.generation_prompt_snapshots AS s
-      WHERE s.image_job_id = j.id
-    );
+  INTO v_active
+  FROM public.image_jobs
+  WHERE status IN ('queued', 'processing');
 
-  IF v_active_without_record > 0 THEN
+  IF v_active > 0 THEN
     RAISE EXCEPTION
-      '実行入力レコードを持たない active ジョブが % 件ある。完了を待ってから再適用すること', v_active_without_record;
+      'active な image_jobs が % 件ある。Worker の cron を止め、キューが空になってから再適用すること', v_active;
   END IF;
 END;
 $$;

--- a/supabase/migrations/20260730100000_contract_generated_images_prompt.sql
+++ b/supabase/migrations/20260730100000_contract_generated_images_prompt.sql
@@ -1,0 +1,496 @@
+-- ===============================================
+-- Phase 0C (contract): 公開列からプロンプトを消し、再発を DB で拒否する
+-- ===============================================
+-- 設計判断: docs/planning/free-prompt-private-mode-implementation-plan.md
+--           ADR-001 / ADR-009 / REQ-020 / REQ-020a
+--
+-- ここが既存漏洩を実際に閉じる工程である。
+-- generated_images は行単位 RLS で anon にも開放されており列を絞れないため、
+-- この列に値がある限り、公開 anon キーで select=prompt が通ってしまう。
+-- 本文の正本は Phase 0B までに author secret / 実行入力レコードへ移してあり、
+-- 表示・生成ともにこの列を読まなくなっている。
+--
+-- ★ 適用順序が重要 ★
+-- この migration より先に、次の2つがデプロイ済みであること。
+--   1. Next.js (legacy フォールバックを外した読み取り)
+--   2. Worker  (直接 INSERT が prompt='' を書く版)
+-- 旧 Worker のまま適用すると、Gemini 経路の INSERT が CHECK 違反で失敗する。
+--
+-- 不可逆性について:
+--   この UPDATE 自体は不可逆だが、本文は secret 側に残っているため、
+--   万一のときは secret から書き戻せる（20260729150000 / 160000 で実証済み）。
+--   日次物理バックアップ(7日分)も確認済み。PITR は不要と判断した。
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+
+-- ===============================================
+-- 0. 事前検証: 空化して表示を失う行が「想定内の孤児」だけであること
+-- ===============================================
+-- 開示対象 (coordinate / free) で本文が残っているのに secret が無い行は、
+-- 空化すると表示手段を失う。事前調査 (2026-07-30) では該当が 3 行で、
+-- いずれも user_id IS NULL・未投稿・ジョブ紐付けなしの孤児だった。
+-- RLS 上、未投稿かつ所有者なしの行は誰にも見えないため、失っても影響がない。
+--
+-- 所有者のいる行が 1 件でも混ざっていたら、backfill 漏れなので中断する。
+
+DO $$
+DECLARE
+  v_owned_loss integer;
+  v_orphan_loss integer;
+BEGIN
+  SELECT
+    count(*) FILTER (WHERE gi.user_id IS NOT NULL),
+    count(*) FILTER (WHERE gi.user_id IS NULL)
+  INTO v_owned_loss, v_orphan_loss
+  FROM public.generated_images AS gi
+  WHERE gi.generation_type IN ('coordinate', 'free')
+    AND gi.prompt <> ''
+    AND NOT EXISTS (
+      SELECT 1
+      FROM public.generated_image_prompt_secrets AS s
+      WHERE s.image_id = gi.id
+    );
+
+  IF v_owned_loss > 0 THEN
+    RAISE EXCEPTION
+      '所有者のいる行 % 件が secret を持たないまま空化されようとしている。backfill 漏れのため中断', v_owned_loss;
+  END IF;
+
+  RAISE NOTICE '空化で表示を失うのは所有者なしの孤児 % 件のみ（想定どおり）', v_orphan_loss;
+END;
+$$;
+
+-- secret と legacy の整合を最終確認する（件数・内容・所有者・運営資産の非混入）
+DO $$
+DECLARE
+  v_digest_mismatch integer;
+  v_platform_leak integer;
+BEGIN
+  SELECT count(*)
+  INTO v_digest_mismatch
+  FROM public.generated_images AS gi
+  JOIN public.generated_image_prompt_secrets AS s ON s.image_id = gi.id
+  WHERE gi.prompt <> ''
+    AND md5(gi.prompt) <> md5(s.prompt);
+
+  IF v_digest_mismatch > 0 THEN
+    RAISE EXCEPTION 'legacy と secret の内容不一致が % 件。中断', v_digest_mismatch;
+  END IF;
+
+  SELECT count(*)
+  INTO v_platform_leak
+  FROM public.generated_image_prompt_secrets AS s
+  JOIN public.generated_images AS gi ON gi.id = s.image_id
+  WHERE gi.generation_type IN ('one_tap_style', 'inspire');
+
+  IF v_platform_leak > 0 THEN
+    RAISE EXCEPTION '運営資産が author secret に % 件混入している。中断', v_platform_leak;
+  END IF;
+END;
+$$;
+
+-- ===============================================
+-- 1. 完了 RPC の dual-write を止める
+-- ===============================================
+-- Phase 0B の complete_image_job_with_prompt_secrets は移行期間の互換として
+-- legacy 値を generated_images.prompt へ書いていた。以後は空文字だけを書く。
+-- author secret の作成はそのまま維持する。
+
+CREATE OR REPLACE FUNCTION public.complete_image_job_with_prompt_secrets(
+  p_job_id uuid,
+  p_images jsonb,
+  p_generation_metadata jsonb DEFAULT NULL::jsonb,
+  p_result_image_url text DEFAULT NULL::text
+)
+RETURNS TABLE (
+  id uuid,
+  image_url text,
+  storage_path text,
+  image_job_result_index integer
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+#variable_conflict use_column
+DECLARE
+  v_job public.image_jobs%ROWTYPE;
+  v_execution public.generation_prompt_snapshots%ROWTYPE;
+  v_expected_count integer;
+  v_image_count integer;
+  v_image jsonb;
+  v_index integer := 0;
+  v_image_url text;
+  v_storage_path text;
+  v_image_width integer;
+  v_image_height integer;
+  v_inserted_id uuid;
+  v_first_image_id uuid;
+  v_first_image_url text;
+BEGIN
+  IF p_images IS NULL OR jsonb_typeof(p_images) <> 'array' THEN
+    RAISE EXCEPTION 'p_images must be a JSON array';
+  END IF;
+
+  SELECT *
+  INTO v_job
+  FROM public.image_jobs
+  WHERE image_jobs.id = p_job_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'image job not found: %', p_job_id;
+  END IF;
+
+  -- 冪等: すでに成功しているなら既存行を返す
+  IF v_job.status = 'succeeded' THEN
+    RETURN QUERY
+    SELECT
+      gi.id,
+      gi.image_url,
+      gi.storage_path,
+      gi.image_job_result_index
+    FROM public.generated_images AS gi
+    WHERE gi.image_job_id = p_job_id
+    ORDER BY gi.image_job_result_index ASC NULLS LAST, gi.created_at ASC;
+    RETURN;
+  END IF;
+
+  IF v_job.status <> 'processing' THEN
+    RAISE EXCEPTION 'image job must be processing to complete: %, status=%', p_job_id, v_job.status;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.generated_images AS gi
+    WHERE gi.image_job_id = p_job_id
+  ) THEN
+    RAISE EXCEPTION 'generated images already exist for job: %', p_job_id;
+  END IF;
+
+  v_expected_count := COALESCE(v_job.requested_image_count, 1);
+  v_image_count := jsonb_array_length(p_images);
+
+  IF v_image_count <> v_expected_count THEN
+    RAISE EXCEPTION 'generated image count mismatch for job %, expected %, got %',
+      p_job_id,
+      v_expected_count,
+      v_image_count;
+  END IF;
+
+  SELECT *
+  INTO v_execution
+  FROM public.generation_prompt_snapshots
+  WHERE generation_prompt_snapshots.image_job_id = p_job_id;
+
+  FOR v_image IN
+    SELECT element
+    FROM jsonb_array_elements(p_images) AS elements(element)
+  LOOP
+    v_image_url := NULLIF(TRIM(v_image->>'image_url'), '');
+    v_storage_path := NULLIF(TRIM(v_image->>'storage_path'), '');
+    v_image_width := CASE
+      WHEN v_image->>'width' ~ '^[1-9][0-9]*$' THEN (v_image->>'width')::integer
+      ELSE NULL
+    END;
+    v_image_height := CASE
+      WHEN v_image->>'height' ~ '^[1-9][0-9]*$' THEN (v_image->>'height')::integer
+      ELSE NULL
+    END;
+
+    IF v_image_url IS NULL THEN
+      RAISE EXCEPTION 'image_url is required for job %, index %', p_job_id, v_index;
+    END IF;
+
+    IF v_storage_path IS NULL THEN
+      RAISE EXCEPTION 'storage_path is required for job %, index %', p_job_id, v_index;
+    END IF;
+
+    INSERT INTO public.generated_images AS gi (
+      user_id,
+      image_url,
+      storage_path,
+      prompt,
+      background_mode,
+      is_posted,
+      generation_type,
+      generation_metadata,
+      model,
+      source_image_stock_id,
+      image_job_id,
+      image_job_result_index,
+      width,
+      height,
+      style_template_id,
+      override_target,
+      override_outfit,
+      override_angle,
+      override_pose,
+      override_background
+    )
+    VALUES (
+      v_job.user_id,
+      v_image_url,
+      v_storage_path,
+      -- 本文はユーザーが読める列に置かない。表示は author secret から
+      -- 解決される (REQ-020)。
+      '',
+      v_job.background_mode,
+      false,
+      v_job.generation_type,
+      COALESCE(p_generation_metadata, v_job.generation_metadata),
+      v_job.model,
+      v_job.source_image_stock_id,
+      p_job_id,
+      v_index,
+      v_image_width,
+      v_image_height,
+      v_job.style_template_id,
+      v_job.override_target,
+      v_job.override_outfit,
+      v_job.override_angle,
+      v_job.override_pose,
+      v_job.override_background
+    )
+    RETURNING gi.id INTO v_inserted_id;
+
+    -- author secret はユーザーへ開示し得る生入力があるときだけ作る。
+    -- 派生 job は snapshot_kind='derived_reference' で author_input を
+    -- 持てない (テーブル CHECK) ため、ここには入らない。
+    IF v_execution.snapshot_kind = 'materialized'
+       AND v_execution.author_input IS NOT NULL
+       AND v_execution.author_input_owner_id IS NOT NULL
+    THEN
+      INSERT INTO public.generated_image_prompt_secrets (
+        image_id,
+        prompt,
+        prompt_owner_id,
+        source_kind
+      )
+      VALUES (
+        v_inserted_id,
+        v_execution.author_input,
+        v_execution.author_input_owner_id,
+        'author_input'
+      )
+      ON CONFLICT (image_id) DO NOTHING;
+    END IF;
+
+    IF v_index = 0 THEN
+      v_first_image_id := v_inserted_id;
+      v_first_image_url := v_image_url;
+    END IF;
+
+    v_index := v_index + 1;
+  END LOOP;
+
+  UPDATE public.image_jobs
+  SET
+    status = 'succeeded',
+    processing_stage = 'completed',
+    result_image_url = COALESCE(NULLIF(TRIM(p_result_image_url), ''), v_first_image_url),
+    error_message = NULL,
+    completed_at = now(),
+    generation_metadata = COALESCE(p_generation_metadata, v_job.generation_metadata),
+    updated_at = now()
+  WHERE image_jobs.id = p_job_id
+    AND image_jobs.status = 'processing';
+
+  UPDATE public.credit_transactions
+  SET related_generation_id = v_first_image_id
+  WHERE credit_transactions.user_id = v_job.user_id
+    AND credit_transactions.related_generation_id IS NULL
+    AND credit_transactions.transaction_type = 'consumption'
+    AND credit_transactions.metadata->>'job_id' = p_job_id::text;
+
+  RETURN QUERY
+  SELECT
+    gi.id,
+    gi.image_url,
+    gi.storage_path,
+    gi.image_job_result_index
+  FROM public.generated_images AS gi
+  WHERE gi.image_job_id = p_job_id
+  ORDER BY gi.image_job_result_index ASC NULLS LAST, gi.created_at ASC;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.complete_image_job_with_prompt_secrets(uuid, jsonb, jsonb, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.complete_image_job_with_prompt_secrets(uuid, jsonb, jsonb, text) FROM anon;
+REVOKE ALL ON FUNCTION public.complete_image_job_with_prompt_secrets(uuid, jsonb, jsonb, text) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.complete_image_job_with_prompt_secrets(uuid, jsonb, jsonb, text) TO service_role;
+
+-- 旧完了 RPC はもう呼ばれないが、定義が残っている限り「呼べば非空を書く」
+-- 経路になる。CHECK 追加後は実行時エラーになるだけだが、prompt_text を
+-- コピーしない版へ置き換えて無害化しておく。
+-- 定義全体の置き換えはせず、INSERT の prompt だけを '' にした版を上書きする。
+
+DO $$
+DECLARE
+  v_def text;
+BEGIN
+  SELECT pg_get_functiondef(p.oid)
+  INTO v_def
+  FROM pg_proc AS p
+  JOIN pg_namespace AS n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public'
+    AND p.proname = 'complete_image_job_with_generated_images';
+
+  IF v_def IS NULL THEN
+    RAISE NOTICE '旧完了RPCは存在しない。スキップ';
+    RETURN;
+  END IF;
+
+  -- v_job.prompt_text を '' に置き換えて再定義する
+  IF v_def NOT LIKE '%v_job.prompt_text,%' THEN
+    RAISE EXCEPTION '旧完了RPCの形が想定と異なる。手動確認が必要';
+  END IF;
+
+  v_def := replace(v_def, 'v_job.prompt_text,', '''''::text, -- 本文は書かない (REQ-020)');
+  EXECUTE v_def;
+END;
+$$;
+
+-- ===============================================
+-- 2. 公開列を空にする
+-- ===============================================
+
+UPDATE public.generated_images
+SET prompt = ''
+WHERE prompt <> '';
+
+-- ===============================================
+-- 3. 再発を DB で拒否する (REQ-020 / REQ-020a)
+-- ===============================================
+-- DEFAULT '' を併せるのは、prompt を省略する INSERT が NOT NULL 違反で
+-- 落ちないようにするため。将来の新しい書き込み経路の事故を減らす。
+
+ALTER TABLE public.generated_images
+  ALTER COLUMN prompt SET DEFAULT '';
+
+ALTER TABLE public.generated_images
+  ADD CONSTRAINT generated_images_prompt_must_be_empty
+  CHECK (prompt = '') NOT VALID;
+
+ALTER TABLE public.generated_images
+  VALIDATE CONSTRAINT generated_images_prompt_must_be_empty;
+
+COMMENT ON COLUMN public.generated_images.prompt IS
+  '常に空。本文は generated_image_prompt_secrets (原作者入力) と generation_prompt_snapshots (生成実行入力) にのみ存在する。列は select("*") 互換のため残している (ADR-001)';
+
+-- ===============================================
+-- 4. image_jobs.prompt_text の終端ジョブを空にする
+-- ===============================================
+-- SELECT RLS が auth.uid() = user_id のため、One-Tap Style の組み立て済み
+-- 全文が生成した本人から読める状態が残っていた (REQ-019)。
+-- queued / processing は Worker が参照する可能性があるため対象外とするが、
+-- 適用時点で 0 件であることを確認する（0 件でなければ中断して待つ）。
+
+DO $$
+DECLARE
+  v_active integer;
+  v_active_without_record integer;
+BEGIN
+  SELECT count(*)
+  INTO v_active
+  FROM public.image_jobs
+  WHERE status IN ('queued', 'processing');
+
+  IF v_active > 0 THEN
+    -- 実行入力レコードを持たない active ジョブが 1 件でもあれば、空化すると
+    -- そのジョブは生成入力を失う。全件レコード持ちなら空化しても影響がない。
+    SELECT count(*)
+    INTO v_active_without_record
+    FROM public.image_jobs AS j
+    WHERE j.status IN ('queued', 'processing')
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.generation_prompt_snapshots AS s
+        WHERE s.image_job_id = j.id
+      );
+
+    IF v_active_without_record > 0 THEN
+      RAISE EXCEPTION
+        '実行入力レコードを持たない active ジョブが % 件ある。完了を待ってから再適用すること', v_active_without_record;
+    END IF;
+  END IF;
+END;
+$$;
+
+-- 実行時の件数を記録してから空化する（固定件数を前提にしない）
+DO $$
+DECLARE
+  r record;
+BEGIN
+  FOR r IN
+    SELECT generation_type, status, count(*) AS n
+    FROM public.image_jobs
+    WHERE prompt_text <> ''
+    GROUP BY 1, 2
+    ORDER BY 1, 2
+  LOOP
+    RAISE NOTICE 'prompt_text 空化対象: % / % = % 件', r.generation_type, r.status, r.n;
+  END LOOP;
+END;
+$$;
+
+UPDATE public.image_jobs
+SET prompt_text = ''
+WHERE prompt_text <> ''
+  AND status NOT IN ('queued', 'processing');
+
+-- ===============================================
+-- 5. 旧 prompt の trigram index を落とす
+-- ===============================================
+-- 列は常に空になったため、この index が支える検索は存在しない。
+-- 検索は caption / nickname の index (20260729170000) へ移行済み。
+
+DROP INDEX IF EXISTS public.idx_generated_images_prompt_trgm;
+
+-- ===============================================
+-- 6. 事後検証
+-- ===============================================
+
+DO $$
+DECLARE
+  v_nonempty_images integer;
+  v_nonempty_terminal_jobs integer;
+BEGIN
+  SELECT count(*)
+  INTO v_nonempty_images
+  FROM public.generated_images
+  WHERE prompt <> '';
+
+  IF v_nonempty_images > 0 THEN
+    RAISE EXCEPTION 'generated_images.prompt に非空が % 件残っている', v_nonempty_images;
+  END IF;
+
+  SELECT count(*)
+  INTO v_nonempty_terminal_jobs
+  FROM public.image_jobs
+  WHERE prompt_text <> ''
+    AND status NOT IN ('queued', 'processing');
+
+  IF v_nonempty_terminal_jobs > 0 THEN
+    RAISE EXCEPTION '終端ジョブの prompt_text に非空が % 件残っている', v_nonempty_terminal_jobs;
+  END IF;
+
+  RAISE NOTICE 'contract 完了: 公開列と終端ジョブからプロンプトが消え、CHECK が有効';
+END;
+$$;
+
+COMMIT;
+
+-- ===============================================
+-- DOWN（緊急時のみ・秘匿境界が開くため原則使わない）:
+-- BEGIN;
+-- ALTER TABLE public.generated_images
+--   DROP CONSTRAINT generated_images_prompt_must_be_empty;
+-- UPDATE public.generated_images gi
+-- SET prompt = s.prompt
+-- FROM public.generated_image_prompt_secrets s
+-- WHERE s.image_id = gi.id;
+-- COMMIT;
+-- ===============================================

--- a/supabase/migrations/20260730100000_contract_generated_images_prompt.sql
+++ b/supabase/migrations/20260730100000_contract_generated_images_prompt.sql
@@ -12,7 +12,7 @@
 --
 -- ★ 適用順序が重要 ★
 -- この migration より先に、次の3つが完了していること。
---   1. expand migration 20260730090000 (完了RPCの6引数化)
+--   1. expand migration 20260730090000 を先行 PR で本番適用済み
 --   2. Next.js (legacy フォールバックを外した読み取り)
 --   3. Worker  (Gemini 経路も原子的 RPC を使い、prompt_text を読まない版)
 --
@@ -22,13 +22,18 @@
 --
 -- さらに、in-flight の処理が残っていないことを確認する。
 -- 手順:
---   a. expand migration 20260730090000 を適用する (旧・新 Worker の両対応)
---   b. Next.js をマージ・デプロイし、新 Worker をデプロイする
---   c. Worker の cron を止め、image_jobs の queued / processing が 0 件になるまで待つ
---   d. この migration を適用する
---   e. Worker の cron を戻す
+--   a. 先行 PR で expand migration 20260730090000 だけをマージ・適用する
+--   b. migration history と PostgREST の旧4引数・新6引数疎通を確認する
+--   c. contract PR を main と同期してからマージし、Next.js / 新 Worker をデプロイする
+--   d. 生成受付を一時停止する（queued を増やさない）
+--   e. Worker cron は動かしたまま、image_jobs の queued / processing が
+--      0 件になるまで drain する
+--   f. active=0 を確認してから Worker cron を止める
+--   g. `supabase db push --dry-run` がこの contract だけを示すことを確認し、
+--      この migration を適用する
+--   h. Worker cron を戻し、生成受付を再開する
 --
--- c で active を 0 にするのは必須である。active を許したまま強いロックを取ると
+-- e で active を 0 にするのは必須である。active を許したまま強いロックを取ると
 -- Worker と互いの次処理を待つ deadlock が成立し、許さずに緩いロックにすると
 -- 空化と生成入力の読み取りが競合する。運用で止めるのが最も単純で安全。
 --

--- a/tests/unit/features/generation/failed-job-billing.test.ts
+++ b/tests/unit/features/generation/failed-job-billing.test.ts
@@ -1,0 +1,152 @@
+/** @jest-environment node */
+
+/**
+ * 最終失敗ジョブの課金後処理のテスト。
+ *
+ * Worker は「failed へ更新 → 返金/release → pgmq_delete」の順で処理する。
+ * この途中でクラッシュすると、再配送側が終端判定でメッセージを削除してしまい、
+ * 未実施の返金が永久に実行されない。ユーザーのペルコインが減算されたまま
+ * 確定してしまう。
+ *
+ * 戻り値が「ack してよいか」を表すことがこの関数の契約なので、レビューで
+ * 指摘された3ケースを固定する。
+ *   1. failed 更新後・返金前にクラッシュ（= 再配送で再実行される）
+ *   2. 返金RPCが一度失敗（= ack せずメッセージを残す）
+ *   3. 返金済み failed の再配送（= 冪等に通り ack できる）
+ */
+
+import { settleFailedJobBilling } from "@/supabase/functions/image-gen-worker/failed-job-billing";
+
+function baseParams(
+  overrides: Partial<Parameters<typeof settleFailedJobBilling>[0]> = {}
+) {
+  return {
+    jobId: "job-1",
+    isFreeOneTapStyleJob: false,
+    reservedAttemptId: null,
+    errorMessage: "Unknown error",
+    releaseFreeAttempt: jest.fn().mockResolvedValue(undefined),
+    refundPercoins: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe("有料ジョブの返金", () => {
+  it("返金が成功すれば ack してよい", async () => {
+    const params = baseParams();
+
+    const settled = await settleFailedJobBilling(params);
+
+    expect(settled).toBe(true);
+    expect(params.refundPercoins).toHaveBeenCalledTimes(1);
+  });
+
+  it("返金が失敗したら ack してはならない", async () => {
+    // ケース2: 返金RPCが一度失敗。メッセージを残して次の配送で再試行する。
+    // ここで true を返すと、減算されたまま確定してしまう。
+    const params = baseParams({
+      refundPercoins: jest.fn().mockRejectedValue(new Error("rpc down")),
+    });
+
+    const settled = await settleFailedJobBilling(params);
+
+    expect(settled).toBe(false);
+  });
+
+  it("再配送で呼び直せば ack できる（冪等な reconciliation）", async () => {
+    // ケース1と3: 返金前にクラッシュした場合も、返金済みの再配送も、
+    // refund_percoins が冪等なので同じ呼び方で収束する。
+    const refundPercoins = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("transient"))
+      .mockResolvedValueOnce(undefined);
+    const params = baseParams({ refundPercoins });
+
+    const first = await settleFailedJobBilling(params);
+    const second = await settleFailedJobBilling(params);
+
+    expect(first).toBe(false);
+    expect(second).toBe(true);
+    expect(refundPercoins).toHaveBeenCalledTimes(2);
+  });
+
+  it("無料枠ジョブでなければ release を呼ばない", async () => {
+    const params = baseParams();
+
+    await settleFailedJobBilling(params);
+
+    expect(params.releaseFreeAttempt).not.toHaveBeenCalled();
+  });
+});
+
+describe("無料枠 One-Tap Style ジョブの release", () => {
+  it("予約があれば release して ack してよい", async () => {
+    const params = baseParams({
+      isFreeOneTapStyleJob: true,
+      reservedAttemptId: "attempt-1",
+    });
+
+    const settled = await settleFailedJobBilling(params);
+
+    expect(settled).toBe(true);
+    expect(params.releaseFreeAttempt).toHaveBeenCalledWith(
+      "attempt-1",
+      "worker_failed"
+    );
+    expect(params.refundPercoins).not.toHaveBeenCalled();
+  });
+
+  it("画像が生成されなかった場合は理由を分けて release する", async () => {
+    const params = baseParams({
+      isFreeOneTapStyleJob: true,
+      reservedAttemptId: "attempt-1",
+      errorMessage: "No images generated",
+    });
+
+    await settleFailedJobBilling(params);
+
+    expect(params.releaseFreeAttempt).toHaveBeenCalledWith(
+      "attempt-1",
+      "no_image_generated"
+    );
+  });
+
+  it("release が失敗したら ack してはならない", async () => {
+    const params = baseParams({
+      isFreeOneTapStyleJob: true,
+      reservedAttemptId: "attempt-1",
+      releaseFreeAttempt: jest.fn().mockRejectedValue(new Error("rpc down")),
+    });
+
+    const settled = await settleFailedJobBilling(params);
+
+    expect(settled).toBe(false);
+  });
+
+  it("安全性ブロックでは枠を返さないが ack してよい", async () => {
+    // 安全性ブロックは枠を消費させる仕様。返すものが無いので完了扱い。
+    const params = baseParams({
+      isFreeOneTapStyleJob: true,
+      reservedAttemptId: "attempt-1",
+      errorMessage: "SAFETY_POLICY_BLOCKED",
+    });
+
+    const settled = await settleFailedJobBilling(params);
+
+    expect(settled).toBe(true);
+    expect(params.releaseFreeAttempt).not.toHaveBeenCalled();
+  });
+
+  it("予約が無ければ何もせず ack してよい", async () => {
+    const params = baseParams({
+      isFreeOneTapStyleJob: true,
+      reservedAttemptId: null,
+    });
+
+    const settled = await settleFailedJobBilling(params);
+
+    expect(settled).toBe(true);
+    expect(params.releaseFreeAttempt).not.toHaveBeenCalled();
+    expect(params.refundPercoins).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/features/generation/failed-job-billing.test.ts
+++ b/tests/unit/features/generation/failed-job-billing.test.ts
@@ -15,7 +15,10 @@
  *   3. 返金済み failed の再配送（= 冪等に通り ack できる）
  */
 
-import { settleFailedJobBilling } from "@/supabase/functions/image-gen-worker/failed-job-billing";
+import {
+  resolveRecordedPercoinRefundAmount,
+  settleFailedJobBilling,
+} from "@/supabase/functions/image-gen-worker/failed-job-billing";
 
 function baseParams(
   overrides: Partial<Parameters<typeof settleFailedJobBilling>[0]> = {}
@@ -77,6 +80,25 @@ describe("有料ジョブの返金", () => {
 
     expect(params.releaseFreeAttempt).not.toHaveBeenCalled();
   });
+});
+
+describe("記録済み消費額からの返金額復元", () => {
+  it("負の消費額を正の返金額へ変換する", () => {
+    expect(resolveRecordedPercoinRefundAmount(-75)).toBe(75);
+  });
+
+  it("DBドライバが数値文字列を返しても復元できる", () => {
+    expect(resolveRecordedPercoinRefundAmount("-120")).toBe(120);
+  });
+
+  it.each([0, 10, null, undefined, "invalid", 1.5])(
+    "消費トランザクションとして不正な値 %p は拒否する",
+    (amount) => {
+      expect(() => resolveRecordedPercoinRefundAmount(amount)).toThrow(
+        "invalid recorded consumption amount",
+      );
+    },
+  );
 });
 
 describe("無料枠 One-Tap Style ジョブの release", () => {

--- a/tests/unit/features/generation/gallery-prompt-resolution.test.ts
+++ b/tests/unit/features/generation/gallery-prompt-resolution.test.ts
@@ -180,15 +180,16 @@ describe("開示できない種別の扱い", () => {
   });
 });
 
-describe("移行前の行", () => {
-  it("secret が無ければ legacy 列を返す", async () => {
-    // backfill 前の既存行。Phase 0C までは legacy 列に値がある。
+describe("secret を持たない行", () => {
+  it("legacy 列へ落とさず空文字にする", async () => {
+    // Phase 0C 以降、本文は secret にしか存在しない。落ちる経路を残すと
+    // 障害や移行漏れのときに古い列の内容が漏れ出る（fail closed）。
     setImages([
       { id: "img-3", prompt: "むかしの入力", generation_type: "coordinate" },
     ]);
 
     const result = await getGeneratedImages("user-1");
 
-    expect(result[0].prompt).toBe("むかしの入力");
+    expect(result[0].prompt).toBe("");
   });
 });

--- a/tests/unit/features/generation/prompt-secrets-client.test.ts
+++ b/tests/unit/features/generation/prompt-secrets-client.test.ts
@@ -42,13 +42,14 @@ describe("resolveOwnVisiblePrompts", () => {
     expect(result[0].prompt).toBe("本人の入力");
   });
 
-  it("secret が無ければ legacy 列へ落とす", async () => {
-    // backfill 前の既存行はまだ secret を持たない
+  it("secret が無ければ空文字にする（legacy 列へ落ちない）", async () => {
+    // Phase 0C 以降、本文は secret にしか存在しない。legacy 列へ落ちる経路を
+    // 残すと、障害や移行漏れのときに古い列の内容が漏れ出る。
     const result = await resolveOwnVisiblePrompts([
       { id: "img-1", prompt: "legacy 値", generation_type: "coordinate" },
     ]);
 
-    expect(result[0].prompt).toBe("legacy 値");
+    expect(result[0].prompt).toBe("");
   });
 
   it("one_tap_style は secret が無くても legacy へ落とさない", async () => {
@@ -92,7 +93,8 @@ describe("resolveOwnVisiblePrompts", () => {
     ]);
 
     expect(inMock).toHaveBeenCalledTimes(1);
-    expect(result.map((r) => r.prompt)).toEqual(["legacy A", "B の入力"]);
+    // secret が無い行は空。legacy 列へは落ちない
+    expect(result.map((r) => r.prompt)).toEqual(["", "B の入力"]);
   });
 
   it("取得に失敗したら legacy へ落とさず投げる", async () => {
@@ -116,7 +118,7 @@ describe("resolveOwnVisiblePrompts", () => {
   it("変化が無いレコードは同一参照のまま返す", async () => {
     const record = {
       id: "img-1",
-      prompt: "legacy 値",
+      prompt: "",
       generation_type: "coordinate" as const,
     };
 

--- a/tests/unit/features/generation/prompt-secrets.test.ts
+++ b/tests/unit/features/generation/prompt-secrets.test.ts
@@ -43,13 +43,14 @@ describe("resolveVisiblePrompts", () => {
     expect(result[0].prompt).toBe("秘密の入力");
   });
 
-  it("secret が無ければ legacy 列へ落とす", async () => {
-    // backfill 前の既存行はまだ secret を持たない
+  it("secret が無ければ空文字にする（legacy 列へ落ちない）", async () => {
+    // Phase 0C 以降、本文は secret にしか存在しない。legacy 列へ落ちる経路を
+    // 残すと、障害や移行漏れのときに古い列の内容が漏れ出る。
     const result = await resolveVisiblePrompts([
       { id: "img-1", prompt: "legacy 値", generation_type: "coordinate" },
     ]);
 
-    expect(result[0].prompt).toBe("legacy 値");
+    expect(result[0].prompt).toBe("");
   });
 
   it("one_tap_style は secret が無くても legacy へ落とさない", async () => {
@@ -105,7 +106,7 @@ describe("resolveVisiblePrompts", () => {
     expect(result.map((r) => r.prompt)).toEqual([
       "A の入力",
       "B の入力",
-      "legacy C",
+      "", // secret が無い行は空。legacy 列へは落ちない
     ]);
   });
 
@@ -131,7 +132,7 @@ describe("resolveVisiblePrompts", () => {
   it("変化が無いレコードは同一参照のまま返す", async () => {
     const record = {
       id: "img-1",
-      prompt: "legacy 値",
+      prompt: "",
       generation_type: "free" as const,
     };
 

--- a/tests/unit/features/generation/worker-billing-contract.test.ts
+++ b/tests/unit/features/generation/worker-billing-contract.test.ts
@@ -1,0 +1,38 @@
+/** @jest-environment node */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const workerSource = readFileSync(
+  join(
+    process.cwd(),
+    "supabase/functions/image-gen-worker/index.ts",
+  ),
+  "utf8",
+);
+
+describe("Worker課金後処理のack契約", () => {
+  it("stale-processing最終失敗も共通settlement成功後だけackする", () => {
+    const staleSectionStart = workerSource.indexOf(
+      "// 最終失敗確定時のみ返金または無料枠release。",
+    );
+    const staleSectionEnd = workerSource.indexOf(
+      "// ステータスを'processing'に更新（排他制御）",
+      staleSectionStart,
+    );
+
+    expect(staleSectionStart).toBeGreaterThanOrEqual(0);
+    expect(staleSectionEnd).toBeGreaterThan(staleSectionStart);
+
+    const staleSection = workerSource.slice(
+      staleSectionStart,
+      staleSectionEnd,
+    );
+    expect(staleSection).toContain(
+      "settleFailedJobBillingWithSupabase",
+    );
+    expect(staleSection).toMatch(
+      /if \(!staleSettled\) \{[\s\S]*?continue;[\s\S]*?pgmq_delete/,
+    );
+  });
+});

--- a/tests/unit/lib/event-server-api.test.ts
+++ b/tests/unit/lib/event-server-api.test.ts
@@ -98,6 +98,8 @@ function createImageRecord(overrides: Record<string, unknown> = {}) {
   return {
     id: "image-1",
     user_id: "event-user-1",
+    // 本文は author secret 側にのみ存在する。この列は常に空（REQ-020）
+    prompt: "",
     is_posted: true,
     posted_at: "2026-03-10T00:00:00.000Z",
     image_url: "https://example.com/event-1.webp",

--- a/tests/unit/lib/my-page-server-api.test.ts
+++ b/tests/unit/lib/my-page-server-api.test.ts
@@ -221,7 +221,9 @@ function createImageRecord(
   return {
     id: "image-1",
     user_id: "user-1",
-    prompt: "prompt",
+    // 本文は author secret 側にのみ存在する。この列は常に空（REQ-020）。
+    // secret を持たない行の表示解決は空文字になる (fail closed)
+    prompt: "",
     image_url: "https://example.com/image.webp",
     is_posted: true,
     created_at: "2026-03-01T00:00:00.000Z",


### PR DESCRIPTION
## ⚠️ マージ前に読むこと

**この PR は準備・レビュー用です。適用は下記の順序で手動運用します。**

```
1. この PR をマージ（Next.js: fail-closed 読み取りがデプロイされる）
2. supabase functions deploy image-gen-worker（prompt='' を書く版）
3. supabase db push（contract migration）
4. anon キーで「もう取れない」ことを確認 ← ここで漏洩が閉じる
```

**旧 Worker のまま 3 を先に実行すると、Gemini 経路の INSERT が CHECK 違反で失敗します。**

## 概要

既存漏洩を実際に閉じる工程（Phase 0C / contract）です。

`generated_images` は行単位 RLS で `anon` にも開放されており列を絞れないため、この列に値がある限り公開 anon キーで `select=prompt` が通ります。本文の正本は Phase 0B までに秘匿テーブルへ移してあり、表示・生成ともにこの列を読まなくなっているので、**公開列を空にして CHECK 制約で再発を拒否**します。

## 変更内容

### 読み取りの fail-closed 化

`resolveVisiblePrompts` / `resolveOwnVisiblePrompts` から legacy 列へのフォールバックを外しました。secret が無い行は空文字です。

落ちる経路を残すと、レコードの作成漏れが「古い列の値で表示できてしまう」形で隠蔽され、空化後に初めて壊れます。事前検証で、フォールバックを失って表示が変わる行は**所有者なし・未投稿・誰にも見えない孤児3件だけ**であることを本番実測済みです。

### Worker の変更

| 変更 | 理由 |
| --- | --- |
| 直接 INSERT が `prompt: ''` を書く | CHECK 制約の前提 |
| 実行入力レコードの必須化（種別ごと） | 欠落時は provider を呼ぶ前に `GENERATION_PROMPT_EXECUTION_MISSING` で終端失敗。失敗時は既存の冪等返金経路でペルコインが戻る |
| claim を `queued` 限定に（ADR-012） | 終端 failed の暗黙再実行が attempts 上限(2)を超える不具合の温床だった（本番実測: attempts=3 が25件） |

### contract マイグレーション（未適用）

事前検証 → dual-write 停止 → 空化 → 制約 → 事後検証を **1トランザクション**に閉じています。1件でもずれたら全体が巻き戻ります。

- 事前検証: 所有者のいる行が secret 無しで空化されようとしたら中断 / legacy と secret の md5 不一致で中断 / 運営資産の混入で中断
- 完了RPC 2本（新旧）を空文字書き込みへ再定義
- `UPDATE` 全行空化 → `DEFAULT ''` → `CHECK (prompt = '') NOT VALID` → `VALIDATE`
- `image_jobs.prompt_text` は終端ジョブのみ空化。実行入力レコードを持たない active ジョブがあれば中断して完了を待つ
- 旧 `idx_generated_images_prompt_trgm` を削除

### 書き込み経路の全数調査

CHECK 追加後に空文字以外を書く経路はすべて実行時エラーになるため、先に全数を洗い出しました。

| 経路 | prompt の値 |
| --- | --- |
| wardrobe claim | `''`（修正済み） |
| `create_collection_completion_post` | `''`（元から） |
| 完了RPC（新・旧） | この migration で `''` へ |
| Worker 直接 INSERT | この PR で `''` へ |
| `saveGeneratedImage(s)` | **未使用のため削除** |
| UPDATE 経路 | 存在しない（DB関数・TS とも確認） |

## 不可逆性への備え

- 本文は secret 側に残るため、万一のときは **secret から書き戻せる**（`20260729150000` / `160000` で実証済み）
- 日次物理バックアップ7日分を確認済み（PITR は不要と判断）

## 検証

```
test      2,854件パス（fail-closed 化に伴い期待値を反転）
lint      23E（既存赤と同数）
typecheck 本番コード 0件
build     --webpack 成功
Worker    deno check 29件（変更前と同数）
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mmqeUvT5TbjAMPNo6Pxsn