### PR TITLE
docs(free-prompt): プロンプト秘匿境界のドキュメントを実装へ同期する (Phase 3b)

### DIFF
--- a/.cursor/rules/database-design.mdc
+++ b/.cursor/rules/database-design.mdc
@@ -141,8 +141,8 @@ alwaysApply: false
 - 主要カラム: `user_id`, `image_url`, `storage_path`, `prompt`, `is_posted`, `caption`, `posted_at`, `created_at`, `view_count`, `generation_type`, `input_images`, `generation_metadata`, `source_image_stock_id`, `image_job_id`, `image_job_result_index`, `width`, `height`, `model`, `storage_path_display`, `storage_path_thumb`, `moderation_status`, `moderation_reason`, `moderation_updated_at`, `moderation_approved_at`, `background_mode`
 - 外部キー: `user_id -> auth.users.id`, `source_image_stock_id -> source_image_stocks.id`, `image_job_id -> image_jobs.id`
 - 備考: `generation_type` は `coordinate/specified_coordinate/full_body/chibi/one_tap_style/inspire/free`（`specified_coordinate/full_body/chibi` は歴史的経緯で CHECK に残るが新規未使用）、`moderation_status` は `visible/pending/removed`、`background_mode` は `keep/ai_auto/include_in_prompt`、`image_job_id` / `image_job_result_index` は OpenAI batched edit の 1 job 複数結果を OpenAI response `data[]` 順で紐づける。`model` は `gemini-2.5-flash-image` の履歴値に加えて `gemini-3.1-flash-image-preview-512` / `gemini-3.1-flash-image-preview-1024` / `gemini-3-pro-image-1k` / `gemini-3-pro-image-2k` / `gemini-3-pro-image-4k` / `gpt-image-2-low-1k` / `gpt-image-2-low-2k` / `gpt-image-2-low-4k` / `gpt-image-2-medium-1k` / `gpt-image-2-medium-2k` / `gpt-image-2-medium-4k` / `gpt-image-2-high-1k` / `gpt-image-2-high-2k` / `gpt-image-2-high-4k`（旧 `gpt-image-2-low` も履歴互換で許可）を保持する。`width` / `height` は画像実寸（INT、`> 0` の CHECK 制約、NULL 許容）で、Post 詳細画面のサイズ表示と画像向き判定用に server-api の lazy compute で fetch 時に保存される
-- 追加カラム(Phase 1): `prompt_visibility`（`public`/`private`・既定 public）, `source_post_id`（派生元 root・**FKなし**）, `source_author_id`（原作者）
-- 制約: `source_post_id` は service role 経路のみ設定可・作成後不変（NULL→非NULLの後付けも拒否）。`source_post_id` があると `prompt_visibility` は private に強制。root で private を選べるのは `generation_type='free'` のみ。いずれも `enforce_generated_image_lineage` trigger で強制
+- 追加カラム(Phase 1): `prompt_visibility`（`public`/`private`・**既定 private**。2026-08-03 に public から反転。ADR-004b「送り忘れたら閉じる側へ倒す」）, `source_post_id`（派生元 root・**FKなし**）, `source_author_id`（原作者）
+- 制約: `source_post_id` は信頼された書き込み経路（`is_trusted_lineage_writer()` = Data API 経由なら service_role の JWT のみ・直接接続は信頼）のみ設定可・作成後不変（NULL→非NULLの後付けも拒否）。`source_post_id` があると `prompt_visibility` は private に強制。root で private を保てるのは `generation_type='free'` のみで、free 以外は **INSERT 時に public へ正規化**（既定値が流れ込むだけなので例外にしない。例外にすると coordinate / one_tap_style の生成が全滅する）・**UPDATE では拒否**（モーダルからの明示指定なので伝える価値がある）。いずれも `enforce_generated_image_lineage` trigger（`UPDATE OF id, source_post_id, source_author_id, prompt_visibility, generation_type` に限定。`record_post_impressions` の集合UPDATEで発火させない）で強制
 - 制約: `prompt` は `CHECK (prompt = '')` + `DEFAULT ''`。本文は `generated_image_prompt_secrets`（原作者入力）と `generation_prompt_snapshots`（生成実行入力）にのみ存在し、この列は `select("*")` 互換のために残している空列（ADR-001 / REQ-020）
 - RLS: 投稿済みかつ `visible` の画像は公開、それ以外は本人のみ。`INSERT/UPDATE/DELETE` は本人のみ
 
@@ -163,9 +163,9 @@ alwaysApply: false
 
 #### `prompt_usage_events`
 - 主キー: `id`
