### PR TITLE
feat(free-prompt): 運営がプロンプト全文を確認できるようにする (Phase 3a)

### DIFF
--- a/app/(app)/admin/moderation/ModerationQueueClient.tsx
+++ b/app/(app)/admin/moderation/ModerationQueueClient.tsx
@@ -225,6 +225,16 @@ export function ModerationQueueClient() {
                 <p className="text-sm font-medium text-slate-900 line-clamp-2">
                   {post.caption || "キャプションなし"}
                 </p>
+                {/*
+                  プロンプト非公開の投稿は、中身の見えないプロンプトを他人に
+                  配っている状態。運営はキューの段階で見分けられるようにする。
+                  本文そのものは投稿詳細（admin 閲覧）で確認できる (REQ-018)。
+                */}
+                {post.prompt_visibility === "private" && (
+                  <span className="inline-flex items-center gap-1 rounded-full bg-slate-200 px-2 py-0.5 text-[11px] font-bold text-slate-700">
+                    🔒 プロンプト非公開
+                  </span>
+                )}
                 <p className="text-xs text-slate-600">
                   通報件数: {post.report_count} / 重み合計:{" "}
                   {post.weighted_report_score.toFixed(2)}

--- a/app/api/admin/moderation/posts/route.ts
+++ b/app/api/admin/moderation/posts/route.ts
@@ -24,7 +24,9 @@ export async function GET(request: NextRequest) {
     const { data: posts, error } = await adminClient
       .from("generated_images")
       .select(
-        "id,user_id,image_url,storage_path_thumb,storage_path,caption,moderation_status,moderation_reason,posted_at,created_at"
+        // prompt_visibility: プロンプト非公開の投稿は「中身の見えないプロンプトを
+        // 他人に配っている」状態なので、キューの段階で見分けられるようにする (REQ-018)
+        "id,user_id,image_url,storage_path_thumb,storage_path,caption,moderation_status,moderation_reason,posted_at,created_at,prompt_visibility"
       )
       .eq("is_posted", true)
       .eq("moderation_status", "pending")

--- a/features/generation/lib/prompt-visibility.ts
+++ b/features/generation/lib/prompt-visibility.ts
@@ -46,10 +46,17 @@ export function shouldHidePromptForGenerationType(
  *    併記する場合、この関数は `prompt` を返し、カードは
  *    `shouldShowPromptWithCard` を見た呼び出し側が本文の上へ並べる。
  * 4. それ以外（coordinate など）は従来どおり、本文があれば `prompt`。
+ *
+ * `isModerator`（運営）は本文の併記について本人と同じ扱いにする（REQ-018）。
+ * プロンプトは通報対応の判断材料そのもので、画像だけで判断させない。
+ * ただし派生投稿は運営でも参照カードのまま。派生投稿自身は本文を所有して
+ * おらず（author secret が無い）、出すべき本文は原作の詳細で見る。
+ * one_tap_style も運営資産のプリセットカードのままにする（全文は
+ * admin のプリセット管理画面が正）。
  */
 export function getPostPromptDisplayMode(
   record: PromptDisplayRecord,
-  options?: { isOwner?: boolean }
+  options?: { isOwner?: boolean; isModerator?: boolean }
 ): PostPromptDisplayMode {
   if (record.source_post_id) {
     return "source_reference";
@@ -81,12 +88,16 @@ export function getPostPromptDisplayMode(
  */
 export function shouldShowPromptWithCard(
   record: PromptDisplayRecord,
-  options?: { isOwner?: boolean }
+  options?: { isOwner?: boolean; isModerator?: boolean }
 ): boolean {
   if (record.source_post_id || record.generation_type !== "free") {
     return false;
   }
-  return !!options?.isOwner || record.prompt_visibility !== "private";
+  return (
+    !!options?.isOwner ||
+    !!options?.isModerator ||
+    record.prompt_visibility !== "private"
+  );
 }
 
 export function getVisiblePrompt<T extends PromptProtectedRecord>(record: T): string {
@@ -109,6 +120,34 @@ export function redactSensitivePrompts<T extends PromptProtectedRecord>(
   records: T[]
 ): T[] {
   return records.map(redactSensitivePrompt);
+}
+
+type ListPromptRecord = PromptProtectedRecord &
+  Pick<GeneratedImageRecord, "prompt_visibility">;
+
+/**
+ * 一覧 payload から `/free` の本文を落とす。
+ *
+ * フィード・プロフィールの一覧はプロンプト欄を持たないのに、payload には
+ * author secret から解決した本文が載っていた。画面に出なくても devtools で
+ * 読めるため、非公開プロンプトがここから漏れる。
+ *
+ * 公開・非公開を問わず落とす。公開でもフォロワー限定の開示であり、
+ * 一覧のキャッシュは閲覧者を跨いで共有され得るため、閲覧者ごとの
+ * 出し分けはできない。本文が要る画面（詳細・シート・コピー）は
+ * `/api/posts/[id]/prompt-text` かオーナー向け経路で取る。
+ *
+ * coordinate は従来どおり残す。一覧カードの alt フォールバックが使う
+ * ことがあり、フォローゲートは詳細画面の伏字が担っている。
+ */
+export function stripFreePromptsForList<T extends ListPromptRecord>(
+  records: T[]
+): T[] {
+  return records.map((record) =>
+    record.generation_type === "free" && record.prompt !== ""
+      ? { ...record, prompt: "" }
+      : record
+  );
 }
 
 export function getPromptSafeAltText<T extends PromptProtectedRecord>(

--- a/features/moderation/types.ts
+++ b/features/moderation/types.ts
@@ -27,6 +27,12 @@ export interface ModerationQueueItem {
   report_count: number;
   weighted_report_score: number;
   latest_reported_at: string | null;
+  /**
+   * プロンプトの公開設定。'private' はフォロワーへ本文を見せずに派生生成だけ
+   * 許している投稿で、キューに「プロンプト非公開」バッジを出す (REQ-018)。
+   * 適用前の行には列が無い場合があるため optional。
+   */
+  prompt_visibility?: "public" | "private";
 }
 
 export interface BlockStatusResponse {

--- a/features/my-page/lib/server-api.ts
+++ b/features/my-page/lib/server-api.ts
@@ -2,7 +2,10 @@ import { cache } from "react";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { createClient } from "@/lib/supabase/server";
 import type { GeneratedImageRecord } from "@/features/generation/lib/database";
-import { redactSensitivePrompts } from "@/features/generation/lib/prompt-visibility";
+import {
+  redactSensitivePrompts,
+  stripFreePromptsForList,
+} from "@/features/generation/lib/prompt-visibility";
 import { resolveVisiblePrompts } from "@/features/generation/lib/prompt-secrets";
 
 export interface PercoinTransaction {
@@ -227,8 +230,12 @@ export async function getUserPostsServer(
     return [];
   }
 
-  // プロンプトの正本は service-only の author secret（ADR-001）
-  return redactSensitivePrompts(await resolveVisiblePrompts(data || []));
+  // プロンプトの正本は service-only の author secret（ADR-001）。
+  // /free の本文は一覧 payload へ載せない（プロフィールは他人も閲覧し、
+  // 一覧は本文を表示しない）。本人も詳細・マイページ経路で読む。
+  return stripFreePromptsForList(
+    redactSensitivePrompts(await resolveVisiblePrompts(data || []))
+  );
 }
 
 /**

--- a/features/posts/components/CachedPostDetail.tsx
+++ b/features/posts/components/CachedPostDetail.tsx
@@ -10,6 +10,7 @@ import {
 } from "../lib/utils";
 import { PostDetailContent } from "./PostDetailContent";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { isFullAdmin } from "@/lib/env";
 import { getOneTapStylePresetMetadata } from "@/shared/generation/one-tap-style-metadata";
 import { getPublishedStylePresetById } from "@/features/style-presets/lib/style-preset-repository";
 import { getUserProfileServer } from "@/features/my-page/lib/server-api";
@@ -128,6 +129,7 @@ export async function CachedPostDetail({
       imageUrl={imageUrl}
       originalImageUrl={originalImageUrl}
       viewerSubscriptionPlan={viewerSubscriptionPlan}
+      viewerIsAdmin={isFullAdmin(currentUserId)}
     />
   );
 }

--- a/features/posts/components/PostDetail.tsx
+++ b/features/posts/components/PostDetail.tsx
@@ -44,6 +44,8 @@ interface PostDetailProps {
    * 投稿者のプランではないので post.user.subscription_plan とは別物。
    */
   viewerSubscriptionPlan?: SubscriptionPlan;
+  /** 閲覧者が運営か。本文の表示だけ本人と同じ扱いにする（REQ-018）。 */
+  viewerIsAdmin?: boolean;
 }
 
 /**
@@ -53,6 +55,7 @@ export function PostDetail({
   post,
   currentUserId,
   viewerSubscriptionPlan = "free",
+  viewerIsAdmin = false,
 }: PostDetailProps) {
   const t = useTranslations("posts");
   const [isFullscreenOpen, setIsFullscreenOpen] = useState(false);
@@ -102,14 +105,21 @@ export function PostDetail({
 
   const followUserId = post.user?.id || post.user_id;
   const isOwner = currentUserId === post.user_id;
-  const canViewPrompt = isOwner || isFollowingAuthor;
+  // 運営は通報対応のためフォロー関係に依らず本文を読める（REQ-018）
+  const canViewPrompt = isOwner || isFollowingAuthor || viewerIsAdmin;
   const oneTapStylePreset = getOneTapStylePresetMetadata(post);
   const visiblePrompt = getVisiblePrompt(post);
   const hasVisiblePrompt = visiblePrompt.trim().length > 0;
   // 表示モードは1箇所で決める（REQ-013）
-  const promptDisplayMode = getPostPromptDisplayMode(post, { isOwner });
+  const promptDisplayMode = getPostPromptDisplayMode(post, {
+    isOwner,
+    isModerator: viewerIsAdmin,
+  });
   // /free の投稿で、本人または公開プロンプトのときはカードと本文を並べる
-  const showsCardWithPrompt = shouldShowPromptWithCard(post, { isOwner });
+  const showsCardWithPrompt = shouldShowPromptWithCard(post, {
+    isOwner,
+    isModerator: viewerIsAdmin,
+  });
   /*
     本人以外の本文は payload に載せていない（未フォロワーのブラウザへ届かせない
     ため）。公開プロンプトを併記するときだけ、サーバー側で認可する

--- a/features/posts/components/PostDetailContent.tsx
+++ b/features/posts/components/PostDetailContent.tsx
@@ -23,6 +23,12 @@ interface PostDetailContentProps {
   originalImageUrl?: string | null;
   /** 閲覧者の購読プラン。派生生成シートのモデル選択・上限に使う。 */
   viewerSubscriptionPlan?: SubscriptionPlan;
+  /**
+   * 閲覧者が運営（full admin）か。サーバー側で isFullAdmin により判定した値。
+   * 通報対応でプロンプト全文を見るために使う（REQ-018）。表示の出し分けで
+   * あり、本文そのものは getPost が admin にだけ payload へ含める。
+   */
+  viewerIsAdmin?: boolean;
 }
 
 export function PostDetailContent({
@@ -37,6 +43,7 @@ export function PostDetailContent({
   imageUrl,
   originalImageUrl,
   viewerSubscriptionPlan,
+  viewerIsAdmin,
 }: PostDetailContentProps) {
   const [hiddenPostId, setHiddenPostId] = useState<string | null>(null);
   const router = useRouter();
@@ -83,6 +90,7 @@ export function PostDetailContent({
         isHidden={isHidden}
         onHidden={() => setHiddenPostId(postId)}
         viewerSubscriptionPlan={viewerSubscriptionPlan}
+          viewerIsAdmin={viewerIsAdmin}
         />
 
       {!isHidden && (

--- a/features/posts/components/PostDetailStatic.tsx
+++ b/features/posts/components/PostDetailStatic.tsx
@@ -55,6 +55,12 @@ interface PostDetailStaticProps {
   isHidden?: boolean;
   onHidden?: () => void;
   /**
+   * 閲覧者が運営か（サーバー側で isFullAdmin 判定済み）。
+   * 通報対応でプロンプト全文を見るために、本文の表示だけ本人と同じ扱いにする
+   * （REQ-018）。編集・削除メニューなど所有者専用の操作には影響しない。
+   */
+  viewerIsAdmin?: boolean;
+  /**
    * 閲覧者の購読プラン。派生生成シートのモデル選択・上限に使う。
    * 投稿者のプランではないので post.user.subscription_plan とは別物。
    */
@@ -69,6 +75,7 @@ export function PostDetailStatic({
   post,
   currentUserId,
   viewerSubscriptionPlan = "free",
+  viewerIsAdmin = false,
   imageAspectRatio,
   postId,
   initialLikeCount,
@@ -107,15 +114,22 @@ export function PostDetailStatic({
   const isOwner = currentUserId === post.user_id;
   const followUserId = post.user?.id || post.user_id;
   const [isFollowingAuthor, setIsFollowingAuthor] = useState(false);
-  const canViewPrompt = isOwner || isFollowingAuthor;
+  // 運営は通報対応のためフォロー関係に依らず本文を読める（REQ-018）
+  const canViewPrompt = isOwner || isFollowingAuthor || viewerIsAdmin;
   const oneTapStylePreset = getOneTapStylePresetMetadata(post);
   const visiblePrompt = getVisiblePrompt(post);
   const hasVisiblePrompt = visiblePrompt.trim().length > 0;
   // 表示モードは1箇所で決める（REQ-013）。
   // 本人には自分の非公開プロンプトを見せる（忘れたときに確認できないと編集もできない）。
-  const promptDisplayMode = getPostPromptDisplayMode(post, { isOwner });
+  const promptDisplayMode = getPostPromptDisplayMode(post, {
+    isOwner,
+    isModerator: viewerIsAdmin,
+  });
   // /free の投稿で、本人または公開プロンプトのときはカードと本文を並べる
-  const showsCardWithPrompt = shouldShowPromptWithCard(post, { isOwner });
+  const showsCardWithPrompt = shouldShowPromptWithCard(post, {
+    isOwner,
+    isModerator: viewerIsAdmin,
+  });
   /*
     本人以外の本文は payload に載せていない（未フォロワーのブラウザへ届かせない
     ため）。公開プロンプトを併記するときだけ、サーバー側で認可する

--- a/features/posts/lib/server-api.ts
+++ b/features/posts/lib/server-api.ts
@@ -14,7 +14,10 @@ import type {
   SortType,
 } from "../types";
 import type { GeneratedImageRecord } from "@/features/generation/lib/database";
-import { redactSensitivePrompt } from "@/features/generation/lib/prompt-visibility";
+import {
+  redactSensitivePrompt,
+  stripFreePromptsForList,
+} from "@/features/generation/lib/prompt-visibility";
 import { resolveVisiblePrompts } from "@/features/generation/lib/prompt-secrets";
 import { getImageDimensions, getPostImageUrl } from "./utils";
 import { resolveSourcePromptReference } from "./source-prompt-reference";
@@ -509,7 +512,13 @@ async function enrichPosts(
   // プロンプトの正本は service-only の author secret。generated_images.prompt は
   // 移行期間の互換用にすぎない（ADR-001）。一覧のたびに N 件引かないよう
   // まとめて解決する。redactSensitivePrompt は防御層として残す。
-  const promptResolvedPosts = await resolveVisiblePrompts(postsData);
+  //
+  // /free の本文は一覧 payload へ載せない。フィードのキャッシュは閲覧者を
+  // 跨いで共有され得るため、閲覧者ごとの出し分けはできない。一覧は本文を
+  // 表示しないので、落としても画面は変わらない。
+  const promptResolvedPosts = stripFreePromptsForList(
+    await resolveVisiblePrompts(postsData)
+  );
 
   // 投稿データにユーザー情報・いいね数・コメント数を結合
   return promptResolvedPosts.map((post) => {
@@ -1033,8 +1042,13 @@ export const getPost = cache(async (
   // から落としておけば、未フォロワーのブラウザには本文が一切届かない。
   //
   // 本人には残す。自分が書いた文章を確認できないと編集もできない。
+  // 運営にも残す（REQ-018）。プロンプトは通報対応の判断材料そのもので、
+  // 画像だけで「不適切かどうか」を決めさせない。getPost のキャッシュは
+  // currentUserId を鍵に含むため、admin 向けの値が他の閲覧者へ漏れることはない。
   const shouldStripPromptFromPayload =
-    promptResolved.generation_type === "free" && !isPostOwner;
+    promptResolved.generation_type === "free" &&
+    !isPostOwner &&
+    !isFullAdminViewer;
 
   // 非公開プロンプト・派生投稿の参照カード（REQ-013）。
   // 検証RPCと集計RPCはどちらも service-only なので、閲覧者の RLS クライアント

--- a/tests/unit/app/api/admin/moderation-queue-route.test.ts
+++ b/tests/unit/app/api/admin/moderation-queue-route.test.ts
@@ -1,0 +1,131 @@
+/** @jest-environment node */
+
+/**
+ * 審査キュー API の回帰テスト。
+ *
+ * prompt_visibility を返すことを固定する (REQ-018)。select の列挙から
+ * 落とすとバッジが黙って消える（型は optional なのでコンパイルは通る）ため、
+ * 列の指定とレスポンスの通過を機械的に検査する。
+ */
+
+jest.mock("next/server", () => {
+  const actual = jest.requireActual("next/server");
+  return {
+    ...actual,
+    connection: jest.fn(async () => {}),
+  };
+});
+
+jest.mock("@/lib/auth", () => ({
+  requireAdmin: jest.fn(),
+}));
+
+jest.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: jest.fn(),
+}));
+
+import { NextRequest } from "next/server";
+import { GET } from "@/app/api/admin/moderation/posts/route";
+import { requireAdmin } from "@/lib/auth";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+const mockRequireAdmin = requireAdmin as jest.MockedFunction<
+  typeof requireAdmin
+>;
+const mockCreateAdminClient = createAdminClient as jest.MockedFunction<
+  typeof createAdminClient
+>;
+
+function createRequest(): NextRequest {
+  return new NextRequest("http://localhost/api/admin/moderation/posts");
+}
+
+/** generated_images と post_reports の2テーブルだけを扱う最小のスタブ。 */
+function createQueueAdminStub(options: {
+  posts: Array<Record<string, unknown>>;
+}) {
+  const selectedColumns: Record<string, string> = {};
+
+  const client = {
+    from: (table: string) => {
+      if (table === "generated_images") {
+        return {
+          select: (columns: string) => {
+            selectedColumns[table] = columns;
+            return {
+              eq: () => ({
+                eq: () => ({
+                  order: () => ({
+                    range: () =>
+                      Promise.resolve({ data: options.posts, error: null }),
+                  }),
+                }),
+              }),
+            };
+          },
+        };
+      }
+      // post_reports
+      return {
+        select: (columns: string) => {
+          selectedColumns[table] = columns;
+          return {
+            in: () => Promise.resolve({ data: [], error: null }),
+          };
+        },
+      };
+    },
+  };
+
+  return { client, selectedColumns };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockRequireAdmin.mockResolvedValue({ id: "admin-1" } as never);
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "https://supabase.example";
+});
+
+describe("GET /api/admin/moderation/posts", () => {
+  it("prompt_visibility を select してレスポンスへ通す", async () => {
+    const { client, selectedColumns } = createQueueAdminStub({
+      posts: [
+        {
+          id: "post-1",
+          user_id: "author-1",
+          image_url: null,
+          storage_path_thumb: "thumb/a.webp",
+          storage_path: "a.png",
+          caption: "test",
+          moderation_status: "pending",
+          moderation_reason: null,
+          posted_at: "2026-08-01T00:00:00.000Z",
+          created_at: "2026-08-01T00:00:00.000Z",
+          prompt_visibility: "private",
+        },
+      ],
+    });
+    mockCreateAdminClient.mockReturnValue(client as never);
+
+    const response = await GET(createRequest());
+    const body = (await response.json()) as {
+      posts: Array<{ prompt_visibility?: string }>;
+    };
+
+    expect(response.status).toBe(200);
+    // 列挙から落とすとバッジが黙って消えるため、指定そのものを固定する
+    expect(selectedColumns["generated_images"]).toContain("prompt_visibility");
+    expect(body.posts[0].prompt_visibility).toBe("private");
+  });
+
+  it("管理者でなければ拒否する", async () => {
+    const { NextResponse } = jest.requireActual("next/server");
+    mockRequireAdmin.mockRejectedValue(
+      NextResponse.json({ error: "forbidden" }, { status: 403 })
+    );
+
+    const response = await GET(createRequest());
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/tests/unit/features/generation/post-prompt-display-mode.test.ts
+++ b/tests/unit/features/generation/post-prompt-display-mode.test.ts
@@ -11,6 +11,7 @@
 import {
   getPostPromptDisplayMode,
   shouldShowPromptWithCard,
+  stripFreePromptsForList,
   type PostPromptDisplayMode,
 } from "@/features/generation/lib/prompt-visibility";
 import type { GeneratedImageRecord } from "@/features/generation/lib/database";
@@ -81,6 +82,35 @@ describe("coordinate（対象外）", () => {
     expect(mode({ generation_type: "coordinate", prompt: "   \n " })).toBe(
       "none"
     );
+  });
+});
+
+describe("運営 (isModerator)", () => {
+  it("非公開の free でも本文を併記する (REQ-018)", () => {
+    // プロンプトは通報対応の判断材料そのもの。画像だけで判断させない。
+    expect(
+      mode({ prompt_visibility: "private" }, { isModerator: true })
+    ).toBe("prompt");
+    expect(
+      shouldShowPromptWithCard(build({ prompt_visibility: "private" }), {
+        isModerator: true,
+      })
+    ).toBe(true);
+  });
+
+  it("派生投稿は運営でも参照カードのまま", () => {
+    // 派生投稿自身は本文を所有していない（author secret が無い）。
+    // 出すべき本文は原作の詳細で見る。
+    expect(
+      mode({ source_post_id: ORIGIN_POST_ID }, { isModerator: true })
+    ).toBe("source_reference");
+  });
+
+  it("one_tap_style は運営でもプリセットカードのまま", () => {
+    // 全文は admin のプリセット管理画面が正
+    expect(
+      mode({ generation_type: "one_tap_style" }, { isModerator: true })
+    ).toBe("one_tap_style");
   });
 });
 
@@ -180,5 +210,35 @@ describe("列が無い既存レコード", () => {
         generation_type: "coordinate",
       })
     ).toBe("prompt");
+  });
+});
+
+describe("一覧 payload の本文除去", () => {
+  it("/free の本文は公開・非公開を問わず落とす", () => {
+    // 一覧のキャッシュは閲覧者を跨いで共有され得るため、
+    // 閲覧者ごとの出し分けはできない。公開でもフォロワー限定の開示である。
+    const rows = stripFreePromptsForList([
+      build({ prompt_visibility: "public", prompt: "公開の本文" }),
+      build({ prompt_visibility: "private", prompt: "非公開の本文" }),
+    ]);
+
+    expect(rows.map((row) => row.prompt)).toEqual(["", ""]);
+  });
+
+  it("coordinate の本文は残す", () => {
+    // 一覧カードの alt フォールバックが使うことがあり、
+    // フォローゲートは詳細画面の伏字が担っている
+    const rows = stripFreePromptsForList([
+      build({ generation_type: "coordinate", prompt: "夏服にして" }),
+    ]);
+
+    expect(rows[0].prompt).toBe("夏服にして");
+  });
+
+  it("既に空なら同じ参照を返す", () => {
+    const record = build({ prompt: "" });
+    const rows = stripFreePromptsForList([record]);
+
+    expect(rows[0]).toBe(record);
   });
 });

--- a/tests/unit/features/posts/post-detail.test.tsx
+++ b/tests/unit/features/posts/post-detail.test.tsx
@@ -389,6 +389,25 @@ describe("PostDetail", () => {
     });
   });
 
+  test("表示_運営閲覧時_フォローに依らず平文を表示する", async () => {
+    // REQ-018: プロンプトは通報対応の判断材料そのもの。
+    // フォローしていない運営にも伏字ではなく全文を出す。
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ isFollowing: false }),
+    });
+    const post = createPost({ prompt: "reported prompt" });
+    await act(async () => {
+      render(
+        <PostDetail post={post} currentUserId="admin-1" viewerIsAdmin />
+      );
+    });
+    await waitFor(() => {
+      expect(screen.getByText("reported prompt")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("***************")).not.toBeInTheDocument();
+  });
+
   test("表示_プロンプト閲覧可の間_平文を表示する", async () => {
     // Spec: POSTDET-008
     const post = createPost({ prompt: "plain here" });

--- a/tests/unit/features/posts/server-api-get-post.test.ts
+++ b/tests/unit/features/posts/server-api-get-post.test.ts
@@ -4,6 +4,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getPost } from "@/features/posts/lib/server-api";
+import { isFullAdmin } from "@/lib/env";
 
 jest.mock("react", () => ({
   cache: <T extends (...args: never[]) => unknown>(fn: T) => fn,
@@ -63,6 +64,8 @@ function createSupabaseMock(
     show_before_image: boolean;
     width: number | null;
     height: number | null;
+    generation_type: string;
+    prompt_visibility: string;
   }> = {},
   jobResult: {
     data: { input_image_url: string | null } | null;
@@ -405,5 +408,69 @@ describe("getPost", () => {
         input_image_url_fallback: null,
       })
     );
+  });
+});
+
+/**
+ * /free 投稿の本文 strip のテスト。
+ *
+ * 公開プロンプトでもフォロワー限定の開示なので、payload には本人と運営にだけ
+ * 本文を載せる。第三者はカード経由（/api/posts/[id]/prompt-text）で取る。
+ */
+describe("getPost の free 本文 strip", () => {
+  const createClientMock = createClient as jest.MockedFunction<
+    typeof createClient
+  >;
+  const isFullAdminMock = isFullAdmin as jest.MockedFunction<typeof isFullAdmin>;
+
+  beforeEach(() => {
+    isFullAdminMock.mockReturnValue(false);
+    (createAdminClient as jest.Mock).mockReturnValue(
+      createPromptSecretAdminStub([
+        { image_id: "post-1", prompt: "ひみつの本文" },
+      ])
+    );
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://supabase.example";
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => createPngHeader(1024, 1024),
+    } as never);
+  });
+
+  function setup() {
+    const { supabase } = createSupabaseMock({
+      generation_type: "free",
+      prompt_visibility: "public",
+      width: 1024,
+      height: 1024,
+    });
+    createClientMock.mockResolvedValue(supabase as never);
+  }
+
+  it("第三者には本文を載せない", async () => {
+    setup();
+
+    const post = await getPost("post-1", "viewer-9", true);
+
+    expect(post?.prompt).toBe("");
+  });
+
+  it("本人には本文を載せる", async () => {
+    setup();
+
+    const post = await getPost("post-1", "author-1", true);
+
+    expect(post?.prompt).toBe("ひみつの本文");
+  });
+
+  it("運営には本文を載せる (REQ-018)", async () => {
+    // プロンプトは通報対応の判断材料そのもの。getPost のキャッシュは
+    // currentUserId を鍵に含むため、admin 向けの値は他の閲覧者へ漏れない。
+    isFullAdminMock.mockReturnValue(true);
+    setup();
+
+    const post = await getPost("post-1", "admin-1", true);
+
+    expect(post?.prompt).toBe("ひみつの本文");
   });
 });


### PR DESCRIPTION
## 概要

プロンプト非公開モードの **Phase 3a（admin 表示）** です。Phase 2 は #470 でマージ済み。**この PR にマイグレーションはありません。**

運営が通報対応でプロンプトを読めるようにし（REQ-018）、着手時の調査で見つけた**一覧 payload の本文漏れ**もあわせて塞ぎます。ドキュメント同期は Phase 3b として別 PR にします。

## 1. 一覧 payload の free 本文漏れ（セキュリティ修正）

Phase 2 の残穴です。`enrichPosts`（ホームフィード）と `getUserPostsServer`（他人のプロフィール）の payload に、`/free` の本文が author secret から解決されたまま載っていました。一覧は本文を表示しませんが、**devtools を開けば非公開プロンプトが読めました**。

`stripFreePromptsForList` で**公開・非公開を問わず**落とします。

- 公開でもフォロワー限定の開示であり、一覧のキャッシュは閲覧者を跨いで共有され得るため、閲覧者ごとの出し分けはできません
- coordinate は従来どおり残します（一覧カードの alt フォールバックが使い、フォローゲートは詳細画面の伏字が担う）
- `getMyImagesServer` は本人専用なので対象外

## 2. 投稿詳細: 運営にプロンプト全文とバッジ（REQ-018）

**これまで運営はプロンプトを読む経路がゼロでした。** `canViewPrompt = isOwner || isFollowingAuthor` に管理者判定が無く、非公開の本文は API も返しません。通報された投稿を画像だけで判断するしかない状態でした。

| 変更 | 内容 |
|---|---|
| `getPost` | payload の strip を admin 免除。キャッシュは `currentUserId` を鍵に含むため他の閲覧者へ漏れない |
| `prompt-visibility` | `isModerator` オプション。**本文の併記だけ**本人と同じ扱い。非公開なら既存の🔒バッジが付く |
| コンポーネント | `CachedPostDetail → PostDetailContent → PostDetailStatic / PostDetail` へ `viewerIsAdmin` を配線。編集・削除など所有者専用の操作には影響しない |

**運営でも見せないもの（意図的）**

- 派生投稿 → 参照カードのまま。派生投稿自身は本文を所有しておらず（author secret が無い）、出すべき本文は原作の詳細で見る
- one_tap_style → プリセットカードのまま。全文は admin のプリセット管理画面が正

## 3. 審査キュー: プロンプト非公開バッジ

`/api/admin/moderation/posts` に `prompt_visibility` を追加し、キューの行へ「🔒 プロンプト非公開」を表示します。非公開プロンプトの投稿は「中身の見えないプロンプトを他人に配っている」状態なので、キューの段階で見分けられます。

## テスト

| ファイル | 内容 |
|---|---|
| `post-prompt-display-mode.test.ts` | isModerator の3分岐（非公開でも本文併記／派生はカードのまま／one_tap_style はカードのまま）、strip ヘルパー |
| `server-api-get-post.test.ts` | strip の3閲覧者（第三者=空／本人=本文／**運営=本文**） |
| `post-detail.test.tsx` | 未フォローの運営に伏字ではなく全文が出る |
| `moderation-queue-route.test.ts`（新規） | select の列挙と `prompt_visibility` の通過を固定（列挙から落とすと型が optional なのでコンパイルが通り、バッジが黙って消えるため）、非管理者の拒否 |

## 検証結果

| コマンド | 結果 |
|---|---|
| `npm run lint` | main とルール別件数まで一致（新規 0） |
| `npm run typecheck` | 非テストのエラー 0 |
| `npm run test` | 307 suites / 3,033 passed（+13 件） |
| `npm run build -- --webpack` | 緑 |

## スコープ外

- Phase 3b: ドキュメント同期（`database-design.mdc` / `docs/API.md` / `data.ja.md` / `data.en.md`）は別 PR
- 通知施策（派生投稿の通知）は別タスクとして計画予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mmqeUvT5TbjAMPNo6Pxsn
