### PR TITLE
fix(campaigns): X応募ボタンを文言のみにし投稿本文を改行レイアウトへ

### DIFF
--- a/features/campaigns/components/XLotteryEntryButton.tsx
+++ b/features/campaigns/components/XLotteryEntryButton.tsx
@@ -78,19 +78,16 @@ export function XLotteryEntryButton({
 
   if (variant === "chrome") {
     // book リーダー用: 没入UIの下部に置くコンパクト版。
-    // 賞品はボタン内に短く出し、詳細は規約リンクへ逃がす。
+    // 賞品などの詳細は規約リンクへ逃がし、ボタンは文言だけに絞る。
     return (
       <div className="flex flex-col items-center gap-1.5">
         <button
           type="button"
           onClick={handleClick}
-          className="inline-flex items-center gap-2 rounded-full bg-[#1d1d1f] px-5 py-2.5 text-sm font-bold text-white shadow-lg transition-transform hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300"
+          className="inline-flex items-center gap-2 rounded-full bg-[#1d1d1f] px-6 py-2.5 text-sm font-bold text-white shadow-lg transition-transform hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300"
         >
           {xIcon}
           Xで応募する
-          <span className="rounded-full bg-amber-400 px-2 py-0.5 text-[10px] font-bold text-black">
-            🎁 {copy.prizeLabel}
-          </span>
         </button>
         <Link
           href={copy.rulesPath}

--- a/features/campaigns/x-lottery-campaign.ts
+++ b/features/campaigns/x-lottery-campaign.ts
@@ -54,9 +54,9 @@ export const X_LOTTERY_CAMPAIGNS: Readonly<Record<string, XLotteryCopy>> = {
   },
   // うちの子のファッション雑誌：夏(2026-08-08 19:00〜08-16 21:59)
   fashion_magazine_summer: {
-    hashtags: ["うちの子のファッション雑誌"],
+    hashtags: ["うちの子のファッション雑誌", "PerstaAI"],
     mention: "mickey_fuku",
-    message: "うちの子のファッション雑誌、1冊完成しました！",
+    message: "うちの子のファッション雑誌、完成しました！",
     prizeLabel: "Amazonギフト券2,000円分",
     winnersLabel: "5名様",
     rulesPath: "/campaigns/fashion-magazine-lottery",
@@ -88,19 +88,28 @@ export function isLotteryEntryOpen(
 
 /**
  * 応募用の X intent(post) URL を組み立てる。
- * text にメッセージ + 主催者メンション、hashtags にタグ、url に台紙シェアURLを渡す。
- * → 投稿に「メッセージ + @メンション + OGPカード + #ハッシュタグ」が入り、
- *   Xガイドラインの「主催者@ユーザー名を含める」を満たしつつ応募回収できる。
+ *
+ * url / hashtags パラメータを使うと本文が1行に連結されて読みにくいため、
+ * 改行込みのレイアウトを text 1パラメータにまとめて渡す:
+ *
+ *   {メッセージ}
+ *   {シェアURL}
+ *   (空行)
+ *   @{メンション}
+ *   #{タグ} #{タグ}
+ *
+ * OGPカードは本文中のURLから展開される。@メンションと#タグが本文に入るので
+ * Xガイドラインの「主催者@ユーザー名を含める」も満たしつつ応募回収できる。
  */
 export function buildXLotteryIntentUrl(
   copy: XLotteryCopy,
   shareUrl: string,
 ): string {
-  const params = new URLSearchParams();
-  params.set("text", `${copy.message} @${copy.mention}`);
-  params.set("url", shareUrl);
+  const lines = [copy.message, shareUrl, "", `@${copy.mention}`];
   if (copy.hashtags.length > 0) {
-    params.set("hashtags", copy.hashtags.join(","));
+    lines.push(copy.hashtags.map((tag) => `#${tag}`).join(" "));
   }
+  const params = new URLSearchParams();
+  params.set("text", lines.join("\n"));
   return `https://x.com/intent/post?${params.toString()}`;
 }

--- a/tests/unit/features/campaigns/x-lottery-campaign.test.ts
+++ b/tests/unit/features/campaigns/x-lottery-campaign.test.ts
@@ -56,7 +56,7 @@ describe("isLotteryEntryOpen", () => {
 });
 
 describe("buildXLotteryIntentUrl", () => {
-  test("text にメッセージ+メンション、hashtags にタグ、url に台紙URLが入る", () => {
+  test("text 1パラメータに「メッセージ/URL/空行/@メンション/タグ行」の改行レイアウトで入る", () => {
     const url = buildXLotteryIntentUrl(
       COPY,
       "https://www.persta.ai/m/abc?v=123",
@@ -64,20 +64,25 @@ describe("buildXLotteryIntentUrl", () => {
     const parsed = new URL(url);
     expect(parsed.origin + parsed.pathname).toBe("https://x.com/intent/post");
     expect(parsed.searchParams.get("text")).toBe(
-      "うちの子のことわざ辞典をコンプリートしました！ @mickey_fuku",
+      [
+        "うちの子のことわざ辞典をコンプリートしました！",
+        "https://www.persta.ai/m/abc?v=123",
+        "",
+        "@mickey_fuku",
+        "#うちの子のことわざ辞典",
+      ].join("\n"),
     );
-    expect(parsed.searchParams.get("hashtags")).toBe("うちの子のことわざ辞典");
-    expect(parsed.searchParams.get("url")).toBe(
-      "https://www.persta.ai/m/abc?v=123",
-    );
+    // 1行連結表示になる url / hashtags パラメータは使わない
+    expect(parsed.searchParams.get("url")).toBeNull();
+    expect(parsed.searchParams.get("hashtags")).toBeNull();
   });
 
-  test("複数ハッシュタグはカンマ区切り", () => {
+  test("複数ハッシュタグは # 付きスペース区切りで1行にまとまる", () => {
     const url = buildXLotteryIntentUrl(
       { ...COPY, hashtags: ["タグA", "タグB"] },
       "https://www.persta.ai/m/abc",
     );
-    expect(new URL(url).searchParams.get("hashtags")).toBe("タグA,タグB");
+    expect(new URL(url).searchParams.get("text")).toContain("#タグA #タグB");
   });
 
   test("登録済みキャンペーンの文面でも組み立てられる", () => {
@@ -92,7 +97,7 @@ describe("getXLotteryCopy", () => {
   test("ファッション雑誌の文面が引ける(タグ・メンション・5名様・規約パス)", () => {
     const copy = getXLotteryCopy("fashion_magazine_summer");
     expect(copy).not.toBeNull();
-    expect(copy?.hashtags).toEqual(["うちの子のファッション雑誌"]);
+    expect(copy?.hashtags).toEqual(["うちの子のファッション雑誌", "PerstaAI"]);
     expect(copy?.mention).toBe("mickey_fuku");
     expect(copy?.winnersLabel).toBe("5名様");
     expect(copy?.prizeLabel).toBe("Amazonギフト券2,000円分");
@@ -109,14 +114,20 @@ describe("getXLotteryCopy", () => {
     expect(getXLotteryCopy("unknown_category")).toBeNull();
   });
 
-  test("応募intentにファッション雑誌の応募要件が全部入る", () => {
+  test("応募intentのファッション雑誌の投稿本文がユーザー確定レイアウトと一致する", () => {
     const copy = getXLotteryCopy("fashion_magazine_summer");
     if (!copy) throw new Error("copy missing");
     const url = new URL(
       buildXLotteryIntentUrl(copy, "https://www.persta.ai/m/abc/book"),
     );
-    expect(url.searchParams.get("text")).toContain("@mickey_fuku");
-    expect(url.searchParams.get("hashtags")).toBe("うちの子のファッション雑誌");
-    expect(url.searchParams.get("url")).toBe("https://www.persta.ai/m/abc/book");
+    expect(url.searchParams.get("text")).toBe(
+      [
+        "うちの子のファッション雑誌、完成しました！",
+        "https://www.persta.ai/m/abc/book",
+        "",
+        "@mickey_fuku",
+        "#うちの子のファッション雑誌 #PerstaAI",
+      ].join("\n"),
+    );
   });
 });


### PR DESCRIPTION
## 概要

実機確認のフィードバック対応です（#491 のフォローアップ）。

## 変更内容

### 1. book リーダーの応募ボタンから賞品バッジを削除

「🎁 Amazonギフト券2,000円分」のバッジを外し、「Xで応募する」のみのシンプルなボタンにしました。賞品などの詳細は従来どおり「応募規約・注意事項をみる」リンクへ誘導します。

### 2. X 投稿本文を改行レイアウトへ

従来は intent の `url` / `hashtags` パラメータを使っていたため本文が1行に連結されていました。すべて `text` 1パラメータに改行込みでまとめ、以下のレイアウトで表示されるようにしました:

```
うちの子のファッション雑誌、完成しました！
https://www.persta.ai/m/{id}/book

@mickey_fuku
#うちの子のファッション雑誌 #PerstaAI
```

- メッセージを「1冊完成しました！」→「完成しました！」に変更（ユーザー確定文言）
- ハッシュタグに `#PerstaAI` を追加
- OGP カードは本文中の URL から従来どおり展開されます

ことわざ企画（受付終了・非表示）の文面定義も同じレイアウトで組み立てられますが、表示されないため挙動影響はありません。

## テスト

- [x] `npm run test` 3,195件パス（intent 本文の完全一致テストをユーザー確定レイアウトで追加）
- [x] `npm run lint` 23 errors / 57 warnings（main と同数）
- [x] `npm run typecheck` 既存赤（tests/**）以外なし
- [x] `npm run build -- --webpack` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mmqeUvT5TbjAMPNo6Pxsn