-- 主要カラム: `image_job_id`（UNIQUE）, `origin_post_id`, `origin_author_id`, `user_id`, `created_at`
-- 外部キー: `image_job_id -> image_jobs.id`（CASCADE）
-- 備考: 派生生成の成功イベント。利用数の算出根拠。`image_job_id` UNIQUE で Worker 再試行・キュー再配送時の重複を防ぐ。`generated_images` を数える案は所有者が書き換えられるため採らない
+- 主要カラム: `image_job_id`（UNIQUE・**FKなし**）, `origin_post_id`, `origin_author_id`, `user_id`, `created_at`
+- 外部キー: なし（すべてスナップショット値。`image_jobs` には本人 DELETE ポリシーがあり、FK CASCADE にすると派生者が自分のジョブを消すだけで原作者に見える利用数を減らせるため張らない）
+- 備考: 派生生成の成功イベント。利用数の算出根拠。`image_job_id` UNIQUE で Worker 再試行・キュー再配送時の重複を防ぐ。`generated_images` を数える案は所有者が書き換えられるため採らない。記録されるのは `sourcePostId` を伴う生成のみで、コピーして /free に貼った生成はアプリ内でも数えられない
 - RLS: 全アクション deny。`PUBLIC` / `anon` / `authenticated` から全 REVOKE（service_role のみ）
 
 #### `source_image_stocks`
@@ -460,7 +460,8 @@ alwaysApply: false
 - `idx_generated_images_moderation_approved_at`
 - ~~`idx_generated_images_prompt_trgm`~~（Phase 0C で削除。prompt 列は常に空）
 - `idx_generated_images_caption_trgm`（`is_posted = true` 部分索引・検索の作品説明マッチ用）
-- `idx_profiles_nickname_trgm`（検索の作者名マッチ用）（`prompt` の trigram 検索用）
+- `idx_profiles_nickname_trgm`（検索の作者名マッチ用）
+- `idx_generated_images_source_post_id`（`source_post_id IS NOT NULL` 部分索引・派生投稿から原作への参照用）
 - `idx_image_jobs_user_id_status`
 - `idx_image_jobs_created_at`
 - `idx_image_jobs_user_id`
@@ -540,7 +541,7 @@ alwaysApply: false
 - 絵師カタログ: `apply_catalog_entry_decision`
 - 画像関連: `increment_view_count`, `insert_source_image_stock`, `update_stock_image_last_used`, `get_stock_image_limit`, `get_stock_image_usage_count`, `complete_image_job_with_generated_images`
 - 派生生成（`service_role` のみ EXECUTE 可）:
-  - `validate_derived_prompt_source(p_source_post_id uuid, p_requester_id uuid)` — 認可を検証し `is_available / root_post_id / origin_author_id` を返す。**本文は返さない**。利用不可の理由も返さない（ADR-005）。派生 ID を渡すと root へ解決する
+  - `validate_derived_prompt_source(p_source_post_id uuid, p_requester_id uuid)` — 認可を検証し `is_available / root_post_id / origin_author_id` を返す。**本文は返さない**。利用不可の理由も返さない（ADR-005）。派生 ID を渡すと root へ解決する。条件: free の root・visible・secret あり・原作者が利用可・双方向ブロックなし・フォロー済みか本人。**公開/非公開は問わない**（2026-07-31 改訂）。`is_posted` は本人が自分の生成物を使う場合だけ問わない（未投稿の下書きから本人は生成できる。`moderation_status` は本人でも緩めない）。API の job 作成前・Worker の減算前・完了RPC の画像INSERT前の3ヶ所で呼ばれる
   - `resolve_derived_prompt_source(p_source_post_id uuid, p_requester_id uuid)` — 認可を再検証してから原作者の入力を返す。**本文を返す唯一の経路**。Worker が provider 送信直前にだけ使う
   - `record_prompt_usage(p_image_job_id uuid)` — 成功済みジョブから origin / 利用者を導出して冪等記録。引数を信用しない
   - `get_prompt_usage_count(p_origin_post_id uuid)` — ユニーク利用者数（原作者を除外）。service-only（任意 UUID での列挙を防ぐ）
@@ -556,6 +557,7 @@ alwaysApply: false
 - `style_presets` は `update_updated_at_column()` trigger で `updated_at` を更新
 - 公開日時: `set_style_preset_published_at` — `style_presets.status` が published へ遷移した INSERT/UPDATE で `published_at = now()` を設定（published のままの編集では更新しない）
 - 絵師カタログ制約: `enforce_catalog_entry_submission_cap`
