### PR TITLE
fix(db): ワーカー起動cronを30秒へ緩和し実行ログ保持をジョブ別にする

### DIFF
--- a/supabase/migrations/20260809120000_reduce_cron_polling_disk_io.sql
+++ b/supabase/migrations/20260809120000_reduce_cron_polling_disk_io.sql
@@ -40,6 +40,9 @@ BEGIN;
 -- ---------------------------------------------
 -- command は変更しないため alter_job で schedule のみ差し替える
 -- (unschedule + schedule だと command の写し間違いが事故になりうる)。
+-- NOTE: image-gen-worker-cron はマイグレーションではなく本番で手動作成された
+--       ジョブのため、マイグレーションのみで構築される環境(Supabase Preview 等)
+--       には存在しない。存在しない環境では何もせず通す(エラーにしない)。
 DO $do$
 DECLARE
   v_job_id BIGINT;
@@ -50,7 +53,8 @@ BEGIN
   LIMIT 1;
 
   IF v_job_id IS NULL THEN
-    RAISE EXCEPTION 'image-gen-worker-cron が見つかりません (想定外の構成)';
+    RAISE NOTICE 'image-gen-worker-cron が無いためスキップ (Preview 等の環境)';
+    RETURN;
   END IF;
 
   PERFORM cron.alter_job(v_job_id, schedule := '30 seconds');
@@ -134,9 +138,10 @@ DECLARE
   v_cleanup_command TEXT;
   v_remaining BIGINT;
 BEGIN
+  -- ワーカー cron がある環境(本番)でのみ間隔を検証する
   SELECT schedule INTO v_schedule
   FROM cron.job WHERE jobname = 'image-gen-worker-cron';
-  IF v_schedule IS DISTINCT FROM '30 seconds' THEN
+  IF v_schedule IS NOT NULL AND v_schedule IS DISTINCT FROM '30 seconds' THEN
     RAISE EXCEPTION 'ワーカー cron の間隔が想定と異なります: %', v_schedule;
   END IF;
 

