### PR TITLE
feat(credits): クリエイター還元をミッションページと /free 投稿シートで告知

### DIFF
--- a/app/api/percoin/usage-reward/route.ts
+++ b/app/api/percoin/usage-reward/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { getPercoinDefaultsForDisplay } from "@/features/credits/lib/get-percoin-defaults";
+
+/**
+ * クリエイター還元の付与額を返す（告知の出し分け用）。
+ *
+ * 0 は「停止中」を意味し、呼び出し側は告知そのものを出さない。
+ * 運営が admin でいつでも変えるため、文言に額を埋め込まずここから取る。
+ *
+ * 認証は不要（告知として誰にでも見せる情報）。サブスク倍率は掛けない
+ * （還元は利用者側の行動で発生し、受け手のプラン特典ではない）。
+ *
+ * 取得元の getPercoinDefaultsForDisplay は React.cache 済みで、呼び出し側も
+ * モジュールスコープでキャッシュするため、ここでは route の revalidate を
+ * 指定しない（このプロジェクトの nextConfig.cacheComponents と非互換）。
+ */
+export async function GET() {
+  try {
+    const defaults = await getPercoinDefaultsForDisplay("free");
+
+    return NextResponse.json({
+      promptUsageRewardAmount: defaults.promptUsageRewardAmount,
+      styleUsageRewardAmount: defaults.styleUsageRewardAmount,
+    });
+  } catch (error) {
+    console.error("[Percoin Usage Reward] GET error:", error);
+    // 取得できないときは「停止中」として扱う。誤って告知を出すより出さない方が安全。
+    return NextResponse.json({
+      promptUsageRewardAmount: 0,
+      styleUsageRewardAmount: 0,
+    });
+  }
+}