+- プロンプト秘匿・系譜: `enforce_generated_image_lineage`（出所列のクライアント設定拒否・不変性・派生の private 強制・free 以外の正規化）, `enforce_image_job_origin`（`origin_post_id` の設定経路と不変性。`UPDATE OF origin_post_id` に限定）, `enforce_prompt_execution_kind`（`origin_post_id` の有無と `snapshot_kind` の整合を cross-table で強制）, `reject_derived_image_prompt_secret`（派生画像への author secret 作成を service_role でも拒否）, `is_trusted_lineage_writer()` / `is_trusted_lineage_writer_for(session_user, jwt_role)`（信頼された書き込み経路の判定。Data API 経由は service_role の JWT のみ信頼・直接接続は信頼。判定本体は引数付き純関数で、migration が6経路を適用時に検証する）
 - アカウント初期化: `handle_new_user`
 - 監視・診断: `detect_generation_billing_anomalies`, `monitor_generation_billing_anomalies`
 - 拡張由来: `pgmq_send`, `pgmq_read`, `pgmq_delete`

--- a/docs/API.md
+++ b/docs/API.md
@@ -249,6 +249,29 @@ admin がシリーズ別 KPI と達成者一覧を取得します。
   - `400`: `limit` または `offset` が不正
   - `500`: 投稿取得失敗
 
+### `GET /api/posts/[id]/prompt-text`
+
+公開プロンプトの本文を返します。`/free` の投稿詳細のコピー・生成シート表示・本文併記が使います。
+
+- Access: `user session`（認証必須）
+- 背景: 公開プロンプトはフォロワー限定の開示のため、本文は投稿詳細の payload に載せません（本人と管理者を除く）。本文が要る場面だけ、この API がサーバー側で認可してから返します。
+- 認可: `validate_derived_prompt_source` と同じ条件（free の root・visible・フォロー済みか本人・ブロックなし）に加えて、**原作が `prompt_visibility = 'public'` であること**。非公開の本文はこの経路から絶対に返しません。
+- 派生投稿の ID を渡した場合は root へ解決して root の本文を返します。
+
+Success response:
+
+```json
+{
+  "postId": "root-post-uuid",
+  "prompt": "原作者が入力した本文"
+}
+```
+
+Main errors:
+
+- `401`: 未認証
+- `404`: 利用不可（`POSTS_PROMPT_TEXT_UNAVAILABLE`）。非公開・未フォロー・削除・投稿取消・公開停止のいずれでも**同じ応答**（原作の状態を推測させない）
+
 ### `POST /api/generate-async`
 
 非同期画像生成ジョブを作成し、キューへ投入します。
@@ -258,7 +281,7 @@ admin がシリーズ別 KPI と達成者一覧を取得します。
 
 ```json
 {
-  "prompt": "string, required, max 1000",
+  "prompt": "string, max 1500 (free は 30000)。sourcePostId 指定時は送らない（同時指定は 400）",
   "sourceImageStockId": "uuid, optional",
   "sourceImageBase64": "string, optional",
   "sourceImageMimeType": "image/png | image/jpeg | image/jpg | image/webp | image/gif | image/heic | image/heif",
@@ -266,7 +289,8 @@ admin がシリーズ別 KPI と達成者一覧を取得します。
   "backgroundMode": "enum, optional",
   "count": "1..4, optional",
   "generationType": "coordinate | specified_coordinate | full_body | chibi | one_tap_style | inspire | free",
-  "model": "gemini-3.1-flash-image-preview-512 | gemini-3.1-flash-image-preview-1024 | gemini-3-pro-image-1k | gemini-3-pro-image-2k | gemini-3-pro-image-4k | gpt-image-2-{low|medium|high}-{1k|2k|4k}"
+  "model": "gemini-3.1-flash-image-preview-512 | gemini-3.1-flash-image-preview-1024 | gemini-3-pro-image-1k | gemini-3-pro-image-2k | gemini-3-pro-image-4k | gpt-image-2-{low|medium|high}-{1k|2k|4k}",
+  "sourcePostId": "uuid, optional (派生生成)"
 }
 ```
 
@@ -282,6 +306,11 @@ admin がシリーズ別 KPI と達成者一覧を取得します。
 - GPT Image 2 では `count` を `acceptedImageCount` として受理し、worker が OpenAI Images Edit API に 1 回で `n=acceptedImageCount` を渡します。上限はサブスクプランの生成枚数上限と `1..4` の小さい方です。
 - Gemini 系モデルでは互換性のため、この API 1 回につき 1 job / 1 画像です。複数枚生成はクライアント側が複数 job を投入します。
 - **Gemini 経路は `generationConfig.imageConfig.aspectRatio` を必ず付与** します。入力画像のアスペクトから 9 段階の離散ラベル (`9:16` / `4:5` / `3:4` / `2:3` / `1:1` / `3:2` / `4:3` / `5:4` / `16:9`) のうち最も近いものを選択し、範囲外は `9:16` / `16:9` にクランプします。`gemini-2.5-flash-image` 等 `imageSize` を持たないモデルでも `aspectRatio` だけは送信されます。
