### PR TITLE
fix(collections): 企画名を「うちの子のファッション雑誌」へ短縮

### DIFF
--- a/app/campaigns/fashion-magazine-lottery/page.tsx
+++ b/app/campaigns/fashion-magazine-lottery/page.tsx
@@ -2,9 +2,9 @@ import type { Metadata } from "next";
 import Link from "next/link";
 
 const PAGE_TITLE =
-  "うちの子のファッション雑誌：夏 Xシェアキャンペーン 応募規約 | Persta.AI";
+  "うちの子のファッション雑誌 Xシェアキャンペーン 応募規約 | Persta.AI";
 const PAGE_DESCRIPTION =
-  "「うちの子のファッション雑誌：夏」を1冊完成させてXにシェアした方から抽選で5名様にAmazonギフト券2,000円分をプレゼント。応募規約・注意事項。";
+  "「うちの子のファッション雑誌」を1冊完成させてXにシェアした方から抽選で5名様にAmazonギフト券2,000円分をプレゼント。応募規約・注意事項。";
 
 export const metadata: Metadata = {
   title: PAGE_TITLE,
@@ -43,12 +43,12 @@ export default function FashionMagazineLotteryRulesPage() {
     <main className="mx-auto max-w-2xl px-5 pb-16 pt-8">
       <p className="text-xs font-bold tracking-wide text-orange-700">CAMPAIGN</p>
       <h1 className="mt-1 text-2xl font-bold leading-relaxed text-gray-900">
-        うちの子のファッション雑誌：夏
+        うちの子のファッション雑誌
         <br />
         Xシェアキャンペーン 応募規約
       </h1>
       <p className="mt-3 rounded-xl bg-orange-50 px-4 py-3 text-sm font-medium text-orange-900">
-        「うちの子のファッション雑誌：夏」の全8ページを完成させ、できあがった雑誌をXにシェアした方の中から、
+        「うちの子のファッション雑誌」の全8ページを完成させ、できあがった雑誌をXにシェアした方の中から、
         抽選で<span className="font-bold">5名様</span>に
         <span className="font-bold">Amazonギフト券2,000円分</span>をお贈りします。
       </p>
@@ -86,7 +86,7 @@ export default function FashionMagazineLotteryRulesPage() {
         <ol className="list-decimal space-y-2 pl-5">
           <li>
             Persta.AI
-            の「うちの子のファッション雑誌：夏」で、表紙から裏表紙まで全8ページを生成し、1冊を完成させる
+            の「うちの子のファッション雑誌」で、表紙から裏表紙まで全8ページを生成し、1冊を完成させる
           </li>
           <li>
             完成ページに表示される「Xで応募する」ボタンから、雑誌をXへ

--- a/app/collections/fashion-magazine/page.tsx
+++ b/app/collections/fashion-magazine/page.tsx
@@ -7,7 +7,7 @@ import { FashionMagazineGuide } from "@/features/collections/components/FashionM
 // カテゴリ: fashion_magazine_summer
 
 const PAGE_TITLE =
-  "うちの子のファッション雑誌：夏｜8ページそろえて1冊完成 | Persta.AI";
+  "うちの子のファッション雑誌｜8ページそろえて1冊完成 | Persta.AI";
 const PAGE_DESCRIPTION =
   "うちの子が夏の誌面の主役に。表紙から裏表紙まで全8ページを生成すると、めくって読めるデジタル雑誌が完成。Xシェアで抽選5名にAmazonギフト券2,000円分。8/8〜8/16開催。";
 
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
   description: PAGE_DESCRIPTION,
   alternates: createCanonicalAlternates("/collections/fashion-magazine"),
   openGraph: {
-    title: "うちの子のファッション雑誌：夏｜8ページそろえて1冊完成",
+    title: "うちの子のファッション雑誌｜8ページそろえて1冊完成",
     description:
       "うちの子が夏の誌面の主役に。全8ページで、めくって読める1冊が完成。Xシェアで抽選5名にAmazonギフト券2,000円分。",
     type: "website",
@@ -28,13 +28,13 @@ export const metadata: Metadata = {
         url: OGP_IMAGE,
         width: 1200,
         height: 630,
-        alt: "うちの子のファッション雑誌：夏 総額10,000円アマギフプレゼントキャンペーン 8/8 19:00〜8/16 21:59",
+        alt: "うちの子のファッション雑誌 総額10,000円アマギフプレゼントキャンペーン 8/8 19:00〜8/16 21:59",
       },
     ],
   },
   twitter: {
     card: "summary_large_image",
-    title: "うちの子のファッション雑誌：夏｜8ページそろえて1冊完成",
+    title: "うちの子のファッション雑誌｜8ページそろえて1冊完成",
     description:
       "うちの子が夏の誌面の主役に。全8ページで、めくって読める1冊が完成。Xシェアで抽選5名にAmazonギフト券2,000円分。",
     images: [OGP_IMAGE],

--- a/features/collections/components/FashionMagazineGuide.tsx
+++ b/features/collections/components/FashionMagazineGuide.tsx
@@ -16,7 +16,7 @@ import Link from "next/link";
 
 const CAMPAIGN = {
   issueLabel: "SUMMER ISSUE 2026",
-  title: "うちの子のファッション雑誌：夏",
+  title: "うちの子のファッション雑誌",
   periodLabel: "8/8(土) 19:00 〜 8/16(日) 21:59",
   pageCount: 8,
   prizeLabel: "Amazonギフト券 2,000円分",


### PR DESCRIPTION
## 概要

企画名の「：夏」を除去し「うちの子のファッション雑誌」に統一します（ユーザー指示）。

## 変更内容

- LP: h1(CAMPAIGN.title)・ページタイトル・OGP/Xカードのタイトル・OGP画像alt
- 応募規約: ページタイトル・description・h1・冒頭文・応募方法の手順1

DB の `display_name_ja/en` はもともと「うちの子のファッション雑誌」のため変更不要（アプリ内UIは既に短縮形）。ハッシュタグ・投稿文面・支給ビジュアルの表記とも一致します。コード内コメントは経緯記録のため現状維持。

## テスト

- [x] `npm run test` 3,195件パス / `npm run lint` 23E/57W(main同数) / `npm run build -- --webpack` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mmqeUvT5TbjAMPNo6Pxsn