### PR TITLE
fix(campaigns): X応募intentをtwitter.com/intent/tweetへ変更しネイティブ投稿画面を開く

### DIFF
--- a/features/campaigns/x-lottery-campaign.ts
+++ b/features/campaigns/x-lottery-campaign.ts
@@ -100,6 +100,13 @@ export function isLotteryEntryOpen(
  *
  * OGPカードは本文中のURLから展開される。@メンションと#タグが本文に入るので
  * Xガイドラインの「主催者@ユーザー名を含める」も満たしつつ応募回収できる。
+ *
+ * エンドポイントはレガシーの twitter.com/intent/tweet を使う。
+ * x.com/intent/post だと iOS の X アプリがネイティブ投稿画面に割り当てず
+ * アプリ内ブラウザ(Web版投稿画面)で開いてしまい、Web版に未ログインの
+ * ユーザーはログイン壁で応募できない(実機検証 2026-08-08)。
+ * twitter.com/intent/tweet はアプリのネイティブ投稿画面へマップされ、
+ * アプリ未インストール時は x.com の Web 投稿画面へリダイレクトされる。
  */
 export function buildXLotteryIntentUrl(
   copy: XLotteryCopy,
@@ -111,5 +118,5 @@ export function buildXLotteryIntentUrl(
   }
   const params = new URLSearchParams();
   params.set("text", lines.join("\n"));
-  return `https://x.com/intent/post?${params.toString()}`;
+  return `https://twitter.com/intent/tweet?${params.toString()}`;
 }

--- a/tests/unit/features/campaigns/x-lottery-campaign.test.ts
+++ b/tests/unit/features/campaigns/x-lottery-campaign.test.ts
@@ -62,7 +62,7 @@ describe("buildXLotteryIntentUrl", () => {
       "https://www.persta.ai/m/abc?v=123",
     );
     const parsed = new URL(url);
-    expect(parsed.origin + parsed.pathname).toBe("https://x.com/intent/post");
+    expect(parsed.origin + parsed.pathname).toBe("https://twitter.com/intent/tweet");
     expect(parsed.searchParams.get("text")).toBe(
       [
         "うちの子のことわざ辞典をコンプリートしました！",
@@ -88,7 +88,7 @@ describe("buildXLotteryIntentUrl", () => {
   test("登録済みキャンペーンの文面でも組み立てられる", () => {
     for (const copy of Object.values(X_LOTTERY_CAMPAIGNS)) {
       const url = buildXLotteryIntentUrl(copy, "https://www.persta.ai/m/x");
-      expect(url.startsWith("https://x.com/intent/post?")).toBe(true);
+      expect(url.startsWith("https://twitter.com/intent/tweet?")).toBe(true);
     }
   });
 });


### PR DESCRIPTION
## 概要

実機検証で「Xで応募する」→ X アプリが一瞬開くもアプリ内ブラウザ(Web版投稿画面)に飛ばされる問題の修正です（#492 のフォローアップ）。

## 原因（実機の画面録画で確認）

iOS の X アプリは `x.com/intent/post` のユニバーサルリンクをネイティブ投稿画面に割り当てておらず、アプリ内ブラウザ（Safari ビュー）で Web 版投稿画面を開く。アプリ内ブラウザは Safari のログイン状態を使うため、Web 版 X に未ログインのユーザーはログイン壁で応募が完了できない。

## 変更内容

- intent エンドポイントを `x.com/intent/post` → **`twitter.com/intent/tweet`**（レガシー）へ変更
  - X アプリはこのエンドポイントをネイティブ投稿画面へマップする（改行 %0A も保持）
  - アプリ未インストール時は twitter.com → x.com の Web 投稿画面へリダイレクトされ、従来挙動から退行しない
- 経緯をコードコメントに記録、テストの期待 URL を更新

## テスト

- [x] `npm run test` 3,195件パス
- [x] `npm run lint` 23 errors / 57 warnings（main と同数）
- [x] `npm run build -- --webpack` 成功
- [ ] マージ後、実機で「X アプリのネイティブ投稿画面が開くこと」を確認（19:00 公開前）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mmqeUvT5TbjAMPNo6Pxsn