+- **派生生成（プロンプト公開・非公開モード）**: `sourcePostId` に原作（`/free` の root 投稿）の ID を渡すと、プロンプト本文をクライアントから送らずに原作と同じプロンプトで生成します。本文は Worker が provider 送信直前に author secret から解決します。
+  - `prompt` との同時指定は `400`（原作の認可だけ借りて本文を差し替える経路を塞ぐ）
+  - `generationType` は `free` 必須（省略時の default `coordinate` では `400`）
+  - 原作が利用不可（削除・投稿取消・公開停止・secret なし・原作者が利用不可・未フォロー・ブロック関係）の場合は `409` + `FREE_SOURCE_UNAVAILABLE`。**理由は区別されない**
+  - 認可は job 作成前・Worker のペルコイン減算前・完了 RPC の画像 INSERT 前の3ヶ所で再検証される。完了時に失効していた場合は成果物を破棄して返金する
 - Base64 元画像は 10MB を超えると `400` になります。
 - HEIC/HEIF はサーバー側で JPEG 変換を試みます。
 - `gemini-2.5-flash-image` と `gemini-2.5-flash-image-preview` は後方互換のため受け付けますが、サーバー側で `gemini-3.1-flash-image-preview-512` に正規化されます。
@@ -314,6 +343,7 @@ Main errors:
 - `400`: バリデーション不正、元画像未指定、画像サイズ超過、残高不足
 - `401`: 未認証
 - `404`: 指定したストック画像が見つからない
+- `409`: 派生生成の原作が利用不可（`FREE_SOURCE_UNAVAILABLE`）
 - `500`: アップロード失敗、ジョブ作成失敗など
 - `202`: ジョブ作成済みだがキュー投入が遅延している可能性あり
 
@@ -693,7 +723,7 @@ Main errors:
 | GET | `/api/admin/materials-images/[slug]` | admin session | フリー素材画像一覧を取得する |
 | POST | `/api/admin/materials-images/[slug]` | admin session | フリー素材画像を追加する |
 | POST | `/api/admin/moderation/posts/[postId]/decision` | admin session | 投稿モデレーションの判定を確定する。reject は `policyCode` と `authorFacingReason` が必須、`idempotencyKey`(UUID) も必須。`internalNote` は任意で投稿者には返さない。対象が審査待ちでなければ 409 |
-| GET | `/api/admin/moderation/posts` | admin session | 審査キューを取得する |
+| GET | `/api/admin/moderation/posts` | admin session | 審査キューを取得する。各行に `prompt_visibility` を含み、非公開プロンプトの投稿をバッジで見分けられる |
 | GET | `/api/admin/moderation/appeals` | admin session | 審査待ちの異議申立てを取得する。他運営の user id は返さず `is_original_decider` の真偽値のみ返す |
 | POST | `/api/admin/moderation/appeals/[appealId]/decision` | admin session | 異議申立てを判定する。`action` は `uphold`(棄却・`removed` のまま) / `overturn`(認容・`visible` へ復帰)。`note` 必須。元判定者と同一なら `independenceExceptionReason` 必須で 400。対象が現在有効な公開停止でなければ 409 |
 | GET | `/api/admin/percoin-defaults` | admin session | デフォルト付与値を取得する |
