### PR TITLE
fix(tutorial): ツアー進行中はナビの直近モード復帰を無効化し詰まりを解消

### DIFF
--- a/components/AppSidebar.tsx
+++ b/components/AppSidebar.tsx
@@ -35,6 +35,7 @@ import {
 } from "@/i18n/config";
 import { requiresAuthForGuestNavigation } from "@/lib/navigation-auth";
 import { getLastGenerationModePath } from "@/features/generation/lib/generation-mode-preference";
+import { isTutorialTourInProgress } from "@/features/tutorial/lib/tutorial-status";
 import { AuthModal } from "@/features/auth/components/AuthModal";
 import { useWardrobeSaveTrigger } from "@/features/wardrobe/hooks/use-wardrobe-save";
 
@@ -150,7 +151,9 @@ export function AppSidebar() {
 
     // 「コーディネート」入口は前回使った生成モードへ復帰させる。
     // 前回 One-Tap Style だった場合は /style へ遷移する。
-    if (normalizedTargetPath === "/coordinate") {
+    // ただしチュートリアルツアー進行中は差し替えない(ツアーの再開先は
+    // /coordinate 固定のため、/style 等へ流すとツアーが再開できず詰まる)。
+    if (normalizedTargetPath === "/coordinate" && !isTutorialTourInProgress()) {
       const preferred = getLastGenerationModePath();
       if (preferred !== "/coordinate") {
         // path 内の "/coordinate" のみ差し替え、ロケールプレフィックスや

--- a/components/NavigationBar.tsx
+++ b/components/NavigationBar.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/i18n/config";
 import { requiresAuthForGuestNavigation } from "@/lib/navigation-auth";
 import { getLastGenerationModePath } from "@/features/generation/lib/generation-mode-preference";
+import { isTutorialTourInProgress } from "@/features/tutorial/lib/tutorial-status";
 
 export function NavigationBar() {
   const pathname = usePathname();
@@ -125,7 +126,9 @@ export function NavigationBar() {
 
     // 「コーディネート」入口は前回使った生成モードへ復帰させる。
     // 前回 One-Tap Style だった場合は /style へ遷移する。
-    if (normalizedTargetPath === "/coordinate") {
+    // ただしチュートリアルツアー進行中は差し替えない(ツアーの再開先は
+    // /coordinate 固定のため、/style 等へ流すとツアーが再開できず詰まる)。
+    if (normalizedTargetPath === "/coordinate" && !isTutorialTourInProgress()) {
       const preferred = getLastGenerationModePath();
       if (preferred !== "/coordinate") {
         // path 内の "/coordinate" のみ差し替え、ロケールプレフィックスや

--- a/features/tutorial/lib/tutorial-status.ts
+++ b/features/tutorial/lib/tutorial-status.ts
@@ -1,6 +1,28 @@
 import { TUTORIAL_STORAGE_KEYS } from "@/features/tutorial/types";
 
 /**
+ * チュートリアルツアーが進行中(sessionStorage の in_progress が立っている)かを返す。
+ *
+ * ナビの「コーディネート」入口は通常「直近に使った生成モード」へ差し替え遷移するが、
+ * ツアー進行中にそれをやると、直近が /style・/free のユーザーはツアーの再開先
+ * (/coordinate)に到達できず無言で詰まる。ツアー中だけ差し替えを止めるための判定。
+ */
+export function isTutorialTourInProgress(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  try {
+    return (
+      window.sessionStorage.getItem(TUTORIAL_STORAGE_KEYS.IN_PROGRESS) ===
+      "true"
+    );
+  } catch {
+    // プライベートモード等でストレージにアクセスできない場合は通常挙動に倒す。
+    return false;
+  }
+}
+
+/**
  * チュートリアルが「表示中 or これから表示される」状態かを判定する。
  * true の間はホーム画面で他のオーバーレイ(ポップアップバナー等)を抑制し、
  * チュートリアルの進行を妨げないために使う。

--- a/tests/unit/features/tutorial/tutorial-status.ssr.test.ts
+++ b/tests/unit/features/tutorial/tutorial-status.ssr.test.ts
@@ -1,6 +1,9 @@
 /** @jest-environment node */
 
-import { isTutorialActiveOrPending } from "@/features/tutorial/lib/tutorial-status";
+import {
+  isTutorialActiveOrPending,
+  isTutorialTourInProgress,
+} from "@/features/tutorial/lib/tutorial-status";
 
 describe("isTutorialActiveOrPending (SSR / window 未定義)", () => {
   it("window が無い環境では false を返す", () => {
@@ -11,5 +14,12 @@ describe("isTutorialActiveOrPending (SSR / window 未定義)", () => {
         tutorialCompleted: false,
       }),
     ).toBe(false);
+  });
+});
+
+describe("isTutorialTourInProgress (SSR / window 未定義)", () => {
+  it("window が無い環境では false を返す", () => {
+    expect(typeof window).toBe("undefined");
+    expect(isTutorialTourInProgress()).toBe(false);
   });
 });

--- a/tests/unit/features/tutorial/tutorial-status.test.ts
+++ b/tests/unit/features/tutorial/tutorial-status.test.ts
@@ -1,4 +1,7 @@
-import { isTutorialActiveOrPending } from "@/features/tutorial/lib/tutorial-status";
+import {
+  isTutorialActiveOrPending,
+  isTutorialTourInProgress,
+} from "@/features/tutorial/lib/tutorial-status";
 
 describe("isTutorialActiveOrPending", () => {
   beforeEach(() => {
@@ -68,5 +71,35 @@ describe("isTutorialActiveOrPending", () => {
     ).toBe(false);
 
     spy.mockRestore();
+  });
+});
+
+describe("isTutorialTourInProgress", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it("in_progress が true なら true(ナビの直近モード復帰を止める)", () => {
+    window.sessionStorage.setItem("tutorial_in_progress", "true");
+    expect(isTutorialTourInProgress()).toBe(true);
+  });
+
+  it("未設定・別値なら false(通常のモード復帰を行う)", () => {
+    expect(isTutorialTourInProgress()).toBe(false);
+    window.sessionStorage.setItem("tutorial_in_progress", "false");
+    expect(isTutorialTourInProgress()).toBe(false);
+  });
+
+  it("sessionStorage が例外を投げる場合は false(通常挙動に倒す)", () => {
+    const spy = jest
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation(() => {
+        throw new Error("blocked");
+      });
+    try {
+      expect(isTutorialTourInProgress()).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## 概要

チュートリアル step1 でナビの「コーディネート」ボタンをタップしたとき、直近モードが One-Tap Style / フリーのユーザーは /style・/free へ差し替え遷移してしまい、/coordinate 固定のツアー再開処理が発火せず**ツアーが無言で停止する**バグの修正です（実機報告あり・機構をコードで確認済み）。

## 原因

- ナビの「コーディネート」入口は `getLastGenerationModePath()` で直近モードへ差し替え遷移（NavigationBar / AppSidebar の両方）
- ツアー再開は「パスが /coordinate」かつコーディネート画面固有の要素が揃ったときのみ発火

新規ユーザー（直近モード未保存 → 既定 /coordinate）は影響なし。先に style/free を触ってからツアーを始めた人・`tutorial_reset=1` での再実行者が対象でした。

## 変更内容

- `isTutorialTourInProgress()` を追加（sessionStorage の進行フラグ・SSR/例外セーフ）
- ツアー進行中のみ、モバイル（NavigationBar）/ PC（AppSidebar）の両方で直近モード差し替えをスキップし /coordinate へ素直に遷移
- ヘルパの単体テスト3件を追加

今後のチュートリアル /free 移行（計画済み）でも「ツアー中はツアーの目的地へ固定遷移」として同じガードを流用します。

## テスト

- [x] `npm run test` 3,198件パス（新規3件含む）
- [x] `npm run lint` 23 errors / 57 warnings（main と同数）
- [x] `npm run build -- --webpack` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mmqeUvT5TbjAMPNo6Pxsn