--- a/features/challenges/components/CachedChallengePageContent.tsx
+++ b/features/challenges/components/CachedChallengePageContent.tsx
@@ -38,6 +38,8 @@ export async function CachedChallengePageContent({
       dailyPostBonusAmount={displayDefaults.dailyPostBonusAmount}
       baseStreakBonusSchedule={baseDefaults.streakBonusSchedule}
       streakBonusSchedule={displayDefaults.streakBonusSchedule}
+      promptUsageRewardAmount={baseDefaults.promptUsageRewardAmount}
+      styleUsageRewardAmount={baseDefaults.styleUsageRewardAmount}
       vercelEnv={process.env.VERCEL_ENV}
     />
   );

--- a/features/challenges/components/ChallengePageContent.tsx
+++ b/features/challenges/components/ChallengePageContent.tsx
@@ -11,6 +11,7 @@ import {
   CheckCircle2,
   ImagePlus,
   Sparkles,
+  Coins,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { useToast } from "@/components/ui/use-toast";
@@ -54,6 +55,12 @@ interface ChallengePageContentProps {
   baseStreakBonusSchedule: readonly number[];
   streakBonusSchedule: readonly number[];
   /**
+   * クリエイター還元の付与額。0 は停止中を意味し、カードごと表示しない
+   * (もらえないのに「もらえます」と書かないため)。
+   */
+  promptUsageRewardAmount?: number;
+  styleUsageRewardAmount?: number;
+  /**
    * Vercel が自動で設定する VERCEL_ENV ("production" | "preview" | "development" | undefined)。
    * preview_streak URL パラメータの本番セーフガード判定に使用する。
    */
@@ -67,9 +74,16 @@ export function ChallengePageContent({
   dailyPostBonusAmount,
   baseStreakBonusSchedule,
   streakBonusSchedule,
+  promptUsageRewardAmount = 0,
+  styleUsageRewardAmount = 0,
   vercelEnv,
 }: ChallengePageContentProps) {
   const t = useTranslations("challenge");
+  // カード見出しの「+◯」には、Free / Style のうち大きい方を出す
+  const maxUsageRewardAmount = Math.max(
+    promptUsageRewardAmount,
+    styleUsageRewardAmount
+  );
   const subscriptionT = useTranslations("subscription");
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -670,6 +684,52 @@ export function ChallengePageContent({
             </div>
           </ChallengeCard>
         </div>
+
+        {/*
+          クリエイター還元。運営が付与額を 0 にしている間は停止中なので、
+          カードごと出さない(もらえないのに「もらえます」と書かない)。
+        */}
+        {maxUsageRewardAmount > 0 && (
+          <div className="mb-6">
+            <ChallengeCard
+              title={t("usageRewardTitle")}
+              description={t("usageRewardDescription")}
+              percoinAmount={maxUsageRewardAmount}
+              icon={Coins}
+              color="orange"
+              className="h-full"
+            >
+              <div className="space-y-3">
+                <ul className="space-y-2 text-sm text-slate-700">
+                  {promptUsageRewardAmount > 0 && (
+                    <li className="flex items-start gap-2">
+                      <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-orange-500" />
+                      <span>
+                        {t("usageRewardFreeItem", {
+                          amount: promptUsageRewardAmount,
+                        })}
+                      </span>
+                    </li>
+                  )}
+                  {styleUsageRewardAmount > 0 && (
+                    <li className="flex items-start gap-2">
+                      <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-orange-500" />
+                      <span>
+                        {t("usageRewardStyleItem", {
+                          amount: styleUsageRewardAmount,
+                        })}
+                      </span>
+                    </li>
+                  )}
+                </ul>
+                <div className="flex items-start gap-2 rounded-lg border border-orange-100 bg-orange-50/50 p-3 text-sm text-orange-700">
+                  <span className="shrink-0 font-bold">{t("tipsLabel")}</span>
+                  <span>{t("usageRewardNote")}</span>
+                </div>
+              </div>
+            </ChallengeCard>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/features/credits/hooks/useUsageRewardAmounts.ts
+++ b/features/credits/hooks/useUsageRewardAmounts.ts
@@ -12,13 +12,34 @@ const ZERO: UsageRewardAmounts = {
   styleUsageRewardAmount: 0,
 };
 
+/** キャッシュの有効期間。 */
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
 /**
  * モジュールスコープのキャッシュ。投稿モーダルは何度も開き閉じされるため、
- * そのたびに取りに行かないようにする。運営が額を変えたときは
- * 次回のページ読み込みで反映される（告知の出し分けに秒単位の即時性は不要）。
+ * そのたびに取りに行かないようにする。
+ *
+ * 期限を持たせるのが要点:
+ *   - 無期限だと、運営が額を 0（停止）にしても、同じタブでは
+ *     ハードリロードするまで古い告知が出続ける（Next.js のクライアント遷移では
+ *     読み込み済みモジュールが保持されるため）
+ *   - 失敗時の 0 もキャッシュする。しないと通信障害中にモーダルを開くたび
+ *     リクエストが飛ぶ
  */
-let cached: UsageRewardAmounts | null = null;
+let cached: { value: UsageRewardAmounts; expiresAt: number } | null = null;
 let inFlight: Promise<UsageRewardAmounts> | null = null;
+
+function putCache(value: UsageRewardAmounts): UsageRewardAmounts {
+  cached = { value, expiresAt: Date.now() + CACHE_TTL_MS };
+  return value;
+}
+
+function readCache(): UsageRewardAmounts | null {
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.value;
+  }
+  return null;
+}
 
 /** テスト専用。モジュールスコープのキャッシュを捨てる。 */
 export function __resetUsageRewardAmountsCacheForTests(): void {
@@ -27,7 +48,8 @@ export function __resetUsageRewardAmountsCacheForTests(): void {
 }
 
 async function fetchUsageRewardAmounts(): Promise<UsageRewardAmounts> {
-  if (cached) return cached;
+  const fresh = readCache();
+  if (fresh) return fresh;
   if (inFlight) return inFlight;
 
   // fetch が無い環境(テストの jsdom 等)では取りに行かず停止中扱いにする。
@@ -38,8 +60,8 @@ async function fetchUsageRewardAmounts(): Promise<UsageRewardAmounts> {
 
   inFlight = fetch("/api/percoin/usage-reward")
     .then((res) => (res.ok ? res.json() : ZERO))
-    .then((data: Partial<UsageRewardAmounts>) => {
-      const value: UsageRewardAmounts = {
+    .then((data: Partial<UsageRewardAmounts>) =>
+      putCache({
         promptUsageRewardAmount:
           typeof data.promptUsageRewardAmount === "number"
             ? data.promptUsageRewardAmount
@@ -48,11 +70,10 @@ async function fetchUsageRewardAmounts(): Promise<UsageRewardAmounts> {
           typeof data.styleUsageRewardAmount === "number"
             ? data.styleUsageRewardAmount
             : 0,
-      };
-      cached = value;
-      return value;
-    })
-    .catch(() => ZERO)
+      })
+    )
+    // 失敗も同じ期限でキャッシュする(障害中の連打を避ける)
+    .catch(() => putCache(ZERO))
     .finally(() => {
       inFlight = null;
     });
@@ -65,7 +86,9 @@ async function fetchUsageRewardAmounts(): Promise<UsageRewardAmounts> {
  * 取得前・取得失敗時も 0 を返すので、「もらえないのに告知が出る」ことはない。
  */
 export function useUsageRewardAmounts(): UsageRewardAmounts {
-  const [amounts, setAmounts] = useState<UsageRewardAmounts>(cached ?? ZERO);
+  const [amounts, setAmounts] = useState<UsageRewardAmounts>(
+    () => readCache() ?? ZERO
+  );
 
   useEffect(() => {
     let active = true;

--- a/features/credits/hooks/useUsageRewardAmounts.ts
+++ b/features/credits/hooks/useUsageRewardAmounts.ts
@@ -1,0 +1,85 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export interface UsageRewardAmounts {
+  promptUsageRewardAmount: number;
+  styleUsageRewardAmount: number;
+}
+
+const ZERO: UsageRewardAmounts = {
+  promptUsageRewardAmount: 0,
+  styleUsageRewardAmount: 0,
+};
+
+/**
+ * モジュールスコープのキャッシュ。投稿モーダルは何度も開き閉じされるため、
+ * そのたびに取りに行かないようにする。運営が額を変えたときは
+ * 次回のページ読み込みで反映される（告知の出し分けに秒単位の即時性は不要）。
+ */
+let cached: UsageRewardAmounts | null = null;
+let inFlight: Promise<UsageRewardAmounts> | null = null;
+
+/** テスト専用。モジュールスコープのキャッシュを捨てる。 */
+export function __resetUsageRewardAmountsCacheForTests(): void {
+  cached = null;
+  inFlight = null;
+}
+
+async function fetchUsageRewardAmounts(): Promise<UsageRewardAmounts> {
+  if (cached) return cached;
+  if (inFlight) return inFlight;
+
+  // fetch が無い環境(テストの jsdom 等)では取りに行かず停止中扱いにする。
+  // 告知は「出さない方が安全」なので 0 で構わない。
+  if (typeof fetch === "undefined") {
+    return ZERO;
+  }
+
+  inFlight = fetch("/api/percoin/usage-reward")
+    .then((res) => (res.ok ? res.json() : ZERO))
+    .then((data: Partial<UsageRewardAmounts>) => {
+      const value: UsageRewardAmounts = {
+        promptUsageRewardAmount:
+          typeof data.promptUsageRewardAmount === "number"
+            ? data.promptUsageRewardAmount
+            : 0,
+        styleUsageRewardAmount:
+          typeof data.styleUsageRewardAmount === "number"
+            ? data.styleUsageRewardAmount
+            : 0,
+      };
+      cached = value;
+      return value;
+    })
+    .catch(() => ZERO)
+    .finally(() => {
+      inFlight = null;
+    });
+
+  return inFlight;
+}
+
+/**
+ * クリエイター還元の付与額。0 は停止中で、呼び出し側は告知を出さない。
+ * 取得前・取得失敗時も 0 を返すので、「もらえないのに告知が出る」ことはない。
+ */
+export function useUsageRewardAmounts(): UsageRewardAmounts {
+  const [amounts, setAmounts] = useState<UsageRewardAmounts>(cached ?? ZERO);
+
+  useEffect(() => {
+    let active = true;
+
+    // cached があっても同期 setState はしない(エフェクト内の同期更新は
+    // 連鎖レンダーの原因になる)。解決済み Promise 経由で次のティックに回す。
+    void fetchUsageRewardAmounts().then((value) => {
+      if (active) setAmounts(value);
+    });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return amounts;
+}

--- a/features/credits/lib/get-percoin-defaults.ts
+++ b/features/credits/lib/get-percoin-defaults.ts
@@ -10,6 +10,13 @@ export type PercoinDefaultsForDisplay = {
   referralBonusAmount: number;
   dailyPostBonusAmount: number;
   streakBonusSchedule: readonly number[];
+  /**
+   * クリエイター還元(自分の作品が他ユーザーに使われたときの付与額)。
+   * 0 は「停止中」を意味し、告知そのものを出さない判断に使う。
+   * サブスク倍率は掛けない(還元は利用者側の行動で発生し、受け手のプラン特典ではない)。
+   */
+  promptUsageRewardAmount: number;
+  styleUsageRewardAmount: number;
 };
 
 export function applySubscriptionBonusMultiplierForDisplay(
@@ -28,6 +35,9 @@ export function applySubscriptionBonusMultiplierForDisplay(
     streakBonusSchedule: defaults.streakBonusSchedule.map((amount) =>
       Math.ceil(amount * multiplier)
     ),
+    // 還元は倍率の対象外(受け手のプランで額が変わる性質のものではない)
+    promptUsageRewardAmount: defaults.promptUsageRewardAmount,
+    styleUsageRewardAmount: defaults.styleUsageRewardAmount,
   };
 }
 
@@ -46,7 +56,12 @@ export const getPercoinDefaultsForDisplay = cache(
       supabase
         .from("percoin_bonus_defaults")
         .select("source, amount")
-        .in("source", ["referral", "daily_post"]),
+        .in("source", [
+          "referral",
+          "daily_post",
+          "prompt_usage_reward",
+          "style_usage_reward",
+        ]),
       supabase
         .from("percoin_streak_defaults")
         .select("streak_day, amount")
@@ -63,10 +78,20 @@ export const getPercoinDefaultsForDisplay = cache(
         ? (streakResult.data.map((r) => r.amount) as readonly number[])
         : ([10, 10, 20, 10, 10, 10, 50, 10, 10, 10, 10, 10, 10, 100] as const);
 
+    // 還元は既定 0 = 停止中。行が無い環境でも 0 として扱い、告知を出さない。
+    const promptUsageRewardAmount =
+      bonusResult.data?.find((r) => r.source === "prompt_usage_reward")?.amount ??
+      0;
+    const styleUsageRewardAmount =
+      bonusResult.data?.find((r) => r.source === "style_usage_reward")?.amount ??
+      0;
+
     const defaults = {
       referralBonusAmount: referralAmount,
       dailyPostBonusAmount: dailyPostAmount,
       streakBonusSchedule: streakSchedule,
+      promptUsageRewardAmount,
+      styleUsageRewardAmount,
     };
 
     return applySubscriptionBonusMultiplierForDisplay(

--- a/features/posts/components/PromptVisibilityField.tsx
+++ b/features/posts/components/PromptVisibilityField.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useTranslations } from "next-intl";
+import { Coins } from "lucide-react";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { useUsageRewardAmounts } from "@/features/credits/hooks/useUsageRewardAmounts";
 
 export type PromptVisibilityValue = "public" | "private";
 
@@ -45,12 +47,26 @@ export function PromptVisibilityField({
   idPrefix,
 }: PromptVisibilityFieldProps) {
   const t = useTranslations("posts");
+  // 還元が停止中(0)なら告知は出さない。取得前・失敗時も 0 なので、
+  // 「もらえないのに告知だけ出る」ことはない。
+  const { promptUsageRewardAmount } = useUsageRewardAmounts();
   const publicId = `${idPrefix}-prompt-visibility-public`;
   const privateId = `${idPrefix}-prompt-visibility-private`;
 
   return (
     <div className="space-y-2">
       <p className="text-sm font-medium">{t("promptVisibilityLabel")}</p>
+
+      {promptUsageRewardAmount > 0 && (
+        <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50/60 p-2.5 text-xs text-amber-900">
+          <Coins className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
+          <span>
+            {t("promptVisibilityRewardHint", {
+              amount: promptUsageRewardAmount,
+            })}
+          </span>
+        </div>
+      )}
 
       <RadioGroup
         value={value}

--- a/messages/ar.ts
+++ b/messages/ar.ts
@@ -71,7 +71,7 @@ export const arMessages = {
     showBeforeImageLabel: "اعرض الصورة قبل التغيير أيضًا",
     promptVisibilityLabel: "ظهور الأمر",
     promptVisibilityRewardHint:
-      "‏تحصل على +{amount} بيركوين في كل مرة ينشئ فيها أحد متابعيك بهذا البرومبت.",
+      "‏تحصل على ما يصل إلى +{amount} بيركوين في كل مرة ينشئ فيها أحد متابعيك بهذا البرومبت.",
     promptVisibilityPublicOption: "إظهار الأمر",
     promptVisibilityPrivateOption: "إبقاء الأمر خاصًا",
     promptVisibilityPublicHint: "يمكن للمتابعين نسخ الأمر. لا تُحتسب الأعمال المُنشأة من نسخة.",
@@ -1369,10 +1369,12 @@ export const arMessages = {
     usageRewardTitle: "مكافآت صنّاع المحتوى",
     usageRewardDescription:
       "احصل على بيركوين عندما ينشئ الآخرون باستخدام برومبتاتك أو ستايلاتك.",
-    usageRewardFreeItem: "‏+{amount} بيركوين عند استخدام برومبت /free الخاص بك",
-    usageRewardStyleItem: "‏+{amount} بيركوين عند استخدام One-Tap Style الخاص بك",
+    usageRewardFreeItem:
+      "‏حتى +{amount} بيركوين عند استخدام برومبت /free الخاص بك",
+    usageRewardStyleItem:
+      "‏حتى +{amount} بيركوين عند استخدام One-Tap Style الخاص بك",
     usageRewardNote:
-      "استخدامك الشخصي لا يُحتسب، وكذلك ما يُنشأ بنسخ البرومبت ولصقه — يُحتسب فقط ما يبدأ من «أنشئ بهذا البرومبت» داخل التطبيق.",
+      "استخدامك الشخصي لا يُحتسب، وكذلك ما يُنشأ بنسخ البرومبت ولصقه — يُحتسب فقط ما يبدأ من «أنشئ بهذا البرومبت» داخل التطبيق. ولا يُمنح شيء عند بلوغ رصيد البيركوين المجاني حدَّه الأقصى.",
     referralTitle: "مكافأة الإحالة",
     referralDescription:
       "ادعُ أصدقاءك لكسب Percoin. تُمنح المكافآت عند تسجيل صديق من خلال رابط الإحالة أو رمز QR الخاص بك.",

--- a/messages/ar.ts
+++ b/messages/ar.ts
@@ -70,6 +70,8 @@ export const arMessages = {
     afterImageAlt: "الصورة المنشأة",
     showBeforeImageLabel: "اعرض الصورة قبل التغيير أيضًا",
     promptVisibilityLabel: "ظهور الأمر",
+    promptVisibilityRewardHint:
+      "‏تحصل على +{amount} بيركوين في كل مرة ينشئ فيها أحد متابعيك بهذا البرومبت.",
     promptVisibilityPublicOption: "إظهار الأمر",
     promptVisibilityPrivateOption: "إبقاء الأمر خاصًا",
     promptVisibilityPublicHint: "يمكن للمتابعين نسخ الأمر. لا تُحتسب الأعمال المُنشأة من نسخة.",
@@ -1364,6 +1366,13 @@ export const arMessages = {
     resetIn: "إعادة التعيين خلال",
     tipsLabel: "نصيحة:",
     dailyResetDescription: "تُعاد هذه المهمة كل يوم في 00:00 JST.",
+    usageRewardTitle: "مكافآت صنّاع المحتوى",
+    usageRewardDescription:
+      "احصل على بيركوين عندما ينشئ الآخرون باستخدام برومبتاتك أو ستايلاتك.",
+    usageRewardFreeItem: "‏+{amount} بيركوين عند استخدام برومبت /free الخاص بك",
+    usageRewardStyleItem: "‏+{amount} بيركوين عند استخدام One-Tap Style الخاص بك",
+    usageRewardNote:
+      "استخدامك الشخصي لا يُحتسب، وكذلك ما يُنشأ بنسخ البرومبت ولصقه — يُحتسب فقط ما يبدأ من «أنشئ بهذا البرومبت» داخل التطبيق.",
     referralTitle: "مكافأة الإحالة",
     referralDescription:
       "ادعُ أصدقاءك لكسب Percoin. تُمنح المكافآت عند تسجيل صديق من خلال رابط الإحالة أو رمز QR الخاص بك.",

--- a/messages/de.ts
+++ b/messages/de.ts
@@ -71,7 +71,7 @@ export const deMessages = {
     showBeforeImageLabel: "Auch das Vorher-Bild anzeigen",
     promptVisibilityLabel: "Sichtbarkeit des Prompts",
     promptVisibilityRewardHint:
-      "Du erhältst +{amount} Percoins, jedes Mal wenn ein Follower mit diesem Prompt erstellt.",
+      "Du erhältst bis zu +{amount} Percoins, jedes Mal wenn ein Follower mit diesem Prompt erstellt.",
     promptVisibilityPublicOption: "Prompt anzeigen",
     promptVisibilityPrivateOption: "Prompt privat halten",
     promptVisibilityPublicHint: "Follower können den Prompt kopieren. Aus einer Kopie erstellte Bilder werden nicht gezählt.",
@@ -1373,10 +1373,12 @@ export const deMessages = {
     usageRewardTitle: "Creator-Belohnungen",
     usageRewardDescription:
       "Verdiene Percoins, wenn andere mit deinen Prompts oder Styles erstellen.",
-    usageRewardFreeItem: "+{amount} Percoins, wenn dein /free-Prompt genutzt wird",
-    usageRewardStyleItem: "+{amount} Percoins, wenn dein One-Tap Style genutzt wird",
+    usageRewardFreeItem:
+      "Bis zu +{amount} Percoins, wenn dein /free-Prompt genutzt wird",
+    usageRewardStyleItem:
+      "Bis zu +{amount} Percoins, wenn dein One-Tap Style genutzt wird",
     usageRewardNote:
-      "Eigene Nutzung zählt nicht. Generierungen per Copy-Paste des Prompts ebenfalls nicht – nur solche über „Mit diesem Prompt erstellen“ in der App.",
+      "Eigene Nutzung zählt nicht. Generierungen per Copy-Paste des Prompts ebenfalls nicht – nur solche über „Mit diesem Prompt erstellen“ in der App. Sobald dein Guthaben an kostenlosen Percoins die Obergrenze erreicht, wird nichts mehr gutgeschrieben.",
     referralTitle: "Empfehlungsbonus",
     referralDescription:
       "Lade Freunde ein, um Percoins zu verdienen. Belohnungen werden gutgeschrieben, wenn sich jemand über deinen Empfehlungslink oder QR-Code anmeldet.",

--- a/messages/de.ts
+++ b/messages/de.ts
@@ -70,6 +70,8 @@ export const deMessages = {
     afterImageAlt: "Generiertes Bild",
     showBeforeImageLabel: "Auch das Vorher-Bild anzeigen",
     promptVisibilityLabel: "Sichtbarkeit des Prompts",
+    promptVisibilityRewardHint:
+      "Du erhältst +{amount} Percoins, jedes Mal wenn ein Follower mit diesem Prompt erstellt.",
     promptVisibilityPublicOption: "Prompt anzeigen",
     promptVisibilityPrivateOption: "Prompt privat halten",
     promptVisibilityPublicHint: "Follower können den Prompt kopieren. Aus einer Kopie erstellte Bilder werden nicht gezählt.",
@@ -1368,6 +1370,13 @@ export const deMessages = {
     resetIn: "Zurücksetzen in",
     tipsLabel: "Tipp:",
     dailyResetDescription: "Diese Mission wird täglich um 00:00 JST zurückgesetzt.",
+    usageRewardTitle: "Creator-Belohnungen",
+    usageRewardDescription:
+      "Verdiene Percoins, wenn andere mit deinen Prompts oder Styles erstellen.",
+    usageRewardFreeItem: "+{amount} Percoins, wenn dein /free-Prompt genutzt wird",
+    usageRewardStyleItem: "+{amount} Percoins, wenn dein One-Tap Style genutzt wird",
+    usageRewardNote:
+      "Eigene Nutzung zählt nicht. Generierungen per Copy-Paste des Prompts ebenfalls nicht – nur solche über „Mit diesem Prompt erstellen“ in der App.",
     referralTitle: "Empfehlungsbonus",
     referralDescription:
       "Lade Freunde ein, um Percoins zu verdienen. Belohnungen werden gutgeschrieben, wenn sich jemand über deinen Empfehlungslink oder QR-Code anmeldet.",

--- a/messages/en.ts
+++ b/messages/en.ts
@@ -71,7 +71,7 @@ export const enMessages = {
     showBeforeImageLabel: "Also display the before image",
     promptVisibilityLabel: "Prompt visibility",
     promptVisibilityRewardHint:
-      "You earn +{amount} Percoins each time a follower creates with this prompt.",
+      "You earn up to +{amount} Percoins each time a follower creates with this prompt.",
     promptVisibilityPublicOption: "Show the prompt",
     promptVisibilityPrivateOption: "Keep the prompt private",
     promptVisibilityPublicHint: "Followers can copy the prompt. Generations made from a copy are not counted.",
@@ -1369,10 +1369,12 @@ export const enMessages = {
     usageRewardTitle: "Creator rewards",
     usageRewardDescription:
       "Earn Percoins when other users create with your prompts or styles.",
-    usageRewardFreeItem: "+{amount} Percoins when your /free prompt is used",
-    usageRewardStyleItem: "+{amount} Percoins when your One-Tap Style is used",
+    usageRewardFreeItem:
+      "Up to +{amount} Percoins when your /free prompt is used",
+    usageRewardStyleItem:
+      "Up to +{amount} Percoins when your One-Tap Style is used",
     usageRewardNote:
-      "Your own usage doesn't count. Generations made by copy-pasting a prompt don't count either — only those started from “Create with this prompt” in the app.",
+      "Your own usage doesn't count. Generations made by copy-pasting a prompt don't count either — only those started from “Create with this prompt” in the app. Nothing is granted once your free Percoin balance reaches its cap.",
     referralTitle: "Referral bonus",
     referralDescription:
       "Invite friends to earn Percoins. Rewards are granted when a friend signs up from your referral link or QR code.",

--- a/messages/en.ts
+++ b/messages/en.ts
@@ -70,6 +70,8 @@ export const enMessages = {
     afterImageAlt: "Generated image",
     showBeforeImageLabel: "Also display the before image",
     promptVisibilityLabel: "Prompt visibility",
+    promptVisibilityRewardHint:
+      "You earn +{amount} Percoins each time a follower creates with this prompt.",
     promptVisibilityPublicOption: "Show the prompt",
     promptVisibilityPrivateOption: "Keep the prompt private",
     promptVisibilityPublicHint: "Followers can copy the prompt. Generations made from a copy are not counted.",
@@ -1364,6 +1366,13 @@ export const enMessages = {
     resetIn: "Resets in",
     tipsLabel: "Tip:",
     dailyResetDescription: "This mission resets every day at 00:00 JST.",
+    usageRewardTitle: "Creator rewards",
+    usageRewardDescription:
+      "Earn Percoins when other users create with your prompts or styles.",
+    usageRewardFreeItem: "+{amount} Percoins when your /free prompt is used",
+    usageRewardStyleItem: "+{amount} Percoins when your One-Tap Style is used",
+    usageRewardNote:
+      "Your own usage doesn't count. Generations made by copy-pasting a prompt don't count either — only those started from “Create with this prompt” in the app.",
     referralTitle: "Referral bonus",
     referralDescription:
       "Invite friends to earn Percoins. Rewards are granted when a friend signs up from your referral link or QR code.",

--- a/messages/es.ts
+++ b/messages/es.ts
@@ -71,7 +71,7 @@ export const esMessages = {
     showBeforeImageLabel: "Mostrar también la imagen original",
     promptVisibilityLabel: "Visibilidad del prompt",
     promptVisibilityRewardHint:
-      "Ganas +{amount} Percoins cada vez que un seguidor crea con este prompt.",
+      "Ganas hasta +{amount} Percoins cada vez que un seguidor crea con este prompt.",
     promptVisibilityPublicOption: "Mostrar el prompt",
     promptVisibilityPrivateOption: "Mantener el prompt privado",
     promptVisibilityPublicHint: "Tus seguidores pueden copiar el prompt. Lo generado desde una copia no se cuenta.",
@@ -1372,10 +1372,12 @@ export const esMessages = {
     usageRewardTitle: "Recompensas para creadores",
     usageRewardDescription:
       "Gana Percoins cuando otras personas creen con tus prompts o estilos.",
-    usageRewardFreeItem: "+{amount} Percoins cuando se usa tu prompt de /free",
-    usageRewardStyleItem: "+{amount} Percoins cuando se usa tu One-Tap Style",
+    usageRewardFreeItem:
+      "Hasta +{amount} Percoins cuando se usa tu prompt de /free",
+    usageRewardStyleItem:
+      "Hasta +{amount} Percoins cuando se usa tu One-Tap Style",
     usageRewardNote:
-      "Tu propio uso no cuenta. Las generaciones hechas copiando y pegando el prompt tampoco: solo cuentan las iniciadas desde «Crear con este prompt» en la app.",
+      "Tu propio uso no cuenta. Las generaciones hechas copiando y pegando el prompt tampoco: solo cuentan las iniciadas desde «Crear con este prompt» en la app. No se otorga nada cuando tu saldo de Percoins gratuitos alcanza el límite.",
     referralTitle: "Bonificación por invitación",
     referralDescription:
       "Invita a tus amigos para ganar Percoins. Las recompensas se conceden cuando un amigo se registra usando tu enlace o código QR.",

--- a/messages/es.ts
+++ b/messages/es.ts
@@ -70,6 +70,8 @@ export const esMessages = {
     afterImageAlt: "Imagen generada",
     showBeforeImageLabel: "Mostrar también la imagen original",
     promptVisibilityLabel: "Visibilidad del prompt",
+    promptVisibilityRewardHint:
+      "Ganas +{amount} Percoins cada vez que un seguidor crea con este prompt.",
     promptVisibilityPublicOption: "Mostrar el prompt",
     promptVisibilityPrivateOption: "Mantener el prompt privado",
     promptVisibilityPublicHint: "Tus seguidores pueden copiar el prompt. Lo generado desde una copia no se cuenta.",
@@ -1367,6 +1369,13 @@ export const esMessages = {
     resetIn: "Reinicio en",
     tipsLabel: "Consejo:",
     dailyResetDescription: "Esta misión se reinicia cada día a las 00:00 JST.",
+    usageRewardTitle: "Recompensas para creadores",
+    usageRewardDescription:
+      "Gana Percoins cuando otras personas creen con tus prompts o estilos.",
+    usageRewardFreeItem: "+{amount} Percoins cuando se usa tu prompt de /free",
+    usageRewardStyleItem: "+{amount} Percoins cuando se usa tu One-Tap Style",
+    usageRewardNote:
+      "Tu propio uso no cuenta. Las generaciones hechas copiando y pegando el prompt tampoco: solo cuentan las iniciadas desde «Crear con este prompt» en la app.",
     referralTitle: "Bonificación por invitación",
     referralDescription:
       "Invita a tus amigos para ganar Percoins. Las recompensas se conceden cuando un amigo se registra usando tu enlace o código QR.",

--- a/messages/fr.ts
+++ b/messages/fr.ts
@@ -71,7 +71,7 @@ export const frMessages = {
     showBeforeImageLabel: "Afficher aussi l'image d'origine",
     promptVisibilityLabel: "Visibilité du prompt",
     promptVisibilityRewardHint:
-      "Vous gagnez +{amount} Percoins chaque fois qu'un abonné crée avec ce prompt.",
+      "Vous gagnez jusqu'à +{amount} Percoins chaque fois qu'un abonné crée avec ce prompt.",
     promptVisibilityPublicOption: "Afficher le prompt",
     promptVisibilityPrivateOption: "Garder le prompt privé",
     promptVisibilityPublicHint: "Vos abonnés peuvent copier le prompt. Les créations issues d'une copie ne sont pas comptées.",
@@ -1372,10 +1372,12 @@ export const frMessages = {
     usageRewardTitle: "Récompenses créateur",
     usageRewardDescription:
       "Gagnez des Percoins quand d'autres créent avec vos prompts ou styles.",
-    usageRewardFreeItem: "+{amount} Percoins quand votre prompt /free est utilisé",
-    usageRewardStyleItem: "+{amount} Percoins quand votre One-Tap Style est utilisé",
+    usageRewardFreeItem:
+      "Jusqu'à +{amount} Percoins quand votre prompt /free est utilisé",
+    usageRewardStyleItem:
+      "Jusqu'à +{amount} Percoins quand votre One-Tap Style est utilisé",
     usageRewardNote:
-      "Votre propre utilisation ne compte pas. Les générations faites en copiant-collant le prompt non plus : seules comptent celles lancées depuis « Créer avec ce prompt » dans l'app.",
+      "Votre propre utilisation ne compte pas. Les générations faites en copiant-collant le prompt non plus : seules comptent celles lancées depuis « Créer avec ce prompt » dans l'app. Rien n'est attribué lorsque votre solde de Percoins gratuits atteint le plafond.",
     referralTitle: "Bonus de parrainage",
     referralDescription:
       "Invitez vos amis pour gagner des Percoins. Les récompenses sont attribuées lorsqu'un ami s'inscrit via votre lien ou votre QR code de parrainage.",

--- a/messages/fr.ts
+++ b/messages/fr.ts
@@ -70,6 +70,8 @@ export const frMessages = {
     afterImageAlt: "Image générée",
     showBeforeImageLabel: "Afficher aussi l'image d'origine",
     promptVisibilityLabel: "Visibilité du prompt",
+    promptVisibilityRewardHint:
+      "Vous gagnez +{amount} Percoins chaque fois qu'un abonné crée avec ce prompt.",
     promptVisibilityPublicOption: "Afficher le prompt",
     promptVisibilityPrivateOption: "Garder le prompt privé",
     promptVisibilityPublicHint: "Vos abonnés peuvent copier le prompt. Les créations issues d'une copie ne sont pas comptées.",
@@ -1367,6 +1369,13 @@ export const frMessages = {
     resetIn: "Réinitialisation dans",
     tipsLabel: "Astuce :",
     dailyResetDescription: "Cette mission se réinitialise chaque jour à 00:00 JST.",
+    usageRewardTitle: "Récompenses créateur",
+    usageRewardDescription:
+      "Gagnez des Percoins quand d'autres créent avec vos prompts ou styles.",
+    usageRewardFreeItem: "+{amount} Percoins quand votre prompt /free est utilisé",
+    usageRewardStyleItem: "+{amount} Percoins quand votre One-Tap Style est utilisé",
+    usageRewardNote:
+      "Votre propre utilisation ne compte pas. Les générations faites en copiant-collant le prompt non plus : seules comptent celles lancées depuis « Créer avec ce prompt » dans l'app.",
     referralTitle: "Bonus de parrainage",
     referralDescription:
       "Invitez vos amis pour gagner des Percoins. Les récompenses sont attribuées lorsqu'un ami s'inscrit via votre lien ou votre QR code de parrainage.",

--- a/messages/hi.ts
+++ b/messages/hi.ts
@@ -70,6 +70,8 @@ export const hiMessages = {
     afterImageAlt: "उत्पन्न छवि",
     showBeforeImageLabel: "पहले की छवि भी दिखाएँ",
     promptVisibilityLabel: "प्रॉम्प्ट की दृश्यता",
+    promptVisibilityRewardHint:
+      "जब भी कोई फ़ॉलोअर इस प्रॉम्प्ट से बनाता है, आपको +{amount} पर्कॉइन मिलते हैं।",
     promptVisibilityPublicOption: "प्रॉम्प्ट दिखाएँ",
     promptVisibilityPrivateOption: "प्रॉम्प्ट निजी रखें",
     promptVisibilityPublicHint: "फ़ॉलोअर्स प्रॉम्प्ट कॉपी कर सकते हैं। कॉपी से बनाई गई रचनाएँ नहीं गिनी जातीं।",
@@ -1365,6 +1367,13 @@ export const hiMessages = {
     resetIn: "रीसेट",
     tipsLabel: "सुझाव:",
     dailyResetDescription: "यह मिशन हर दिन 00:00 JST पर रीसेट होता है।",
+    usageRewardTitle: "क्रिएटर रिवॉर्ड",
+    usageRewardDescription:
+      "जब दूसरे लोग आपके प्रॉम्प्ट या स्टाइल से बनाते हैं, तो आपको पर्कॉइन मिलते हैं।",
+    usageRewardFreeItem: "आपका /free प्रॉम्प्ट इस्तेमाल होने पर +{amount} पर्कॉइन",
+    usageRewardStyleItem: "आपका One-Tap Style इस्तेमाल होने पर +{amount} पर्कॉइन",
+    usageRewardNote:
+      "अपना उपयोग नहीं गिना जाता। प्रॉम्प्ट कॉपी-पेस्ट करके बनाई गई इमेज भी नहीं — केवल ऐप में “इस प्रॉम्प्ट से बनाएं” से शुरू की गई।",
     referralTitle: "रेफ़रल बोनस",
     referralDescription:
       "Percoin कमाने के लिए दोस्तों को आमंत्रित करें। जब कोई दोस्त आपके रेफ़रल लिंक या QR कोड से साइन अप करता है तो पुरस्कार दिए जाते हैं।",

--- a/messages/hi.ts
+++ b/messages/hi.ts
@@ -71,7 +71,7 @@ export const hiMessages = {
     showBeforeImageLabel: "पहले की छवि भी दिखाएँ",
     promptVisibilityLabel: "प्रॉम्प्ट की दृश्यता",
     promptVisibilityRewardHint:
-      "जब भी कोई फ़ॉलोअर इस प्रॉम्प्ट से बनाता है, आपको +{amount} पर्कॉइन मिलते हैं।",
+      "जब भी कोई फ़ॉलोअर इस प्रॉम्प्ट से बनाता है, आपको अधिकतम +{amount} पर्कॉइन मिलते हैं।",
     promptVisibilityPublicOption: "प्रॉम्प्ट दिखाएँ",
     promptVisibilityPrivateOption: "प्रॉम्प्ट निजी रखें",
     promptVisibilityPublicHint: "फ़ॉलोअर्स प्रॉम्प्ट कॉपी कर सकते हैं। कॉपी से बनाई गई रचनाएँ नहीं गिनी जातीं।",
@@ -1370,10 +1370,12 @@ export const hiMessages = {
     usageRewardTitle: "क्रिएटर रिवॉर्ड",
     usageRewardDescription:
       "जब दूसरे लोग आपके प्रॉम्प्ट या स्टाइल से बनाते हैं, तो आपको पर्कॉइन मिलते हैं।",
-    usageRewardFreeItem: "आपका /free प्रॉम्प्ट इस्तेमाल होने पर +{amount} पर्कॉइन",
-    usageRewardStyleItem: "आपका One-Tap Style इस्तेमाल होने पर +{amount} पर्कॉइन",
+    usageRewardFreeItem:
+      "आपका /free प्रॉम्प्ट इस्तेमाल होने पर अधिकतम +{amount} पर्कॉइन",
+    usageRewardStyleItem:
+      "आपका One-Tap Style इस्तेमाल होने पर अधिकतम +{amount} पर्कॉइन",
     usageRewardNote:
-      "अपना उपयोग नहीं गिना जाता। प्रॉम्प्ट कॉपी-पेस्ट करके बनाई गई इमेज भी नहीं — केवल ऐप में “इस प्रॉम्प्ट से बनाएं” से शुरू की गई।",
+      "अपना उपयोग नहीं गिना जाता। प्रॉम्प्ट कॉपी-पेस्ट करके बनाई गई इमेज भी नहीं — केवल ऐप में “इस प्रॉम्प्ट से बनाएं” से शुरू की गई। मुफ़्त पर्कॉइन बैलेंस सीमा पर पहुँचने के बाद कुछ नहीं मिलता।",
     referralTitle: "रेफ़रल बोनस",
     referralDescription:
       "Percoin कमाने के लिए दोस्तों को आमंत्रित करें। जब कोई दोस्त आपके रेफ़रल लिंक या QR कोड से साइन अप करता है तो पुरस्कार दिए जाते हैं।",

--- a/messages/id.ts
+++ b/messages/id.ts
@@ -70,6 +70,8 @@ export const idMessages = {
     afterImageAlt: "Gambar yang dihasilkan",
     showBeforeImageLabel: "Tampilkan juga gambar sebelum",
     promptVisibilityLabel: "Visibilitas prompt",
+    promptVisibilityRewardHint:
+      "Kamu dapat +{amount} Percoin setiap kali pengikut berkreasi dengan prompt ini.",
     promptVisibilityPublicOption: "Tampilkan prompt",
     promptVisibilityPrivateOption: "Jadikan prompt privat",
     promptVisibilityPublicHint: "Pengikut dapat menyalin prompt. Hasil dari salinan tidak dihitung.",
@@ -1366,6 +1368,13 @@ export const idMessages = {
     resetIn: "Reset dalam",
     tipsLabel: "Tips:",
     dailyResetDescription: "Misi ini reset setiap hari pukul 00:00 JST.",
+    usageRewardTitle: "Imbalan kreator",
+    usageRewardDescription:
+      "Dapatkan Percoin saat pengguna lain berkreasi dengan prompt atau gaya kamu.",
+    usageRewardFreeItem: "+{amount} Percoin saat prompt /free kamu dipakai",
+    usageRewardStyleItem: "+{amount} Percoin saat One-Tap Style kamu dipakai",
+    usageRewardNote:
+      "Penggunaan sendiri tidak dihitung. Generasi hasil salin-tempel prompt juga tidak — hanya yang dimulai dari “Buat dengan prompt ini” di aplikasi.",
     referralTitle: "Bonus referral",
     referralDescription:
       "Undang teman untuk mendapat Percoin. Hadiah diberikan saat teman mendaftar dari tautan atau QR code referralmu.",

--- a/messages/id.ts
+++ b/messages/id.ts
@@ -71,7 +71,7 @@ export const idMessages = {
     showBeforeImageLabel: "Tampilkan juga gambar sebelum",
     promptVisibilityLabel: "Visibilitas prompt",
     promptVisibilityRewardHint:
-      "Kamu dapat +{amount} Percoin setiap kali pengikut berkreasi dengan prompt ini.",
+      "Kamu dapat hingga +{amount} Percoin setiap kali pengikut berkreasi dengan prompt ini.",
     promptVisibilityPublicOption: "Tampilkan prompt",
     promptVisibilityPrivateOption: "Jadikan prompt privat",
     promptVisibilityPublicHint: "Pengikut dapat menyalin prompt. Hasil dari salinan tidak dihitung.",
@@ -1371,10 +1371,12 @@ export const idMessages = {
     usageRewardTitle: "Imbalan kreator",
     usageRewardDescription:
       "Dapatkan Percoin saat pengguna lain berkreasi dengan prompt atau gaya kamu.",
-    usageRewardFreeItem: "+{amount} Percoin saat prompt /free kamu dipakai",
-    usageRewardStyleItem: "+{amount} Percoin saat One-Tap Style kamu dipakai",
+    usageRewardFreeItem:
+      "Hingga +{amount} Percoin saat prompt /free kamu dipakai",
+    usageRewardStyleItem:
+      "Hingga +{amount} Percoin saat One-Tap Style kamu dipakai",
     usageRewardNote:
-      "Penggunaan sendiri tidak dihitung. Generasi hasil salin-tempel prompt juga tidak — hanya yang dimulai dari “Buat dengan prompt ini” di aplikasi.",
+      "Penggunaan sendiri tidak dihitung. Generasi hasil salin-tempel prompt juga tidak — hanya yang dimulai dari “Buat dengan prompt ini” di aplikasi. Tidak ada pemberian saat saldo Percoin gratismu mencapai batas.",
     referralTitle: "Bonus referral",
     referralDescription:
       "Undang teman untuk mendapat Percoin. Hadiah diberikan saat teman mendaftar dari tautan atau QR code referralmu.",

--- a/messages/it.ts
+++ b/messages/it.ts
@@ -71,7 +71,7 @@ export const itMessages = {
     showBeforeImageLabel: "Mostra anche l'immagine prima",
     promptVisibilityLabel: "Visibilità del prompt",
     promptVisibilityRewardHint:
-      "Guadagni +{amount} Percoin ogni volta che un follower crea con questo prompt.",
+      "Guadagni fino a +{amount} Percoin ogni volta che un follower crea con questo prompt.",
     promptVisibilityPublicOption: "Mostra il prompt",
     promptVisibilityPrivateOption: "Mantieni il prompt privato",
     promptVisibilityPublicHint: "I follower possono copiare il prompt. Le generazioni da una copia non vengono conteggiate.",
@@ -1372,10 +1372,12 @@ export const itMessages = {
     usageRewardTitle: "Ricompense per i creator",
     usageRewardDescription:
       "Guadagna Percoin quando altri creano con i tuoi prompt o stili.",
-    usageRewardFreeItem: "+{amount} Percoin quando il tuo prompt di /free viene usato",
-    usageRewardStyleItem: "+{amount} Percoin quando il tuo One-Tap Style viene usato",
+    usageRewardFreeItem:
+      "Fino a +{amount} Percoin quando il tuo prompt di /free viene usato",
+    usageRewardStyleItem:
+      "Fino a +{amount} Percoin quando il tuo One-Tap Style viene usato",
     usageRewardNote:
-      "Il tuo utilizzo non conta. Nemmeno le generazioni fatte copiando e incollando il prompt: valgono solo quelle avviate da «Crea con questo prompt» nell'app.",
+      "Il tuo utilizzo non conta. Nemmeno le generazioni fatte copiando e incollando il prompt: valgono solo quelle avviate da «Crea con questo prompt» nell'app. Nulla viene accreditato quando il saldo di Percoin gratuiti raggiunge il limite.",
     referralTitle: "Bonus invito",
     referralDescription:
       "Invita amici per guadagnare Percoin. Le ricompense vengono assegnate quando un amico si iscrive dal tuo link o QR code di invito.",

--- a/messages/it.ts
+++ b/messages/it.ts
@@ -70,6 +70,8 @@ export const itMessages = {
     afterImageAlt: "Immagine generata",
     showBeforeImageLabel: "Mostra anche l'immagine prima",
     promptVisibilityLabel: "Visibilità del prompt",
+    promptVisibilityRewardHint:
+      "Guadagni +{amount} Percoin ogni volta che un follower crea con questo prompt.",
     promptVisibilityPublicOption: "Mostra il prompt",
     promptVisibilityPrivateOption: "Mantieni il prompt privato",
     promptVisibilityPublicHint: "I follower possono copiare il prompt. Le generazioni da una copia non vengono conteggiate.",
@@ -1367,6 +1369,13 @@ export const itMessages = {
     resetIn: "Azzera tra",
     tipsLabel: "Suggerimento:",
     dailyResetDescription: "Questa missione si azzera ogni giorno alle 00:00 JST.",
+    usageRewardTitle: "Ricompense per i creator",
+    usageRewardDescription:
+      "Guadagna Percoin quando altri creano con i tuoi prompt o stili.",
+    usageRewardFreeItem: "+{amount} Percoin quando il tuo prompt di /free viene usato",
+    usageRewardStyleItem: "+{amount} Percoin quando il tuo One-Tap Style viene usato",
+    usageRewardNote:
+      "Il tuo utilizzo non conta. Nemmeno le generazioni fatte copiando e incollando il prompt: valgono solo quelle avviate da «Crea con questo prompt» nell'app.",
     referralTitle: "Bonus invito",
     referralDescription:
       "Invita amici per guadagnare Percoin. Le ricompense vengono assegnate quando un amico si iscrive dal tuo link o QR code di invito.",

--- a/messages/ja.ts
+++ b/messages/ja.ts
@@ -67,6 +67,8 @@ export const jaMessages = {
     afterImageAlt: "生成済み画像",
     showBeforeImageLabel: "生成前の画像も表示する",
     promptVisibilityLabel: "プロンプトの公開設定",
+    promptVisibilityRewardHint:
+      "フォロワーがこのプロンプトで生成すると、1回につき +{amount} ペルコインが還元されます。",
     promptVisibilityPublicOption: "プロンプトを公開する",
     promptVisibilityPrivateOption: "プロンプトを非公開にする",
     promptVisibilityPublicHint: "フォロワーはプロンプトをコピーできます。コピーから作られた分は利用数に入りません。",
@@ -1310,6 +1312,13 @@ export const jaMessages = {
     resetIn: "リセットまで",
     tipsLabel: "Tips:",
     dailyResetDescription: "日本時間（JST）で毎日0時にリセットされます",
+    usageRewardTitle: "クリエイター還元",
+    usageRewardDescription:
+      "あなたのプロンプトやスタイルが他のユーザーに使われると、ペルコインが還元されます。",
+    usageRewardFreeItem: "あなたの /free のプロンプトが使われると +{amount} ペルコイン",
+    usageRewardStyleItem: "あなたの One-Tap Style が使われると +{amount} ペルコイン",
+    usageRewardNote:
+      "自分自身の利用は対象外です。プロンプトをコピーして貼り付けた生成も対象外で、アプリ内の「このプロンプトで作る」から使われた場合が対象です。",
     referralTitle: "友達紹介特典",
     referralDescription:
       "友達を招待してペルコインをゲット！紹介リンクまたはQRコードから友達が新規登録すると特典が付与されます。",

--- a/messages/ja.ts
+++ b/messages/ja.ts
@@ -68,7 +68,7 @@ export const jaMessages = {
     showBeforeImageLabel: "生成前の画像も表示する",
     promptVisibilityLabel: "プロンプトの公開設定",
     promptVisibilityRewardHint:
-      "フォロワーがこのプロンプトで生成すると、1回につき +{amount} ペルコインが還元されます。",
+      "フォロワーがこのプロンプトで生成すると、1回につき最大 +{amount} ペルコインが還元されます。",
     promptVisibilityPublicOption: "プロンプトを公開する",
     promptVisibilityPrivateOption: "プロンプトを非公開にする",
     promptVisibilityPublicHint: "フォロワーはプロンプトをコピーできます。コピーから作られた分は利用数に入りません。",
@@ -1315,10 +1315,12 @@ export const jaMessages = {
     usageRewardTitle: "クリエイター還元",
     usageRewardDescription:
       "あなたのプロンプトやスタイルが他のユーザーに使われると、ペルコインが還元されます。",
-    usageRewardFreeItem: "あなたの /free のプロンプトが使われると +{amount} ペルコイン",
-    usageRewardStyleItem: "あなたの One-Tap Style が使われると +{amount} ペルコイン",
+    usageRewardFreeItem:
+      "あなたの /free のプロンプトが使われると 最大 +{amount} ペルコイン",
+    usageRewardStyleItem:
+      "あなたの One-Tap Style が使われると 最大 +{amount} ペルコイン",
     usageRewardNote:
-      "自分自身の利用は対象外です。プロンプトをコピーして貼り付けた生成も対象外で、アプリ内の「このプロンプトで作る」から使われた場合が対象です。",
+      "自分自身の利用は対象外です。プロンプトをコピーして貼り付けた生成も対象外で、アプリ内の「このプロンプトで作る」から使われた場合が対象です。無料ペルコイン残高が上限に達している場合は還元されません。",
     referralTitle: "友達紹介特典",
     referralDescription:
       "友達を招待してペルコインをゲット！紹介リンクまたはQRコードから友達が新規登録すると特典が付与されます。",

--- a/messages/ko.ts
+++ b/messages/ko.ts
@@ -71,7 +71,7 @@ export const koMessages = {
     showBeforeImageLabel: "변경 전 이미지도 함께 표시",
     promptVisibilityLabel: "프롬프트 공개 설정",
     promptVisibilityRewardHint:
-      "팔로워가 이 프롬프트로 생성할 때마다 +{amount} 페르코인이 지급됩니다.",
+      "팔로워가 이 프롬프트로 생성할 때마다 최대 +{amount} 페르코인이 지급됩니다.",
     promptVisibilityPublicOption: "프롬프트 공개",
     promptVisibilityPrivateOption: "프롬프트 비공개",
     promptVisibilityPublicHint: "팔로워가 프롬프트를 복사할 수 있습니다. 복사본으로 만든 생성은 이용 수에 포함되지 않습니다.",
@@ -1368,10 +1368,12 @@ export const koMessages = {
     usageRewardTitle: "크리에이터 보상",
     usageRewardDescription:
       "다른 사용자가 회원님의 프롬프트나 스타일로 생성하면 페르코인이 지급됩니다.",
-    usageRewardFreeItem: "회원님의 /free 프롬프트가 이용되면 +{amount} 페르코인",
-    usageRewardStyleItem: "회원님의 One-Tap Style이 이용되면 +{amount} 페르코인",
+    usageRewardFreeItem:
+      "회원님의 /free 프롬프트가 이용되면 최대 +{amount} 페르코인",
+    usageRewardStyleItem:
+      "회원님의 One-Tap Style이 이용되면 최대 +{amount} 페르코인",
     usageRewardNote:
-      "본인의 이용은 제외됩니다. 프롬프트를 복사해 붙여넣은 생성도 제외되며, 앱 내 ‘이 프롬프트로 만들기’에서 이용된 경우가 대상입니다.",
+      "본인의 이용은 제외됩니다. 프롬프트를 복사해 붙여넣은 생성도 제외되며, 앱 내 ‘이 프롬프트로 만들기’에서 이용된 경우가 대상입니다. 무료 페르코인 잔액이 상한에 도달하면 지급되지 않습니다.",
     referralTitle: "추천 보너스",
     referralDescription:
       "친구를 초대하면 Percoin을 받을 수 있습니다. 친구가 추천 링크 또는 QR 코드로 가입하면 보상이 지급됩니다.",

--- a/messages/ko.ts
+++ b/messages/ko.ts
@@ -70,6 +70,8 @@ export const koMessages = {
     afterImageAlt: "생성된 이미지",
     showBeforeImageLabel: "변경 전 이미지도 함께 표시",
     promptVisibilityLabel: "프롬프트 공개 설정",
+    promptVisibilityRewardHint:
+      "팔로워가 이 프롬프트로 생성할 때마다 +{amount} 페르코인이 지급됩니다.",
     promptVisibilityPublicOption: "프롬프트 공개",
     promptVisibilityPrivateOption: "프롬프트 비공개",
     promptVisibilityPublicHint: "팔로워가 프롬프트를 복사할 수 있습니다. 복사본으로 만든 생성은 이용 수에 포함되지 않습니다.",
@@ -1363,6 +1365,13 @@ export const koMessages = {
     resetIn: "초기화까지",
     tipsLabel: "팁:",
     dailyResetDescription: "이 미션은 매일 JST 00:00에 초기화됩니다.",
+    usageRewardTitle: "크리에이터 보상",
+    usageRewardDescription:
+      "다른 사용자가 회원님의 프롬프트나 스타일로 생성하면 페르코인이 지급됩니다.",
+    usageRewardFreeItem: "회원님의 /free 프롬프트가 이용되면 +{amount} 페르코인",
+    usageRewardStyleItem: "회원님의 One-Tap Style이 이용되면 +{amount} 페르코인",
+    usageRewardNote:
+      "본인의 이용은 제외됩니다. 프롬프트를 복사해 붙여넣은 생성도 제외되며, 앱 내 ‘이 프롬프트로 만들기’에서 이용된 경우가 대상입니다.",
     referralTitle: "추천 보너스",
     referralDescription:
       "친구를 초대하면 Percoin을 받을 수 있습니다. 친구가 추천 링크 또는 QR 코드로 가입하면 보상이 지급됩니다.",

--- a/messages/pt.ts
+++ b/messages/pt.ts
@@ -71,7 +71,7 @@ export const ptMessages = {
     showBeforeImageLabel: "Mostrar também a imagem antes",
     promptVisibilityLabel: "Visibilidade do prompt",
     promptVisibilityRewardHint:
-      "Você ganha +{amount} Percoins cada vez que um seguidor cria com este prompt.",
+      "Você ganha até +{amount} Percoins cada vez que um seguidor cria com este prompt.",
     promptVisibilityPublicOption: "Mostrar o prompt",
     promptVisibilityPrivateOption: "Manter o prompt privado",
     promptVisibilityPublicHint: "Seus seguidores podem copiar o prompt. Gerações feitas a partir de uma cópia não são contadas.",
@@ -1372,10 +1372,12 @@ export const ptMessages = {
     usageRewardTitle: "Recompensas para criadores",
     usageRewardDescription:
       "Ganhe Percoins quando outras pessoas criarem com seus prompts ou estilos.",
-    usageRewardFreeItem: "+{amount} Percoins quando seu prompt do /free é usado",
-    usageRewardStyleItem: "+{amount} Percoins quando seu One-Tap Style é usado",
+    usageRewardFreeItem:
+      "Até +{amount} Percoins quando seu prompt do /free é usado",
+    usageRewardStyleItem:
+      "Até +{amount} Percoins quando seu One-Tap Style é usado",
     usageRewardNote:
-      "Seu próprio uso não conta. Gerações feitas copiando e colando o prompt também não: só valem as iniciadas em “Criar com este prompt” no app.",
+      "Seu próprio uso não conta. Gerações feitas copiando e colando o prompt também não: só valem as iniciadas em “Criar com este prompt” no app. Nada é concedido quando seu saldo de Percoins gratuitos atinge o limite.",
     referralTitle: "Bônus de indicação",
     referralDescription:
       "Convide amigos para ganhar Percoins. As recompensas são concedidas quando alguém se cadastra pelo seu link ou QR code de indicação.",

--- a/messages/pt.ts
+++ b/messages/pt.ts
@@ -70,6 +70,8 @@ export const ptMessages = {
     afterImageAlt: "Imagem gerada",
     showBeforeImageLabel: "Mostrar também a imagem antes",
     promptVisibilityLabel: "Visibilidade do prompt",
+    promptVisibilityRewardHint:
+      "Você ganha +{amount} Percoins cada vez que um seguidor cria com este prompt.",
     promptVisibilityPublicOption: "Mostrar o prompt",
     promptVisibilityPrivateOption: "Manter o prompt privado",
     promptVisibilityPublicHint: "Seus seguidores podem copiar o prompt. Gerações feitas a partir de uma cópia não são contadas.",
@@ -1367,6 +1369,13 @@ export const ptMessages = {
     resetIn: "Reseta em",
     tipsLabel: "Dica:",
     dailyResetDescription: "Esta missão reseta todos os dias às 00:00 JST.",
+    usageRewardTitle: "Recompensas para criadores",
+    usageRewardDescription:
+      "Ganhe Percoins quando outras pessoas criarem com seus prompts ou estilos.",
+    usageRewardFreeItem: "+{amount} Percoins quando seu prompt do /free é usado",
+    usageRewardStyleItem: "+{amount} Percoins quando seu One-Tap Style é usado",
+    usageRewardNote:
+      "Seu próprio uso não conta. Gerações feitas copiando e colando o prompt também não: só valem as iniciadas em “Criar com este prompt” no app.",
     referralTitle: "Bônus de indicação",
     referralDescription:
       "Convide amigos para ganhar Percoins. As recompensas são concedidas quando alguém se cadastra pelo seu link ou QR code de indicação.",

--- a/messages/th.ts
+++ b/messages/th.ts
@@ -71,7 +71,7 @@ export const thMessages = {
     showBeforeImageLabel: "แสดงรูปก่อนเปลี่ยนด้วย",
     promptVisibilityLabel: "การเปิดเผยพรอมต์",
     promptVisibilityRewardHint:
-      "คุณจะได้รับ +{amount} เพอร์คอยน์ ทุกครั้งที่ผู้ติดตามสร้างด้วยพรอมต์นี้",
+      "คุณจะได้รับสูงสุด +{amount} เพอร์คอยน์ ทุกครั้งที่ผู้ติดตามสร้างด้วยพรอมต์นี้",
     promptVisibilityPublicOption: "แสดงพรอมต์",
     promptVisibilityPrivateOption: "ตั้งพรอมต์เป็นส่วนตัว",
     promptVisibilityPublicHint: "ผู้ติดตามคัดลอกพรอมต์ได้ งานที่สร้างจากสำเนาจะไม่ถูกนับ",
@@ -1368,10 +1368,12 @@ export const thMessages = {
     usageRewardTitle: "รางวัลครีเอเตอร์",
     usageRewardDescription:
       "รับเพอร์คอยน์เมื่อผู้ใช้คนอื่นสร้างผลงานด้วยพรอมต์หรือสไตล์ของคุณ",
-    usageRewardFreeItem: "+{amount} เพอร์คอยน์ เมื่อพรอมต์ /free ของคุณถูกใช้",
-    usageRewardStyleItem: "+{amount} เพอร์คอยน์ เมื่อ One-Tap Style ของคุณถูกใช้",
+    usageRewardFreeItem:
+      "สูงสุด +{amount} เพอร์คอยน์ เมื่อพรอมต์ /free ของคุณถูกใช้",
+    usageRewardStyleItem:
+      "สูงสุด +{amount} เพอร์คอยน์ เมื่อ One-Tap Style ของคุณถูกใช้",
     usageRewardNote:
-      "การใช้งานของคุณเองไม่นับ การสร้างด้วยการคัดลอกพรอมต์ไปวางก็ไม่นับ นับเฉพาะที่เริ่มจาก “สร้างด้วยพรอมต์นี้” ในแอปเท่านั้น",
+      "การใช้งานของคุณเองไม่นับ การสร้างด้วยการคัดลอกพรอมต์ไปวางก็ไม่นับ นับเฉพาะที่เริ่มจาก “สร้างด้วยพรอมต์นี้” ในแอปเท่านั้น และจะไม่ได้รับเมื่อยอดเพอร์คอยน์ฟรีถึงขีดจำกัดแล้ว",
     referralTitle: "โบนัสแนะนำ",
     referralDescription:
       "ชวนเพื่อนเพื่อรับ Percoin จะได้รับรางวัลเมื่อมีคนสมัครจากลิงก์หรือ QR code แนะนำของคุณ",

--- a/messages/th.ts
+++ b/messages/th.ts
@@ -70,6 +70,8 @@ export const thMessages = {
     afterImageAlt: "รูปที่สร้าง",
     showBeforeImageLabel: "แสดงรูปก่อนเปลี่ยนด้วย",
     promptVisibilityLabel: "การเปิดเผยพรอมต์",
+    promptVisibilityRewardHint:
+      "คุณจะได้รับ +{amount} เพอร์คอยน์ ทุกครั้งที่ผู้ติดตามสร้างด้วยพรอมต์นี้",
     promptVisibilityPublicOption: "แสดงพรอมต์",
     promptVisibilityPrivateOption: "ตั้งพรอมต์เป็นส่วนตัว",
     promptVisibilityPublicHint: "ผู้ติดตามคัดลอกพรอมต์ได้ งานที่สร้างจากสำเนาจะไม่ถูกนับ",
@@ -1363,6 +1365,13 @@ export const thMessages = {
     resetIn: "รีเซ็ตในอีก",
     tipsLabel: "เคล็ดลับ:",
     dailyResetDescription: "ภารกิจนี้รีเซ็ตทุกวันเวลา 00:00 JST",
+    usageRewardTitle: "รางวัลครีเอเตอร์",
+    usageRewardDescription:
+      "รับเพอร์คอยน์เมื่อผู้ใช้คนอื่นสร้างผลงานด้วยพรอมต์หรือสไตล์ของคุณ",
+    usageRewardFreeItem: "+{amount} เพอร์คอยน์ เมื่อพรอมต์ /free ของคุณถูกใช้",
+    usageRewardStyleItem: "+{amount} เพอร์คอยน์ เมื่อ One-Tap Style ของคุณถูกใช้",
+    usageRewardNote:
+      "การใช้งานของคุณเองไม่นับ การสร้างด้วยการคัดลอกพรอมต์ไปวางก็ไม่นับ นับเฉพาะที่เริ่มจาก “สร้างด้วยพรอมต์นี้” ในแอปเท่านั้น",
     referralTitle: "โบนัสแนะนำ",
     referralDescription:
       "ชวนเพื่อนเพื่อรับ Percoin จะได้รับรางวัลเมื่อมีคนสมัครจากลิงก์หรือ QR code แนะนำของคุณ",

--- a/messages/vi.ts
+++ b/messages/vi.ts
@@ -70,6 +70,8 @@ export const viMessages = {
     afterImageAlt: "Hình đã tạo",
     showBeforeImageLabel: "Hiển thị cả hình trước khi đổi",
     promptVisibilityLabel: "Hiển thị câu lệnh",
+    promptVisibilityRewardHint:
+      "Bạn nhận +{amount} Percoin mỗi lần người theo dõi tạo ảnh bằng prompt này.",
     promptVisibilityPublicOption: "Hiện câu lệnh",
     promptVisibilityPrivateOption: "Giữ câu lệnh riêng tư",
     promptVisibilityPublicHint: "Người theo dõi có thể sao chép câu lệnh. Ảnh tạo từ bản sao không được tính.",
@@ -1364,6 +1366,13 @@ export const viMessages = {
     resetIn: "Reset trong",
     tipsLabel: "Mẹo:",
     dailyResetDescription: "Nhiệm vụ này reset hằng ngày lúc 00:00 JST.",
+    usageRewardTitle: "Thưởng cho nhà sáng tạo",
+    usageRewardDescription:
+      "Nhận Percoin khi người khác sáng tạo bằng prompt hoặc style của bạn.",
+    usageRewardFreeItem: "+{amount} Percoin khi prompt /free của bạn được dùng",
+    usageRewardStyleItem: "+{amount} Percoin khi One-Tap Style của bạn được dùng",
+    usageRewardNote:
+      "Bạn tự dùng thì không tính. Tạo ảnh bằng cách sao chép prompt cũng không tính — chỉ tính khi bắt đầu từ “Tạo với prompt này” trong ứng dụng.",
     referralTitle: "Thưởng giới thiệu",
     referralDescription:
       "Mời bạn bè để nhận Percoin. Phần thưởng được cấp khi bạn bè đăng ký từ liên kết hoặc QR code giới thiệu của bạn.",

--- a/messages/vi.ts
+++ b/messages/vi.ts
@@ -71,7 +71,7 @@ export const viMessages = {
     showBeforeImageLabel: "Hiển thị cả hình trước khi đổi",
     promptVisibilityLabel: "Hiển thị câu lệnh",
     promptVisibilityRewardHint:
-      "Bạn nhận +{amount} Percoin mỗi lần người theo dõi tạo ảnh bằng prompt này.",
+      "Bạn nhận tối đa +{amount} Percoin mỗi lần người theo dõi tạo ảnh bằng prompt này.",
     promptVisibilityPublicOption: "Hiện câu lệnh",
     promptVisibilityPrivateOption: "Giữ câu lệnh riêng tư",
     promptVisibilityPublicHint: "Người theo dõi có thể sao chép câu lệnh. Ảnh tạo từ bản sao không được tính.",
@@ -1369,10 +1369,12 @@ export const viMessages = {
     usageRewardTitle: "Thưởng cho nhà sáng tạo",
     usageRewardDescription:
       "Nhận Percoin khi người khác sáng tạo bằng prompt hoặc style của bạn.",
-    usageRewardFreeItem: "+{amount} Percoin khi prompt /free của bạn được dùng",
-    usageRewardStyleItem: "+{amount} Percoin khi One-Tap Style của bạn được dùng",
+    usageRewardFreeItem:
+      "Tối đa +{amount} Percoin khi prompt /free của bạn được dùng",
+    usageRewardStyleItem:
+      "Tối đa +{amount} Percoin khi One-Tap Style của bạn được dùng",
     usageRewardNote:
-      "Bạn tự dùng thì không tính. Tạo ảnh bằng cách sao chép prompt cũng không tính — chỉ tính khi bắt đầu từ “Tạo với prompt này” trong ứng dụng.",
+      "Bạn tự dùng thì không tính. Tạo ảnh bằng cách sao chép prompt cũng không tính — chỉ tính khi bắt đầu từ “Tạo với prompt này” trong ứng dụng. Sẽ không được cộng khi số dư Percoin miễn phí đã đạt giới hạn.",
     referralTitle: "Thưởng giới thiệu",
     referralDescription:
       "Mời bạn bè để nhận Percoin. Phần thưởng được cấp khi bạn bè đăng ký từ liên kết hoặc QR code giới thiệu của bạn.",

--- a/messages/zh-CN.ts
+++ b/messages/zh-CN.ts
@@ -71,7 +71,7 @@ export const zhCnMessages = {
     showBeforeImageLabel: "同时显示更换前的图片",
     promptVisibilityLabel: "提示词公开设置",
     promptVisibilityRewardHint:
-      "关注者每次使用此提示词生成，你将获得 +{amount} 佩尔币。",
+      "关注者每次使用此提示词生成，你最多可获得 +{amount} 佩尔币。",
     promptVisibilityPublicOption: "公开提示词",
     promptVisibilityPrivateOption: "将提示词设为私密",
     promptVisibilityPublicHint: "关注者可以复制提示词。用复制的内容生成不计入使用数。",
@@ -1367,10 +1367,12 @@ export const zhCnMessages = {
     usageRewardTitle: "创作者回馈",
     usageRewardDescription:
       "当其他用户使用你的提示词或风格生成时，你将获得佩尔币。",
-    usageRewardFreeItem: "你的 /free 提示词被使用时 +{amount} 佩尔币",
-    usageRewardStyleItem: "你的 One-Tap Style 被使用时 +{amount} 佩尔币",
+    usageRewardFreeItem:
+      "你的 /free 提示词被使用时 最多 +{amount} 佩尔币",
+    usageRewardStyleItem:
+      "你的 One-Tap Style 被使用时 最多 +{amount} 佩尔币",
     usageRewardNote:
-      "自己使用不计入。复制粘贴提示词的生成也不计入，仅限从应用内“用这个提示词创作”发起的生成。",
+      "自己使用不计入。复制粘贴提示词的生成也不计入，仅限从应用内“用这个提示词创作”发起的生成。免费佩尔币余额达到上限后将不再发放。",
     referralTitle: "推荐奖励",
     referralDescription:
       "邀请好友即可获得 Percoin。当有人通过你的推荐链接或二维码注册时，会发放奖励。",

--- a/messages/zh-CN.ts
+++ b/messages/zh-CN.ts
@@ -70,6 +70,8 @@ export const zhCnMessages = {
     afterImageAlt: "生成图片",
     showBeforeImageLabel: "同时显示更换前的图片",
     promptVisibilityLabel: "提示词公开设置",
+    promptVisibilityRewardHint:
+      "关注者每次使用此提示词生成，你将获得 +{amount} 佩尔币。",
     promptVisibilityPublicOption: "公开提示词",
     promptVisibilityPrivateOption: "将提示词设为私密",
     promptVisibilityPublicHint: "关注者可以复制提示词。用复制的内容生成不计入使用数。",
@@ -1362,6 +1364,13 @@ export const zhCnMessages = {
     resetIn: "距重置",
     tipsLabel: "提示:",
     dailyResetDescription: "本任务每天 JST 00:00 重置。",
+    usageRewardTitle: "创作者回馈",
+    usageRewardDescription:
+      "当其他用户使用你的提示词或风格生成时，你将获得佩尔币。",
+    usageRewardFreeItem: "你的 /free 提示词被使用时 +{amount} 佩尔币",
+    usageRewardStyleItem: "你的 One-Tap Style 被使用时 +{amount} 佩尔币",
+    usageRewardNote:
+      "自己使用不计入。复制粘贴提示词的生成也不计入，仅限从应用内“用这个提示词创作”发起的生成。",
     referralTitle: "推荐奖励",
     referralDescription:
       "邀请好友即可获得 Percoin。当有人通过你的推荐链接或二维码注册时，会发放奖励。",

--- a/messages/zh-TW.ts
+++ b/messages/zh-TW.ts
@@ -71,7 +71,7 @@ export const zhTwMessages = {
     showBeforeImageLabel: "同時顯示更換前的圖片",
     promptVisibilityLabel: "提示詞公開設定",
     promptVisibilityRewardHint:
-      "追蹤者每次使用此提示詞生成，你將獲得 +{amount} 佩爾幣。",
+      "追蹤者每次使用此提示詞生成，你最多可獲得 +{amount} 佩爾幣。",
     promptVisibilityPublicOption: "公開提示詞",
     promptVisibilityPrivateOption: "將提示詞設為私密",
     promptVisibilityPublicHint: "追蹤者可以複製提示詞。用複製的內容生成不計入使用數。",
@@ -1367,10 +1367,12 @@ export const zhTwMessages = {
     usageRewardTitle: "創作者回饋",
     usageRewardDescription:
       "當其他使用者使用你的提示詞或風格生成時，你將獲得佩爾幣。",
-    usageRewardFreeItem: "你的 /free 提示詞被使用時 +{amount} 佩爾幣",
-    usageRewardStyleItem: "你的 One-Tap Style 被使用時 +{amount} 佩爾幣",
+    usageRewardFreeItem:
+      "你的 /free 提示詞被使用時 最多 +{amount} 佩爾幣",
+    usageRewardStyleItem:
+      "你的 One-Tap Style 被使用時 最多 +{amount} 佩爾幣",
     usageRewardNote:
-      "自己使用不計入。複製貼上提示詞的生成也不計入，僅限從應用程式內「用這個提示詞創作」發起的生成。",
+      "自己使用不計入。複製貼上提示詞的生成也不計入，僅限從應用程式內「用這個提示詞創作」發起的生成。免費佩爾幣餘額達到上限後將不再發放。",
     referralTitle: "推薦獎勵",
     referralDescription:
       "邀請好友即可獲得 Percoin。當有人透過你的推薦連結或 QR Code 註冊時，即會發放獎勵。",

--- a/messages/zh-TW.ts
+++ b/messages/zh-TW.ts
@@ -70,6 +70,8 @@ export const zhTwMessages = {
     afterImageAlt: "生成圖片",
     showBeforeImageLabel: "同時顯示更換前的圖片",
     promptVisibilityLabel: "提示詞公開設定",
+    promptVisibilityRewardHint:
+      "追蹤者每次使用此提示詞生成，你將獲得 +{amount} 佩爾幣。",
     promptVisibilityPublicOption: "公開提示詞",
     promptVisibilityPrivateOption: "將提示詞設為私密",
     promptVisibilityPublicHint: "追蹤者可以複製提示詞。用複製的內容生成不計入使用數。",
@@ -1362,6 +1364,13 @@ export const zhTwMessages = {
     resetIn: "距離重置",
     tipsLabel: "小提示:",
     dailyResetDescription: "本任務每天 JST 00:00 重置。",
+    usageRewardTitle: "創作者回饋",
+    usageRewardDescription:
+      "當其他使用者使用你的提示詞或風格生成時，你將獲得佩爾幣。",
+    usageRewardFreeItem: "你的 /free 提示詞被使用時 +{amount} 佩爾幣",
+    usageRewardStyleItem: "你的 One-Tap Style 被使用時 +{amount} 佩爾幣",
+    usageRewardNote:
+      "自己使用不計入。複製貼上提示詞的生成也不計入，僅限從應用程式內「用這個提示詞創作」發起的生成。",
     referralTitle: "推薦獎勵",
     referralDescription:
       "邀請好友即可獲得 Percoin。當有人透過你的推薦連結或 QR Code 註冊時，即會發放獎勵。",

--- a/tests/unit/features/credits/use-usage-reward-amounts.test.tsx
+++ b/tests/unit/features/credits/use-usage-reward-amounts.test.tsx
@@ -79,4 +79,65 @@ describe("useUsageRewardAmounts", () => {
     });
     expect(result.current.promptUsageRewardAmount).toBe(0);
   });
+
+  describe("キャッシュの契約", () => {
+    test("期限内は再取得しない（モーダルの開閉でリクエストが増えない）", async () => {
+      mockFetchJson({ promptUsageRewardAmount: 2, styleUsageRewardAmount: 5 });
+
+      const first = renderHook(() => useUsageRewardAmounts());
+      await waitFor(() => {
+        expect(first.result.current.promptUsageRewardAmount).toBe(2);
+      });
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+
+      // 開き直し（再マウント）
+      const second = renderHook(() => useUsageRewardAmounts());
+      await waitFor(() => {
+        expect(second.result.current.promptUsageRewardAmount).toBe(2);
+      });
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    test("期限が切れたら取り直す（運営が0へ変えたら告知が消える）", async () => {
+      const now = Date.now();
+      const nowSpy = jest.spyOn(Date, "now").mockReturnValue(now);
+      mockFetchJson({ promptUsageRewardAmount: 2, styleUsageRewardAmount: 5 });
+
+      const first = renderHook(() => useUsageRewardAmounts());
+      await waitFor(() => {
+        expect(first.result.current.promptUsageRewardAmount).toBe(2);
+      });
+
+      // 5分経過 + 運営が停止(0)に変更
+      nowSpy.mockReturnValue(now + 5 * 60 * 1000 + 1);
+      mockFetchJson({ promptUsageRewardAmount: 0, styleUsageRewardAmount: 0 });
+
+      const second = renderHook(() => useUsageRewardAmounts());
+      await waitFor(() => {
+        expect(second.result.current.promptUsageRewardAmount).toBe(0);
+      });
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+
+      nowSpy.mockRestore();
+    });
+
+    test("通信失敗も期限内はキャッシュする（障害中に連打しない）", async () => {
+      global.fetch = jest
+        .fn()
+        .mockRejectedValue(new Error("network down")) as unknown as typeof fetch;
+
+      const first = renderHook(() => useUsageRewardAmounts());
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+      });
+      expect(first.result.current.promptUsageRewardAmount).toBe(0);
+
+      const second = renderHook(() => useUsageRewardAmounts());
+      await waitFor(() => {
+        expect(second.result.current.promptUsageRewardAmount).toBe(0);
+      });
+      // 開き直しても再試行しない
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/tests/unit/features/credits/use-usage-reward-amounts.test.tsx
+++ b/tests/unit/features/credits/use-usage-reward-amounts.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * features/credits/hooks/useUsageRewardAmounts のテスト。
+ *
+ * クリエイター還元の告知は「運営が付与額を0にしている間は出さない」のが要件。
+ * 取得前・取得失敗・不正な値のいずれでも 0 を返し、
+ * 「もらえないのに告知だけ出る」ことがないことを固定する。
+ */
+import { renderHook, waitFor } from "@testing-library/react";
+import {
+  useUsageRewardAmounts,
+  __resetUsageRewardAmountsCacheForTests,
+} from "@/features/credits/hooks/useUsageRewardAmounts";
+
+const originalFetch = global.fetch;
+
+function mockFetchJson(body: unknown, ok = true) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok,
+    json: async () => body,
+  }) as unknown as typeof fetch;
+}
+
+describe("useUsageRewardAmounts", () => {
+  beforeEach(() => {
+    __resetUsageRewardAmountsCacheForTests();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  test("取得前は0を返し、取得できたら設定値になる", async () => {
+    mockFetchJson({ promptUsageRewardAmount: 2, styleUsageRewardAmount: 5 });
+
+    const { result } = renderHook(() => useUsageRewardAmounts());
+
+    // 初回レンダー時点では 0（告知を出さない側に倒す）
+    expect(result.current.promptUsageRewardAmount).toBe(0);
+
+    await waitFor(() => {
+      expect(result.current.promptUsageRewardAmount).toBe(2);
+    });
+    expect(result.current.styleUsageRewardAmount).toBe(5);
+  });
+
+  test("取得に失敗しても0のままで例外を投げない", async () => {
+    global.fetch = jest
+      .fn()
+      .mockRejectedValue(new Error("network down")) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useUsageRewardAmounts());
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled();
+    });
+    expect(result.current.promptUsageRewardAmount).toBe(0);
+    expect(result.current.styleUsageRewardAmount).toBe(0);
+  });
+
+  test("数値以外が返っても0として扱う", async () => {
+    mockFetchJson({ promptUsageRewardAmount: "2" });
+
+    const { result } = renderHook(() => useUsageRewardAmounts());
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled();
+    });
+    expect(result.current.promptUsageRewardAmount).toBe(0);
+    expect(result.current.styleUsageRewardAmount).toBe(0);
+  });
+
+  test("レスポンスがokでないときも0", async () => {
+    mockFetchJson({ promptUsageRewardAmount: 9 }, false);
+
+    const { result } = renderHook(() => useUsageRewardAmounts());
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled();
+    });
+    expect(result.current.promptUsageRewardAmount).toBe(0);
+  });
+});


### PR DESCRIPTION
## 概要

クリエイター還元（#483 の付与・#486 の通知）は本番稼働していますが、**ユーザー向けの案内がどこにもなく、通知が届いて初めて存在に気づく**状態でした。「使われると還元がある」と事前に知っていれば投稿の動機になるため、2箇所で告知します。

## 表示場所

### ① ミッションページ（`/challenge`）
デイリー投稿・連続ログイン・友達紹介が並ぶ場所に「**クリエイター還元**」カードを追加。Free / Style それぞれの付与額を併記します。

### ② `/free` 投稿シート（プロンプトの公開設定の上）
> 🪙 フォロワーがこのプロンプトで生成すると、1回につき +2 ペルコインが還元されます。

投稿する直前に見えるので、動機づけとして最も効く位置です。

## 「0なら非表示」の担保

運営が付与額を0（停止中）にしている間は、**カードも一行も出しません**。さらに：

- **取得前**（初回レンダー時）も 0 扱い
- **取得失敗時**も 0 扱い
- **数値以外が返ったとき**も 0 扱い
- **`fetch` が無い環境**でも 0 扱い

いずれも「出さない側」に倒しているので、**もらえないのに告知だけ出ることはありません**。テストで固定しています。

## 額の扱い

額は admin でいつでも変わる（通常2・イベント時5・停止時0）ため、**文言に埋め込まず設定値から取ります**。

- `getPercoinDefaultsForDisplay` を還元2種に拡張（ミッションページはサーバー側で取得）
- 投稿シートはクライアントなので `/api/percoin/usage-reward` 経由。投稿モーダルは何度も開閉されるため**モジュールスコープでキャッシュ**して都度リクエストしない
- **サブスク倍率は掛けません**（還元は利用者側の行動で発生するもので、受け手のプラン特典ではないため）

## 注意書き

両方に、還元されない条件を明記しています：

- 自分自身の利用は対象外
- **プロンプトをコピーして貼り付けた生成は対象外**（アプリ内の「このプロンプトで作る」経由のみ）

## 検証

- `npm run lint` … main 既存の 23E/57W と同一（新規指摘ゼロ）
- `npm run typecheck` … エラーなし
- `npm run test` … 314 suites / 3,154 passed（新規4件）
- `npm run build -- --webpack` … 成功

実装中に、追加した API の `revalidate` がこのプロジェクトの `nextConfig.cacheComponents` と非互換でビルドが落ちたため削除し、`useEffect` 内の同期 `setState` も lint 規約（`react-hooks/set-state-in-effect`）に合わせて解消しています。