@@ -815,9 +845,10 @@ POST `/api/comments/[id]/replies` の request body は `{ "content": string, "re
 | POST | `/api/posts/[id]/view` | public | 閲覧数を加算する。ログイン中の管理者閲覧はカウントしない |
 | POST | `/api/posts/comments/batch` | public | 複数投稿のコメント数を一括取得する |
 | POST | `/api/posts/likes/batch` | public | 複数投稿のいいね数を一括取得する |
-| POST | `/api/posts/post` | user session | 投稿完了処理とデイリー特典付与を行う |
+| POST | `/api/posts/post` | user session | 投稿完了処理とデイリー特典付与を行う。`prompt_visibility`（`public`/`private`・`/free` のみ）を受け付ける |
 | GET | `/api/posts` | public | 投稿一覧を取得する |
-| PUT | `/api/posts/update` | user session | 投稿キャプションを更新する |
+| GET | `/api/posts/[id]/prompt-text` | user session | 公開プロンプトの本文を返す（フォロワー限定・非公開は返さない） |
+| PUT | `/api/posts/update` | user session | 投稿キャプション・`prompt_visibility` を更新する |
 
 ### referral
 

--- a/docs/architecture/data.en.md
+++ b/docs/architecture/data.en.md
@@ -277,6 +277,13 @@ These are EARS-inspired summaries for the flows that new developers most often b
 - `postconditions`: On success, one or more `generated_images` rows are inserted, `image_jobs.status = succeeded`, and the consumption transaction is linked to the generated image. For OpenAI batch generation, `generated_images.image_job_id` is the aggregation key. On terminal failure, the job ends in `failed` and refund is attempted once.
 - `postconditions_ja`: 成功時は `generated_images` が追加され、`image_jobs.status = succeeded` となり、消費トランザクションが生成画像に紐づく。終端失敗時はジョブが `failed` で確定し、返金が1回だけ試行される。
 
+### PROMPT-SECRECY-001
+
+- `ears`: The system shall never persist prompt text into user-readable rows (`generated_images.prompt` / `image_jobs.prompt_text`); the text shall exist only in the service-only tables `generated_image_prompt_secrets` (author input) and `generation_prompt_snapshots` (execution input).
+- `preconditions`: Job creation goes through `create_image_job_with_prompt_execution` (job + execution record in one transaction). Completion goes through `complete_image_job_with_prompt_secrets` (images, author secret, job success and billing linkage in one transaction).
+- `postconditions`: The public columns stay empty via `CHECK (prompt = '')` (even `service_role` cannot write non-empty values). Reads resolve through `resolveVisiblePrompts` and fail closed (no fallback to legacy columns). List payloads unconditionally strip `/free` prompt text (`stripFreePromptsForList`); the detail payload carries it only for the owner and admins; everyone else fetches via `/api/posts/[id]/prompt-text` (public prompts, follower-gated). Derived generation accepts only `sourcePostId` from clients; the worker resolves the text via `resolve_derived_prompt_source` immediately before the provider call and keeps it in memory only. Authorization is re-verified at three points (`validate_derived_prompt_source`: before job creation, before percoin deduction, before the completion RPC inserts images); if it lapsed by completion the output is discarded and refunded.
+- See: `docs/planning/free-prompt-private-mode-implementation-plan.md` (ADR-001..011) and `tests/unit/features/generation/prompt-read-paths.test.ts` (mechanically detects read paths that bypass the resolver).
+
 ### BILLING-STRIPE-001
 
 - `ears`: When Stripe confirms `checkout.session.completed`, the system shall apply the purchase exactly once to the user wallet.
@@ -339,6 +346,12 @@ The table below focuses on RPCs that application developers are likely to touch.
 | `cancel_account_deletion` | `/api/account/reactivate` | user | `status` | Cancels scheduled deletion |
 | `get_due_deletion_candidates` | `/api/internal/account-purge` | limit | candidate rows | Lists users ready for purge |
 | `record_forfeiture_ledger` | `/api/internal/account-purge` | user, email hash, deleted time | `void` | Writes wallet forfeiture audit |
+| `create_image_job_with_prompt_execution` | `/api/generate-async` (admin client) | job jsonb, prompt execution jsonb | `image_jobs` row | Creates the job and its `generation_prompt_snapshots` row in one transaction; normalizes `prompt_text` to empty. **service_role only** |
+| `complete_image_job_with_prompt_secrets` | Edge Function worker | job id, images jsonb, metadata, result url, model, background mode | generated image rows | Finalizes images, author secret, job success and billing linkage in one transaction. Derived jobs re-verify authorization before insert; if lapsed, raises (output discarded, refunded). **service_role only** |
+| `validate_derived_prompt_source` | `/api/generate-async`, worker, completion RPC, reference-card resolver | source post id, requester id | `is_available / root_post_id / origin_author_id` | Authorizes derived generation. **Returns neither text nor reason** (ADR-005). Public and private origins both pass; owners may use their own unposted works. **service_role only** |
+| `resolve_derived_prompt_source` | Edge Function worker (immediately before the provider call) | source post id, requester id | `author_input` | Re-verifies authorization, then returns the author input. **The only RPC that returns prompt text.** **service_role only** |
+| `record_prompt_usage` | completion RPC | image job id | `void` | Idempotently records a successful derived generation (`image_job_id` UNIQUE); derives values from the job, not from arguments |
+| `get_prompt_usage_count` | post-detail reference-card resolver | origin post id | `integer` | Unique user count excluding the origin author. **service_role only** (prevents enumeration by arbitrary UUIDs) |
 
 ## Trigger map
 
@@ -357,6 +370,10 @@ The table below focuses on RPCs that application developers are likely to touch.
 | `follows` `AFTER INSERT` | `notify_on_follow()` | Create follow notification |
 | `follows` `AFTER DELETE` | `delete_notification_on_follow_removal()` | Remove follow notification on unfollow |
 | `generated_images` `AFTER INSERT` | `update_stock_image_last_used()` | Update stock-image usage metadata after generation |
+| `generated_images` `BEFORE INSERT / UPDATE OF id, source_post_id, source_author_id, prompt_visibility, generation_type` | `enforce_generated_image_lineage()` | Rejects client writes to lineage columns, keeps them immutable, forces derived posts private, normalizes visibility for non-free rows. Does not fire on hot `impression_count` updates |
+| `image_jobs` `BEFORE INSERT / UPDATE OF origin_post_id` | `enforce_image_job_origin()` | Restricts `origin_post_id` to trusted writers and keeps it immutable |
+| `generation_prompt_snapshots` `BEFORE INSERT/UPDATE` | `enforce_prompt_execution_kind()` | Cross-table check that `snapshot_kind` matches the job's `origin_post_id` |
+| `generated_image_prompt_secrets` `BEFORE INSERT/UPDATE` | `reject_derived_image_prompt_secret()` | Rejects author secrets for derived images, even from `service_role` |
 | `comments`, `image_jobs`, `profiles`, `source_image_stocks`, `user_credits` `BEFORE UPDATE` | `update_updated_at_column()` | Maintain generic `updated_at` values |
 | `notification_preferences` `BEFORE UPDATE` | `update_notification_preferences_updated_at()` | Maintain notification preference timestamp |
 | `banners` `BEFORE UPDATE` | `update_banners_updated_at()` | Maintain banner timestamp |
@@ -402,6 +419,9 @@ Use this section to decide whether a new feature should use session access, serv
 | Table | Why it is not a normal client CRUD target |
 | --- | --- |
 | `generation_percoin_allocations` | Internal billing allocation detail |
+| `generated_image_prompt_secrets` | Canonical store of author prompt text. `authenticated` may SELECT only its own rows; writes go through service role / SECURITY DEFINER only. Follower disclosure happens in server paths that apply visibility rules |
+| `generation_prompt_snapshots` | Execution input, 1:1 with jobs. All roles denied except service role. One-Tap Style operator prompts also live here |
+| `prompt_usage_events` | Successful derived generations (basis of usage counts). All roles denied. No FK on `image_job_id` so deleting one's own job cannot shrink the author's count |
 | `percoin_bonus_defaults` | Operational defaults table |
 | `percoin_streak_defaults` | Operational defaults table |
 | `credit_forfeiture_ledger` | Audit-only, direct public access blocked |

--- a/docs/architecture/data.ja.md
+++ b/docs/architecture/data.ja.md
@@ -284,6 +284,13 @@ RLS をバイパスする必要があるサーバー処理では `createAdminCli
 - `preconditions`: 認証済みセッションであること。リクエストが妥当であること。元画像がストックまたはアップロードから解決できること。事前残高チェックを満たすこと。
 - `postconditions`: 成功時は `generated_images` が 1 件以上追加され、`image_jobs.status = succeeded` となり、消費トランザクションが生成画像に紐づく。OpenAI バッチでは `generated_images.image_job_id` が集計キーになる。終端失敗時はジョブが `failed` で確定し、返金が1回だけ試行される。
 
