### PR TITLE
fix(free-prompt): フォローボタンの重複をなくしフォロー直後にカードを有効にする

### DIFF
--- a/features/posts/components/PostDetail.tsx
+++ b/features/posts/components/PostDetail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import Image from "next/image";
 import { useTranslations } from "next-intl";
 import { User, Heart, Copy, Check, MoreHorizontal, Edit, Trash2, Share2, Lock } from "lucide-react";
@@ -249,6 +249,38 @@ export function PostDetail({
     };
   }, [showsCardWithPrompt, isOwner, post.id, visiblePrompt]);
 
+
+  /*
+    上部（ユーザーアイコン横）のフォローボタンと参照カードの状態を同期する。
+
+    root の /free 投稿では投稿者＝原作者なので、上でフォローした瞬間に
+    カードの「このプロンプトで作る」が出るべきである。別々の state のままだと
+    画面を更新するまで反映されない（実際に報告された）。
+
+    useCallback にするのは、FollowButton が onFollowChange を effect の依存に
+    持つため。毎レンダーで新しい関数を渡すと follow-status の取得が
+    レンダーごとに走る。
+  */
+  const handleAuthorFollowChange = useCallback(
+    (isFollowing: boolean) => {
+      setIsFollowingAuthor(isFollowing);
+      if (sourceAuthorId && sourceAuthorId === followUserId) {
+        setFollowedSourceAuthorId(isFollowing ? sourceAuthorId : null);
+      }
+    },
+    [sourceAuthorId, followUserId]
+  );
+
+  /* カード内のフォローボタン（派生投稿で原作者が別人のとき）用。 */
+  const handleSourceAuthorFollowChange = useCallback(
+    (isFollowing: boolean) => {
+      setFollowedSourceAuthorId(
+        isFollowing && sourceAuthorId ? sourceAuthorId : null
+      );
+    },
+    [sourceAuthorId]
+  );
+
   const maskedPrompt = hasVisiblePrompt ? "*".repeat(visiblePrompt.length) : "";
   /*
     表示する本文。
@@ -336,7 +368,7 @@ export function PostDetail({
               <FollowButton
                 userId={followUserId}
                 currentUserId={currentUserId}
-                onFollowChange={setIsFollowingAuthor}
+                onFollowChange={handleAuthorFollowChange}
               />
             )}
 
@@ -434,6 +466,11 @@ export function PostDetail({
               isFollowingAuthor={isFollowingSourceAuthor}
               isDerivedPost={!!post.source_post_id}
               subscriptionPlan={viewerSubscriptionPlan}
+              hideFollowButton={
+                !!post.source_reference?.authorId &&
+                post.source_reference.authorId === post.user_id
+              }
+              onFollowChange={handleSourceAuthorFollowChange}
             />
           </div>
         ) : promptDisplayMode === "prompt" ? (
@@ -447,6 +484,11 @@ export function PostDetail({
                   isFollowingAuthor={isFollowingSourceAuthor}
                   isDerivedPost={!!post.source_post_id}
                   subscriptionPlan={viewerSubscriptionPlan}
+                  hideFollowButton={
+                    !!post.source_reference?.authorId &&
+                    post.source_reference.authorId === post.user_id
+                  }
+                  onFollowChange={handleSourceAuthorFollowChange}
                 />
               </div>
             ) : null}

--- a/features/posts/components/PostDetailStatic.tsx
+++ b/features/posts/components/PostDetailStatic.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, lazy, Suspense } from "react";
+import { useState, useEffect, useRef, useCallback, lazy, Suspense } from "react";
 import { useTranslations } from "next-intl";
 import { PostDetailStatsContent } from "./PostDetailStatsContent";
 import { PostDetailStatsSkeleton } from "./PostDetailStatsSkeleton";
@@ -258,6 +258,38 @@ export function PostDetailStatic({
     };
   }, [showsCardWithPrompt, isOwner, post.id, visiblePrompt]);
 
+
+  /*
+    上部（ユーザーアイコン横）のフォローボタンと参照カードの状態を同期する。
+
+    root の /free 投稿では投稿者＝原作者なので、上でフォローした瞬間に
+    カードの「このプロンプトで作る」が出るべきである。別々の state のままだと
+    画面を更新するまで反映されない（実際に報告された）。
+
+    useCallback にするのは、FollowButton が onFollowChange を effect の依存に
+    持つため。毎レンダーで新しい関数を渡すと follow-status の取得が
+    レンダーごとに走る。
+  */
+  const handleAuthorFollowChange = useCallback(
+    (isFollowing: boolean) => {
+      setIsFollowingAuthor(isFollowing);
+      if (sourceAuthorId && sourceAuthorId === followUserId) {
+        setFollowedSourceAuthorId(isFollowing ? sourceAuthorId : null);
+      }
+    },
+    [sourceAuthorId, followUserId]
+  );
+
+  /* カード内のフォローボタン（派生投稿で原作者が別人のとき）用。 */
+  const handleSourceAuthorFollowChange = useCallback(
+    (isFollowing: boolean) => {
+      setFollowedSourceAuthorId(
+        isFollowing && sourceAuthorId ? sourceAuthorId : null
+      );
+    },
+    [sourceAuthorId]
+  );
+
   const maskedPrompt = hasVisiblePrompt ? "*".repeat(visiblePrompt.length) : "";
   /*
     表示する本文。
@@ -473,7 +505,7 @@ export function PostDetailStatic({
               <FollowButton
                 userId={followUserId}
                 currentUserId={currentUserId}
-                onFollowChange={setIsFollowingAuthor}
+                onFollowChange={handleAuthorFollowChange}
               />
             )}
 
@@ -580,6 +612,11 @@ export function PostDetailStatic({
               isFollowingAuthor={isFollowingSourceAuthor}
               isDerivedPost={!!post.source_post_id}
               subscriptionPlan={viewerSubscriptionPlan}
+              hideFollowButton={
+                !!post.source_reference?.authorId &&
+                post.source_reference.authorId === post.user_id
+              }
+              onFollowChange={handleSourceAuthorFollowChange}
             />
           </div>
         ) : promptDisplayMode === "prompt" ? (
@@ -593,6 +630,11 @@ export function PostDetailStatic({
                   isFollowingAuthor={isFollowingSourceAuthor}
                   isDerivedPost={!!post.source_post_id}
                   subscriptionPlan={viewerSubscriptionPlan}
+                  hideFollowButton={
+                    !!post.source_reference?.authorId &&
+                    post.source_reference.authorId === post.user_id
+                  }
+                  onFollowChange={handleSourceAuthorFollowChange}
                 />
               </div>
             ) : null}

--- a/features/posts/components/SourcePromptReferenceCard.tsx
+++ b/features/posts/components/SourcePromptReferenceCard.tsx
@@ -78,6 +78,20 @@ interface SourcePromptReferenceCardProps {
   /** 派生投稿の詳細で表示しているか。表題を「原作の〜」に変える。 */
   isDerivedPost: boolean;
   subscriptionPlan: SubscriptionPlan;
