### PR TITLE
feat(style): 「これまでに◯◯回つくられました」から公開前テスト生成を除外(記録時ゲート)

### DIFF
--- a/app/(app)/style/events/handler.ts
+++ b/app/(app)/style/events/handler.ts
@@ -9,6 +9,7 @@ import {
   type StylePublicUsageEventType,
 } from "@/features/style/lib/style-usage-events";
 import { getPublishedStylePresetById } from "@/features/style-presets/lib/style-preset-repository";
+import { shouldRecordStylePresetUsage } from "@/features/style-presets/lib/style-preset-usage-recording";
 import { getAdminPreviewUserIds, getAdminUserIds } from "@/lib/env";
 
 const STYLE_USAGE_EVENT_TYPES = new Set<StylePublicUsageEventType>([
@@ -76,11 +77,21 @@ export async function postStyleEventsRoute(
         ? payload.styleId.trim()
         : null;
 
-    if (
-      styleId &&
-      !(await getPublishedStylePresetByIdFn(styleId, { includeAdminOnly }))
-    ) {
-      return jsonError(copy.invalidStylePreset, "STYLE_INVALID_STYLE", 400);
+    if (styleId) {
+      const preset = await getPublishedStylePresetByIdFn(styleId, {
+        includeAdminOnly,
+      });
+      if (!preset) {
+        return jsonError(copy.invalidStylePreset, "STYLE_INVALID_STYLE", 400);
+      }
+      // 公開中でないプリセット(admin の公開前テスト・表示期間外等)に紐づく
+      // 利用イベントは記録しない(「◯◯回つくられました」カウンタ/KPI への混入防止)。
+      // トラッキングは UX に影響させない方針のため、エラーではなく ok で応答する。
+      // 非 admin は上の取得(includeAdminOnly=false)で既に 400 になるため、
+      // ここに到達してスキップされるのは実質 admin の公開前テストのみ。
+      if (!shouldRecordStylePresetUsage(preset)) {
+        return NextResponse.json({ ok: true });
+      }
     }
 
     const authState: StyleUsageAuthState = user ? "authenticated" : "guest";

--- a/app/(app)/style/generate/handler.ts
+++ b/app/(app)/style/generate/handler.ts
@@ -17,6 +17,7 @@ import {
 } from "@/shared/generation/style-prompts";
 import { resolveAllPromptTemplates } from "@/features/generation-prompts/lib/resolve-templates";
 import { recordStyleUsageEvent } from "@/features/style/lib/style-usage-events";
+import { shouldRecordStylePresetUsage } from "@/features/style-presets/lib/style-preset-usage-recording";
 import {
   checkAndConsumeStyleGenerateRateLimit,
   releaseStyleGenerateRateLimitAttempt,
@@ -259,6 +260,13 @@ export async function postStyleGenerateRoute(
     if (preset.category.visibility === "admin_only") {
       return jsonError(copy.invalidStylePreset, "STYLE_INVALID_STYLE", 400);
     }
+    // 公開中でないプリセット(表示期間外・is_active=false 等)の利用イベントは記録しない
+    // (「◯◯回つくられました」カウンタ/KPI へのテスト・期間外生成の混入防止)。
+    // 生成自体は従来どおり動かし、以降の記録だけを no-op に差し替える。
+    const gatedRecordStyleUsageEventFn: typeof recordStyleUsageEventFn =
+      shouldRecordStylePresetUsage(preset)
+        ? recordStyleUsageEventFn
+        : async () => {};
     // ゲストの無料生成は category.allow_guest_generation が true のカテゴリのみ許可。
     // 許可カテゴリは admin のカテゴリ編集から切り替える(既定 false = ログイン必須)。
     // クライアントでも制御するが defense-in-depth としてサーバーでも検証する。
@@ -442,7 +450,7 @@ export async function postStyleGenerateRoute(
     if (!rateLimitResult.allowed) {
       if (rateLimitResult.reason === "guest_short") {
         await recordStyleRateLimitedEvent({
-          recordStyleUsageEventFn,
+          recordStyleUsageEventFn: gatedRecordStyleUsageEventFn,
           userId: null,
           authState,
           styleId,
@@ -459,7 +467,7 @@ export async function postStyleGenerateRoute(
 
       if (rateLimitResult.reason === "guest_daily") {
         await recordStyleRateLimitedEvent({
-          recordStyleUsageEventFn,
+          recordStyleUsageEventFn: gatedRecordStyleUsageEventFn,
           userId: null,
           authState,
           styleId,
@@ -486,7 +494,7 @@ export async function postStyleGenerateRoute(
       }
 
       await recordStyleRateLimitedEvent({
-        recordStyleUsageEventFn,
+        recordStyleUsageEventFn: gatedRecordStyleUsageEventFn,
         userId: null,
         authState,
         styleId,
@@ -526,7 +534,7 @@ export async function postStyleGenerateRoute(
 
     if (authState === "guest") {
       await recordStyleGenerateAttemptEvent({
-        recordStyleUsageEventFn,
+        recordStyleUsageEventFn: gatedRecordStyleUsageEventFn,
         userId: null,
         authState,
         styleId,
@@ -574,7 +582,7 @@ export async function postStyleGenerateRoute(
 
       if (dispatchResult.kind === "success") {
         try {
-          await recordStyleUsageEventFn({
+          await gatedRecordStyleUsageEventFn({
             userId: null,
             authState,
             eventType: "generate",

--- a/docs/planning/style-usage-count-visibility-gate-implementation-plan.md
+++ b/docs/planning/style-usage-count-visibility-gate-implementation-plan.md
@@ -1,0 +1,93 @@
+# 「これまでに◯◯回つくられました」公開前テスト除外（記録時ゲート） 実装計画書
+
+作成日: 2026-08-05
+ステータス: A案（記録時ゲート・最小）でユーザー承認済み → 実装（本計画書は実装と同一 PR に同梱）
+
+## 背景・ゴール
+
+ホーム・/style・/styles の「これまでに◯◯回つくられました」（プリセット別）と /style 上部の
+「これまでに生成された枚数 N 枚！」（サイト全体）は `style_usage_events`（`event_type='generate'`）の
+集計で、**記録時に公開状態のチェックが無い**。そのため admin_only カテゴリでの公開前テスト生成も
+カウントに乗る。
+
+本対応（A案）では、**公開中でないプリセットに紐づく利用イベントを記録しない**ようにする。
+判定条件は #479（クリエイター通知の `style_preset_usage_events` ゲート）と同一:
+
+```
+status='published' × カテゴリ visibility='public' × is_active × 表示期間 [starts, ends) 内
+```
+
+- 過去のテストイベントは残す（表示は不変。気になるプリセットは依頼ベースで個別対応）
+- admin テストが KPI 集計からも消えるが、それはノイズ除去として許容（ユーザー承認済みの A案）
+- 通知用 `style_preset_usage_events`（#479 でゲート済み）とは別テーブル。今回は表示・KPI 用の
+  `style_usage_events` が対象
+
+## コードベース調査結果
+
+| 対象 | 場所 | 現状 |
+|------|------|------|
+| カウンタのデータ源 | `features/style/lib/style-popularity.ts`（プリセット別・`get_style_generate_counts` RPC）/ `style-usage-stats.ts`（サイト全体） | `style_usage_events` の `event_type='generate'` を集計。公開状態の条件なし |
+| 記録関数 | `features/style/lib/style-usage-events.ts` `recordStyleUsageEvent` | admin client で無条件 INSERT |
+| 記録面①（本命） | `app/(app)/style/events/handler.ts` | クライアント送信イベント（visit/download/**generate**/signup_click/wardrobe_save_click）。**async（認証）フローの 'generate' はここだけ**で記録される。styleId 指定時は `getPublishedStylePresetById(styleId, { includeAdminOnly })` で**プリセット取得済み** → 追加クエリ不要でゲート可能 |
+| 記録面② | `app/(app)/style/generate/handler.ts`（sync=ゲスト経路） | rate_limited / generate_attempt / generate（成功時）。**admin_only カテゴリは既に 400 拒否**（`handler.ts` 内 visibility チェック）のため実質は表示期間外・is_active=false の防御追加。全記録箇所がプリセット取得後 |
+| 記録なし | `app/(app)/style/generate-async/handler.ts` | `recordStyleUsageEvent` は import のみで**呼び出しゼロ**（'generate' はクライアント→記録面①経由）。変更不要 |
+| スコープ外 | `app/api/collections/mount|share-event`、`app/api/wardrobe/claim` | mount_generated / mount_shared / wardrobe_save_completed はプリセット生成フローではない別ライフサイクル。カウンタにも無関係 |
+| 期間判定ヘルパー | `features/collections/lib/collection-display-period.ts` `isCollectionDisplayPeriodActive` | [starts, ends) 判定 = #479 の SQL ゲートと同一セマンティクス。再利用する |
+| 既存テスト | `tests/integration/app/style-events-route.test.ts` / `style-generate-route.test.ts` | DI（dependencies 注入）方式。ゲートのケースを追加拡張できる |
+
+## 設計
+
+新規の共有述語 `features/style-presets/lib/style-preset-usage-recording.ts`:
+
+```
+shouldRecordStylePresetUsage(preset):
+  (preset.status が無い型では published 前提、あれば 'published' を要求)
+  && category.visibility === 'public'
+  && category.isActive
+  && isCollectionDisplayPeriodActive(category の表示期間)
+```
+
+- 記録面①: styleId 指定時、取得済みプリセットが述語 false なら**記録せず `{ ok: true }` を返す**
+  （トラッキング失敗は UX に影響させない既存方針と同じ。エラーにしない = プリセット状態の漏洩も防ぐ）。
+  styleId ありイベント全種（generate だけでなく download 等）を同一ルールでスキップし、
+  「公開中でないプリセットの利用イベントは一切記録しない」という一貫した意味論にする
+- 記録面②: プリセット取得後に述語を 1 回評価し、rate_limited / generate_attempt / generate の
+  記録をスキップ（生成自体は今までどおり動く。記録だけしない）
+- DB 変更なし・マイグレーションなし（アプリ層のみ）→ 適用順序の制約もなし
+
+### ADR-001: DB トリガーではなくアプリ層でゲートする
+
+- **Context**: #479 は DB 関数内でゲートした。今回も DB トリガー化は可能。
+- **Decision**: アプリ層（記録呼び出し前）でゲートする。
+- **Reason**: `style_usage_events` は INSERT がアプリの `recordStyleUsageEvent` 一本に集約済みで、
+  記録面①②とも**プリセットが取得済み**のため追加クエリゼロでゲートできる。DB トリガーだと
+  イベント行→プリセット→カテゴリの JOIN が全 INSERT に走る。#479 と違い「クライアント直
+  INSERT 経路」は存在しない（RLS 全拒否・service_role のみ）ため、アプリ層で十分。
+- **Consequence**: 将来 INSERT 経路を増やす場合は述語の適用を忘れないこと（`style-usage-events.ts`
+  のコメントで明示する）。
+
+## 実装計画
+
+### Phase 1: 共有述語 + 記録面①②のゲート
+- [ ] `features/style-presets/lib/style-preset-usage-recording.ts` 新規（述語 + JSDoc で #479 と同一条件であることを明記）
+- [ ] `app/(app)/style/events/handler.ts` — 取得済みプリセットで述語評価 → false なら記録スキップで ok 応答
+- [ ] `app/(app)/style/generate/handler.ts` — 述語 false なら 3 種の記録をスキップ
+- [ ] `features/style/lib/style-usage-events.ts` — 「新規 INSERT 経路を作る場合は述語を通すこと」のコメント追記
+
+### Phase 2: テスト + ドキュメント + 検証
+- [ ] 述語の単体テスト（4 条件 × 境界: 期間 [starts, ends)・is_active・visibility・status）
+- [ ] `style-events-route.test.ts` — admin + 非公開プリセット → `ok:true` かつ記録関数未呼び出し / 公開中 → 記録される
+- [ ] `style-generate-route.test.ts` — ゲート時に generate 記録がスキップされるケース
+- [ ] `docs/architecture/data.ja.md` / `data.en.md` の該当箇所（必要なら）+ `.cursor/rules/database-design.mdc` は DB 変更なしのため対象外
+- [ ] `npm run lint` / `typecheck` / `test` / `build -- --webpack` 全通過
+
+## 品質・テスト観点
+
+- [ ] **後方互換**: 公開中プリセットの記録は 1 件も変わらない（既存テストが緑のまま）
+- [ ] **UX 不変**: ゲート時もクライアントにはエラーを返さない（生成は成功・記録だけスキップ）
+- [ ] **KPI 影響の明示**: admin テストが今後 KPI に乗らなくなることを PR 本文に記載
+- [ ] 過去イベントは無変更（カウンタが下がらない）
+
+## ロールバック方針
+
+- アプリ層のみ・DB 変更なし。revert 一発で完全に元に戻る

--- a/features/style-presets/lib/style-preset-usage-recording.ts
+++ b/features/style-presets/lib/style-preset-usage-recording.ts
@@ -1,0 +1,43 @@
+import {
+  isCollectionDisplayPeriodActive,
+} from "@/features/collections/lib/collection-display-period";
+import type { StylePresetStatus } from "@/features/style-presets/lib/schema";
+
+/**
+ * 「公開中でないプリセットに紐づく利用イベント(style_usage_events)は記録しない」
+ * ための共有述語。admin の公開前テスト生成が「これまでに◯◯回つくられました」
+ * (プリセット別カウンタ)や /style 上部の総生成数・KPI 集計に乗るのを防ぐ。
+ *
+ * 判定条件はクリエイター通知の記録ゲート(#479 / 20260805120000 の
+ * record_style_preset_usage)と同一:
+ *   status='published' × カテゴリ visibility='public' × is_active
+ *   × コレクション表示期間 [starts, ends) 内
+ *
+ * status を持たない型(StylePresetPublicSummary)は published のみが流通する
+ * 前提のため、status 未定義は published とみなす。
+ */
+export function shouldRecordStylePresetUsage(preset: {
+  status?: StylePresetStatus;
+  category: {
+    visibility: string;
+    isActive: boolean;
+    /** 未指定(undefined)は「期間制限なし」として扱う(NULL と同じ)。 */
+    collectionDisplayStartsAt?: string | null;
+    collectionDisplayEndsAt?: string | null;
+  };
+}): boolean {
+  if (preset.status !== undefined && preset.status !== "published") {
+    return false;
+  }
+  const category = preset.category;
+  if (category.visibility !== "public") {
+    return false;
+  }
+  if (!category.isActive) {
+    return false;
+  }
+  return isCollectionDisplayPeriodActive({
+    collectionDisplayStartsAt: category.collectionDisplayStartsAt ?? null,
+    collectionDisplayEndsAt: category.collectionDisplayEndsAt ?? null,
+  });
+}

--- a/features/style/lib/style-usage-events.ts
+++ b/features/style/lib/style-usage-events.ts
@@ -33,6 +33,13 @@ export interface RecordStyleUsageEventInput {
   styleId?: string | null;
 }
 
+/**
+ * 注意: styleId を伴うイベントを新しい経路から記録する場合は、記録前に
+ * `shouldRecordStylePresetUsage`(features/style-presets/lib/style-preset-usage-recording)
+ * を通すこと。公開中でないプリセット(admin の公開前テスト等)のイベントが
+ * 「◯◯回つくられました」カウンタや KPI 集計に混入するのを防ぐゲートで、
+ * 既存経路(/style/events・/style/generate)は適用済み。
+ */
 export async function recordStyleUsageEvent({
   userId,
   authState,

--- a/tests/integration/app/style-events-route.test.ts
+++ b/tests/integration/app/style-events-route.test.ts
@@ -21,6 +21,24 @@ async function readJson(response: Response): Promise<JsonRecord> {
   return (await response.json()) as JsonRecord;
 }
 
+/**
+ * getPublishedStylePresetById が返す公開中プリセットの最小形。
+ * 記録ゲート(shouldRecordStylePresetUsage)が category の公開状態を読むため、
+ * カテゴリを含めて返す(実リポジトリの戻り値と同じく category 必須)。
+ */
+function buildPublicPreset(categoryOverrides: Record<string, unknown> = {}) {
+  return {
+    id: STYLE_ID,
+    category: {
+      visibility: "public",
+      isActive: true,
+      collectionDisplayStartsAt: null,
+      collectionDisplayEndsAt: null,
+      ...categoryOverrides,
+    },
+  };
+}
+
 describe("StyleEventsRoute integration tests", () => {
   let getUserFn: jest.Mock;
   let getAdminUserIdsFn: jest.Mock;
@@ -34,7 +52,7 @@ describe("StyleEventsRoute integration tests", () => {
     getPublishedStylePresetByIdFn = jest
       .fn()
       .mockImplementation(async (styleId: string) =>
-        styleId === STYLE_ID ? { id: STYLE_ID } : null
+        styleId === STYLE_ID ? buildPublicPreset() : null
       );
     recordStyleUsageEventFn = jest.fn().mockResolvedValue(undefined);
     consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {
@@ -175,5 +193,72 @@ describe("StyleEventsRoute integration tests", () => {
       eventType: "download",
       styleId: STYLE_ID,
     });
+  });
+
+  // 記録ゲート(shouldRecordStylePresetUsage): 公開中でないプリセットに紐づく
+  // 利用イベントは記録しない。エラーではなく ok を返す(UX 影響なし)。
+  test("postStyleEventsRoute_adminOnlyカテゴリのプリセットは記録せずokを返す(公開前テスト除外)", async () => {
+    getUserFn.mockResolvedValueOnce({ id: "admin-1" });
+    getAdminUserIdsFn.mockReturnValueOnce(["admin-1"]);
+    getPublishedStylePresetByIdFn.mockResolvedValueOnce(
+      buildPublicPreset({ visibility: "admin_only" })
+    );
+
+    const response = await postStyleEventsRoute(
+      createRequest({ eventType: "generate", styleId: STYLE_ID }),
+      {
+        getUserFn,
+        getAdminUserIdsFn,
+        getPublishedStylePresetByIdFn,
+        recordStyleUsageEventFn,
+      }
+    );
+    const body = await readJson(response);
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ ok: true });
+    expect(recordStyleUsageEventFn).not.toHaveBeenCalled();
+  });
+
+  test("postStyleEventsRoute_表示期間外のプリセットは記録せずokを返す", async () => {
+    getPublishedStylePresetByIdFn.mockResolvedValueOnce(
+      buildPublicPreset({ collectionDisplayEndsAt: "2020-01-01T00:00:00Z" })
+    );
+
+    const response = await postStyleEventsRoute(
+      createRequest({ eventType: "generate", styleId: STYLE_ID }),
+      {
+        getUserFn,
+        getAdminUserIdsFn,
+        getPublishedStylePresetByIdFn,
+        recordStyleUsageEventFn,
+      }
+    );
+    const body = await readJson(response);
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ ok: true });
+    expect(recordStyleUsageEventFn).not.toHaveBeenCalled();
+  });
+
+  test("postStyleEventsRoute_inactiveカテゴリのプリセットは記録せずokを返す", async () => {
+    getPublishedStylePresetByIdFn.mockResolvedValueOnce(
+      buildPublicPreset({ isActive: false })
+    );
+
+    const response = await postStyleEventsRoute(
+      createRequest({ eventType: "download", styleId: STYLE_ID }),
+      {
+        getUserFn,
+        getAdminUserIdsFn,
+        getPublishedStylePresetByIdFn,
+        recordStyleUsageEventFn,
+      }
+    );
+    const body = await readJson(response);
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ ok: true });
+    expect(recordStyleUsageEventFn).not.toHaveBeenCalled();
   });
 });

--- a/tests/integration/app/style-generate-route.test.ts
+++ b/tests/integration/app/style-generate-route.test.ts
@@ -314,6 +314,42 @@ describe("StyleGenerateRoute integration tests", () => {
     });
   });
 
+  // 記録ゲート(shouldRecordStylePresetUsage): 公開中でないプリセット
+  // (ここでは表示期間外の公開カテゴリ)は生成自体は成功するが、
+  // 利用イベント(generate_attempt / generate)を一切記録しない。
+  test("postStyleGenerateRoute_表示期間外カテゴリは生成は成功するが利用イベントを記録しない", async () => {
+    getUserFn.mockResolvedValueOnce(null);
+    getPublishedStylePresetForGenerationFn.mockResolvedValueOnce(
+      buildStylePresetForGeneration({
+        category: {
+          ...TEST_COORDINATE_CATEGORY,
+          collectionDisplayEndsAt: "2020-01-01T00:00:00Z",
+        },
+      })
+    );
+    const formData = new FormData();
+    formData.set("styleId", STYLE_ID);
+    formData.set("uploadImage", createUploadImage());
+
+    const response = await postStyleGenerateRoute(createRequest(formData), {
+      fetchFn,
+      geminiApiKey: "test-api-key",
+      getUserFn,
+      getPublishedStylePresetForGenerationFn,
+      recordStyleUsageEventFn,
+      checkAndConsumeRateLimitFn,
+      releaseRateLimitAttemptFn,
+    });
+    const body = await readJson(response);
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      imageDataUrl: "data:image/png;base64,generated-image-base64",
+      mimeType: "image/png",
+    });
+    expect(recordStyleUsageEventFn).not.toHaveBeenCalled();
+  });
+
   test("postStyleGenerateRoute_不正styleIdの場合_400を返す", async () => {
     const formData = new FormData();
     formData.set("styleId", "unknown-style");

--- a/tests/unit/features/style-presets/style-preset-usage-recording.test.ts
+++ b/tests/unit/features/style-presets/style-preset-usage-recording.test.ts
@@ -1,0 +1,91 @@
+/**
+ * features/style-presets/lib/style-preset-usage-recording のテスト。
+ *
+ * 「公開中でないプリセットに紐づく利用イベント(style_usage_events)は記録しない」
+ * 共有述語。判定条件はクリエイター通知の記録ゲート(#479)と同一:
+ *   status='published' × visibility='public' × is_active × 表示期間 [starts, ends)
+ */
+import { shouldRecordStylePresetUsage } from "@/features/style-presets/lib/style-preset-usage-recording";
+
+function buildPreset(overrides: {
+  status?: "draft" | "pending" | "published" | "rejected";
+  visibility?: string;
+  isActive?: boolean;
+  startsAt?: string | null;
+  endsAt?: string | null;
+}) {
+  return {
+    ...(overrides.status !== undefined ? { status: overrides.status } : {}),
+    category: {
+      visibility: overrides.visibility ?? "public",
+      isActive: overrides.isActive ?? true,
+      collectionDisplayStartsAt: overrides.startsAt ?? null,
+      collectionDisplayEndsAt: overrides.endsAt ?? null,
+    },
+  };
+}
+
+describe("shouldRecordStylePresetUsage", () => {
+  test("公開中(public × active × 期間制限なし)は記録する", () => {
+    expect(shouldRecordStylePresetUsage(buildPreset({}))).toBe(true);
+  });
+
+  test("status を持つ型では published のみ記録する", () => {
+    expect(
+      shouldRecordStylePresetUsage(buildPreset({ status: "published" })),
+    ).toBe(true);
+    expect(shouldRecordStylePresetUsage(buildPreset({ status: "draft" }))).toBe(
+      false,
+    );
+    expect(
+      shouldRecordStylePresetUsage(buildPreset({ status: "pending" })),
+    ).toBe(false);
+    expect(
+      shouldRecordStylePresetUsage(buildPreset({ status: "rejected" })),
+    ).toBe(false);
+  });
+
+  test("status 未定義(PublicSummary 型)は published とみなす", () => {
+    // getPublishedStylePresetById は published のみ返すため
+    expect(shouldRecordStylePresetUsage(buildPreset({}))).toBe(true);
+  });
+
+  test("admin_only カテゴリは記録しない(公開前テスト除外)", () => {
+    expect(
+      shouldRecordStylePresetUsage(buildPreset({ visibility: "admin_only" })),
+    ).toBe(false);
+  });
+
+  test("inactive カテゴリは記録しない", () => {
+    expect(
+      shouldRecordStylePresetUsage(buildPreset({ isActive: false })),
+    ).toBe(false);
+  });
+
+  test("表示期間 [starts, ends) を尊重する(開始前・終了後は記録しない)", () => {
+    const past = "2020-01-01T00:00:00Z";
+    const future = "2099-01-01T00:00:00Z";
+    // 期間内
+    expect(
+      shouldRecordStylePresetUsage(
+        buildPreset({ startsAt: past, endsAt: future }),
+      ),
+    ).toBe(true);
+    // 開始前
+    expect(
+      shouldRecordStylePresetUsage(buildPreset({ startsAt: future })),
+    ).toBe(false);
+    // 終了後(ends は排他端)
+    expect(shouldRecordStylePresetUsage(buildPreset({ endsAt: past }))).toBe(
+      false,
+    );
+  });
+
+  test("期間フィールドが undefined でも「制限なし」として扱う(テスト用最小形の互換)", () => {
+    expect(
+      shouldRecordStylePresetUsage({
+        category: { visibility: "public", isActive: true },
+      }),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## 概要

ホーム・/style・/styles の「これまでに◯◯回つくられました」（プリセット別）と /style 上部の「これまでに生成された枚数 N 枚！」（サイト全体）の元データ `style_usage_events` に、admin の**公開前テスト生成が混入する問題**を、**記録時ゲート（A案・最小）**で解消します。

計画書: `docs/planning/style-usage-count-visibility-gate-implementation-plan.md`（本 PR に同梱）

## 方針

**公開中でないプリセットに紐づく利用イベントは記録しない。** 判定条件は #479（クリエイター通知の `style_preset_usage_events` ゲート）と同一：

```
status='published' × カテゴリ visibility='public' × is_active × 表示期間 [starts, ends) 内
```

- 生成自体は従来どおり動作し、**記録だけをスキップ**（応答も ok のまま = UX 不変）
- 過去のイベントは無変更（カウンタは 1 も下がらない）。今後の新プリセットは公開後の実利用のみカウント
- admin テストが KPI 集計からも今後は乗らなくなる（ノイズ除去として意図した挙動）
- **DB 変更なし・マイグレーションなし**（アプリ層のみ。revert 一発で完全に戻る）

## 変更内容

- **共有述語 `shouldRecordStylePresetUsage`**（新規 `features/style-presets/lib/style-preset-usage-recording.ts`）— 期間判定は既存 `isCollectionDisplayPeriodActive`（[starts, ends)）を再利用
- **`/style/events`**（async 経路の 'generate' はここだけで記録される本命）— styleId 検証で取得済みのプリセットを使い追加クエリゼロでゲート。非公開時はエラーではなく `{ ok: true }`（非 admin は従来どおり 400 のため、スキップに到達するのは実質 admin の公開前テストのみ）
- **`/style/generate`**（sync=ゲスト経路）— プリセット取得後に記録関数を no-op へ差し替え（rate_limited / generate_attempt / generate の全5記録箇所）。admin_only は既に 400 拒否のため、実質は表示期間外・inactive の防御追加
- `generate-async` は記録呼び出しが元々ゼロのため変更なし。コレクション/ワードローブ系イベント（mount_generated 等）は別ライフサイクルのためスコープ外
- `recordStyleUsageEvent` に「新規経路は述語を通すこと」の注意コメント

## テスト

- `npm run lint` … main 既存の 23E/57W と同一（新規指摘ゼロ）
- `npm run typecheck` … アプリコードのエラーなし（tests/** の既存赤のみ）
- `npm run test` … 312 suites / 3,110 passed（新規: 述語8 + events 3 + generate 1。既存モックは実リポジトリ同様の category 付き形状へ更新）
- `npm run build -- --webpack` … 成功

## 動作確認手順（マージ後）

1. admin_only カテゴリのプリセットで生成 → 「◯◯回つくられました」が増えないこと
2. 公開中プリセットでの通常生成 → 従来どおりカウントが増えること（カウンタはキャッシュ数時間のため反映は遅延）