+### PROMPT-SECRECY-001
+
+- `ears`: システムはプロンプト本文をユーザーが読める行（`generated_images.prompt` / `image_jobs.prompt_text`）へ保存してはならず、本文は service-only の `generated_image_prompt_secrets`（原作者入力）と `generation_prompt_snapshots`（生成実行入力）にのみ存在しなければならない。
+- `preconditions`: job 作成は `create_image_job_with_prompt_execution`（job と実行入力を同一トランザクションで作成）、完了は `complete_image_job_with_prompt_secrets`（画像・author secret・job 成功・課金紐づけを同一トランザクションで確定）を通ること。
+- `postconditions`: 公開列は `CHECK (prompt = '')` で常に空（service_role でも非空は書けない）。読み取りは `resolveVisiblePrompts`（サーバー）経由で fail closed（secret が無ければ空。legacy 列へのフォールバック禁止）。`/free` の本文は一覧 payload から無条件で落とし（`stripFreePromptsForList`）、詳細 payload には本人と管理者にだけ載せる。第三者は `/api/posts/[id]/prompt-text`（公開のみ・フォロワー限定）で取る。派生生成はクライアントから `sourcePostId` のみを受け取り、本文は Worker が provider 送信直前に `resolve_derived_prompt_source` で解決してメモリ上でのみ使う。認可は API の job 作成前・Worker の減算前・完了 RPC の画像 INSERT 前の3ヶ所で `validate_derived_prompt_source` により再検証され、完了時に失効していた場合は成果物を破棄して返金する。
+- 関連: `docs/planning/free-prompt-private-mode-implementation-plan.md`（ADR-001〜ADR-011）、`tests/unit/features/generation/prompt-read-paths.test.ts`（未経由の読み取り経路を機械検出）。
+
 ### BILLING-STRIPE-001
 
 - `ears`: Stripe が `checkout.session.completed` を通知したとき、システムは購入結果をユーザーのウォレットへ厳密に1回だけ反映しなければならない。