+  /**
+   * ページ上に同じ相手へのフォローボタンが既にあるとき true。
+   *
+   * root の投稿では投稿者＝原作者で、ヘッダー（ユーザーアイコン横）のボタンと
+   * 二重になるため隠す。派生投稿では原作者はページの投稿者と別人なので、
+   * カードのボタンが唯一の導線になり、隠してはいけない。
+   */
+  hideFollowButton?: boolean;
+  /**
+   * カード内のフォローボタンで状態が変わったとき親へ伝える。
+   * 親が持つフォロー状態と食い違うと、フォローしたのに
+   * 「このプロンプトで作る」が出ない（再読込が要る）状態になる。
+   */
+  onFollowChange?: (isFollowing: boolean) => void;
 }
 
 /**
@@ -116,6 +130,8 @@ export function SourcePromptReferenceCard({
   isFollowingAuthor,
   isDerivedPost,
   subscriptionPlan,
+  hideFollowButton = false,
+  onFollowChange,
 }: SourcePromptReferenceCardProps) {
   const t = useTranslations("posts");
   const router = useRouter();
@@ -398,13 +414,15 @@ export function SourcePromptReferenceCard({
           未フォローならカード内で解消できるようにする（ヒアリング済みの決定）。
           原作が使えない状態でフォローを促しても解決しないので、そのときは出さない。
         */}
