### PR TITLE
fix(migration): 還元マイグレーションの Style 側 ROWTYPE 参照を修正

### DIFF
--- a/supabase/migrations/20260806150000_add_creator_usage_percoin_reward.sql
+++ b/supabase/migrations/20260806150000_add_creator_usage_percoin_reward.sql
@@ -437,7 +437,7 @@ BEGIN
     AND e.reward_status = 'pending'
   RETURNING e.* INTO v_event;
 
-  IF v_event.id IS NULL THEN
+  IF v_event.generated_image_id IS NULL THEN
     RETURN;
   END IF;
 


### PR DESCRIPTION
## 概要

#484 の続きです。再適用したところ dry-run が別のエラーで失敗しました（**本番は全ロールバックで無傷**）。

```
ERROR: record "v_event" has no field "id" (SQLSTATE 42703)
```

## 原因

#484 で `WHERE` 句の `e.id` は `generated_image_id` に直しましたが、**test-and-set 後の存在判定が残っていました**。

```sql
UPDATE public.style_preset_usage_events e
SET reward_status = 'granted'
WHERE e.generated_image_id = p_generated_image_id ...
RETURNING e.* INTO v_event;

IF v_event.id IS NULL THEN   -- v_event は %ROWTYPE。この表に id 列は無い
```

`generated_image_id` を見るよう修正しました（1行）。

## 再発防止：本番データでのリハーサル

同じ種類の取りこぼしを繰り返さないため、**マイグレーションファイル全体の `COMMIT` を `ROLLBACK` に置き換えて本番データで通し実行**しました。

- dry-run を含む全ステートメントが**エラーなく完走**することを確認
- 実行後に本番へ何も残っていないことを確認（`reprocess_pending_usage_rewards` 関数 0件・cron ジョブ 0件）

PL/pgSQL は関数本体の列参照を CREATE 時に検証せず、Supabase Preview は空DBで dry-run がスキップされるため、この種のバグは**本番データで実行して初めて分かります**。今後この規模のマイグレーションでは、適用前にこのリハーサルを標準手順にします。

## 確認

適用は引き続きユーザーと一緒に `supabase db push` で行い、NOTICE が「スキップ」ではなく「**実データ dry-run OK**」であることを確認します。