@@ -347,6 +354,12 @@ RLS をバイパスする必要があるサーバー処理では `createAdminCli
 | `cancel_account_deletion` | `/api/account/reactivate` | user | `status` | 退会予約の取り消し |
 | `get_due_deletion_candidates` | `/api/internal/account-purge` | limit | 対象ユーザー一覧 | purge 対象列挙 |
 | `record_forfeiture_ledger` | `/api/internal/account-purge` | user, email hash, deleted time | `void` | ウォレット失効台帳の記録 |
+| `create_image_job_with_prompt_execution` | `/api/generate-async`(admin client) | job jsonb, prompt execution jsonb | `image_jobs` row | job と `generation_prompt_snapshots` を同一トランザクションで作成。`prompt_text` は常に空へ正規化。**service_role 専用** |
+| `complete_image_job_with_prompt_secrets` | Edge Function worker | job id, images jsonb, metadata, result url, model, background mode | 生成画像の一覧 | 生成画像・author secret・job 成功更新・`credit_transactions` 紐づけを同一トランザクションで確定。派生 job は完了前に認可を再検証し、失効なら例外（成果物破棄→返金）。**service_role 専用** |
+| `validate_derived_prompt_source` | `/api/generate-async`, worker, 完了RPC内, 参照カード解決 | source post id, requester id | `is_available / root_post_id / origin_author_id` | 派生生成の認可判定。**本文も理由も返さない**（ADR-005）。公開/非公開とも可・本人は未投稿も可。**service_role 専用** |
+| `resolve_derived_prompt_source` | Edge Function worker（provider 送信直前のみ） | source post id, requester id | `author_input` | 認可を再検証してから原作者の入力を返す。**本文を返す唯一の RPC**。**service_role 専用** |
+| `record_prompt_usage` | 完了RPC内 | image job id | `void` | 派生生成の成功イベントを冪等記録（`image_job_id` UNIQUE）。引数を信用せず job から導出 |
+| `get_prompt_usage_count` | 投稿詳細の参照カード解決 | origin post id | `integer` | ユニーク利用者数（原作者除外）。**service_role 専用**（任意 UUID の列挙防止） |
 
 ## Trigger 一覧
 
@@ -365,6 +378,10 @@ RLS をバイパスする必要があるサーバー処理では `createAdminCli
 | `follows` `AFTER INSERT` | `notify_on_follow()` | フォロー通知作成 |
 | `follows` `AFTER DELETE` | `delete_notification_on_follow_removal()` | フォロー解除時の通知削除 |
 | `generated_images` `AFTER INSERT` | `update_stock_image_last_used()` | 元画像ストックの利用状況更新 |
+| `generated_images` `BEFORE INSERT / UPDATE OF id, source_post_id, source_author_id, prompt_visibility, generation_type` | `enforce_generated_image_lineage()` | 出所列のクライアント設定拒否・作成後不変・派生の private 強制・free 以外の可視性正規化。ホットな `impression_count` 更新では発火しない |
+| `image_jobs` `BEFORE INSERT / UPDATE OF origin_post_id` | `enforce_image_job_origin()` | `origin_post_id` の設定経路（信頼された書き込みのみ）と作成後不変 |
+| `generation_prompt_snapshots` `BEFORE INSERT/UPDATE` | `enforce_prompt_execution_kind()` | `image_jobs.origin_post_id` の有無と `snapshot_kind` の整合を cross-table で強制 |
+| `generated_image_prompt_secrets` `BEFORE INSERT/UPDATE` | `reject_derived_image_prompt_secret()` | 派生画像への author secret 作成を service_role でも拒否 |
 | `comments`, `image_jobs`, `profiles`, `source_image_stocks`, `user_credits` `BEFORE UPDATE` | `update_updated_at_column()` | 汎用 `updated_at` 更新 |
 | `notification_preferences` `BEFORE UPDATE` | `update_notification_preferences_updated_at()` | 通知設定の更新時刻管理 |
 | `banners` `BEFORE UPDATE` | `update_banners_updated_at()` | バナー更新時刻管理 |