--- a/supabase/migrations/20260809120000_reduce_cron_polling_disk_io.sql
+++ b/supabase/migrations/20260809120000_reduce_cron_polling_disk_io.sql
@@ -1,0 +1,179 @@
+-- ===============================================
+-- Disk IO 削減: ワーカー起動 cron の間隔緩和 + 実行ログ保持の最適化
+-- ===============================================
+-- 背景 (2026-08-09 障害):
+--   Disk IO Budget 枯渇により DB が完全無応答となり、サービスが停止した
+--   (compute を Nano→Small へ引き上げて復旧)。
+--   同種の警告は 2026-06-10 にも発生しており
+--   (20260611090000_schedule_db_log_tables_cleanup_cron.sql)、そのときは
+--   肥大化した内部ログテーブルの掃除という「症状」への対処だった。
+--   本マイグレーションは残っていた根本原因である「常時ポーリングの書き込み量」
+--   に対処する。
+--
+-- 実測 (直近7日 / 426 ジョブ):
+--   - 生成所要時間: 平均 32.0 秒 / 中央値 31.6 秒 / p90 38.6 秒
+--   - 作成→処理開始の待ち時間:
+--       2 秒未満  387 件 (91%)  ... アプリからの直接起動で拾えている
+--       2-12 秒    20 件 (4.7%) ... cron が拾った分 (= cron の実効価値)
+--       62 秒以上  17 件 (4%)   ... リトライ経路 (可視性タイムアウト後)
+--   → 1 日 8,640 回のポーリングで実際に救っているのは 1 日 3 件程度。
+--
+-- 変更 1: image-gen-worker-cron を 10 秒 → 30 秒
+--   通常の生成はアプリ側 (generate-async handler) が受付時にワーカーを直接
+--   起動しており、cron は「直接起動が失敗した場合」と「リトライの拾い上げ」の
+--   保険。間隔を 3 倍にしても 91% のジョブには影響せず、cron に拾われる
+--   約 5% の待ちが最大 10 秒 → 最大 30 秒 になるのみ(生成自体が約 32 秒の
+--   サービスであり許容範囲)。ポーリングは 1 日 8,640 回 → 2,880 回。
+--   1 回ごとに cron.job_run_details / net._http_request_queue /
+--   net._http_response へ行が書かれるため、書き込み量は約 1/3 になる。
+--
+-- 変更 2: cron.job_run_details の保持を「一律 7 日」→ ジョブ別
+--   実測の内訳: image-gen-worker-cron 81.3% / moderation dispatch 13.6%
+--   (上位 2 つで 95%)。高頻度ジョブのログだけ 1 日で捨て、それ以外は
+--   30 日保持する。一律短縮より削除量は同等のまま、月次ジョブ
+--   (expire_free_percoin_monthly 等) の実行記録を監査目的で残せる。
+
+BEGIN;
+
+-- ---------------------------------------------
+-- 変更 1: ワーカー起動 cron の間隔緩和
+-- ---------------------------------------------
+-- command は変更しないため alter_job で schedule のみ差し替える
+-- (unschedule + schedule だと command の写し間違いが事故になりうる)。
+DO $do$
+DECLARE
+  v_job_id BIGINT;
+BEGIN
+  SELECT jobid INTO v_job_id
+  FROM cron.job
+  WHERE jobname = 'image-gen-worker-cron'
+  LIMIT 1;
+
+  IF v_job_id IS NULL THEN
+    RAISE EXCEPTION 'image-gen-worker-cron が見つかりません (想定外の構成)';
+  END IF;
+
+  PERFORM cron.alter_job(v_job_id, schedule := '30 seconds');
+END;
+$do$;
+
+-- ---------------------------------------------
+-- 変更 2: 実行ログの保持期間をジョブ別にする
+-- ---------------------------------------------
+-- 高頻度ポーリング系は 1 日、それ以外は 30 日。
+-- 対象ジョブが unschedule 済みで cron.job に存在しない場合の孤児行も、
+-- 30 日側の条件で回収される。
+CREATE OR REPLACE FUNCTION public.cleanup_cron_job_run_details()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  -- 実行ログの 95% を占める高頻度ジョブ。増えたらここに足す。
+  v_noisy_job_names TEXT[] := ARRAY[
+    'image-gen-worker-cron',
+    'moderation_notification_outbox_dispatch'
+  ];
+  v_noisy_job_ids BIGINT[];
+BEGIN
+  SELECT array_agg(jobid) INTO v_noisy_job_ids
+  FROM cron.job
+  WHERE jobname = ANY(v_noisy_job_names);
+
+  IF v_noisy_job_ids IS NOT NULL THEN
+    DELETE FROM cron.job_run_details
+    WHERE jobid = ANY(v_noisy_job_ids)
+      AND start_time < now() - interval '1 day';
+  END IF;
+
+  -- 高頻度ジョブ以外 (および孤児行) は 30 日保持
+  DELETE FROM cron.job_run_details
+  WHERE (v_noisy_job_ids IS NULL OR jobid <> ALL(v_noisy_job_ids))
+    AND start_time < now() - interval '30 days';
+END;
+$$;
+
+COMMENT ON FUNCTION public.cleanup_cron_job_run_details() IS
+  'pg_cron 実行ログの掃除。高頻度ポーリング系は 1 日、それ以外は 30 日保持する。';
+
+REVOKE ALL ON FUNCTION public.cleanup_cron_job_run_details() FROM PUBLIC;
+
+-- 既存の一律 7 日削除ジョブを、上の関数呼び出しに差し替える
+DO $do$
+DECLARE
+  v_job_id BIGINT;
+BEGIN
+  SELECT jobid INTO v_job_id
+  FROM cron.job
+  WHERE jobname = 'cleanup_cron_job_run_details_daily'
+  LIMIT 1;
+
+  IF v_job_id IS NOT NULL THEN
+    PERFORM cron.unschedule(v_job_id);
+  END IF;
+
+  -- 毎日 19:00 UTC = JST 4:00 (低トラフィック帯。従来と同じ時刻)
+  PERFORM cron.schedule(
+    'cleanup_cron_job_run_details_daily',
+    '0 19 * * *',
+    $$SELECT public.cleanup_cron_job_run_details()$$
+  );
+END;
+$do$;
+
+-- 溜まっている分は次回の定期実行を待たずここで一度掃除する
+SELECT public.cleanup_cron_job_run_details();
+
+-- ---------------------------------------------
+-- 検証
+-- ---------------------------------------------
+DO $do$
+DECLARE
+  v_schedule TEXT;
+  v_cleanup_command TEXT;
+  v_remaining BIGINT;
+BEGIN
+  SELECT schedule INTO v_schedule
+  FROM cron.job WHERE jobname = 'image-gen-worker-cron';
+  IF v_schedule IS DISTINCT FROM '30 seconds' THEN
+    RAISE EXCEPTION 'ワーカー cron の間隔が想定と異なります: %', v_schedule;
+  END IF;
+
+  SELECT command INTO v_cleanup_command
+  FROM cron.job WHERE jobname = 'cleanup_cron_job_run_details_daily';
+  IF v_cleanup_command NOT LIKE '%cleanup_cron_job_run_details%' THEN
+    RAISE EXCEPTION '掃除ジョブが差し替わっていません: %', v_cleanup_command;
+  END IF;
+
+  SELECT count(*) INTO v_remaining FROM cron.job_run_details;
+  RAISE NOTICE 'OK: ワーカー cron=30 秒 / 掃除ジョブ差し替え済み / 実行ログ残 % 行', v_remaining;
+END;
+$do$;
+
+COMMIT;
+
+-- ===============================================
+-- DOWN:
+-- BEGIN;
+-- DO $do$
+-- DECLARE v_job_id BIGINT;
+-- BEGIN
+--   SELECT jobid INTO v_job_id FROM cron.job WHERE jobname = 'image-gen-worker-cron' LIMIT 1;
+--   IF v_job_id IS NOT NULL THEN
+--     PERFORM cron.alter_job(v_job_id, schedule := '10 seconds');
+--   END IF;
+--   SELECT jobid INTO v_job_id FROM cron.job WHERE jobname = 'cleanup_cron_job_run_details_daily' LIMIT 1;
+--   IF v_job_id IS NOT NULL THEN
+--     PERFORM cron.unschedule(v_job_id);
+--   END IF;
+--   PERFORM cron.schedule(
+--     'cleanup_cron_job_run_details_daily',
+--     '0 19 * * *',
+--     $$DELETE FROM cron.job_run_details WHERE start_time < now() - interval '7 days'$$
+--   );
+-- END;
+-- $do$;
+-- DROP FUNCTION IF EXISTS public.cleanup_cron_job_run_details();
+-- COMMIT;
+-- ===============================================


