### PR TITLE
fix(credits): 紹介ページのリード文を調整

### DIFF
--- a/features/credits/components/CreatorRewardsGuide.tsx
+++ b/features/credits/components/CreatorRewardsGuide.tsx
@@ -355,9 +355,9 @@ export function CreatorRewardsGuide({
 
         <PopIn delay={80} rotate={0}>
           <p className="mx-auto mt-8 max-w-sm px-6 text-sm font-medium leading-loose text-gray-600">
-            つくった作品が誰かに使われるたびに、
+            つくった作品が使われるたびに、
             <br />
-            ペルコインがあなたに届きます。
+            ペルコインがあなたに届きます！
           </p>
         </PopIn>
 


### PR DESCRIPTION
## 概要

`/creator-rewards` のヒーロー下のリード文を調整します（文言のみ・1行）。

- 変更前: つくった作品が**誰かに**使われるたびに、ペルコインがあなたに届き**ます。**
- 変更後: つくった作品が使われるたびに、ペルコインがあなたに届き**ます！**

## テスト

- [x] `npm run lint` 23 errors / 57 warnings（main と同数）
- [x] `npm run build -- --webpack` 成功
- [x] 紹介ページの単体テスト 4件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mmqeUvT5TbjAMPNo6Pxsn