@@ -410,6 +427,9 @@ RLS をバイパスする必要があるサーバー処理では `createAdminCli
 | テーブル | 理由 |
 | --- | --- |
 | `generation_percoin_allocations` | 内部課金配分の明細 |
+| `generated_image_prompt_secrets` | プロンプト本文（原作者入力）の正本。`authenticated` の直接 SELECT は本人行のみ・書き込みは service role / SECURITY DEFINER のみ。フォロワーへの開示はサーバー経路が可視性ルールを適用する |
+| `generation_prompt_snapshots` | 生成実行入力（job と 1:1）。全ロール deny で service role のみ。One-Tap Style の運営プリセット全文もここ |
+| `prompt_usage_events` | 派生生成の成功イベント（利用数の根拠）。全ロール deny。`image_job_id` に FK を張らない（本人の job 削除で利用数が減るのを防ぐ） |
 | `percoin_bonus_defaults` | 運用設定テーブル |
 | `percoin_streak_defaults` | 運用設定テーブル |
 | `credit_forfeiture_ledger` | 監査専用で、直接公開アクセス禁止 |


### PR DESCRIPTION
## 概要

プロンプト秘匿境界の **Phase 3b（ドキュメント同期）** です。**コード変更なし・マイグレーションなし**。ドキュメント4ファイルのみです。

Phase 0〜3a（#464〜#473）で DB 構造・API・アクセスモデルが大きく変わりましたが、ドキュメントが追随していませんでした。次に触る人（人間でもエージェントでも）が古い前提で壊すのを防ぎます。

## `.cursor/rules/database-design.mdc` — 既存記述の是正5点

Phase 0〜1 時点で書かれた記述が、その後の変更で古くなっていました。**うち1つは実装と逆のことが書いてある状態**でした。

| 記述 | 実際 |
|---|---|
| `prompt_visibility` 既定 public | **既定 private**（ADR-004b・8/3 反転） |
| root で private を選べるのは free のみ | free 以外は **INSERT で public へ正規化・UPDATE で拒否**（正規化しないと coordinate / one_tap_style の生成が全滅する） |
| `prompt_usage_events.image_job_id` **FK CASCADE** | **FK なし**（本人の job 削除で利用数が減るのを防ぐためレビューで撤去済み） |
| `validate_derived_prompt_source` の条件が未記載 | 公開/非公開とも可・本人は未投稿も可・moderation は本人でも緩めない・3ヶ所で再検証 |
| インデックス節に編集残骸 | 除去し `idx_generated_images_source_post_id` を追記 |

trigger / helper 一覧へ系譜・秘匿の4 trigger と `is_trusted_lineage_writer` も追加しました。

## `docs/API.md` — free-prompt 関連の記述がゼロだった

- `POST /api/generate-async`: `sourcePostId`（派生生成）の仕様。`prompt` との排他・`generationType=free` 必須・`409 FREE_SOURCE_UNAVAILABLE`（理由は区別されない）・3段再検証
- **`GET /api/posts/[id]/prompt-text` の節を新設**: 認可条件と、失敗理由を区別しない同一応答（ADR-005）
- Endpoint Inventory: posts の `prompt_visibility`、審査キューの `prompt_visibility`
- **既存の誤記も是正**: `prompt` は "required, max 1000" と書かれていたが、実際は任意（派生時は送らない）・上限 1500 / free 30000

## `docs/architecture/data.ja.md` / `data.en.md`

- 実装契約 **PROMPT-SECRECY-001** を新設。本文の置き場所・原子的 RPC・fail closed 読み取り・payload strip・3段認可・読み取り経路の機械検出（`prompt-read-paths.test.ts`）を1つの契約として記述
- RPC カタログへ派生生成4 RPC ＋ job 作成/完了 RPC
- Trigger 一覧へ系譜・秘匿の4 trigger（発火列の限定も記載）
- service role テーブル一覧へ secret 3テーブル

ja / en は同内容です。

## 記述の正確性について

ドキュメントに書いた挙動は、いずれもこのセッション中に本番 DB で実測済みの事実に基づいています（既定値・trigger の正規化・FK の不在・validate の6経路）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mmqeUvT5TbjAMPNo6Pxsn
