### PR TITLE
feat(generation): 生成モードタブを「ワンタップ > フリー > コーディネート」順へ変更

### DIFF
--- a/components/GenerationModeTabs.tsx
+++ b/components/GenerationModeTabs.tsx
@@ -10,8 +10,10 @@ import { setLastGenerationModePath } from "@/features/generation/lib/generation-
 import { cn } from "@/lib/utils";
 
 /**
- * /coordinate・/style・/free を相互に行き来するためのアニメーション付き
+ * /style・/free・/coordinate を相互に行き来するためのアニメーション付き
  * セグメントタブ。ボトムナビ/サイドバーに無い style / free 画面への導線を兼ねる。
+ * 並び順は利用を促したい順(ワンタップ > フリー > コーディネート)。
+ * コーディネートは将来的な縮退を見据えて末尾に置く。
  *
  * (app)/layout.tsx に配置されており、モード間の遷移中も
  * インスタンスが保持される。そのため usePathname の更新に合わせて
@@ -24,9 +26,9 @@ import { cn } from "@/lib/utils";
  * とは別キー)にして、タブだけ英語ブランド名「Coordinate」にできるようにしている。
  */
 const TABS = [
-  { path: "/coordinate", icon: Sparkles },
   { path: "/style", icon: Wand2 },
   { path: "/free", icon: PenLine },
+  { path: "/coordinate", icon: Sparkles },
 ] as const;
 
 export function GenerationModeTabs() {
@@ -96,9 +98,9 @@ export function GenerationModeTabs() {
   if (activeIndex === -1) return null;
 
   const labels = [
-    coordinateT("tabLabel"),
     styleT("pageTitle"),
     freeT("tabLabel"),
+    coordinateT("tabLabel"),
   ];
 
   return (


### PR DESCRIPTION
## 概要

コーディネート画面上部のセグメントタブ（/coordinate・/style・/free 共通）の並び順を「ワンタップスタイル ＞ フリースタイル ＞ コーディネート」に変更します。将来的にコーディネート画面を縮退させる方針のため、利用を促したい順に並べ、コーディネートを末尾に置きます。

## 変更内容

- `GenerationModeTabs` の `TABS` 定数と `labels` 配列を並べ替え（アイコンとパスの対応は維持）
- 並び順の意図をコメントに記録

## 影響範囲の確認（調査済み）

- タブ＝ルートへの Link のため、URL・ディープリンク・既存導線は不変
- **新規登録時のチュートリアルは影響なし**: 遷移は `router.push("/coordinate")` のルート直指定で、ツアーのアンカー（`data-tour=coordinate-nav-*`）はボトムナビ/サイドバー側。セグメントタブには `data-tour` なし
- ボトムナビの「直近モード復帰」の既定（`/coordinate`）も不変
- アクティブ背景のピルは実測方式のため並び替えに自動追従

## テスト

- [x] `npm run test` 3,195件パス / `npm run lint` 23E/57W(main同数) / `npm run typecheck` 既存赤以外なし / `npm run build -- --webpack` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mmqeUvT5TbjAMPNo6Pxsn