-        {reference.isAvailable &&
+        {!hideFollowButton &&
+        reference.isAvailable &&
         reference.authorId &&
         !isOwnPrompt &&
         !isFollowingAuthor ? (
           <FollowButton
             userId={reference.authorId}
             currentUserId={currentUserId}
+            onFollowChange={onFollowChange}
           />
         ) : null}
       </div>

--- a/tests/unit/features/posts/post-detail.test.tsx
+++ b/tests/unit/features/posts/post-detail.test.tsx
@@ -130,10 +130,29 @@ jest.mock("@/features/posts/components/CommentList", () => {
 });
 
 jest.mock("@/features/users/components/FollowButton", () => ({
-  FollowButton: ({ userId }: { userId: string }) => (
-    <div data-testid="follow-button" data-user-id={userId} />
+  FollowButton: ({
+    userId,
+    onFollowChange,
+  }: {
+    userId: string;
+    onFollowChange?: (isFollowing: boolean) => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="follow-button"
+      data-user-id={userId}
+      onClick={() => onFollowChange?.(true)}
+    />
   ),
 }));
+
+// 参照カードの生成シートは vaul と生成フォーム一式を抱えるため差し替える
+jest.mock(
+  "@/features/generation/components/PromptLockedGenerationSheet",
+  () => ({
+    PromptLockedGenerationSheet: () => null,
+  })
+);
 
 jest.mock("@/components/ui/dropdown-menu", () => ({
   DropdownMenu: ({ children }: { children: React.ReactNode }) => (
@@ -386,6 +405,56 @@ describe("PostDetail", () => {
     });
     await waitFor(() => {
       expect(screen.getByText("***")).toBeInTheDocument();
+    });
+  });
+
+test("フォロー_上部のボタンでフォローすると再読込なしでカードが有効になる", async () => {
+    // 上部のボタンとカードの state が別々のままだと、フォローしても
+    // 「このプロンプトで作る」が出ず、画面の更新が要る（実際に報告された）。
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ isFollowing: false }),
+    });
+    // 原作者はページの投稿者と同一（root の /free 投稿）。
+    // createPost の既定 user.id と揃えないと、上部のボタンが別人を指してしまう
+    const post = createPost({
+      generation_type: "free",
+      prompt_visibility: "private",
+      prompt: "",
+      source_reference: {
+        postId: "img-1",
+        isAvailable: true,
+        authorId: "owner-1",
+        authorNickname: "作者",
+        authorAvatarUrl: null,
+        thumbnailUrl: null,
+        thumbnailWidth: null,
+        thumbnailHeight: null,
+        beforeThumbnailUrl: null,
+        promptVisibility: "private",
+        usageCount: 0,
+      },
+    });
+
+    await act(async () => {
+      render(<PostDetail post={post} currentUserId="viewer-1" />);
+    });
+
+    // 未フォロー: 生成ボタンは無い。フォロー導線はヘッダーの1つだけ
+    // （カード側は同じ相手なので隠れる）
+    expect(
+      screen.queryByRole("button", { name: /sourcePromptCardTitle/ })
+    ).not.toBeInTheDocument();
+    expect(screen.getAllByTestId("follow-button")).toHaveLength(1);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("follow-button"));
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /sourcePromptCardTitle/ })
+      ).toBeInTheDocument();
     });
   });
 

