### PR TITLE
feat(tutorial): 新規登録チュートリアルをOne-Tap Styleの軽量5ステップツアーへ刷新

### DIFF
--- a/components/AppSidebar.tsx
+++ b/components/AppSidebar.tsx
@@ -35,7 +35,10 @@ import {
 } from "@/i18n/config";
 import { requiresAuthForGuestNavigation } from "@/lib/navigation-auth";
 import { getLastGenerationModePath } from "@/features/generation/lib/generation-mode-preference";
-import { isTutorialTourInProgress } from "@/features/tutorial/lib/tutorial-status";
+import {
+  TUTORIAL_TOUR_ENTRY_PATH,
+  isTutorialTourInProgress,
+} from "@/features/tutorial/lib/tutorial-status";
 import { AuthModal } from "@/features/auth/components/AuthModal";
 import { useWardrobeSaveTrigger } from "@/features/wardrobe/hooks/use-wardrobe-save";
 
@@ -151,10 +154,12 @@ export function AppSidebar() {
 
     // 「コーディネート」入口は前回使った生成モードへ復帰させる。
     // 前回 One-Tap Style だった場合は /style へ遷移する。
-    // ただしチュートリアルツアー進行中は差し替えない(ツアーの再開先は
-    // /coordinate 固定のため、/style 等へ流すとツアーが再開できず詰まる)。
-    if (normalizedTargetPath === "/coordinate" && !isTutorialTourInProgress()) {
-      const preferred = getLastGenerationModePath();
+    // ただしチュートリアルツアー進行中は直近モードに関わらずツアーの目的地
+    // (/style)へ固定する(他モードへ流すとツアーが再開できず詰まる)。
+    if (normalizedTargetPath === "/coordinate") {
+      const preferred = isTutorialTourInProgress()
+        ? TUTORIAL_TOUR_ENTRY_PATH
+        : getLastGenerationModePath();
       if (preferred !== "/coordinate") {
         // path 内の "/coordinate" のみ差し替え、ロケールプレフィックスや
         // クエリ・ハッシュ等の付随情報を維持する。

--- a/components/NavigationBar.tsx
+++ b/components/NavigationBar.tsx
@@ -27,7 +27,10 @@ import {
 } from "@/i18n/config";
 import { requiresAuthForGuestNavigation } from "@/lib/navigation-auth";
 import { getLastGenerationModePath } from "@/features/generation/lib/generation-mode-preference";
-import { isTutorialTourInProgress } from "@/features/tutorial/lib/tutorial-status";
+import {
+  TUTORIAL_TOUR_ENTRY_PATH,
+  isTutorialTourInProgress,
+} from "@/features/tutorial/lib/tutorial-status";
 
 export function NavigationBar() {
   const pathname = usePathname();
@@ -126,10 +129,12 @@ export function NavigationBar() {
 
     // 「コーディネート」入口は前回使った生成モードへ復帰させる。
     // 前回 One-Tap Style だった場合は /style へ遷移する。
-    // ただしチュートリアルツアー進行中は差し替えない(ツアーの再開先は
-    // /coordinate 固定のため、/style 等へ流すとツアーが再開できず詰まる)。
-    if (normalizedTargetPath === "/coordinate" && !isTutorialTourInProgress()) {
-      const preferred = getLastGenerationModePath();
+    // ただしチュートリアルツアー進行中は直近モードに関わらずツアーの目的地
+    // (/style)へ固定する(他モードへ流すとツアーが再開できず詰まる)。
+    if (normalizedTargetPath === "/coordinate") {
+      const preferred = isTutorialTourInProgress()
+        ? TUTORIAL_TOUR_ENTRY_PATH
+        : getLastGenerationModePath();
       if (preferred !== "/coordinate") {
         // path 内の "/coordinate" のみ差し替え、ロケールプレフィックスや
         // クエリ・ハッシュ等の付随情報を維持する。

--- a/docs/planning/style-tutorial-migration-implementation-plan.md
+++ b/docs/planning/style-tutorial-migration-implementation-plan.md
@@ -1,0 +1,105 @@
+# 新規登録チュートリアルの One-Tap Style ミニツアー化 実装計画書
+
+作成日: 2026-08-08（同日中に2回改訂: /free 移行案 → /style 実生成案 → 本案）
+ステータス: 承認済み・実装中
+
+## ゴール
+
+新規登録時のチュートリアルを「コーディネート画面で実際に1枚生成する重いツアー」から、**One-Tap Style 画面の3ステップミニツアーを土台にした軽量ツアー（ツールチップのみ・生成なし・画像挿入なし）**へ置き換える。完了時のペルコイン付与は現行の仕組み（`grant_tour_bonus`・冪等・通知つき・admin 額設定）をそのまま流用し、額はリリース時に admin で **10** にする。
+
+## 決定事項（ユーザー確定 2026-08-08）
+
+| 項目 | 決定 |
+|---|---|
+| ツアー内容 | **全5ステップ・すべてツールチップのみ**。生成もデモ画像挿入もしない |
+| 構成 | ①ナビ入口案内（ホーム・新規作成）→ /style 遷移 → ②スタイル選択 ③キャラクター写真 ④生成ボタン（②〜④は既存ミニツアー流用）→ ⑤締め＋付与 |
+| スタイル事前選択 | **しない**（生成しないため固定不要。「好きなスタイルを選ぼう」の既存文言で自然） |
+| 無料生成 | **不要になったため廃止**（課金経路・worker には一切触らない） |
+| ナビ入口の既定着地 | `DEFAULT_PATH` を `/coordinate` → **`/style`** へ |
+| ツアー中のナビ遷移先 | #499 のガードを拡張し、ツアー中は**常に /style** へ（直近モード復帰より優先） |
+| 完了付与額 | **10**（リリース時に admin `/admin/percoin-defaults` の `tour_bonus` 20→10。コード変更不要） |
+| 旧コーデ版ツアー | 削除（デモ画像・プロンプト注入・生成完了待ちの配線ごと撤去） |
+| 既存ミニツアー（StyleTourButton） | **現状維持**（/style 上の手動リプレイとして併存。新ツアーはステップ定義を共用） |
+
+## トレードオフ（記録）
+
+ツアー内での「実生成の成功体験」は失うが、現行ツアーの生成は**デモ画像（他人のキャラ）**であり本質的な感動（うちの子で生成）はもともと提供できていない。ツアー終了時点でユーザーは /style におり、完了ボーナス10で初回生成1回分がまかなえるため実害は小さい、と判断（ユーザー合意済み）。
+
+## コードベース調査結果（2026-08-08 検証済み）
+
+| 対象 | 場所 | 含意 |
+|---|---|---|
+| オーケストレーター | `features/tutorial/components/TutorialTourProvider.tsx` | 遷移 `router.push` と再開判定を /style へ。デモ画像・プロンプト・生成完了待ち・ギャラリー切替のイベント群は削除 |
+| 旧ステップ定義 | `features/tutorial/lib/tour-steps.ts` | 11ステップ → 5ステップへ全面改稿 |
+| 既存ミニツアー | `features/style/lib/style-tour-steps.ts`（3ステップ: `style-tour-preset` / `style-tour-character` / `style-tour-generate`） | アンカーは `StylePageClient` に実装済み。**StylePageClient への改修は不要** |
+| ナビ詰まりガード | `isTutorialTourInProgress()`（#499） | ツアー中の遷移先を「差し替えスキップ(/coordinate)」から「**/style 固定**」へ拡張（NavigationBar / AppSidebar） |
+| ナビ既定 | `features/generation/lib/generation-mode-preference.ts` `DEFAULT_PATH` | `/style` へ変更 |
+| 完了API/報酬 | `app/api/tutorial/complete/route.ts` → `grant_tour_bonus` RPC | 無改修（冪等・通知・admin 額） |
+| 付与額のUI表示 | `features/tutorial/lib/constants.ts` `TUTORIAL_BONUS_AMOUNT=20`（ハードコード） | admin 設定値参照へ（`useUsageRewardAmounts` の5分TTLキャッシュ方式を踏襲した小さな API+フック） |
+| 再実行導線 | `ChallengeTutorialCard` → `CoordinateTourButton` | /style 版へ差し替え |
+| 文言 | `messages/{15言語}.ts` `tutorial` セクション | 新規は①ナビ案内と⑤締めのみ。②〜④は style ミニツアーの既存キーを共用。旧コーデツアー用キーは削除 |
+
+## 新フロー
+
+```mermaid
+flowchart TD
+    A["新規登録 or tutorial_reset=1"] --> B["開始モーダル(ホーム)"]
+    B -->|はじめる| C["step1: ナビ入口ボタンをハイライト"]
+    C -->|タップ| D["/style へ遷移(ガードで固定)"]
+    D --> E["step2: スタイル選択エリア(既存)"]
+    E --> F["step3: キャラクター写真エリア(既存)"]
+    F --> G["step4: 生成ボタン(既存)"]
+    G --> H["step5: 締め『完了ボーナスをプレゼント』"]
+    H --> I["POST /api/tutorial/complete → 付与(admin額)+通知(冪等)"]
+    B -->|あとで| J["スキップ。ミッション画面から再開可"]
+```
+
+## EARS（主要要件）
+
+- When 新規ユーザーが開始モーダルで「はじめる」を選ぶ, the system shall ナビ入口をハイライトし、タップで `/style` に遷移する（ツアー中は直近モード復帰より優先）
+- When `/style` に到達しミニツアーの3アンカーが揃う, the system shall ②〜④のステップを順に表示する
+- When ⑤締めステップで完了操作をする, the system shall `grant_tour_bonus` により付与・通知し（冪等）、`tutorial_completed` を立てる
+- If ユーザーがスキップする, then the system shall `tutorial_completed` を更新せず、ミッション画面から再開可能にする
+- Where `?tutorial_reset=1`, the system shall 完了・スキップ状態に関わらず開始モーダルを再表示する（付与は冪等で0）
+- While ツアー表示中, the system shall 生成・課金経路に一切影響を与えない（ツールチップのみ）
+
+## 実装計画
+
+### Phase 1: ツアー本体の /style 化＋5ステップ化
+- [ ] `tour-steps.ts`: 5ステップへ改稿（②〜④は style-tour-steps のアンカー/文言を共用）
+- [ ] `TutorialTourProvider`: 遷移・再開判定を /style へ。旧イベント配線（デモ画像・プロンプト・生成完了待ち・ギャラリー）削除。⑤で完了API呼び出し
+- [ ] `generation-mode-preference.ts`: `DEFAULT_PATH` → `/style`
+- [ ] NavigationBar / AppSidebar: ツアー中は生成入口の遷移先を `/style` 固定（#499 ガードの拡張）
+
+### Phase 2: 文言（15言語）
+- [ ] ①ナビ案内・⑤締めの新キー追加、旧コーデツアーキー削除
+
+### Phase 3: 付与額表示の admin 値化
+- [ ] `GET /api/percoin/tour-bonus`（`get_percoin_bonus_default('tour_bonus')` を返す・キャッシュ）＋クライアントフック
+- [ ] `TUTORIAL_BONUS_AMOUNT` 参照箇所（開始モーダル・ミッションカード・⑤締め等）を置換・定数削除
+
+### Phase 4: 再実行導線
+- [ ] `CoordinateTourButton` → /style 版へ差し替え（`ChallengeTutorialCard` 含む）
+
+### Phase 5: 検証・PR
+- [ ] 単体テスト（ステップ構成・ガード遷移先・付与額フック）
+- [ ] `npm run lint` / `typecheck` / `test` / `build -- --webpack`
+- [ ] 実機（`tutorial_reset=1`）: モバイル/PC × 開始→/style→②〜④→⑤→付与(冪等0)。新規垢で実付与
+- [ ] PR（本計画書同梱・日本語）
+
+### リリース時（ユーザーと一緒に）
+- [ ] admin `/admin/percoin-defaults`: `tour_bonus` 20 → **10**
+
+DB・API スキーマ変更: **なし** ／ Edge Function: **なし**
+
+## 品質・テスト観点
+
+- [ ] 生成・課金経路に無変更（ツアーはツールチップのみ）
+- [ ] 既存完了者・スキップ者に再表示されない／付与の冪等性維持
+- [ ] ツアー中のナビタップが必ず /style に着地（モバイル/PC・直近モードが style/free/coordinate いずれでも）
+- [ ] StyleTourButton（手動リプレイ）が従来どおり動く
+- [ ] 付与額表示が admin 設定に追従（取得失敗時は額を出さない等 fail-safe）
+
+## ロールバック方針
+
+- コード revert のみで旧ツアーへ復帰（DB・worker 変更なし）

--- a/features/generation/components/CoordinateTourButton.tsx
+++ b/features/generation/components/CoordinateTourButton.tsx
@@ -105,15 +105,14 @@ export function CoordinateTourButton() {
         nextBtnText: t("nextButton"),
         doneBtnText: t("doneButton"),
         steps: getCoordinateTourSteps({
-          // タイトルと操作ボタンは tutorial の既存キーを流用。説明文は
-          // 新規ユーザー向け(体験用画像/プロンプトのセット、コイン返却)を
-          // 前提としており簡易ツアーには不正確なため、coordinate 専用の
-          // 説明文に差し替える。
-          uploadTitle: t("stepUploadTitle"),
+          // 操作ボタン(戻る/次へ/完了)のみ tutorial の共通キーを流用し、
+          // ステップ文言は coordinate 専用キーで完結させる
+          // (新規ユーザー向けツアーの文言変更に巻き込まれないように)。
+          uploadTitle: coordinateT("tourStepUploadTitle"),
           uploadDescription: coordinateT("tourStepUploadDescription"),
-          promptTitle: t("stepPromptTitle"),
+          promptTitle: coordinateT("tourStepPromptTitle"),
           promptDescription: coordinateT("tourStepPromptDescription"),
-          generateTitle: t("stepGenerateTitle"),
+          generateTitle: coordinateT("tourStepGenerateTitle"),
           generateDescription: coordinateT("tourStepGenerateDescription"),
         }),
         onNextClick: (_el, _step, opts) => {

--- a/features/generation/lib/generation-mode-preference.ts
+++ b/features/generation/lib/generation-mode-preference.ts
@@ -8,7 +8,8 @@
  *    読み取り、前回が One-Tap Style / じゆうモード なら該当ページへ復帰させる
  *
  * localStorage のみを使い、読み取り失敗(プライベートモード等)時は既定の
- * /coordinate にフォールバックする。SSR では window が無いため既定値を返す。
+ * /style にフォールバックする(新規ユーザーの初回着地を One-Tap Style に
+ * 寄せる方針)。SSR では window が無いため既定値を返す。
  */
 export const GENERATION_MODE_PATHS = {
   coordinate: "/coordinate",
@@ -20,7 +21,7 @@ export type GenerationModePath =
   (typeof GENERATION_MODE_PATHS)[keyof typeof GENERATION_MODE_PATHS];
 
 const STORAGE_KEY = "persta-ai:last-generation-mode";
-const DEFAULT_PATH: GenerationModePath = GENERATION_MODE_PATHS.coordinate;
+const DEFAULT_PATH: GenerationModePath = GENERATION_MODE_PATHS.style;
 
 /** 与えられた path が生成モードのルートかどうか。 */
 export function isGenerationModePath(
@@ -33,7 +34,7 @@ export function isGenerationModePath(
   );
 }
 
-/** 直近に使った生成モードのパスを返す(未保存・失敗時は /coordinate)。 */
+/** 直近に使った生成モードのパスを返す(未保存・失敗時は /style)。 */
 export function getLastGenerationModePath(): GenerationModePath {
   if (typeof window === "undefined") {
     return DEFAULT_PATH;

--- a/features/tutorial/components/TutorialTourProvider.tsx
+++ b/features/tutorial/components/TutorialTourProvider.tsx
@@ -323,6 +323,11 @@ export function TutorialTourProvider() {
         showProgress: true,
         animate: !prefersReducedMotion(),
         allowClose: true,
+        // ツールチップのみのツアーのため、ハイライト中の要素も操作不可にする。
+        // スタイル選択・写真設定・生成ボタンをツアー中に触れると、意図しない
+        // 生成(コイン消費)が起きうる(①のナビタップだけは遷移手段なので、
+        // ホーム側のドライバーでは操作可能のまま)。
+        disableActiveInteraction: true,
         // Persta 共通のポップなトーン（/style と統一。globals.css 参照）
         popoverClass: "persta-tour-popover",
         overlayOpacity: 0.6,

--- a/features/tutorial/components/TutorialTourProvider.tsx
+++ b/features/tutorial/components/TutorialTourProvider.tsx
@@ -287,6 +287,25 @@ export function TutorialTourProvider() {
           sessionStorage.removeItem(TUTORIAL_STORAGE_KEYS.CURRENT_STEP);
           void completeTutorial();
           opts.driver.destroy();
+          // 閉じたあと、すぐ操作を始められるようスタイル選択セクションまで
+          // スクロールして戻す(StyleTourButton の「さっそく試す！」と同じ挙動)
+          requestAnimationFrame(() => {
+            const presetSection = document.querySelector(
+              '[data-tour="style-tour-preset"]'
+            );
+            if (!presetSection) return;
+            // スティッキーヘッダーに「スタイル選択」見出しが隠れないよう、
+            // ヘッダー分のマージンを引いてスクロールする
+            const STICKY_HEADER_OFFSET = 72;
+            const top =
+              presetSection.getBoundingClientRect().top +
+              window.scrollY -
+              STICKY_HEADER_OFFSET;
+            window.scrollTo({
+              top: Math.max(top, 0),
+              behavior: prefersReducedMotion() ? "auto" : "smooth",
+            });
+          });
         }, 100);
       };
       if (lastStep?.popover) {

--- a/features/tutorial/components/TutorialTourProvider.tsx
+++ b/features/tutorial/components/TutorialTourProvider.tsx
@@ -7,18 +7,16 @@ import type { Driver, DriveStep } from "driver.js";
 import { getCurrentUser } from "@/features/auth/lib/auth-client";
 import { createClient } from "@/lib/supabase/client";
 import { TutorialStartModal } from "./TutorialStartModal";
-import { getTourSteps } from "../lib/tour-steps";
-import { getJapanMonth } from "../lib/constants";
+import { getTourSteps, type TutorialTourCopy } from "../lib/tour-steps";
 import { TUTORIAL_STORAGE_KEYS } from "../types";
+import { TUTORIAL_TOUR_ENTRY_PATH } from "../lib/tutorial-status";
 import { stripLocalePrefix } from "@/i18n/config";
-import { writePreferredGalleryView } from "@/features/generation/lib/gallery-view-preference";
 
 const prefersReducedMotion = () =>
   typeof window !== "undefined" &&
   window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
 const SCROLL_TRANSITION_MS = 450;
-const GENERATION_COMPLETE_TRANSITION_DELAY_MS = 5000;
 
 /** driver.js をチュートリアル開始時のみ遅延読み込み（bundle-dynamic-imports） */
 async function loadDriver() {
@@ -66,17 +64,25 @@ function runTransitionFlow(
   }, SCROLL_TRANSITION_MS);
 }
 
+/**
+ * 新規登録チュートリアル(全5ステップ・ツールチップのみ)のオーケストレーター。
+ *
+ * ホームで開始モーダル → ①ナビ入口を案内 → タップで /style へ遷移
+ * (NavigationBar/AppSidebar 側がツアー進行中は直近モード復帰を止めて /style
+ * に固定する) → ②〜④は One-Tap Style のミニツアーと同じアンカー →
+ * ⑤締めの「完了」で /api/tutorial/complete を呼び、完了ボーナスを付与する。
+ * 生成・デモ画像挿入は行わない(課金経路に影響しない)。
+ */
 export function TutorialTourProvider() {
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
   const t = useTranslations("tutorial");
+  const styleT = useTranslations("style");
   const [showModal, setShowModal] = useState(false);
   const [isChecking, setIsChecking] = useState(true);
   const driverRef = useRef<Driver | null>(null);
-  const coordinateTourStartedRef = useRef(false);
-  const generationCompleteDelayTimerRef =
-    useRef<ReturnType<typeof setTimeout> | null>(null);
+  const styleTourStartedRef = useRef(false);
   const normalizedPath = pathname ? stripLocalePrefix(pathname).pathname : "/";
 
   // チュートリアル開始判定（rerender-dependencies: プリミティブな依存のみ）
@@ -144,6 +150,20 @@ export function TutorialTourProvider() {
     // スキップ扱い：tutorial_completed は更新しない（後からミッション画面のボタンで再開可能）
   };
 
+  const buildTourCopy = (): TutorialTourCopy => ({
+    navigateTitle: t("stepNavigateTitle"),
+    navigateDescription: t("stepNavigateDescription"),
+    // ②〜④は /style ミニツアー(StyleTourButton)と同じ文言を共用する
+    presetTitle: styleT("tourStepPresetTitle"),
+    presetDescription: styleT("tourStepPresetDescription"),
+    characterTitle: styleT("tourStepCharacterTitle"),
+    characterDescription: styleT("tourStepCharacterDescription"),
+    generateTitle: styleT("tourStepGenerateTitle"),
+    generateDescription: styleT("tourStepGenerateDescription"),
+    finishedTitle: t("stepFinishedTitle"),
+    finishedDescription: t("stepFinishedDescription"),
+  });
+
   const startTourFromHome = async () => {
     setShowModal(false);
     if (typeof sessionStorage !== "undefined") {
@@ -151,34 +171,11 @@ export function TutorialTourProvider() {
       sessionStorage.setItem(TUTORIAL_STORAGE_KEYS.CURRENT_STEP, "0");
     }
 
-    const tourSteps = getTourSteps({
-      coordinateTitle: t("stepCoordinateTitle"),
-      coordinateDescription: t("stepCoordinateDescription"),
-      uploadTitle: t("stepUploadTitle"),
-      uploadDescription: t("stepUploadDescription"),
-      promptTitle: t("stepPromptTitle"),
-      promptDescription: t("stepPromptDescription"),
-      backgroundTitle: t("stepBackgroundTitle"),
-      backgroundDescription: t("stepBackgroundDescription"),
-      modelTitle: t("stepModelTitle"),
-      modelDescription: t("stepModelDescription"),
-      sizeTitle: t("stepSizeTitle"),
-      sizeDescription: t("stepSizeDescription"),
-      generateTitle: t("stepGenerateTitle"),
-      generateDescription: t("stepGenerateDescription"),
-      generatingTitle: t("stepGeneratingTitle"),
-      generatingDescription: t("stepGeneratingDescription"),
-      completedTitle: t("stepCompletedTitle"),
-      firstImageTitle: t("stepFirstImageTitle"),
-      firstImageDescription: t("stepFirstImageDescription"),
-      finishedTitle: t("stepFinishedTitle"),
-      finishedDescription: t("stepFinishedDescription"),
-    });
-
+    const tourSteps = getTourSteps(buildTourCopy());
     const driver = await loadDriver();
 
     const steps = [...tourSteps];
-    // Step1: モバイルは下部ナビ、PCはサイドバーのコーディネートをハイライト
+    // Step1: モバイルは下部ナビ、PCはサイドバーの生成入口をハイライト
     const isMobileOrTablet =
       typeof window !== "undefined" && window.innerWidth < 1024;
     steps[0] = {
@@ -190,7 +187,7 @@ export function TutorialTourProvider() {
         return (el ?? document.body) as Element;
       },
     };
-    // ②のステップ: ボタン非表示、コーディネートタップで遷移
+    // ①のステップ: ボタン非表示、入口ボタンのタップで /style へ遷移
     if (steps[0]?.popover) {
       const originalPopover = steps[0].popover as Record<string, unknown>;
       steps[0] = {
@@ -198,9 +195,12 @@ export function TutorialTourProvider() {
         popover: {
           ...originalPopover,
           showButtons: [],
-          onNextClick: (_element: Element | undefined, _step: unknown, options: { driver: Driver }) => {
-            writePreferredGalleryView("grid");
-            router.push("/coordinate");
+          onNextClick: (
+            _element: Element | undefined,
+            _step: unknown,
+            options: { driver: Driver }
+          ) => {
+            router.push(TUTORIAL_TOUR_ENTRY_PATH);
             options.driver.destroy();
           },
         },
@@ -229,56 +229,21 @@ export function TutorialTourProvider() {
     driverObj.drive(0);
   };
 
-  const startTourFromCoordinate = async () => {
+  const startTourFromStyle = async () => {
     if (typeof sessionStorage === "undefined") return;
 
     const inProgress = sessionStorage.getItem(TUTORIAL_STORAGE_KEYS.IN_PROGRESS);
     if (inProgress !== "true") return;
 
     const driver = await loadDriver();
-    const tourSteps = getTourSteps({
-      coordinateTitle: t("stepCoordinateTitle"),
-      coordinateDescription: t("stepCoordinateDescription"),
-      uploadTitle: t("stepUploadTitle"),
-      uploadDescription: t("stepUploadDescription"),
-      promptTitle: t("stepPromptTitle"),
-      promptDescription: t("stepPromptDescription"),
-      backgroundTitle: t("stepBackgroundTitle"),
-      backgroundDescription: t("stepBackgroundDescription"),
-      modelTitle: t("stepModelTitle"),
-      modelDescription: t("stepModelDescription"),
-      sizeTitle: t("stepSizeTitle"),
-      sizeDescription: t("stepSizeDescription"),
-      generateTitle: t("stepGenerateTitle"),
-      generateDescription: t("stepGenerateDescription"),
-      generatingTitle: t("stepGeneratingTitle"),
-      generatingDescription: t("stepGeneratingDescription"),
-      completedTitle: t("stepCompletedTitle"),
-      firstImageTitle: t("stepFirstImageTitle"),
-      firstImageDescription: t("stepFirstImageDescription"),
-      finishedTitle: t("stepFinishedTitle"),
-      finishedDescription: t("stepFinishedDescription"),
-    });
+    const tourSteps = getTourSteps(buildTourCopy());
 
-    // DOM の準備を待つ
+    // DOM の準備を待つ(②〜④のアンカーは /style ページ側に実装済み)
     const startFromStep = () => {
-      writePreferredGalleryView("grid");
-      document.dispatchEvent(
-        new CustomEvent("tutorial:prepare-coordinate-state", {
-          bubbles: true,
-        })
-      );
-      document.dispatchEvent(
-        new CustomEvent("tutorial:set-gallery-grid", {
-          bubbles: true,
-        })
-      );
-
       const hasRequiredElements = [
-        '[data-tour="tour-image-upload"]',
-        '[data-tour="tour-prompt-input"]',
-        '[data-tour="tour-model-select"]',
-        '[data-tour="tour-gpt-image-2-size"]',
+        '[data-tour="style-tour-preset"]',
+        '[data-tour="style-tour-character"]',
+        '[data-tour="style-tour-generate"]',
       ].every((sel) => document.querySelector(sel));
 
       if (!hasRequiredElements) {
@@ -286,156 +251,33 @@ export function TutorialTourProvider() {
         return;
       }
 
-      document.dispatchEvent(
-        new CustomEvent("tutorial:set-gpt-image-2-default-model", {
-          bubbles: true,
-        })
-      );
-
       const baseSteps = [...tourSteps];
       const lastIndex = baseSteps.length - 1;
 
-      // 生成開始（index 6）までは中断可能
-      const INTERRUPTIBLE_UNTIL_INDEX = 6;
-
-      // ③画像アップロード説明のステップでデモ画像を自動セット
-      // ④着せ替え内容入力のステップでプロンプトを自動セット（日本時間の現在月を基準）
+      // ②〜④(締めの手前まで)は「閉じる」で中断できるようにする
       let stepsWithCallbacks = baseSteps.map((step, idx) => {
-        // 中断可能なステップには「閉じる」ボタンを追加（既存の「戻る」「次へ」は維持）
-        let mergedStep = step;
-        if (idx <= INTERRUPTIBLE_UNTIL_INDEX && step.popover) {
-          const currentButtons =
-            (step.popover as { showButtons?: Array<"next" | "previous" | "close"> }).showButtons;
-          let newButtons: Array<"next" | "previous" | "close">;
-          if (currentButtons === undefined || currentButtons.length === 0) {
-            // 指定なし: デフォルトで「戻る」「次へ」+「閉じる」
-            newButtons = ["previous", "next", "close"];
-          } else {
-            // 既存のボタンに「閉じる」を追加
-            newButtons = [...currentButtons];
-            if (!newButtons.includes("close")) {
-              newButtons.push("close");
-            }
+        if (idx === 0 || idx === lastIndex || !step.popover) return step;
+        const currentButtons = (
+          step.popover as {
+            showButtons?: Array<"next" | "previous" | "close">;
           }
-          mergedStep = {
-            ...step,
-            popover: {
-              ...step.popover,
-              showButtons: newButtons,
-            },
-          };
-        }
-        if (idx === 1) {
-          return {
-            ...mergedStep,
-            onHighlighted: (element: Element | undefined) => {
-              document.dispatchEvent(
-                new CustomEvent("tutorial:set-demo-image", { bubbles: true })
-              );
-              // Step2: 画像アップロード欄を画面中央付近にスクロール
-              if (element && element !== document.body) {
-                requestAnimationFrame(() => {
-                  element.scrollIntoView({
-                    behavior: "smooth",
-                    block: "center",
-                    inline: "nearest",
-                  });
-                });
-              }
-            },
-          };
-        }
-        if (idx === 2) {
-          return {
-            ...mergedStep,
-            onHighlighted: (element: Element | undefined) => {
-              document.dispatchEvent(
-                new CustomEvent("tutorial:set-prompt", {
-                  bubbles: true,
-                  detail: {
-                    prompt: t("promptTemplate", { month: getJapanMonth() }),
-                  },
-                })
-              );
-              // Step3: 着せ替え内容入力欄を画面中央付近にスクロール（カスタムonHighlightedのためここで実行）
-              if (element && element !== document.body) {
-                requestAnimationFrame(() => {
-                  element.scrollIntoView({
-                    behavior: "smooth",
-                    block: "center",
-                    inline: "nearest",
-                  });
-                });
-              }
-            },
-          };
-        }
-        if (idx === 3) {
-          return {
-            ...mergedStep,
-            onHighlighted: (element: Element | undefined) => {
-              document.dispatchEvent(
-                new CustomEvent("tutorial:set-background-mode", {
-                  bubbles: true,
-                  detail: { mode: "ai_auto" },
-                })
-              );
-              // Step4: 背景設定オプションを画面中央付近にスクロール
-              if (element && element !== document.body) {
-                requestAnimationFrame(() => {
-                  element.scrollIntoView({
-                    behavior: "smooth",
-                    block: "center",
-                    inline: "nearest",
-                  });
-                });
-              }
-            },
-          };
-        }
-        if (idx === 4 || idx === 5) {
-          return {
-            ...mergedStep,
-            onHighlighted: (element: Element | undefined) => {
-              document.dispatchEvent(
-                new CustomEvent("tutorial:set-gpt-image-2-default-model", {
-                  bubbles: true,
-                })
-              );
-              if (element && element !== document.body) {
-                requestAnimationFrame(() => {
-                  element.scrollIntoView({
-                    behavior: "smooth",
-                    block: "center",
-                    inline: "nearest",
-                  });
-                });
-              }
-            },
-          };
-        }
-        if (idx === 9) {
-          return {
-            ...mergedStep,
-            onHighlighted: (element: Element | undefined) => {
-              document.body.setAttribute("data-tour-step-first-image", "true");
-              document.dispatchEvent(new CustomEvent("tutorial:step-11-changed"));
-              if (element && element !== document.body) {
-                requestAnimationFrame(() => {
-                  element.scrollIntoView({
-                    behavior: "smooth",
-                    block: "center",
-                    inline: "nearest",
-                  });
-                });
-              }
-            },
-          };
-        }
-        return mergedStep;
+        ).showButtons;
+        const newButtons: Array<"next" | "previous" | "close"> =
+          currentButtons === undefined || currentButtons.length === 0
+            ? ["previous", "next", "close"]
+            : currentButtons.includes("close")
+              ? [...currentButtons]
+              : [...currentButtons, "close"];
+        return {
+          ...step,
+          popover: {
+            ...step.popover,
+            showButtons: newButtons,
+          },
+        };
       });
 
-      // 最後のステップで完了時にAPIを呼ぶ（next/done/close いずれでも）
+      // 締めのステップ: 「完了」で完了APIを呼ぶ(付与は冪等)
       const lastStep = stepsWithCallbacks[lastIndex];
       const handleTourComplete = (opts: { driver: Driver }) => {
         document.body.setAttribute("data-tour-transitioning", "true");
@@ -454,10 +296,16 @@ export function TutorialTourProvider() {
           ...lastStep,
           popover: {
             ...orig,
-            onNextClick: (_el: Element | undefined, _step: unknown, opts: { driver: Driver }) =>
-              handleTourComplete(opts),
-            onCloseClick: (_el: Element | undefined, _step: unknown, opts: { driver: Driver }) =>
-              handleTourComplete(opts),
+            onNextClick: (
+              _el: Element | undefined,
+              _step: unknown,
+              opts: { driver: Driver }
+            ) => handleTourComplete(opts),
+            onCloseClick: (
+              _el: Element | undefined,
+              _step: unknown,
+              opts: { driver: Driver }
+            ) => handleTourComplete(opts),
           },
         };
       }
@@ -468,10 +316,6 @@ export function TutorialTourProvider() {
         if (typeof document !== "undefined") {
           document.body.removeAttribute("data-tour-in-progress");
           document.body.removeAttribute("data-tour-transitioning");
-          document.body.removeAttribute("data-tour-step-first-image");
-          document.dispatchEvent(new CustomEvent("tutorial:step-11-changed"));
-          // チュートリアル用の画像・プロンプト等をクリアして画面を初期状態に戻す
-          document.dispatchEvent(new CustomEvent("tutorial:clear", { bubbles: true }));
         }
       };
 
@@ -490,7 +334,7 @@ export function TutorialTourProvider() {
         steps: stepsWithCallbacks,
         onDestroyStarted: (_el, _step, opts) => {
           const idx = opts.driver.getActiveIndex() ?? 0;
-          if (idx <= INTERRUPTIBLE_UNTIL_INDEX) {
+          if (idx < lastIndex) {
             handleTourInterrupt();
             opts.driver.destroy();
           }
@@ -508,12 +352,6 @@ export function TutorialTourProvider() {
           runTransitionFlow(d, prevIndex, () => d.movePrevious());
         },
         onHighlighted: (element) => {
-          // 生成結果ハイライト以外では投稿/ダウンロード無効化を解除
-          const idx = driverRef.current?.getActiveIndex();
-          if (idx !== 9) {
-            document.body.removeAttribute("data-tour-step-first-image");
-            document.dispatchEvent(new CustomEvent("tutorial:step-11-changed"));
-          }
           // 初回表示時: ハイライト要素を画面中央付近にスクロール
           if (element && element !== document.body) {
             requestAnimationFrame(() => {
@@ -530,8 +368,6 @@ export function TutorialTourProvider() {
           if (typeof document !== "undefined") {
             document.body.removeAttribute("data-tour-in-progress");
             document.body.removeAttribute("data-tour-transitioning");
-            document.body.removeAttribute("data-tour-step-first-image");
-            document.dispatchEvent(new CustomEvent("tutorial:step-11-changed"));
           }
         },
       });
@@ -540,7 +376,7 @@ export function TutorialTourProvider() {
       if (typeof document !== "undefined") {
         document.body.setAttribute("data-tour-in-progress", "true");
       }
-      driverObj.drive(1); // ③から開始（index 1）
+      driverObj.drive(1); // ②から開始（index 1）
     };
 
     requestAnimationFrame(startFromStep);
@@ -569,53 +405,16 @@ export function TutorialTourProvider() {
     }
   };
 
-  // コーデスタート押下で1秒後に生成中ステップへ進む
+  // /style に遷移したらツアー再開
   useEffect(() => {
-    const handler = () => {
-      setTimeout(() => {
-        const d = driverRef.current;
-        if (!d || d.isLastStep()) return;
-        const nextIndex = (d.getActiveIndex() ?? 0) + 1;
-        runTransitionFlow(d, nextIndex, () => d.moveNext());
-      }, 1000);
-    };
-    document.addEventListener("tutorial:advance-to-next", handler);
-    return () => document.removeEventListener("tutorial:advance-to-next", handler);
-  }, []);
-
-  // 生成完了で完了アニメーション表示後に「完了しました！」へ進む
-  useEffect(() => {
-    const handler = () => {
-      // 同イベントの重複発火時は二重遷移を防ぐ
-      if (generationCompleteDelayTimerRef.current) return;
-      generationCompleteDelayTimerRef.current = setTimeout(() => {
-        generationCompleteDelayTimerRef.current = null;
-        const d = driverRef.current;
-        if (!d || d.isLastStep()) return;
-        const nextIndex = (d.getActiveIndex() ?? 0) + 1;
-        runTransitionFlow(d, nextIndex, () => d.moveNext());
-      }, GENERATION_COMPLETE_TRANSITION_DELAY_MS);
-    };
-    document.addEventListener("tutorial:generation-complete", handler);
-    return () => {
-      document.removeEventListener("tutorial:generation-complete", handler);
-      if (generationCompleteDelayTimerRef.current) {
-        clearTimeout(generationCompleteDelayTimerRef.current);
-        generationCompleteDelayTimerRef.current = null;
-      }
-    };
-  }, []);
-
-  // /coordinate に遷移したらツアー再開
-  useEffect(() => {
-    if (normalizedPath !== "/coordinate") {
-      coordinateTourStartedRef.current = false;
+    if (normalizedPath !== TUTORIAL_TOUR_ENTRY_PATH) {
+      styleTourStartedRef.current = false;
       return;
     }
     if (isChecking) return;
-    if (coordinateTourStartedRef.current) return;
+    if (styleTourStartedRef.current) return;
 
-    coordinateTourStartedRef.current = true;
+    styleTourStartedRef.current = true;
     let cancelled = false;
 
     if (driverRef.current) {
@@ -630,7 +429,7 @@ export function TutorialTourProvider() {
         return;
       }
 
-      void startTourFromCoordinate();
+      void startTourFromStyle();
     };
 
     const timer = window.setTimeout(resumeTourWhenReady, 300);

--- a/features/tutorial/lib/constants.ts
+++ b/features/tutorial/lib/constants.ts
@@ -3,13 +3,3 @@
  */
 
 export const TUTORIAL_DEMO_IMAGE_PATH = "/tutorial-demo.jpg";
-
-/** 日本時間の現在月を取得 */
-export function getJapanMonth(): number {
-  const japanDate = new Date(
-    new Date().toLocaleString("en-US", { timeZone: "Asia/Tokyo" })
-  );
-  return japanDate.getMonth() + 1; // 1-12
-}
-
-export const TUTORIAL_BONUS_AMOUNT = 20;

--- a/features/tutorial/lib/tour-steps.ts
+++ b/features/tutorial/lib/tour-steps.ts
@@ -1,122 +1,65 @@
 import type { DriveStep } from "driver.js";
 
 export interface TutorialTourCopy {
-  coordinateTitle: string;
-  coordinateDescription: string;
-  uploadTitle: string;
-  uploadDescription: string;
-  promptTitle: string;
-  promptDescription: string;
-  backgroundTitle: string;
-  backgroundDescription: string;
-  modelTitle: string;
-  modelDescription: string;
-  sizeTitle: string;
-  sizeDescription: string;
+  navigateTitle: string;
+  navigateDescription: string;
+  presetTitle: string;
+  presetDescription: string;
+  characterTitle: string;
+  characterDescription: string;
   generateTitle: string;
   generateDescription: string;
-  generatingTitle: string;
-  generatingDescription: string;
-  completedTitle: string;
-  firstImageTitle: string;
-  firstImageDescription: string;
   finishedTitle: string;
   finishedDescription: string;
 }
 
+/**
+ * 新規登録チュートリアル(全5ステップ・ツールチップのみ)のステップ定義。
+ *
+ * ① ホームでナビの生成入口を案内(タップで /style へ遷移)
+ * ②〜④ One-Tap Style のミニツアー(style-tour-*)と同じアンカーを共用
+ *       (スタイル選択 → キャラクター写真 → 生成ボタン)
+ * ⑤ 締め(「完了」で完了APIを呼び、完了ボーナスを付与)
+ *
+ * 生成もデモ画像の挿入も行わないため、課金経路には一切影響しない。
+ * ①の element はモバイル/PC でナビの実体が異なるため Provider 側で差し替える。
+ */
 export function getTourSteps(copy: TutorialTourCopy): DriveStep[] {
   return [
     {
-      element: '[data-tour="coordinate-nav"]',
+      element: '[data-tour="coordinate-nav-mobile"]',
       popover: {
-        title: copy.coordinateTitle,
-        description: copy.coordinateDescription,
+        title: copy.navigateTitle,
+        description: copy.navigateDescription,
         side: "top",
         align: "center",
       },
     },
     {
-      element: '[data-tour="tour-image-upload"]',
+      element: '[data-tour="style-tour-preset"]',
       popover: {
-        title: copy.uploadTitle,
-        description: copy.uploadDescription,
+        title: copy.presetTitle,
+        description: copy.presetDescription,
         side: "bottom",
-        align: "start",
-      },
-    },
-    {
-      element: '[data-tour="tour-prompt-input"]',
-      popover: {
-        title: copy.promptTitle,
-        description: copy.promptDescription,
-        side: "top",
-        align: "start",
-      },
-    },
-    {
-      element: '[data-tour="tour-background-change"]',
-      popover: {
-        title: copy.backgroundTitle,
-        description: copy.backgroundDescription,
-        side: "right",
         align: "center",
       },
     },
     {
-      element: '[data-tour="tour-model-select"]',
+      element: '[data-tour="style-tour-character"]',
       popover: {
-        title: copy.modelTitle,
-        description: copy.modelDescription,
+        title: copy.characterTitle,
+        description: copy.characterDescription,
         side: "top",
-        align: "start",
+        align: "center",
       },
     },
     {
-      element: '[data-tour="tour-gpt-image-2-size"]',
-      popover: {
-        title: copy.sizeTitle,
-        description: copy.sizeDescription,
-        side: "top",
-        align: "start",
-      },
-    },
-    {
-      element: '[data-tour="tour-generate-btn"]',
+      element: '[data-tour="style-tour-generate"]',
       popover: {
         title: copy.generateTitle,
         description: copy.generateDescription,
         side: "top",
         align: "center",
-        showButtons: ["previous"],
-      },
-    },
-    {
-      element: '[data-tour="tour-generating"]',
-      popover: {
-        title: copy.generatingTitle,
-        description: copy.generatingDescription,
-        side: "top",
-        align: "start",
-        showButtons: [],
-      },
-    },
-    {
-      popover: {
-        title: copy.completedTitle,
-        description: "",
-        side: "over",
-        align: "center",
-        showButtons: ["next"],
-      },
-    },
-    {
-      element: '[data-tour="tour-first-image"]',
-      popover: {
-        title: copy.firstImageTitle,
-        description: copy.firstImageDescription,
-        side: "top",
-        align: "center",
-        showButtons: ["next"],
       },
     },
     {

--- a/features/tutorial/lib/tutorial-status.ts
+++ b/features/tutorial/lib/tutorial-status.ts
@@ -1,11 +1,18 @@
 import { TUTORIAL_STORAGE_KEYS } from "@/features/tutorial/types";
 
 /**
+ * 新規登録チュートリアルツアーの目的地(ツアー②〜④を表示する画面)。
+ * ツアー進行中は、ナビの生成入口タップを直近モードに関わらずここへ固定する。
+ */
+export const TUTORIAL_TOUR_ENTRY_PATH = "/style";
+
+/**
  * チュートリアルツアーが進行中(sessionStorage の in_progress が立っている)かを返す。
  *
  * ナビの「コーディネート」入口は通常「直近に使った生成モード」へ差し替え遷移するが、
- * ツアー進行中にそれをやると、直近が /style・/free のユーザーはツアーの再開先
- * (/coordinate)に到達できず無言で詰まる。ツアー中だけ差し替えを止めるための判定。
+ * ツアー進行中にそれをやると、直近モードのユーザーはツアーの再開先
+ * (TUTORIAL_TOUR_ENTRY_PATH)に到達できず無言で詰まる。
+ * ツアー中だけ遷移先を固定するための判定。
  */
 export function isTutorialTourInProgress(): boolean {
   if (typeof window === "undefined") {

--- a/messages/ar.ts
+++ b/messages/ar.ts
@@ -936,8 +936,11 @@ export const arMessages = {
   coordinate: {
     tabLabel: "Coordinate",
     tourButton: "الدليل التعليمي",
+    tourStepUploadTitle: "ارفع صورة",
     tourStepUploadDescription: "ارفع هنا صورة الشخصية التي تريد إعادة تنسيقها.",
+    tourStepPromptTitle: "أدخل النص الموجِّه للتنسيق",
     tourStepPromptDescription: "صف نوع الإطلالة التي تريدها.",
+    tourStepGenerateTitle: "بدء التوليد",
     tourStepGenerateDescription: "اختر \"بدء التنسيق\" للبدء.",
     pageTitle: "Coordinate",
     pageDescription: "ارفع صورة شخص وغيّر الملابس بسهولة. حافظ على الوضعية والتكوين الأصليين، وغيّر الملابس فقط بشكل طبيعي.",
@@ -1417,38 +1420,11 @@ export const arMessages = {
     prevButton: "رجوع",
     nextButton: "التالي",
     doneButton: "تم",
-    promptTemplate:
-      "يُرجى تنسيق الإطلالة بما يلائم موسم الشهر {month}.",
-    stepCoordinateTitle: "افتح التنسيق",
-    stepCoordinateDescription: "اضغط هنا لفتح شاشة التنسيق.",
-    stepUploadTitle: "ارفع صورة",
-    stepUploadDescription:
-      "ارفع هنا صورة الشخصية التي تريد إعادة تنسيقها. حضّرنا بالفعل صورة تجريبية لهذا الدليل.",
-    stepPromptTitle: "أدخل النص الموجِّه للتنسيق",
-    stepPromptDescription:
-      "صف نوع الإطلالة التي تريدها. سنستخدم هذا المثال للدليل.",
-    stepBackgroundTitle: "إعدادات الخلفية",
-    stepBackgroundDescription:
-      "اختر هنا كيفية التعامل مع الخلفية. لهذا الدليل، لنتابع بـ \"اترك الأمر للذكاء الاصطناعي\".",
-    stepModelTitle: "اختر نموذج التوليد",
-    stepModelDescription:
-      "سنستخدم في هذا الدليل ChatGPT Images 2.0 Low. إذا كان نموذج آخر محددًا، فسيتم التبديل إليه تلقائيًا هنا.",
-    stepSizeTitle: "تحقق من حجم الإخراج",
-    stepSizeDescription:
-      "سنبقي حجم الإخراج على القياسي. يتم ضبط الأبعاد الفعلية تلقائيًا حسب اتجاه الصورة.",
-    stepGenerateTitle: "بدء التوليد",
-    stepGenerateDescription:
-      "اختر \"بدء التنسيق\" للبدء. ستُعاد لك Percoin بعد الدليل، فلا تتردد في المتابعة.",
-    stepGeneratingTitle: "جارٍ التوليد...",
-    stepGeneratingDescription:
-      "يمكنك متابعة التقدم أدناه. يُرجى الانتظار لحظة حتى الانتهاء!",
-    stepCompletedTitle: "جاهز!",
-    stepFirstImageTitle: "اكتمل تغيير إطلالتك",
-    stepFirstImageDescription:
-      "يمكنك الآن نشر النتيجة أو تنزيلها. جرّبها.",
+    stepNavigateTitle: "ابدأ الإنشاء من هنا!",
+    stepNavigateDescription: "اضغط هنا للمتابعة.",
     stepFinishedTitle: "اكتملت الجولة",
     stepFinishedDescription:
-      "أحسنت. استمتع بإنشاء المزيد من تغييرات الإطلالة من هنا. اضغط \"تم\" لاستلام مكافأة Percoin.",
+      "كل شيء جاهز! اختر النمط والصورة المفضلين لديك لإنشاء أول صورة. أكمل الجولة للحصول على مكافأة Percoin.",
   },
   free: {
     tabLabel: "Free Style",

--- a/messages/ar.ts
+++ b/messages/ar.ts
@@ -1424,7 +1424,7 @@ export const arMessages = {
     stepNavigateDescription: "اضغط هنا للمتابعة.",
     stepFinishedTitle: "اكتملت الجولة",
     stepFinishedDescription:
-      "كل شيء جاهز! اختر النمط والصورة المفضلين لديك لإنشاء أول صورة. أكمل الجولة للحصول على مكافأة Percoin.",
+      "أحسنت! جرّب إنشاء صورة الآن! اضغط على «تم» للحصول على مكافأة Percoin.",
   },
   free: {
     tabLabel: "Free Style",
@@ -1683,9 +1683,9 @@ export const arMessages = {
     tourNextButton: "التالي",
     tourDoneButton: "جرّبه الآن!",
     tourStepPresetTitle: "✨ ① اختر النمط",
-    tourStepPresetDescription: "اختر النمط الذي تريد ارتداءه!",
+    tourStepPresetDescription: "هنا تختار النمط المفضل لديك!",
     tourStepCharacterTitle: "💖 ② اختر شخصيتك",
-    tourStepCharacterDescription: "اختر الشخصية التي تريد تغيير ملابسها!",
+    tourStepCharacterDescription: "هنا تقوم بإعداد شخصيتك!",
     tourStepGenerateTitle: "🚀 ③ ابدأ التنسيق!",
     tourStepGenerateDescription: "اضغط وستبدأ عملية الإنشاء! ما عليك سوى الانتظار!",
   },

--- a/messages/de.ts
+++ b/messages/de.ts
@@ -1428,7 +1428,7 @@ export const deMessages = {
     stepNavigateDescription: "Tippe hier, um fortzufahren.",
     stepFinishedTitle: "Tour abgeschlossen",
     stepFinishedDescription:
-      "Alles bereit! Wähle einen Stil und ein Foto und erstelle dein erstes Bild. Schließe die Tour ab, um deinen Percoin-Bonus zu erhalten.",
+      "Gut gemacht! Probiere es aus und erstelle ein Bild! Tippe auf „Fertig“, um deinen Bonus-Percoin zu erhalten.",
   },
   free: {
     tabLabel: "Free Style",
@@ -1687,9 +1687,9 @@ export const deMessages = {
     tourNextButton: "Weiter",
     tourDoneButton: "Gleich ausprobieren!",
     tourStepPresetTitle: "✨ ① Stil auswählen",
-    tourStepPresetDescription: "Wähle den Stil, den du anziehen möchtest!",
+    tourStepPresetDescription: "Hier wählst du deinen Lieblingsstil aus!",
     tourStepCharacterTitle: "💖 ② Charakter auswählen",
-    tourStepCharacterDescription: "Wähle den Charakter, den du umstylen möchtest!",
+    tourStepCharacterDescription: "Hier legst du deinen Charakter fest!",
     tourStepGenerateTitle: "🚀 ③ Outfit starten!",
     tourStepGenerateDescription: "Antippen und die Generierung beginnt – einfach abwarten!",
   },

--- a/messages/de.ts
+++ b/messages/de.ts
@@ -939,8 +939,11 @@ export const deMessages = {
   coordinate: {
     tabLabel: "Coordinate",
     tourButton: "Tutorial",
+    tourStepUploadTitle: "Bild hochladen",
     tourStepUploadDescription: "Lade hier das Charakterbild hoch, das du restylen willst.",
+    tourStepPromptTitle: "Styling-Prompt eingeben",
     tourStepPromptDescription: "Beschreibe das gewünschte Outfit.",
+    tourStepGenerateTitle: "Generierung starten",
     tourStepGenerateDescription: "Wähle \"Styling starten\", um zu beginnen.",
     pageTitle: "Coordinate",
     pageDescription: "Lade ein Foto hoch und wechsle das Outfit ganz einfach. Behalte Pose und Bildausschnitt bei und ändere nur die Kleidung – ganz natürlich.",
@@ -1421,38 +1424,11 @@ export const deMessages = {
     prevButton: "Zurück",
     nextButton: "Weiter",
     doneButton: "Fertig",
-    promptTemplate:
-      "Bitte gestalte das Outfit passend zur Jahreszeit von Monat {month}.",
-    stepCoordinateTitle: "Koordinieren öffnen",
-    stepCoordinateDescription: "Tippe hier, um den Koordinieren-Bildschirm zu öffnen.",
-    stepUploadTitle: "Bild hochladen",
-    stepUploadDescription:
-      "Lade hier das Charakterbild hoch, das du restylen willst. Wir haben für diese Tour bereits ein Demo-Bild vorbereitet.",
-    stepPromptTitle: "Styling-Prompt eingeben",
-    stepPromptDescription:
-      "Beschreibe das gewünschte Outfit. Wir verwenden dieses Beispiel für das Tutorial.",
-    stepBackgroundTitle: "Hintergrund-Einstellungen",
-    stepBackgroundDescription:
-      "Wähle hier, wie der Hintergrund behandelt wird. Für dieses Tutorial bleiben wir bei \"KI entscheiden lassen\".",
-    stepModelTitle: "Generierungsmodell auswählen",
-    stepModelDescription:
-      "Für dieses Tutorial verwenden wir ChatGPT Images 2.0 Low. Wenn ein anderes Modell ausgewählt war, wird es hier automatisch umgestellt.",
-    stepSizeTitle: "Ausgabegröße prüfen",
-    stepSizeDescription:
-      "Die Ausgabegröße bleibt auf Standard. Die tatsächlichen Abmessungen werden automatisch an die Bildausrichtung angepasst.",
-    stepGenerateTitle: "Generierung starten",
-    stepGenerateDescription:
-      "Wähle \"Styling starten\", um zu beginnen. Deine Percoins werden nach dem Tutorial wieder gutgeschrieben.",
-    stepGeneratingTitle: "Wird generiert...",
-    stepGeneratingDescription:
-      "Du kannst den Fortschritt unten verfolgen. Bitte warte einen Moment, bis es fertig ist!",
-    stepCompletedTitle: "Es ist fertig!",
-    stepFirstImageTitle: "Dein Outfit-Wechsel ist abgeschlossen",
-    stepFirstImageDescription:
-      "Jetzt kannst du das Ergebnis veröffentlichen oder herunterladen. Probier es aus.",
+    stepNavigateTitle: "Hier geht's los!",
+    stepNavigateDescription: "Tippe hier, um fortzufahren.",
     stepFinishedTitle: "Tour abgeschlossen",
     stepFinishedDescription:
-      "Gut gemacht. Genieße jetzt das Erstellen weiterer Outfit-Wechsel. Klicke auf \"Fertig\", um deine Percoin-Belohnung zu erhalten.",
+      "Alles bereit! Wähle einen Stil und ein Foto und erstelle dein erstes Bild. Schließe die Tour ab, um deinen Percoin-Bonus zu erhalten.",
   },
   free: {
     tabLabel: "Free Style",

--- a/messages/en.ts
+++ b/messages/en.ts
@@ -936,8 +936,11 @@ export const enMessages = {
   coordinate: {
     tabLabel: "Coordinate",
     tourButton: "Tutorial",
+    tourStepUploadTitle: "Upload an image",
     tourStepUploadDescription: "Upload the character image you want to restyle here.",
+    tourStepPromptTitle: "Enter the styling prompt",
     tourStepPromptDescription: "Describe the kind of outfit you want.",
+    tourStepGenerateTitle: "Start generating",
     tourStepGenerateDescription: "Select “Start styling” to begin.",
     pageTitle: "Coordinate",
     pageDescription: "Upload a photo and change outfits with ease. Keep the original pose and composition while naturally swapping just the clothing.",
@@ -1417,38 +1420,11 @@ export const enMessages = {
     prevButton: "Back",
     nextButton: "Next",
     doneButton: "Done",
-    promptTemplate:
-      "Please style the outfit to match the season in month {month}.",
-    stepCoordinateTitle: "Open Coordinate",
-    stepCoordinateDescription: "Tap here to open the coordinate screen.",
-    stepUploadTitle: "Upload an image",
-    stepUploadDescription:
-      "Upload the character image you want to restyle here. We've already prepared a demo image for this walkthrough.",
-    stepPromptTitle: "Enter the styling prompt",
-    stepPromptDescription:
-      "Describe the kind of outfit you want. We'll use this example for the tutorial.",
-    stepBackgroundTitle: "Background settings",
-    stepBackgroundDescription:
-      "Choose how to handle the background here. For this tutorial, let's continue with “Let AI decide.”",
-    stepModelTitle: "Select the generation model",
-    stepModelDescription:
-      "For this tutorial, we'll use ChatGPT Images 2.0 Low. If another model was selected, it is switched automatically here.",
-    stepSizeTitle: "Check the output size",
-    stepSizeDescription:
-      "We'll keep the output size set to Standard. The exact dimensions are adjusted automatically to match the image orientation.",
-    stepGenerateTitle: "Start generating",
-    stepGenerateDescription:
-      "Select “Start styling” to begin. Your Percoins will be restored after the tutorial, so feel free to continue.",
-    stepGeneratingTitle: "Generating...",
-    stepGeneratingDescription:
-      "You can track the progress below. Please wait a moment for it to finish!",
-    stepCompletedTitle: "It's ready!",
-    stepFirstImageTitle: "Your outfit swap is complete",
-    stepFirstImageDescription:
-      "You can now post or download the result. Give it a try.",
+    stepNavigateTitle: "Start creating here!",
+    stepNavigateDescription: "Tap here to continue.",
     stepFinishedTitle: "Tour complete",
     stepFinishedDescription:
-      "Nice work. Enjoy creating more outfit swaps from here. Click “Done” to receive your Percoin reward.",
+      "You're all set! Pick a style and a photo to create your first image. Complete the tour to receive your Percoin bonus.",
   },
   free: {
     tabLabel: "Free Style",

--- a/messages/en.ts
+++ b/messages/en.ts
@@ -1424,7 +1424,7 @@ export const enMessages = {
     stepNavigateDescription: "Tap here to continue.",
     stepFinishedTitle: "Tour complete",
     stepFinishedDescription:
-      "You're all set! Pick a style and a photo to create your first image. Complete the tour to receive your Percoin bonus.",
+      "Great job! Go ahead and try creating an image! Tap “Done” to receive your bonus Percoin.",
   },
   free: {
     tabLabel: "Free Style",
@@ -1683,9 +1683,9 @@ export const enMessages = {
     tourNextButton: "Next",
     tourDoneButton: "Try it now!",
     tourStepPresetTitle: "✨ 1. Pick a style",
-    tourStepPresetDescription: "Choose the style you want to dress up in!",
+    tourStepPresetDescription: "Here you'll pick your favorite style!",
     tourStepCharacterTitle: "💖 2. Pick your character",
-    tourStepCharacterDescription: "Choose the character you want to dress up!",
+    tourStepCharacterDescription: "Here you'll set up your character!",
     tourStepGenerateTitle: "🚀 3. Start the outfit!",
     tourStepGenerateDescription: "Tap it and generation begins — then just wait!",
   },

--- a/messages/es.ts
+++ b/messages/es.ts
@@ -1427,7 +1427,7 @@ export const esMessages = {
     stepNavigateDescription: "Toca aquí para continuar.",
     stepFinishedTitle: "Recorrido completado",
     stepFinishedDescription:
-      "¡Todo listo! Elige un estilo y una foto para crear tu primera imagen. Al completar el tour recibirás tu bono de Percoin.",
+      "¡Buen trabajo! ¡Anímate a crear una imagen! Al tocar «Listo» recibirás tu Percoin de bonificación.",
   },
   free: {
     tabLabel: "Free Style",
@@ -1686,9 +1686,9 @@ export const esMessages = {
     tourNextButton: "Siguiente",
     tourDoneButton: "¡Pruébalo ya!",
     tourStepPresetTitle: "✨ ① Elige un estilo",
-    tourStepPresetDescription: "¡Selecciona el estilo con el que quieres vestir!",
+    tourStepPresetDescription: "¡Aquí eliges tu estilo favorito!",
     tourStepCharacterTitle: "💖 ② Elige tu personaje",
-    tourStepCharacterDescription: "¡Elige el personaje al que quieres cambiar de look!",
+    tourStepCharacterDescription: "¡Aquí configuras tu personaje!",
     tourStepGenerateTitle: "🚀 ③ ¡Empieza el outfit!",
     tourStepGenerateDescription: "Al pulsarlo comienza la generación. ¡Solo queda esperar!",
   },

--- a/messages/es.ts
+++ b/messages/es.ts
@@ -939,8 +939,11 @@ export const esMessages = {
   coordinate: {
     tabLabel: "Coordinate",
     tourButton: "Tutorial",
+    tourStepUploadTitle: "Sube una imagen",
     tourStepUploadDescription: "Sube aquí la imagen del personaje que quieres restilizar.",
+    tourStepPromptTitle: "Introduce el prompt de styling",
     tourStepPromptDescription: "Describe el tipo de conjunto que quieres.",
+    tourStepGenerateTitle: "Empieza a generar",
     tourStepGenerateDescription: "Selecciona \"Empezar styling\" para empezar.",
     pageTitle: "Coordinate",
     pageDescription: "Sube una foto y cambia de outfit con facilidad. Mantén la pose y la composición originales y cambia solo la ropa de forma natural.",
@@ -1420,38 +1423,11 @@ export const esMessages = {
     prevButton: "Atrás",
     nextButton: "Siguiente",
     doneButton: "Listo",
-    promptTemplate:
-      "Diseña un conjunto acorde con la temporada del mes {month}.",
-    stepCoordinateTitle: "Abrir Coordinar",
-    stepCoordinateDescription: "Toca aquí para abrir la pantalla de coordinación.",
-    stepUploadTitle: "Sube una imagen",
-    stepUploadDescription:
-      "Sube aquí la imagen del personaje que quieres restilizar. Hemos preparado una imagen de demostración para este recorrido.",
-    stepPromptTitle: "Introduce el prompt de styling",
-    stepPromptDescription:
-      "Describe el tipo de conjunto que quieres. Usaremos este ejemplo para el tutorial.",
-    stepBackgroundTitle: "Configuración del fondo",
-    stepBackgroundDescription:
-      "Elige aquí cómo gestionar el fondo. Para este tutorial, sigamos con \"Que decida la IA\".",
-    stepModelTitle: "Selecciona el modelo de generación",
-    stepModelDescription:
-      "En este tutorial usaremos ChatGPT Images 2.0 Low. Si había otro modelo seleccionado, se cambiará automáticamente aquí.",
-    stepSizeTitle: "Comprueba el tamaño de salida",
-    stepSizeDescription:
-      "Mantendremos el tamaño de salida en Estándar. Las dimensiones exactas se ajustan automáticamente según la orientación de la imagen.",
-    stepGenerateTitle: "Empieza a generar",
-    stepGenerateDescription:
-      "Selecciona \"Empezar styling\" para empezar. Tus Percoins se restituirán tras el tutorial, así que sigue sin preocupaciones.",
-    stepGeneratingTitle: "Generando...",
-    stepGeneratingDescription:
-      "Puedes seguir el progreso debajo. ¡Espera un momento a que termine!",
-    stepCompletedTitle: "¡Listo!",
-    stepFirstImageTitle: "Tu cambio de conjunto está completo",
-    stepFirstImageDescription:
-      "Ahora puedes publicar o descargar el resultado. ¡Pruébalo!",
+    stepNavigateTitle: "¡Empieza a crear aquí!",
+    stepNavigateDescription: "Toca aquí para continuar.",
     stepFinishedTitle: "Recorrido completado",
     stepFinishedDescription:
-      "Buen trabajo. Sigue creando más cambios de conjunto a partir de aquí. Pulsa \"Listo\" para recibir tu recompensa de Percoins.",
+      "¡Todo listo! Elige un estilo y una foto para crear tu primera imagen. Al completar el tour recibirás tu bono de Percoin.",
   },
   free: {
     tabLabel: "Free Style",

--- a/messages/fr.ts
+++ b/messages/fr.ts
@@ -1427,7 +1427,7 @@ export const frMessages = {
     stepNavigateDescription: "Touchez ici pour continuer.",
     stepFinishedTitle: "Visite terminée",
     stepFinishedDescription:
-      "C'est prêt ! Choisissez un style et une photo pour créer votre première image. Terminez la visite pour recevoir votre bonus Percoin.",
+      "Bravo ! Lancez-vous et créez une image ! Touchez « Terminer » pour recevoir votre bonus Percoin.",
   },
   free: {
     tabLabel: "Free Style",
@@ -1686,9 +1686,10 @@ export const frMessages = {
     tourNextButton: "Suivant",
     tourDoneButton: "Essayer tout de suite !",
     tourStepPresetTitle: "✨ ① Choisissez un style",
-    tourStepPresetDescription: "Sélectionnez le style que vous voulez porter !",
+    tourStepPresetDescription:
+      "Ici, vous choisissez votre style préféré !",
     tourStepCharacterTitle: "💖 ② Choisissez votre personnage",
-    tourStepCharacterDescription: "Choisissez le personnage à relooker !",
+    tourStepCharacterDescription: "Ici, vous définissez votre personnage !",
     tourStepGenerateTitle: "🚀 ③ Lancez la tenue !",
     tourStepGenerateDescription: "Touchez le bouton et la génération démarre. Il n'y a plus qu'à attendre !",
   },

--- a/messages/fr.ts
+++ b/messages/fr.ts
@@ -939,8 +939,11 @@ export const frMessages = {
   coordinate: {
     tabLabel: "Coordinate",
     tourButton: "Tutoriel",
+    tourStepUploadTitle: "Télécharger une image",
     tourStepUploadDescription: "Téléchargez ici l’image du personnage que vous souhaitez restyler.",
+    tourStepPromptTitle: "Saisir le prompt de styling",
     tourStepPromptDescription: "Décrivez le type de tenue souhaité.",
+    tourStepGenerateTitle: "Lancer la génération",
     tourStepGenerateDescription: "Sélectionnez « Démarrer le styling ».",
     pageTitle: "Coordinate",
     pageDescription: "Importez une photo et changez de tenue en toute simplicité. Gardez la pose et le cadrage d'origine en ne modifiant que les vêtements, naturellement.",
@@ -1420,38 +1423,11 @@ export const frMessages = {
     prevButton: "Retour",
     nextButton: "Suivant",
     doneButton: "Terminer",
-    promptTemplate:
-      "Veuillez créer une tenue adaptée à la saison du mois de {month}.",
-    stepCoordinateTitle: "Ouvrir Coordonner",
-    stepCoordinateDescription: "Touchez ici pour ouvrir l'écran Coordonner.",
-    stepUploadTitle: "Télécharger une image",
-    stepUploadDescription:
-      "Téléchargez ici l'image du personnage que vous souhaitez restyler. Une image de démonstration est déjà préparée pour cette visite.",
-    stepPromptTitle: "Saisir le prompt de styling",
-    stepPromptDescription:
-      "Décrivez le type de tenue souhaité. Nous utiliserons cet exemple pour le tutoriel.",
-    stepBackgroundTitle: "Paramètres d'arrière-plan",
-    stepBackgroundDescription:
-      "Choisissez ici comment gérer l'arrière-plan. Pour ce tutoriel, continuons avec « Laisser l'IA décider ».",
-    stepModelTitle: "Sélectionner le modèle de génération",
-    stepModelDescription:
-      "Pour ce tutoriel, nous utiliserons ChatGPT Images 2.0 Low. Si un autre modèle était sélectionné, il sera remplacé automatiquement ici.",
-    stepSizeTitle: "Vérifier la taille de sortie",
-    stepSizeDescription:
-      "Nous garderons la taille de sortie sur Standard. Les dimensions exactes sont ajustées automatiquement selon l'orientation de l'image.",
-    stepGenerateTitle: "Lancer la génération",
-    stepGenerateDescription:
-      "Sélectionnez « Démarrer le styling ». Vos Percoins seront restitués à la fin du tutoriel, n'hésitez pas à continuer.",
-    stepGeneratingTitle: "Génération...",
-    stepGeneratingDescription:
-      "Vous pouvez suivre la progression ci-dessous. Patientez un instant !",
-    stepCompletedTitle: "C'est prêt !",
-    stepFirstImageTitle: "Votre changement de tenue est terminé",
-    stepFirstImageDescription:
-      "Vous pouvez maintenant publier ou télécharger le résultat. Essayez !",
+    stepNavigateTitle: "Commencez à créer ici !",
+    stepNavigateDescription: "Touchez ici pour continuer.",
     stepFinishedTitle: "Visite terminée",
     stepFinishedDescription:
-      "Bravo. Profitez maintenant pour créer plus de changements de tenue. Cliquez sur « Terminer » pour recevoir votre récompense en Percoins.",
+      "C'est prêt ! Choisissez un style et une photo pour créer votre première image. Terminez la visite pour recevoir votre bonus Percoin.",
   },
   free: {
     tabLabel: "Free Style",

--- a/messages/hi.ts
+++ b/messages/hi.ts
@@ -937,8 +937,11 @@ export const hiMessages = {
   coordinate: {
     tabLabel: "Coordinate",
     tourButton: "ट्यूटोरियल",
+    tourStepUploadTitle: "एक छवि अपलोड करें",
     tourStepUploadDescription: "जिस कैरेक्टर छवि को आप फिर से स्टाइल करना चाहते हैं उसे यहाँ अपलोड करें।",
+    tourStepPromptTitle: "स्टाइलिंग प्रॉम्प्ट दर्ज करें",
     tourStepPromptDescription: "जिस तरह का आउटफ़िट आप चाहते हैं उसका वर्णन करें।",
+    tourStepGenerateTitle: "जनरेट करना शुरू करें",
     tourStepGenerateDescription: "शुरू करने के लिए \"स्टाइलिंग शुरू करें\" चुनें।",
     pageTitle: "Coordinate",
     pageDescription: "किसी व्यक्ति की फ़ोटो अपलोड करें और आसानी से पहनावा बदलें। मूल पोज़ और कंपोज़िशन वैसा ही रखते हुए, सिर्फ़ कपड़े स्वाभाविक रूप से बदलें।",
@@ -1418,38 +1421,11 @@ export const hiMessages = {
     prevButton: "वापस",
     nextButton: "अगला",
     doneButton: "हो गया",
-    promptTemplate:
-      "कृपया महीने {month} के मौसम के अनुसार आउटफ़िट स्टाइल करें।",
-    stepCoordinateTitle: "कोऑर्डिनेट खोलें",
-    stepCoordinateDescription: "कोऑर्डिनेट स्क्रीन खोलने के लिए यहाँ टैप करें।",
-    stepUploadTitle: "एक छवि अपलोड करें",
-    stepUploadDescription:
-      "जिस कैरेक्टर छवि को आप फिर से स्टाइल करना चाहते हैं उसे यहाँ अपलोड करें। हमने इस वॉकथ्रू के लिए पहले ही एक डेमो छवि तैयार कर ली है।",
-    stepPromptTitle: "स्टाइलिंग प्रॉम्प्ट दर्ज करें",
-    stepPromptDescription:
-      "जिस तरह का आउटफ़िट आप चाहते हैं उसका वर्णन करें। हम ट्यूटोरियल के लिए इस उदाहरण का उपयोग करेंगे।",
-    stepBackgroundTitle: "पृष्ठभूमि सेटिंग्स",
-    stepBackgroundDescription:
-      "यहाँ चुनें कि पृष्ठभूमि को कैसे संभालना है। इस ट्यूटोरियल के लिए, चलिए \"AI को तय करने दें\" के साथ जारी रखते हैं।",
-    stepModelTitle: "जनरेशन मॉडल चुनें",
-    stepModelDescription:
-      "इस ट्यूटोरियल में हम ChatGPT Images 2.0 Low का उपयोग करेंगे। यदि कोई दूसरा मॉडल चुना हुआ है, तो यहाँ वह अपने आप बदल जाएगा।",
-    stepSizeTitle: "आउटपुट आकार जांचें",
-    stepSizeDescription:
-      "हम आउटपुट आकार को स्टैंडर्ड पर रखेंगे। वास्तविक आयाम छवि की दिशा के अनुसार अपने आप समायोजित होते हैं।",
-    stepGenerateTitle: "जनरेट करना शुरू करें",
-    stepGenerateDescription:
-      "शुरू करने के लिए \"स्टाइलिंग शुरू करें\" चुनें। ट्यूटोरियल के बाद आपके Percoin पुनः बहाल हो जाएँगे, इसलिए बेझिझक जारी रखें।",
-    stepGeneratingTitle: "उत्पन्न हो रहा है...",
-    stepGeneratingDescription:
-      "आप नीचे प्रगति को ट्रैक कर सकते हैं। पूरा होने के लिए कृपया एक पल प्रतीक्षा करें!",
-    stepCompletedTitle: "यह तैयार है!",
-    stepFirstImageTitle: "आपका आउटफ़िट स्वैप पूरा हो गया",
-    stepFirstImageDescription:
-      "अब आप परिणाम पोस्ट कर सकते हैं या डाउनलोड कर सकते हैं। इसे आज़माएँ।",
+    stepNavigateTitle: "यहाँ से बनाना शुरू करें!",
+    stepNavigateDescription: "जारी रखने के लिए यहाँ टैप करें।",
     stepFinishedTitle: "टूर पूरा हुआ",
     stepFinishedDescription:
-      "अच्छा काम। यहाँ से और आउटफ़िट स्वैप बनाने का आनंद लें। Percoin पुरस्कार पाने के लिए \"हो गया\" क्लिक करें।",
+      "सब तैयार है! अपनी पसंद की स्टाइल और फ़ोटो चुनकर पहली इमेज बनाएं। टूर पूरा करने पर आपको बोनस Percoin मिलेगा।",
   },
   free: {
     tabLabel: "Free Style",

--- a/messages/hi.ts
+++ b/messages/hi.ts
@@ -1425,7 +1425,7 @@ export const hiMessages = {
     stepNavigateDescription: "जारी रखने के लिए यहाँ टैप करें।",
     stepFinishedTitle: "टूर पूरा हुआ",
     stepFinishedDescription:
-      "सब तैयार है! अपनी पसंद की स्टाइल और फ़ोटो चुनकर पहली इमेज बनाएं। टूर पूरा करने पर आपको बोनस Percoin मिलेगा।",
+      "बहुत बढ़िया! अब एक इमेज बनाकर देखें! “हो गया” टैप करने पर आपको बोनस Percoin मिलेगा।",
   },
   free: {
     tabLabel: "Free Style",
@@ -1684,9 +1684,9 @@ export const hiMessages = {
     tourNextButton: "आगे",
     tourDoneButton: "अभी आज़माएँ!",
     tourStepPresetTitle: "✨ ① स्टाइल चुनें",
-    tourStepPresetDescription: "वह स्टाइल चुनें जिसे आप पहनना चाहते हैं!",
+    tourStepPresetDescription: "यहाँ आप अपनी पसंदीदा स्टाइल चुनते हैं!",
     tourStepCharacterTitle: "💖 ② अपना कैरेक्टर चुनें",
-    tourStepCharacterDescription: "वह कैरेक्टर चुनें जिसकी ड्रेस बदलनी है!",
+    tourStepCharacterDescription: "यहाँ आप अपना कैरेक्टर सेट करते हैं!",
     tourStepGenerateTitle: "🚀 ③ कोऑर्डिनेट शुरू करें!",
     tourStepGenerateDescription: "टैप करते ही जनरेशन शुरू! बस थोड़ा इंतज़ार कीजिए!",
   },

--- a/messages/id.ts
+++ b/messages/id.ts
@@ -938,8 +938,11 @@ export const idMessages = {
   coordinate: {
     tabLabel: "Coordinate",
     tourButton: "Tutorial",
+    tourStepUploadTitle: "Unggah gambar",
     tourStepUploadDescription: "Unggah di sini gambar karakter yang ingin kamu styling ulang.",
+    tourStepPromptTitle: "Masukkan prompt styling",
     tourStepPromptDescription: "Jelaskan jenis outfit yang kamu inginkan.",
+    tourStepGenerateTitle: "Mulai pembuatan",
     tourStepGenerateDescription: "Pilih \"Mulai styling\" untuk memulai.",
     pageTitle: "Coordinate",
     pageDescription: "Unggah foto dan ganti busana dengan mudah. Pertahankan pose dan komposisi asli, cukup ubah pakaiannya secara alami.",
@@ -1419,38 +1422,11 @@ export const idMessages = {
     prevButton: "Kembali",
     nextButton: "Lanjut",
     doneButton: "Selesai",
-    promptTemplate:
-      "Mohon padukan outfit sesuai musim bulan {month}.",
-    stepCoordinateTitle: "Buka Koordinat",
-    stepCoordinateDescription: "Ketuk di sini untuk membuka layar Koordinat.",
-    stepUploadTitle: "Unggah gambar",
-    stepUploadDescription:
-      "Unggah di sini gambar karakter yang ingin kamu styling ulang. Untuk panduan ini, kami sudah menyiapkan gambar demo.",
-    stepPromptTitle: "Masukkan prompt styling",
-    stepPromptDescription:
-      "Jelaskan jenis outfit yang kamu inginkan. Kami akan pakai contoh ini untuk tutorial.",
-    stepBackgroundTitle: "Pengaturan latar belakang",
-    stepBackgroundDescription:
-      "Pilih di sini cara menangani latar belakang. Untuk tutorial ini, lanjut dengan \"Biarkan AI memutuskan\".",
-    stepModelTitle: "Pilih model pembuatan",
-    stepModelDescription:
-      "Untuk tutorial ini, kita akan memakai ChatGPT Images 2.0 Low. Jika model lain sedang dipilih, model akan otomatis diganti di sini.",
-    stepSizeTitle: "Periksa ukuran output",
-    stepSizeDescription:
-      "Ukuran output akan tetap Standard. Dimensi sebenarnya akan disesuaikan otomatis dengan orientasi gambar.",
-    stepGenerateTitle: "Mulai pembuatan",
-    stepGenerateDescription:
-      "Pilih \"Mulai styling\" untuk memulai. Percoinmu akan dikembalikan setelah tutorial, jadi tenang saja lanjutkan.",
-    stepGeneratingTitle: "Membuat...",
-    stepGeneratingDescription:
-      "Kamu bisa memantau progresnya di bawah. Tunggu sebentar sampai selesai!",
-    stepCompletedTitle: "Sudah siap!",
-    stepFirstImageTitle: "Pergantian outfitmu selesai",
-    stepFirstImageDescription:
-      "Kamu sekarang bisa memposting atau mengunduh hasilnya. Coba!",
+    stepNavigateTitle: "Mulai membuat di sini!",
+    stepNavigateDescription: "Ketuk di sini untuk melanjutkan.",
     stepFinishedTitle: "Tur selesai",
     stepFinishedDescription:
-      "Kerja bagus. Selanjutnya nikmati pembuatan pergantian outfit lainnya. Klik \"Selesai\" untuk menerima hadiah Percoin.",
+      "Semua siap! Pilih gaya dan foto untuk membuat gambar pertamamu. Selesaikan tur untuk menerima bonus Percoin.",
   },
   free: {
     tabLabel: "Free Style",

--- a/messages/id.ts
+++ b/messages/id.ts
@@ -1426,7 +1426,7 @@ export const idMessages = {
     stepNavigateDescription: "Ketuk di sini untuk melanjutkan.",
     stepFinishedTitle: "Tur selesai",
     stepFinishedDescription:
-      "Semua siap! Pilih gaya dan foto untuk membuat gambar pertamamu. Selesaikan tur untuk menerima bonus Percoin.",
+      "Kerja bagus! Silakan coba membuat gambar! Ketuk “Selesai” untuk menerima bonus Percoin.",
   },
   free: {
     tabLabel: "Free Style",
@@ -1685,9 +1685,9 @@ export const idMessages = {
     tourNextButton: "Lanjut",
     tourDoneButton: "Coba sekarang!",
     tourStepPresetTitle: "✨ ① Pilih gaya",
-    tourStepPresetDescription: "Pilih gaya yang ingin kamu kenakan!",
+    tourStepPresetDescription: "Di sini kamu memilih gaya favoritmu!",
     tourStepCharacterTitle: "💖 ② Pilih karaktermu",
-    tourStepCharacterDescription: "Pilih karakter yang ingin kamu ganti pakaiannya!",
+    tourStepCharacterDescription: "Di sini kamu mengatur karaktermu!",
     tourStepGenerateTitle: "🚀 ③ Mulai padu padan!",
     tourStepGenerateDescription: "Ketuk dan proses pembuatan dimulai! Tinggal tunggu saja!",
   },

--- a/messages/it.ts
+++ b/messages/it.ts
@@ -939,8 +939,11 @@ export const itMessages = {
   coordinate: {
     tabLabel: "Coordinate",
     tourButton: "Tutorial",
+    tourStepUploadTitle: "Carica un'immagine",
     tourStepUploadDescription: "Carica qui l’immagine del personaggio che vuoi restilizzare.",
+    tourStepPromptTitle: "Inserisci il prompt di styling",
     tourStepPromptDescription: "Descrivi il tipo di outfit che desideri.",
+    tourStepGenerateTitle: "Avvia la generazione",
     tourStepGenerateDescription: "Seleziona \"Avvia styling\" per iniziare.",
     pageTitle: "Coordinate",
     pageDescription: "Carica una foto e cambia outfit con facilità. Mantieni posa e inquadratura originali, cambiando solo l'abbigliamento in modo naturale.",
@@ -1420,38 +1423,11 @@ export const itMessages = {
     prevButton: "Indietro",
     nextButton: "Avanti",
     doneButton: "Fatto",
-    promptTemplate:
-      "Per favore, crea un outfit adatto alla stagione del mese {month}.",
-    stepCoordinateTitle: "Apri Coordina",
-    stepCoordinateDescription: "Tocca qui per aprire la schermata di coordinazione.",
-    stepUploadTitle: "Carica un'immagine",
-    stepUploadDescription:
-      "Carica qui l'immagine del personaggio che vuoi restilizzare. Per questa procedura abbiamo già preparato un'immagine demo.",
-    stepPromptTitle: "Inserisci il prompt di styling",
-    stepPromptDescription:
-      "Descrivi il tipo di outfit che desideri. Useremo questo esempio per il tutorial.",
-    stepBackgroundTitle: "Impostazioni dello sfondo",
-    stepBackgroundDescription:
-      "Scegli qui come gestire lo sfondo. Per questo tutorial proseguiamo con \"Lascia decidere all'IA\".",
-    stepModelTitle: "Seleziona il modello di generazione",
-    stepModelDescription:
-      "Per questo tutorial useremo ChatGPT Images 2.0 Low. Se era selezionato un altro modello, qui verrà cambiato automaticamente.",
-    stepSizeTitle: "Controlla la dimensione output",
-    stepSizeDescription:
-      "Terremo la dimensione di output su Standard. Le dimensioni effettive vengono regolate automaticamente in base all'orientamento dell'immagine.",
-    stepGenerateTitle: "Avvia la generazione",
-    stepGenerateDescription:
-      "Seleziona \"Avvia styling\" per iniziare. I tuoi Percoin verranno restituiti dopo il tutorial, quindi prosegui senza preoccupazioni.",
-    stepGeneratingTitle: "Generazione...",
-    stepGeneratingDescription:
-      "Puoi seguire l'avanzamento qui sotto. Attendi un momento il completamento!",
-    stepCompletedTitle: "È pronto!",
-    stepFirstImageTitle: "Il tuo cambio di outfit è completo",
-    stepFirstImageDescription:
-      "Ora puoi pubblicare o scaricare il risultato. Provaci.",
+    stepNavigateTitle: "Inizia a creare qui!",
+    stepNavigateDescription: "Tocca qui per continuare.",
     stepFinishedTitle: "Tour completato",
     stepFinishedDescription:
-      "Ottimo lavoro. Goditi la creazione di altri cambi di outfit. Tocca \"Fatto\" per ricevere la ricompensa in Percoin.",
+      "Tutto pronto! Scegli uno stile e una foto per creare la tua prima immagine. Completa il tour per ricevere il bonus in Percoin.",
   },
   free: {
     tabLabel: "Free Style",

--- a/messages/it.ts
+++ b/messages/it.ts
@@ -1427,7 +1427,7 @@ export const itMessages = {
     stepNavigateDescription: "Tocca qui per continuare.",
     stepFinishedTitle: "Tour completato",
     stepFinishedDescription:
-      "Tutto pronto! Scegli uno stile e una foto per creare la tua prima immagine. Completa il tour per ricevere il bonus in Percoin.",
+      "Ottimo lavoro! Prova subito a creare un'immagine! Tocca «Fatto» per ricevere il bonus in Percoin.",
   },
   free: {
     tabLabel: "Free Style",
@@ -1686,9 +1686,9 @@ export const itMessages = {
     tourNextButton: "Avanti",
     tourDoneButton: "Provalo subito!",
     tourStepPresetTitle: "✨ ① Scegli uno stile",
-    tourStepPresetDescription: "Seleziona lo stile che vuoi indossare!",
+    tourStepPresetDescription: "Qui scegli il tuo stile preferito!",
     tourStepCharacterTitle: "💖 ② Scegli il tuo personaggio",
-    tourStepCharacterDescription: "Scegli il personaggio a cui cambiare look!",
+    tourStepCharacterDescription: "Qui imposti il tuo personaggio!",
     tourStepGenerateTitle: "🚀 ③ Avvia l'outfit!",
     tourStepGenerateDescription: "Toccandolo inizia la generazione. Poi basta aspettare!",
   },

--- a/messages/ja.ts
+++ b/messages/ja.ts
@@ -913,8 +913,11 @@ export const jaMessages = {
   coordinate: {
     tabLabel: "Coordinate",
     tourButton: "チュートリアル",
+    tourStepUploadTitle: "画像をアップロード！",
     tourStepUploadDescription: "ここで着せ替えたい人物画像をアップロードします。",
+    tourStepPromptTitle: "着せ替え内容を入力！",
     tourStepPromptDescription: "どんなコーデにしたいか入力します。",
+    tourStepGenerateTitle: "生成開始！",
     tourStepGenerateDescription: "「コーデスタート」ボタンを選択して、開始しましょう！",
     pageTitle: "Coordinate",
     pageDescription: "人物画像をアップロードして、かんたん着せ替え。元のポーズや構図はそのままに、衣装だけを自然にチェンジできます。",
@@ -1361,37 +1364,11 @@ export const jaMessages = {
     prevButton: "戻る",
     nextButton: "次へ",
     doneButton: "完了",
-    promptTemplate: "{month}月の季節に合う素敵な服装にしてください。",
-    stepCoordinateTitle: "コーディネート画面へ！",
-    stepCoordinateDescription: "ここをタップしてください。",
-    stepUploadTitle: "画像をアップロード！",
-    stepUploadDescription:
-      "ここで着せ替えたい人物画像をアップロードします。今回は体験用の画像をセットしました！",
-    stepPromptTitle: "着せ替え内容を入力！",
-    stepPromptDescription:
-      "どんなコーデにしたいか入力します。今回は、この内容で進めます！",
-    stepBackgroundTitle: "背景設定",
-    stepBackgroundDescription:
-      "ここでは背景の扱いを選べます。今回は「AIに依頼」を選択して進めてみましょう！",
-    stepModelTitle: "生成モデルを選択",
-    stepModelDescription:
-      "ここで、ChatGPTまたはGeminiのモデルを選ぶことができます。今回はChatGPTを選択します。",
-    stepSizeTitle: "出力サイズを確認",
-    stepSizeDescription:
-      "ここで、画像サイズを選択することができます。今回は、標準の1Kサイズで進めます。",
-    stepGenerateTitle: "生成開始！",
-    stepGenerateDescription:
-      "「コーデスタート」ボタンを選択して、開始しましょう！ ※コインが消費されますが、ツアー完了後に戻るのでご安心ください。",
-    stepGeneratingTitle: "生成しています！",
-    stepGeneratingDescription:
-      "進捗バーで生成の状態を確認できます。完了まで少々お待ちください！",
-    stepCompletedTitle: "完了しました！",
-    stepFirstImageTitle: "着せ替え完了！",
-    stepFirstImageDescription:
-      "投稿やダウンロードが可能です！ぜひ試してみてください！",
+    stepNavigateTitle: "生成はここから！",
+    stepNavigateDescription: "ここをタップしてください。",
     stepFinishedTitle: "ツアー完了！",
     stepFinishedDescription:
-      "お疲れ様でした！引き続き、着せ替えをお楽しみください！ ※「完了」をクリックするとコインが付与されます。",
+      "お疲れ様でした！お好きなスタイルと写真を選んで、さっそく1枚つくってみましょう！ツアーを完了すると、ボーナスのペルコインが付与されます。",
   },
   free: {
     tabLabel: "Free Style",

--- a/messages/ja.ts
+++ b/messages/ja.ts
@@ -1368,7 +1368,7 @@ export const jaMessages = {
     stepNavigateDescription: "ここをタップしてください。",
     stepFinishedTitle: "ツアー完了！",
     stepFinishedDescription:
-      "お疲れ様でした！お好きなスタイルと写真を選んで、さっそく1枚つくってみましょう！ツアーを完了すると、ボーナスのペルコインが付与されます。",
+      "お疲れ様でした！ぜひ、生成してみてくださいね！『完了』を押すと、ボーナスのペルコインが付与されます。",
   },
   free: {
     tabLabel: "Free Style",
@@ -1621,9 +1621,9 @@ export const jaMessages = {
     tourNextButton: "つぎへ",
     tourDoneButton: "さっそく試す！",
     tourStepPresetTitle: "✨ ① スタイルを選択",
-    tourStepPresetDescription: "着せ替えたいスタイルを選択してください！",
+    tourStepPresetDescription: "ここでお好みのスタイルを選択します！",
     tourStepCharacterTitle: "💖 ② マイキャラ選択",
-    tourStepCharacterDescription: "着せ替えたいキャラクターを選んでください！",
+    tourStepCharacterDescription: "ここで、あなたのキャラクターを設定します！",
     tourStepGenerateTitle: "🚀 ③ コーデを開始！",
     tourStepGenerateDescription: "選択すると生成が始まります！あとは待つだけ！",
   },

--- a/messages/ko.ts
+++ b/messages/ko.ts
@@ -1423,7 +1423,7 @@ export const koMessages = {
     stepNavigateDescription: "여기를 탭해 주세요.",
     stepFinishedTitle: "투어 완료",
     stepFinishedDescription:
-      "수고하셨습니다! 마음에 드는 스타일과 사진을 골라 첫 이미지를 만들어 보세요! 투어를 완료하면 보너스 페르코인이 지급됩니다.",
+      "수고하셨습니다! 이제 직접 생성해 보세요! “완료”를 누르면 보너스 페르코인이 지급됩니다.",
   },
   free: {
     tabLabel: "Free Style",
@@ -1682,9 +1682,9 @@ export const koMessages = {
     tourNextButton: "다음",
     tourDoneButton: "바로 해보기!",
     tourStepPresetTitle: "✨ ① 스타일 선택",
-    tourStepPresetDescription: "갈아입히고 싶은 스타일을 선택해 주세요!",
+    tourStepPresetDescription: "여기에서 마음에 드는 스타일을 선택합니다!",
     tourStepCharacterTitle: "💖 ② 마이 캐릭터 선택",
-    tourStepCharacterDescription: "갈아입히고 싶은 캐릭터를 골라 주세요!",
+    tourStepCharacterDescription: "여기에서 당신의 캐릭터를 설정합니다!",
     tourStepGenerateTitle: "🚀 ③ 코디 시작!",
     tourStepGenerateDescription: "선택하면 생성이 시작돼요! 이제 기다리기만 하면 돼요!",
   },

--- a/messages/ko.ts
+++ b/messages/ko.ts
@@ -936,8 +936,11 @@ export const koMessages = {
   coordinate: {
     tabLabel: "Coordinate",
     tourButton: "튜토리얼",
+    tourStepUploadTitle: "이미지 업로드",
     tourStepUploadDescription: "다시 스타일링하고 싶은 캐릭터 이미지를 여기에 업로드합니다.",
+    tourStepPromptTitle: "스타일링 프롬프트 입력",
     tourStepPromptDescription: "원하는 코디를 설명해 주세요.",
+    tourStepGenerateTitle: "생성 시작",
     tourStepGenerateDescription: "“스타일링 시작”을 선택해 시작해 주세요.",
     pageTitle: "Coordinate",
     pageDescription: "인물 이미지를 업로드해 간편하게 옷을 갈아입혀 보세요. 원래 포즈와 구도는 그대로, 의상만 자연스럽게 바꿀 수 있습니다.",
@@ -1416,38 +1419,11 @@ export const koMessages = {
     prevButton: "뒤로",
     nextButton: "다음",
     doneButton: "완료",
-    promptTemplate:
-      "{month}월의 계절감에 맞춰 코디를 부탁드립니다.",
-    stepCoordinateTitle: "코디 열기",
-    stepCoordinateDescription: "여기를 탭하면 코디 화면이 열립니다.",
-    stepUploadTitle: "이미지 업로드",
-    stepUploadDescription:
-      "다시 스타일링하고 싶은 캐릭터 이미지를 여기에 업로드합니다. 이번 가이드용으로는 데모 이미지가 미리 준비되어 있습니다.",
-    stepPromptTitle: "스타일링 프롬프트 입력",
-    stepPromptDescription:
-      "원하는 코디를 설명해 주세요. 튜토리얼에서는 이 예시를 사용합니다.",
-    stepBackgroundTitle: "배경 설정",
-    stepBackgroundDescription:
-      "여기서 배경 처리 방식을 선택할 수 있습니다. 이 튜토리얼에서는 “AI에게 맡기기”로 진행합니다.",
-    stepModelTitle: "생성 모델 선택",
-    stepModelDescription:
-      "이 튜토리얼에서는 ChatGPT Images 2.0 Low를 사용합니다. 다른 모델이 선택되어 있어도 여기서 자동으로 전환됩니다.",
-    stepSizeTitle: "출력 크기 확인",
-    stepSizeDescription:
-      "출력 크기는 표준으로 유지합니다. 실제 크기는 이미지 방향에 맞춰 자동으로 조정됩니다.",
-    stepGenerateTitle: "생성 시작",
-    stepGenerateDescription:
-      "“스타일링 시작”을 선택해 시작해 주세요. 튜토리얼이 끝나면 사용한 Percoin은 돌려드리니 안심하고 진행하셔도 됩니다.",
-    stepGeneratingTitle: "생성 중...",
-    stepGeneratingDescription:
-      "아래에서 진행 상황을 확인할 수 있습니다. 완료될 때까지 잠시 기다려 주세요!",
-    stepCompletedTitle: "완성!",
-    stepFirstImageTitle: "코디 변경이 완료되었습니다",
-    stepFirstImageDescription:
-      "이제 결과를 게시하거나 다운로드할 수 있습니다. 한번 시도해 보세요.",
+    stepNavigateTitle: "생성은 여기에서!",
+    stepNavigateDescription: "여기를 탭해 주세요.",
     stepFinishedTitle: "투어 완료",
     stepFinishedDescription:
-      "수고하셨습니다. 이제부터 자유롭게 더 많은 코디를 즐겨보세요. “완료”를 누르면 Percoin 보상을 받을 수 있습니다.",
+      "수고하셨습니다! 마음에 드는 스타일과 사진을 골라 첫 이미지를 만들어 보세요! 투어를 완료하면 보너스 페르코인이 지급됩니다.",
   },
   free: {
     tabLabel: "Free Style",

--- a/messages/pt.ts
+++ b/messages/pt.ts
@@ -1427,7 +1427,7 @@ export const ptMessages = {
     stepNavigateDescription: "Toque aqui para continuar.",
     stepFinishedTitle: "Tour concluído",
     stepFinishedDescription:
-      "Tudo pronto! Escolha um estilo e uma foto para criar sua primeira imagem. Ao concluir o tour, você recebe seu bônus de Percoin.",
+      "Bom trabalho! Experimente criar uma imagem! Ao tocar em “Concluir”, você recebe seu Percoin de bônus.",
   },
   free: {
     tabLabel: "Free Style",
@@ -1686,9 +1686,9 @@ export const ptMessages = {
     tourNextButton: "Avançar",
     tourDoneButton: "Experimente agora!",
     tourStepPresetTitle: "✨ ① Escolha um estilo",
-    tourStepPresetDescription: "Selecione o estilo que você quer vestir!",
+    tourStepPresetDescription: "Aqui você escolhe seu estilo favorito!",
     tourStepCharacterTitle: "💖 ② Escolha seu personagem",
-    tourStepCharacterDescription: "Escolha o personagem que você quer trocar de roupa!",
+    tourStepCharacterDescription: "Aqui você define seu personagem!",
     tourStepGenerateTitle: "🚀 ③ Comece o look!",
     tourStepGenerateDescription: "Ao tocar, a geração começa. Depois é só esperar!",
   },

--- a/messages/pt.ts
+++ b/messages/pt.ts
@@ -939,8 +939,11 @@ export const ptMessages = {
   coordinate: {
     tabLabel: "Coordinate",
     tourButton: "Tutorial",
+    tourStepUploadTitle: "Fazer upload de imagem",
     tourStepUploadDescription: "Faça upload aqui da imagem de personagem que você quer restilizar.",
+    tourStepPromptTitle: "Digitar o prompt de styling",
     tourStepPromptDescription: "Descreva o tipo de look que você quer.",
+    tourStepGenerateTitle: "Iniciar a geração",
     tourStepGenerateDescription: "Selecione \"Iniciar styling\" para começar.",
     pageTitle: "Coordinate",
     pageDescription: "Envie uma foto e troque de look com facilidade. Mantenha a pose e a composição originais, mudando apenas a roupa de forma natural.",
@@ -1420,38 +1423,11 @@ export const ptMessages = {
     prevButton: "Voltar",
     nextButton: "Próximo",
     doneButton: "Concluir",
-    promptTemplate:
-      "Por favor, crie um look adequado à estação do mês {month}.",
-    stepCoordinateTitle: "Abrir Coordenar",
-    stepCoordinateDescription: "Toque aqui para abrir a tela de coordenação.",
-    stepUploadTitle: "Fazer upload de imagem",
-    stepUploadDescription:
-      "Faça upload aqui da imagem de personagem que você quer restilizar. Já preparamos uma imagem de demonstração para este passo a passo.",
-    stepPromptTitle: "Digitar o prompt de styling",
-    stepPromptDescription:
-      "Descreva o tipo de look que você quer. Vamos usar este exemplo no tutorial.",
-    stepBackgroundTitle: "Configurações de fundo",
-    stepBackgroundDescription:
-      "Escolha aqui como tratar o fundo. Para este tutorial, sigamos com \"Deixar a IA decidir\".",
-    stepModelTitle: "Selecionar o modelo de geração",
-    stepModelDescription:
-      "Neste tutorial, usaremos o ChatGPT Images 2.0 Low. Se outro modelo estiver selecionado, ele será alterado automaticamente aqui.",
-    stepSizeTitle: "Verifique o tamanho de saída",
-    stepSizeDescription:
-      "Manteremos o tamanho de saída em Padrão. As dimensões reais são ajustadas automaticamente conforme a orientação da imagem.",
-    stepGenerateTitle: "Iniciar a geração",
-    stepGenerateDescription:
-      "Selecione \"Iniciar styling\" para começar. Seus Percoins serão restituídos depois do tutorial, então fique à vontade para continuar.",
-    stepGeneratingTitle: "Gerando...",
-    stepGeneratingDescription:
-      "Você pode acompanhar o progresso abaixo. Aguarde um instante até concluir!",
-    stepCompletedTitle: "Pronto!",
-    stepFirstImageTitle: "Sua troca de look está completa",
-    stepFirstImageDescription:
-      "Agora você pode publicar ou baixar o resultado. Experimente!",
+    stepNavigateTitle: "Comece a criar aqui!",
+    stepNavigateDescription: "Toque aqui para continuar.",
     stepFinishedTitle: "Tour concluído",
     stepFinishedDescription:
-      "Bom trabalho. Aproveite para criar mais trocas de look a partir daqui. Toque em \"Concluir\" para receber sua recompensa em Percoins.",
+      "Tudo pronto! Escolha um estilo e uma foto para criar sua primeira imagem. Ao concluir o tour, você recebe seu bônus de Percoin.",
   },
   free: {
     tabLabel: "Free Style",

--- a/messages/th.ts
+++ b/messages/th.ts
@@ -936,8 +936,11 @@ export const thMessages = {
   coordinate: {
     tabLabel: "Coordinate",
     tourButton: "บทช่วยสอน",
+    tourStepUploadTitle: "อัปโหลดรูป",
     tourStepUploadDescription: "อัปโหลดที่นี่เพื่อรูปตัวละครที่ต้องการจัดสไตล์ใหม่",
+    tourStepPromptTitle: "กรอกพรอมป์การจัดสไตล์",
     tourStepPromptDescription: "อธิบายชุดที่ต้องการ",
+    tourStepGenerateTitle: "เริ่มสร้าง",
     tourStepGenerateDescription: "เลือก \"เริ่มจัดสไตล์\" เพื่อเริ่ม",
     pageTitle: "Coordinate",
     pageDescription: "อัปโหลดรูปบุคคลแล้วเปลี่ยนชุดได้ง่าย ๆ คงท่าทางและองค์ประกอบเดิมไว้ เปลี่ยนแค่เสื้อผ้าอย่างเป็นธรรมชาติ",
@@ -1416,38 +1419,11 @@ export const thMessages = {
     prevButton: "ย้อนกลับ",
     nextButton: "ถัดไป",
     doneButton: "เสร็จแล้ว",
-    promptTemplate:
-      "โปรดจัดชุดให้เข้ากับฤดูกาลของเดือน {month}",
-    stepCoordinateTitle: "เปิดจัดเซ็ต",
-    stepCoordinateDescription: "แตะที่นี่เพื่อเปิดหน้าจัดเซ็ต",
-    stepUploadTitle: "อัปโหลดรูป",
-    stepUploadDescription:
-      "อัปโหลดที่นี่เพื่อรูปตัวละครที่ต้องการจัดสไตล์ใหม่ เราเตรียมรูปสาธิตไว้สำหรับบทเรียนนี้แล้ว",
-    stepPromptTitle: "กรอกพรอมป์การจัดสไตล์",
-    stepPromptDescription:
-      "อธิบายชุดที่ต้องการ เราจะใช้ตัวอย่างนี้สำหรับบทเรียน",
-    stepBackgroundTitle: "การตั้งค่าพื้นหลัง",
-    stepBackgroundDescription:
-      "เลือกที่นี่ว่าจะจัดการพื้นหลังอย่างไร สำหรับบทเรียนนี้ ใช้ \"ให้ AI ตัดสินใจ\" ต่อไป",
-    stepModelTitle: "เลือกโมเดลสร้างภาพ",
-    stepModelDescription:
-      "บทเรียนนี้จะใช้ ChatGPT Images 2.0 Low หากเลือกโมเดลอื่นไว้ ระบบจะเปลี่ยนเป็นโมเดลนี้โดยอัตโนมัติ",
-    stepSizeTitle: "ตรวจสอบขนาดเอาต์พุต",
-    stepSizeDescription:
-      "เราจะใช้ขนาดเอาต์พุตมาตรฐาน ขนาดจริงจะปรับโดยอัตโนมัติตามแนวภาพ",
-    stepGenerateTitle: "เริ่มสร้าง",
-    stepGenerateDescription:
-      "เลือก \"เริ่มจัดสไตล์\" เพื่อเริ่ม Percoin ของคุณจะถูกคืนหลังบทเรียน จึงดำเนินการต่อได้อย่างสบายใจ",
-    stepGeneratingTitle: "กำลังสร้าง...",
-    stepGeneratingDescription:
-      "คุณติดตามความคืบหน้าได้ด้านล่าง โปรดรอสักครู่จนเสร็จ!",
-    stepCompletedTitle: "เสร็จแล้ว!",
-    stepFirstImageTitle: "เปลี่ยนชุดของคุณเสร็จแล้ว",
-    stepFirstImageDescription:
-      "ตอนนี้คุณโพสต์หรือดาวน์โหลดผลลัพธ์ได้ ลองดู",
+    stepNavigateTitle: "เริ่มสร้างได้ที่นี่!",
+    stepNavigateDescription: "แตะที่นี่เพื่อดำเนินการต่อ",
     stepFinishedTitle: "ทัวร์เสร็จแล้ว",
     stepFinishedDescription:
-      "ทำได้ดี เพลิดเพลินกับการเปลี่ยนชุดเพิ่มเติมจากที่นี่ คลิก \"เสร็จแล้ว\" เพื่อรับรางวัล Percoin",
+      "เรียบร้อยแล้ว! เลือกสไตล์และรูปภาพที่ชอบเพื่อสร้างภาพแรกของคุณ ทำทัวร์ให้เสร็จเพื่อรับโบนัส Percoin",
   },
   free: {
     tabLabel: "Free Style",

--- a/messages/th.ts
+++ b/messages/th.ts
@@ -1423,7 +1423,7 @@ export const thMessages = {
     stepNavigateDescription: "แตะที่นี่เพื่อดำเนินการต่อ",
     stepFinishedTitle: "ทัวร์เสร็จแล้ว",
     stepFinishedDescription:
-      "เรียบร้อยแล้ว! เลือกสไตล์และรูปภาพที่ชอบเพื่อสร้างภาพแรกของคุณ ทำทัวร์ให้เสร็จเพื่อรับโบนัส Percoin",
+      "เยี่ยมมาก! ลองสร้างภาพดูเลย! แตะ “เสร็จแล้ว” เพื่อรับโบนัส Percoin",
   },
   free: {
     tabLabel: "Free Style",
@@ -1682,9 +1682,9 @@ export const thMessages = {
     tourNextButton: "ถัดไป",
     tourDoneButton: "ลองเลย!",
     tourStepPresetTitle: "✨ ① เลือกสไตล์",
-    tourStepPresetDescription: "เลือกสไตล์ที่อยากเปลี่ยนลุค!",
+    tourStepPresetDescription: "เลือกสไตล์ที่คุณชอบได้ที่นี่!",
     tourStepCharacterTitle: "💖 ② เลือกตัวละครของฉัน",
-    tourStepCharacterDescription: "เลือกตัวละครที่อยากแต่งตัวให้!",
+    tourStepCharacterDescription: "ตั้งค่าตัวละครของคุณได้ที่นี่!",
     tourStepGenerateTitle: "🚀 ③ เริ่มจัดชุด!",
     tourStepGenerateDescription: "แตะแล้วระบบจะเริ่มสร้างภาพ ที่เหลือแค่รอเท่านั้น!",
   },

--- a/messages/vi.ts
+++ b/messages/vi.ts
@@ -1424,7 +1424,7 @@ export const viMessages = {
     stepNavigateDescription: "Chạm vào đây để tiếp tục.",
     stepFinishedTitle: "Đã hoàn thành tour",
     stepFinishedDescription:
-      "Xong rồi! Hãy chọn phong cách và ảnh yêu thích để tạo bức ảnh đầu tiên. Hoàn thành chuyến tham quan để nhận thưởng Percoin.",
+      "Tuyệt vời! Hãy thử tạo một bức ảnh nhé! Chạm “Hoàn thành” để nhận thưởng Percoin.",
   },
   free: {
     tabLabel: "Free Style",
@@ -1683,9 +1683,9 @@ export const viMessages = {
     tourNextButton: "Tiếp theo",
     tourDoneButton: "Thử ngay!",
     tourStepPresetTitle: "✨ ① Chọn phong cách",
-    tourStepPresetDescription: "Hãy chọn phong cách bạn muốn thay đổi!",
+    tourStepPresetDescription: "Tại đây bạn chọn phong cách yêu thích!",
     tourStepCharacterTitle: "💖 ② Chọn nhân vật của bạn",
-    tourStepCharacterDescription: "Hãy chọn nhân vật bạn muốn thay trang phục!",
+    tourStepCharacterDescription: "Tại đây bạn thiết lập nhân vật của mình!",
     tourStepGenerateTitle: "🚀 ③ Bắt đầu phối đồ!",
     tourStepGenerateDescription: "Chạm vào là quá trình tạo ảnh bắt đầu! Chỉ việc chờ thôi!",
   },

--- a/messages/vi.ts
+++ b/messages/vi.ts
@@ -936,8 +936,11 @@ export const viMessages = {
   coordinate: {
     tabLabel: "Coordinate",
     tourButton: "Hướng dẫn",
+    tourStepUploadTitle: "Tải hình lên",
     tourStepUploadDescription: "Tải lên đây hình nhân vật bạn muốn phối lại.",
+    tourStepPromptTitle: "Nhập prompt styling",
     tourStepPromptDescription: "Mô tả loại trang phục bạn muốn.",
+    tourStepGenerateTitle: "Bắt đầu tạo",
     tourStepGenerateDescription: "Chọn \"Bắt đầu styling\" để bắt đầu.",
     pageTitle: "Coordinate",
     pageDescription: "Tải ảnh nhân vật lên và thay trang phục thật dễ dàng. Giữ nguyên tư thế và bố cục gốc, chỉ thay đổi trang phục một cách tự nhiên.",
@@ -1417,38 +1420,11 @@ export const viMessages = {
     prevButton: "Quay lại",
     nextButton: "Tiếp",
     doneButton: "Hoàn thành",
-    promptTemplate:
-      "Hãy phối trang phục theo cảm giác mùa của tháng {month}.",
-    stepCoordinateTitle: "Mở Phối đồ",
-    stepCoordinateDescription: "Chạm vào đây để mở màn hình phối đồ.",
-    stepUploadTitle: "Tải hình lên",
-    stepUploadDescription:
-      "Tải lên đây hình nhân vật bạn muốn phối lại. Chúng tôi đã chuẩn bị sẵn hình demo cho hướng dẫn này.",
-    stepPromptTitle: "Nhập prompt styling",
-    stepPromptDescription:
-      "Mô tả loại trang phục bạn muốn. Chúng tôi sẽ dùng ví dụ này cho hướng dẫn.",
-    stepBackgroundTitle: "Cài đặt nền",
-    stepBackgroundDescription:
-      "Chọn ở đây cách xử lý nền. Trong hướng dẫn này, hãy tiếp tục với \"Để AI quyết định\".",
-    stepModelTitle: "Chọn mô hình tạo ảnh",
-    stepModelDescription:
-      "Trong hướng dẫn này, chúng ta sẽ dùng ChatGPT Images 2.0 Low. Nếu đang chọn mô hình khác, hệ thống sẽ tự động chuyển tại đây.",
-    stepSizeTitle: "Kiểm tra kích thước đầu ra",
-    stepSizeDescription:
-      "Chúng ta sẽ giữ kích thước đầu ra ở mức Tiêu chuẩn. Kích thước thực tế sẽ tự động điều chỉnh theo hướng của ảnh.",
-    stepGenerateTitle: "Bắt đầu tạo",
-    stepGenerateDescription:
-      "Chọn \"Bắt đầu styling\" để bắt đầu. Percoin của bạn sẽ được hoàn lại sau hướng dẫn, nên bạn có thể tiếp tục an tâm.",
-    stepGeneratingTitle: "Đang tạo...",
-    stepGeneratingDescription:
-      "Bạn có thể theo dõi tiến trình ở dưới. Vui lòng đợi cho đến khi hoàn tất!",
-    stepCompletedTitle: "Sẵn sàng!",
-    stepFirstImageTitle: "Đã đổi đồ xong",
-    stepFirstImageDescription:
-      "Bây giờ bạn có thể đăng hoặc tải kết quả. Hãy thử nhé.",
+    stepNavigateTitle: "Bắt đầu tạo tại đây!",
+    stepNavigateDescription: "Chạm vào đây để tiếp tục.",
     stepFinishedTitle: "Đã hoàn thành tour",
     stepFinishedDescription:
-      "Tuyệt vời. Tận hưởng việc tạo thêm các lần đổi đồ từ đây. Nhấn \"Hoàn thành\" để nhận thưởng Percoin.",
+      "Xong rồi! Hãy chọn phong cách và ảnh yêu thích để tạo bức ảnh đầu tiên. Hoàn thành chuyến tham quan để nhận thưởng Percoin.",
   },
   free: {
     tabLabel: "Free Style",

--- a/messages/zh-CN.ts
+++ b/messages/zh-CN.ts
@@ -935,8 +935,11 @@ export const zhCnMessages = {
   coordinate: {
     tabLabel: "Coordinate",
     tourButton: "教程",
+    tourStepUploadTitle: "上传图片",
     tourStepUploadDescription: "在此上传想要重新造型的角色图片。",
+    tourStepPromptTitle: "输入造型提示词",
     tourStepPromptDescription: "请描述想要的搭配。",
+    tourStepGenerateTitle: "开始生成",
     tourStepGenerateDescription: "选择 “开始造型” 即可开始。",
     pageTitle: "Coordinate",
     pageDescription: "上传人物图片，轻松换装。保持原本的姿势和构图，只自然地更换服装。",
@@ -1415,38 +1418,11 @@ export const zhCnMessages = {
     prevButton: "上一步",
     nextButton: "下一步",
     doneButton: "完成",
-    promptTemplate:
-      "请按 {month} 月的季节感为我搭配。",
-    stepCoordinateTitle: "打开搭配",
-    stepCoordinateDescription: "点击此处即可打开搭配页面。",
-    stepUploadTitle: "上传图片",
-    stepUploadDescription:
-      "在此上传想要重新造型的角色图片。本次教程已为你准备好示例图片。",
-    stepPromptTitle: "输入造型提示词",
-    stepPromptDescription:
-      "请描述想要的搭配。本教程将使用此示例。",
-    stepBackgroundTitle: "背景设置",
-    stepBackgroundDescription:
-      "在这里选择如何处理背景。本教程将使用 “交给 AI 处理” 继续。",
-    stepModelTitle: "选择生成模型",
-    stepModelDescription:
-      "本教程将使用 ChatGPT Images 2.0 Low。即使已选择其他模型，也会在这里自动切换。",
-    stepSizeTitle: "确认输出尺寸",
-    stepSizeDescription:
-      "输出尺寸将保持为标准。实际尺寸会根据图片方向自动调整。",
-    stepGenerateTitle: "开始生成",
-    stepGenerateDescription:
-      "选择 “开始造型” 即可开始。教程结束后将退还使用的 Percoin，请放心继续。",
-    stepGeneratingTitle: "生成中...",
-    stepGeneratingDescription:
-      "下方可以查看进度，请耐心等候完成!",
-    stepCompletedTitle: "完成啦!",
-    stepFirstImageTitle: "换装完成",
-    stepFirstImageDescription:
-      "现在你可以发布或下载结果，欢迎尝试。",
+    stepNavigateTitle: "从这里开始生成！",
+    stepNavigateDescription: "请点击这里。",
     stepFinishedTitle: "教程结束",
     stepFinishedDescription:
-      "辛苦了。接下来请尽情享受更多搭配。点击 “完成” 即可领取 Percoin 奖励。",
+      "辛苦了！选择喜欢的风格和照片，马上生成第一张图片吧！完成导览即可获得奖励Percoin。",
   },
   free: {
     tabLabel: "Free Style",

--- a/messages/zh-CN.ts
+++ b/messages/zh-CN.ts
@@ -1421,8 +1421,7 @@ export const zhCnMessages = {
     stepNavigateTitle: "从这里开始生成！",
     stepNavigateDescription: "请点击这里。",
     stepFinishedTitle: "教程结束",
-    stepFinishedDescription:
-      "辛苦了！选择喜欢的风格和照片，马上生成第一张图片吧！完成导览即可获得奖励Percoin。",
+    stepFinishedDescription: "辛苦了！快去试着生成一张吧！点击“完成”即可获得奖励Percoin。",
   },
   free: {
     tabLabel: "Free Style",
@@ -1680,9 +1679,9 @@ export const zhCnMessages = {
     tourNextButton: "下一步",
     tourDoneButton: "马上试试！",
     tourStepPresetTitle: "✨ ① 选择风格",
-    tourStepPresetDescription: "请选择想要换装的风格！",
+    tourStepPresetDescription: "在这里选择你喜欢的风格！",
     tourStepCharacterTitle: "💖 ② 选择我的角色",
-    tourStepCharacterDescription: "请选择想要换装的角色！",
+    tourStepCharacterDescription: "在这里设置你的角色！",
     tourStepGenerateTitle: "🚀 ③ 开始搭配！",
     tourStepGenerateDescription: "点击后即开始生成！接下来只需等待！",
   },

--- a/messages/zh-TW.ts
+++ b/messages/zh-TW.ts
@@ -1421,8 +1421,7 @@ export const zhTwMessages = {
     stepNavigateTitle: "從這裡開始生成！",
     stepNavigateDescription: "請點擊這裡。",
     stepFinishedTitle: "教學結束",
-    stepFinishedDescription:
-      "辛苦了！選擇喜歡的風格和照片，馬上生成第一張圖片吧！完成導覽即可獲得獎勵Percoin。",
+    stepFinishedDescription: "辛苦了！快去試著生成一張吧！點擊「完成」即可獲得獎勵Percoin。",
   },
   free: {
     tabLabel: "Free Style",
@@ -1680,9 +1679,9 @@ export const zhTwMessages = {
     tourNextButton: "下一步",
     tourDoneButton: "馬上試試！",
     tourStepPresetTitle: "✨ ① 選擇風格",
-    tourStepPresetDescription: "請選擇想換裝的風格！",
+    tourStepPresetDescription: "在這裡選擇你喜歡的風格！",
     tourStepCharacterTitle: "💖 ② 選擇我的角色",
-    tourStepCharacterDescription: "請選擇想換裝的角色！",
+    tourStepCharacterDescription: "在這裡設定你的角色！",
     tourStepGenerateTitle: "🚀 ③ 開始穿搭！",
     tourStepGenerateDescription: "點選後就會開始生成！接著只要等待就好！",
   },

--- a/messages/zh-TW.ts
+++ b/messages/zh-TW.ts
@@ -935,8 +935,11 @@ export const zhTwMessages = {
   coordinate: {
     tabLabel: "Coordinate",
     tourButton: "教學",
+    tourStepUploadTitle: "上傳圖片",
     tourStepUploadDescription: "在此上傳想要重新造型的角色圖片。",
+    tourStepPromptTitle: "輸入造型提示詞",
     tourStepPromptDescription: "請描述想要的穿搭。",
+    tourStepGenerateTitle: "開始生成",
     tourStepGenerateDescription: "選擇 “開始造型” 即可開始。",
     pageTitle: "Coordinate",
     pageDescription: "上傳人物圖片，輕鬆換裝。保持原本的姿勢與構圖，只自然地更換服裝。",
@@ -1415,38 +1418,11 @@ export const zhTwMessages = {
     prevButton: "上一步",
     nextButton: "下一步",
     doneButton: "完成",
-    promptTemplate:
-      "請依 {month} 月的季節感為我搭配。",
-    stepCoordinateTitle: "開啟穿搭",
-    stepCoordinateDescription: "點擊此處即可開啟穿搭頁面。",
-    stepUploadTitle: "上傳圖片",
-    stepUploadDescription:
-      "在此上傳想要重新造型的角色圖片。本次教學已為你準備好示範圖片。",
-    stepPromptTitle: "輸入造型提示詞",
-    stepPromptDescription:
-      "請描述想要的穿搭。本教學將使用此範例。",
-    stepBackgroundTitle: "背景設定",
-    stepBackgroundDescription:
-      "在這裡選擇如何處理背景。本教學將使用 “交給 AI” 繼續。",
-    stepModelTitle: "選擇生成模型",
-    stepModelDescription:
-      "本教學將使用 ChatGPT Images 2.0 Low。即使已選擇其他模型，也會在這裡自動切換。",
-    stepSizeTitle: "確認輸出尺寸",
-    stepSizeDescription:
-      "輸出尺寸將保持為標準。實際尺寸會依照圖片方向自動調整。",
-    stepGenerateTitle: "開始生成",
-    stepGenerateDescription:
-      "選擇 “開始造型” 即可開始。教學結束後會退還使用的 Percoin，請放心繼續。",
-    stepGeneratingTitle: "生成中...",
-    stepGeneratingDescription:
-      "下方可以查看進度，請耐心等候完成!",
-    stepCompletedTitle: "完成囉!",
-    stepFirstImageTitle: "換裝完成",
-    stepFirstImageDescription:
-      "現在你可以發佈或下載結果，歡迎試試。",
+    stepNavigateTitle: "從這裡開始生成！",
+    stepNavigateDescription: "請點擊這裡。",
     stepFinishedTitle: "教學結束",
     stepFinishedDescription:
-      "辛苦了。從現在起請盡情享受更多穿搭。點擊 “完成” 即可領取 Percoin 獎勵。",
+      "辛苦了！選擇喜歡的風格和照片，馬上生成第一張圖片吧！完成導覽即可獲得獎勵Percoin。",
   },
   free: {
     tabLabel: "Free Style",

--- a/tests/unit/features/generation/generation-mode-preference.test.ts
+++ b/tests/unit/features/generation/generation-mode-preference.test.ts
@@ -1,0 +1,39 @@
+import {
+  GENERATION_MODE_PATHS,
+  getLastGenerationModePath,
+  isGenerationModePath,
+  setLastGenerationModePath,
+} from "@/features/generation/lib/generation-mode-preference";
+
+describe("generation-mode-preference", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  test("未保存時の既定は /style (新規ユーザーの初回着地を One-Tap Style に寄せる)", () => {
+    expect(getLastGenerationModePath()).toBe(GENERATION_MODE_PATHS.style);
+  });
+
+  test("保存済みの直近モードを返す", () => {
+    setLastGenerationModePath(GENERATION_MODE_PATHS.free);
+    expect(getLastGenerationModePath()).toBe("/free");
+    setLastGenerationModePath(GENERATION_MODE_PATHS.coordinate);
+    expect(getLastGenerationModePath()).toBe("/coordinate");
+  });
+
+  test("不正な保存値は既定 /style に倒す", () => {
+    window.localStorage.setItem(
+      "persta-ai:last-generation-mode",
+      "/unknown-path",
+    );
+    expect(getLastGenerationModePath()).toBe("/style");
+  });
+
+  test("isGenerationModePath は3ルートのみ真", () => {
+    expect(isGenerationModePath("/style")).toBe(true);
+    expect(isGenerationModePath("/free")).toBe(true);
+    expect(isGenerationModePath("/coordinate")).toBe(true);
+    expect(isGenerationModePath("/dashboard")).toBe(false);
+    expect(isGenerationModePath(null)).toBe(false);
+  });
+});

--- a/tests/unit/features/tutorial/tour-steps.test.ts
+++ b/tests/unit/features/tutorial/tour-steps.test.ts
@@ -1,0 +1,45 @@
+import { getTourSteps } from "@/features/tutorial/lib/tour-steps";
+
+const COPY = {
+  navigateTitle: "生成はここから！",
+  navigateDescription: "ここをタップしてください。",
+  presetTitle: "① スタイルを選択",
+  presetDescription: "着せ替えたいスタイルを選択してください！",
+  characterTitle: "② マイキャラ選択",
+  characterDescription: "着せ替えたいキャラクターを選んでください！",
+  generateTitle: "③ コーデを開始！",
+  generateDescription: "選択すると生成が始まります！",
+  finishedTitle: "ツアー完了！",
+  finishedDescription: "お疲れ様でした！",
+};
+
+describe("getTourSteps (新規登録チュートリアル・5ステップ)", () => {
+  test("①ナビ案内 → ②〜④は style ミニツアーのアンカー → ⑤締め、の順で5ステップ", () => {
+    const steps = getTourSteps(COPY);
+    expect(steps).toHaveLength(5);
+    expect(steps.map((s) => s.element)).toEqual([
+      '[data-tour="coordinate-nav-mobile"]',
+      '[data-tour="style-tour-preset"]',
+      '[data-tour="style-tour-character"]',
+      '[data-tour="style-tour-generate"]',
+      undefined,
+    ]);
+  });
+
+  test("文言が各ステップの popover に反映される", () => {
+    const steps = getTourSteps(COPY);
+    expect(steps[0].popover?.title).toBe(COPY.navigateTitle);
+    expect(steps[1].popover?.title).toBe(COPY.presetTitle);
+    expect(steps[2].popover?.description).toBe(COPY.characterDescription);
+    expect(steps[3].popover?.title).toBe(COPY.generateTitle);
+    expect(steps[4].popover?.title).toBe(COPY.finishedTitle);
+  });
+
+  test("⑤締めは要素なしの中央表示で「次へ(完了)」ボタンのみ", () => {
+    const steps = getTourSteps(COPY);
+    const finale = steps[4];
+    expect(finale.element).toBeUndefined();
+    expect(finale.popover?.showButtons).toEqual(["next"]);
+    expect(finale.popover?.side).toBe("over");
+  });
+});


### PR DESCRIPTION
## 概要

新規登録時のチュートリアルを、コーディネート画面で実生成する重いツアー（11ステップ・デモ画像・コイン実消費）から、**One-Tap Style のミニツアーを土台にした全5ステップの軽量ツアー（ツールチップのみ・生成なし）**へ刷新します。

計画書: `docs/planning/style-tutorial-migration-implementation-plan.md`（/free 移行案 → /style 実生成案 → 本案の経緯も記録）

## 新しいツアー

```
① ホームでナビ入口をハイライト「生成はここから！」
   → タップで /style へ遷移（ツアー中は直近モードに関わらず /style 固定）
② スタイル選択エリア ┐
③ キャラクター写真   ├ 既存 style-tour-* のアンカー/文言を共用（StylePageClient 無改修）
④ 生成ボタン         ┘
⑤ 締め →「完了」で /api/tutorial/complete（付与・通知・冪等）
```

## 変更内容

- **TutorialTourProvider**: /style 起点へ全面改稿。デモ画像・プロンプト注入・生成完了待ち・ギャラリー切替などのイベント配線を撤去（**生成・課金経路に無変更**）
- **tour-steps.ts**: 5ステップへ改稿（②〜④は style ミニツアーの文言キーを共用）
- **ナビ既定**: `DEFAULT_PATH` を `/coordinate` → `/style`（新規ユーザーの初回着地方針。既存ユーザーは直近モード保存済みのため影響ほぼなし）
- **ナビガード拡張（#499）**: ツアー中はモバイル/PC ともナビの生成入口を `/style` 固定
- **CoordinateTourButton**（コーデ画面の独立ミニツアー）: 借用していたタイトル3キーを coordinate 名前空間へ移設し自己完結化（挙動不変）
- **15言語**: 旧ツアー20キー削除・ナビ案内2キー追加・締め文言更新（キー整合テストでパリティ担保）
- 未使用になった `TUTORIAL_BONUS_AMOUNT` / `getJapanMonth` を削除

## 無改修で流用されるもの

報酬（`grant_tour_bonus`・冪等・完了通知・admin 額設定）／完了フラグ（`user_metadata`）／スキップ記録／`?tutorial_reset=1`／ミッション画面の再実行（ホームへ戻して開始モーダルを出す方式のため）／StyleTourButton（/style の手動リプレイ）

## リリース時（マージ・デプロイ後）

- admin `/admin/percoin-defaults` で `tour_bonus` を 20 → **10** に変更（ツアー中の消費が無くなったため、ネットは従来の 50−10+20=60 と同一の 50+10=60）
- 実機確認: `?tutorial_reset=1` でモバイル/PC × 開始 → /style 遷移 → ②〜④ → ⑤完了（既完了アカウントは冪等で付与0）

## テスト

- [x] `npm run test` 3,206件パス（tour-steps 3件・mode-preference 4件を新規追加）
- [x] `npm run lint` 23 errors / 57 warnings（main と同数）
- [x] `npm run typecheck` 既存赤（tests/**）以外なし
- [x] `npm run build -- --webpack` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mmqeUvT5TbjAMPNo6Pxsn