### PR DESCRIPTION
## 概要

2026-08-09 に発生した **Disk IO Budget 枯渇による DB 全停止**の根本原因に対処します。

同種の警告は **2026-06-10 にも発生**しており（`20260611090000_schedule_db_log_tables_cleanup_cron.sql` に記録）、そのときは肥大化したログテーブルの掃除という**症状への対処**にとどまっていました。根本原因である「常時ポーリングの書き込み量」は手つかずで、2ヶ月後に再発した形です。本 PR はそこに対処します。

## 実測データ（直近7日・426ジョブ）

- 生成所要時間: 平均 **32.0秒** / 中央値 31.6秒 / p90 38.6秒
- 作成 → 処理開始の待ち時間:

| 待ち | 件数 | 意味 |
|---|---|---|
| 2秒未満 | 387件（**91%**） | アプリからの直接起動で成立 |
| 2〜12秒 | 20件（4.7%） | cron が拾った分＝cron の実効価値 |
| 62秒以上 | 17件（4%） | リトライ経路 |

→ **1日8,640回のポーリングで、実際に救っているのは1日3件程度**でした。

## 変更内容

### ① `image-gen-worker-cron`: 10秒 → 30秒
- ポーリング **1日8,640回 → 2,880回**（書き込み量 約1/3）
- 通常の生成はアプリ側（generate-async handler）が受付時にワーカーを直接起動しており、cron は「直接起動の失敗」と「リトライ拾い上げ」の保険
- 影響: 91%のジョブは無関係。cron依存の約5%の待ちが最大10秒→最大30秒（生成自体が約32秒のため許容範囲）
- `cron.alter_job` で schedule のみ差し替え（command の写し間違い事故を回避）

### ② `cron.job_run_details` の保持: 一律7日 → ジョブ別
- 実測の内訳: worker cron 81.3% / moderation dispatch 13.6%（**上位2つで95%**）
- 高頻度2ジョブは**1日**、それ以外は**30日**保持
- 一律短縮より削除量は同等のまま、**月次ジョブ（ペルコイン失効等）の実行記録を監査用に残せる**
- 適用時に滞留分も掃除（81,529 → 14,067行）

## 適用状況

**本番適用済み**（ユーザー承認のうえ実施）。

- COMMIT→ROLLBACK リハーサルを本番で実行し、**残留ゼロを確認**してから適用
- 適用後の検証: worker cron が **30秒間隔で succeeded** していることを実測（12:21:24 → 12:21:54 → 12:22:24 → 12:22:54）
- 掃除後に `VACUUM` 実行済み（空き領域の再利用を有効化）

## 今後（このPRのスコープ外）

- ワーカーの自己再起動（処理後に待ち行列が残っていれば自分を再呼び出し）を入れれば、cron は完全な保険になり60秒以上に緩められます
- 企画終了後、Disk IO グラフを数日観察してから compute を Small → Micro へ降格（Micro は旧 Nano と同額でメモリ2倍）

## テスト

- SQL のみの変更のためアプリコードへの影響なし（CI の Jest / build で確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mmqeUvT5TbjAMPNo6Pxsn