--- a/tests/unit/features/posts/source-prompt-reference-card.test.tsx
+++ b/tests/unit/features/posts/source-prompt-reference-card.test.tsx
@@ -104,8 +104,19 @@ jest.mock("@/features/posts/lib/source-prompt-text-api", () => ({
 }));
 
 jest.mock("@/features/users/components/FollowButton", () => ({
-  FollowButton: ({ userId }: { userId: string }) => (
-    <button type="button" data-testid="follow-button" data-user-id={userId}>
+  FollowButton: ({
+    userId,
+    onFollowChange,
+  }: {
+    userId: string;
+    onFollowChange?: (isFollowing: boolean) => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="follow-button"
+      data-user-id={userId}
+      onClick={() => onFollowChange?.(true)}
+    >
       フォロー
     </button>
   ),
@@ -668,6 +679,34 @@ describe("原作の投稿への遷移", () => {
     expect(
       screen.queryByRole("button", { name: "原作のページに移動しますか？" })
     ).not.toBeInTheDocument();
+  });
+});
+
+describe("フォローボタンの重複と同期", () => {
+  it("ページ上に同じ相手のボタンがあるときは隠す", () => {
+    // root の投稿ではヘッダー（ユーザーアイコン横）のボタンと二重になる
+    renderCard({ isFollowingAuthor: false, hideFollowButton: true });
+
+    expect(screen.queryByTestId("follow-button")).not.toBeInTheDocument();
+    // 文言は残す。解消の導線はヘッダー側が担う
+    expect(screen.getByText("フォローすると使えます")).toBeInTheDocument();
+  });
+
+  it("派生投稿（原作者が別人）では隠さない", () => {
+    renderCard({ isFollowingAuthor: false, hideFollowButton: false });
+
+    expect(screen.getByTestId("follow-button")).toBeInTheDocument();
+  });
+
+  it("カード内でフォローしたら親へ伝える", () => {
+    // 親のフォロー状態と食い違うと、フォローしたのに
+    // 「このプロンプトで作る」が出ない（再読込が要る）状態になる
+    const onFollowChange = jest.fn();
+    renderCard({ isFollowingAuthor: false, onFollowChange });
+
+    fireEvent.click(screen.getByTestId("follow-button"));
+
+    expect(onFollowChange).toHaveBeenCalledWith(true);
   });
 });
 


### PR DESCRIPTION
## 概要

`/free` 投稿詳細のフォローボタンについての2件の修正です。マイグレーションはありません。

## 1. フォローボタンの重複

root の `/free` 投稿では、**ユーザーアイコン横とカード内に同じ相手へのフォローボタンが2つ**出ていました。原作者がページの投稿者と同一のときはカード側を隠し、ヘッダー側だけを残します。

**派生投稿では隠しません。** 原作者はページの投稿者と別人で、カードのボタンが唯一の導線です。

| 画面 | ヘッダーのボタン | カードのボタン |
|---|---|---|
| root の /free 投稿 | 出す（投稿者=原作者） | **隠す** |
| 派生投稿 | 出す（派生者向け） | 出す（原作者向け・別人） |

## 2. フォローしても再読込しないと反映されない

ヘッダーのボタンは本文の伏字ゲート（`isFollowingAuthor`）だけを更新し、カードが見る state（`followedSourceAuthorId`）を更新していませんでした。フォローしても「このプロンプトで作る」が出ず、画面の更新が必要でした。

`handleAuthorFollowChange` で両方を同期します。原作者がページの投稿者と同一のときだけカード側も更新するので、**派生投稿でヘッダーのフォロー（派生者向け）がカード（原作者向け）に誤って影響することはありません**。カード内のボタンにも `onFollowChange` を配線し、どちらから押しても即時反映されます。

## テスト

- 上部のボタンでフォローすると**再読込なしで「このプロンプトで作る」が現れる**（実クリックで検証）
- root ではフォロー導線が1つだけであること
- 派生投稿ではカードのボタンを隠さないこと
- カード内のフォローが親へ伝わること

`npm run lint`（main と一致）/ `typecheck` 0 / `test` 3,037 passed / `build --webpack` 緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mmqeUvT5TbjAMPNo6Pxsn
