### PR TITLE
fix(users): アバターを保存時に256px WebPへ縮める

### DIFF
--- a/app/api/users/[userId]/avatar/route.ts
+++ b/app/api/users/[userId]/avatar/route.ts
@@ -7,6 +7,23 @@ import { env } from "@/lib/env";
 import { jsonError } from "@/lib/api/json-error";
 import { getRouteLocale } from "@/lib/api/route-locale";
 import { getUserRouteCopy } from "@/features/users/lib/route-copy";
+import { convertToWebP } from "@/features/generation/lib/webp-converter";
+
+/**
+ * 保存するアバターの最大辺（px）。
+ *
+ * 表示は 24〜36px（Retina で最大 72px）だが、将来プロフィール画面で大きく出す
+ * 余地を残して 256px にしている。これでも 1件あたり十数KB に収まる。
+ *
+ * リサイズしていなかった頃は、本番の 44 件で合計 34MB・中央値 746KB・最大 2.0MB
+ * だった（クライアントの切り抜きが PNG を吐くため）。36px の丸アイコンのために
+ * 毎回そのサイズを Storage から取りに行っており、画像最適化のたびに費用と
+ * 待ち時間になっていた。
+ */
+const AVATAR_MAX_SIZE_PX = 256;
+
+/** WebP 品質。アイコンなので 80 で十分（既存の変換ヘルパーの既定と同じ）。 */
+const AVATAR_WEBP_QUALITY = 80;
 
 /**
  * プロフィール画像アップロードAPI（POST）
@@ -81,18 +98,48 @@ export async function POST(
       .eq("user_id", userId)
       .single();
 
+    /*
+      保存前に 256px の WebP へ縮める。
+
+      受付上限(10MB)は据え置きで、**受け取ってから縮める**。ユーザーは今までどおり
+      撮った写真をそのまま上げられる。
+
+      変換に失敗したときは元のファイルをそのまま保存する(従来の挙動)。
+      アイコンが重いのは困るが、アップロード自体が失敗する方が困る。
+      なお現状クライアントは切り抜き時に PNG へ変換して送るため、
+      sharp が扱えない形式(HEIF 等)がここへ届くことはない想定。
+    */
+    let uploadBody: File | Buffer = file;
+    let fileExt = getFileExtensionFromMimeType(file.type);
+    let contentType: string | undefined;
+    try {
+      const originalBuffer = Buffer.from(await file.arrayBuffer());
+      uploadBody = await convertToWebP(originalBuffer, {
+        maxWidth: AVATAR_MAX_SIZE_PX,
+        maxHeight: AVATAR_MAX_SIZE_PX,
+        quality: AVATAR_WEBP_QUALITY,
+      });
+      fileExt = "webp";
+      contentType = "image/webp";
+    } catch (conversionError) {
+      console.error(
+        "[avatar] WebP 変換に失敗したため元のファイルを保存します:",
+        conversionError
+      );
+    }
+
     // ファイル名を生成（フォルダ: avatars/{userId}/タイムスタンプ.拡張子）
-    // MIMEタイプから拡張子を決定（file.nameに依存しない）
-    const fileExt = getFileExtensionFromMimeType(file.type);
+    // 拡張子は変換結果から決める（変換できたときは常に webp）
     const fileName = `avatars/${userId}/${Date.now()}.${fileExt}`;
     const filePath = fileName;
 
     // Supabase Storageにアップロード
     const { data: uploadData, error: uploadError } = await supabase.storage
       .from(AVATAR_BUCKET)
-      .upload(filePath, file, {
+      .upload(filePath, uploadBody, {
         cacheControl: "3600",
         upsert: true,
+        ...(contentType ? { contentType } : {}),
       });
 
     if (uploadError) {

--- a/tests/unit/app/api/users/avatar-route.test.ts
+++ b/tests/unit/app/api/users/avatar-route.test.ts
@@ -1,0 +1,178 @@
+/** @jest-environment node */
+
+/**
+ * POST /api/users/[userId]/avatar のテスト。
+ *
+ * ここが誤ると (a) 原寸のまま保存されて全画面のアイコンが重くなる、
+ * (b) 変換に失敗したときアップロードごと失敗する、のどちらかが起きる。
+ * 本番では 44 件で合計 34MB（中央値 746KB・最大 2.0MB）になっていた。
+ */
+
+jest.mock("@/lib/auth", () => ({
+  getUser: jest.fn(),
+}));
+
+jest.mock("@/lib/supabase/server", () => ({
+  createClient: jest.fn(),
+}));
+
+jest.mock("@/features/generation/lib/webp-converter", () => ({
+  convertToWebP: jest.fn(),
+}));
+
+jest.mock("next/cache", () => ({
+  revalidateTag: jest.fn(),
+}));
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/users/[userId]/avatar/route";
+import { getUser } from "@/lib/auth";
+import { createClient } from "@/lib/supabase/server";
+import { convertToWebP } from "@/features/generation/lib/webp-converter";
+
+const mockGetUser = getUser as jest.MockedFunction<typeof getUser>;
+const mockCreateClient = createClient as jest.MockedFunction<typeof createClient>;
+const mockConvertToWebP = convertToWebP as jest.MockedFunction<typeof convertToWebP>;
+
+const USER_ID = "11111111-1111-4111-8111-111111111111";
+
+interface UploadCall {
+  path: string;
+  body: unknown;
+  options: { contentType?: string } | undefined;
+}
+
+function mockSupabase() {
+  const uploads: UploadCall[] = [];
+  const upload = jest.fn(
+    (path: string, body: unknown, options?: { contentType?: string }) => {
+      uploads.push({ path, body, options });
+      return Promise.resolve({ data: { path }, error: null });
+    }
+  );
+
+  mockCreateClient.mockResolvedValue({
+    from: jest.fn(() => ({
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      update: jest.fn().mockReturnThis(),
+      single: jest.fn(() =>
+        Promise.resolve({ data: { avatar_url: null }, error: null })
+      ),
+    })),
+    storage: {
+      from: jest.fn(() => ({
+        upload,
+        getPublicUrl: jest.fn((path: string) => ({
+          data: { publicUrl: `https://example.test/${path}` },
+        })),
+        remove: jest.fn(() => Promise.resolve({ error: null })),
+      })),
+    },
+  } as unknown as Awaited<ReturnType<typeof createClient>>);
+
+  return uploads;
+}
+
+function buildRequest(file: File): NextRequest {
+  const formData = new FormData();
+  formData.set("file", file);
+  return new NextRequest(`http://localhost/api/users/${USER_ID}/avatar`, {
+    method: "POST",
+    body: formData,
+  });
+}
+
+/** 2MB 相当の PNG に見せかけたファイル（本番の実データと同じ規模）。 */
+function bigPngFile(): File {
+  return new File([new Uint8Array(2 * 1024 * 1024)], "avatar.png", {
+    type: "image/png",
+  });
+}
+
+const params = Promise.resolve({ userId: USER_ID });
+
+describe("POST /api/users/[userId]/avatar", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetUser.mockResolvedValue({ id: USER_ID } as never);
+    mockConvertToWebP.mockResolvedValue(Buffer.from("webp-bytes"));
+  });
+
+  test("256px の WebP へ縮めて保存する", async () => {
+    const uploads = mockSupabase();
+
+    const response = await POST(buildRequest(bigPngFile()), { params });
+
+    expect(response.status).toBe(200);
+    expect(mockConvertToWebP).toHaveBeenCalledWith(expect.any(Buffer), {
+      maxWidth: 256,
+      maxHeight: 256,
+      quality: 80,
+    });
+    expect(uploads).toHaveLength(1);
+    expect(uploads[0].path).toMatch(/^avatars\/.+\.webp$/);
+    expect(uploads[0].body).toEqual(Buffer.from("webp-bytes"));
+    expect(uploads[0].options?.contentType).toBe("image/webp");
+  });
+
+  test("拡張子は元の MIME ではなく変換結果で決める", async () => {
+    const uploads = mockSupabase();
+
+    await POST(
+      buildRequest(
+        new File([new Uint8Array(16)], "avatar.jpg", { type: "image/jpeg" })
+      ),
+      { params }
+    );
+
+    expect(uploads[0].path.endsWith(".webp")).toBe(true);
+  });
+
+  test("変換に失敗しても元のファイルで保存を続ける(アップロードを失敗させない)", async () => {
+    const uploads = mockSupabase();
+    mockConvertToWebP.mockRejectedValue(new Error("unsupported format"));
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    const response = await POST(buildRequest(bigPngFile()), { params });
+
+    expect(response.status).toBe(200);
+    expect(uploads).toHaveLength(1);
+    // 元の拡張子・元のファイル本体で保存される
+    expect(uploads[0].path.endsWith(".png")).toBe(true);
+    expect(uploads[0].options?.contentType).toBeUndefined();
+    errorSpy.mockRestore();
+  });
+
+  test("他人のアバターは変更できない", async () => {
+    mockSupabase();
+    mockGetUser.mockResolvedValue({ id: "another-user" } as never);
+
+    const response = await POST(buildRequest(bigPngFile()), { params });
+
+    expect(response.status).toBe(403);
+    expect(mockConvertToWebP).not.toHaveBeenCalled();
+  });
+
+  test("10MB 超は受け付けない(変換を試みる前に弾く)", async () => {
+    mockSupabase();
+    const file = new File([new Uint8Array(10 * 1024 * 1024 + 1)], "big.png", {
+      type: "image/png",
+    });
+
+    const response = await POST(buildRequest(file), { params });
+
+    expect(response.status).toBe(400);
+    expect(mockConvertToWebP).not.toHaveBeenCalled();
+  });
+
+  test("画像以外は受け付けない", async () => {
+    mockSupabase();
+    const file = new File([new Uint8Array(16)], "a.txt", { type: "text/plain" });
+
+    const response = await POST(buildRequest(file), { params });
+
+    expect(response.status).toBe(400);
+    expect(mockConvertToWebP).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
アバター画像がリサイズされずに保存されていた問題の修正です。

## 何が起きていたか

`app/api/users/[userId]/avatar/route.ts` に**リサイズ処理がありませんでした**。MIME から拡張子を決めるだけで、受け取ったファイルをそのまま保存していました。

本番の実データ44件を全件測った結果です。

| | 実測 |
|---|---|
| 合計 | **34.0 MB** |
| 中央値 | 746 KB |
| 最大 | **2.0 MB** |
| 1MB超 | 13件 |

これを **24〜36px の丸アイコン**として表示していました。クライアントは切り抜き時に canvas で PNG に変換して送るため、切り抜き結果がそのまま数MBの PNG になっていたのが原因です。

Next の画像最適化自体は効いていますが（実測 2.1MB → 8.5KB）、**キャッシュが切れるたびに最適化サーバーが原寸を Storage から取りに行く**ため、初回表示の待ち時間・Supabase の転送量・Vercel の画像変換コストになっていました。ホーム（グリッド／フィード）・投稿詳細・プロフィール・コメント・通知と、アイコンが出る全画面に効いています。

## 変更内容

- 保存前に `convertToWebP` で **256px の WebP** へ変換します（`sharp` は依存済み、既存ヘルパーをそのまま使用）
- 拡張子は元の MIME ではなく**変換結果**から決めます（変換できたら常に `.webp`）
- **受付上限（10MB）は据え置き**です。受け取ってから縮めるので、ユーザーは今までどおり撮った写真をそのまま上げられます
- **変換に失敗したら元のファイルで保存を続けます**。アイコンが重いのは困りますが、アップロード自体が失敗する方が困るためです

### なぜ 256px か

アプリでの最大表示は **96px**（プロフィールヘッダー / `ProfileHeader.tsx:162`）で、Retina でも192pxです。256px なら余裕があり、それでも1件あたり十数KBに収まります。

## 既存データのバックフィル（実施済み）

40件を変換して差し替えました。

```
33.61MB -> 0.55MB (98.4% 減) / 失敗 0 件
```

- 全44件のうち **4件は外部URL（Google / X ログイン）** で Supabase 上に無いため対象外です
- 処理順は「新規アップロード → `profiles.avatar_url` 更新」で、途中で失敗しても表示は壊れません
- **旧ファイルは削除していません**。プロフィールは `cacheLife("minutes")` でキャッシュされており、外部スクリプトからは `revalidateTag` を呼べないため、キャッシュが切れるまでの数分は古いURLを指したページが残ります。ここで消すとその間アイコンが404になります。残しても増えるのは保管容量だけ（転送は発生しない）で、削減効果は `avatar_url` を軽いファイルへ切り替えることで既に得られています。原本が残るので、後からサイズを変えたくなったときにも作り直せます

### 適用後の検証

- `profiles`: webp 40件 / **未変換 0件** / 外部URL 4件
- 全40URLへのアクセス: **HTTP 200 が40件**、合計 570KB（最大 21KB）

## 検証

- `npm run lint` — main と同数（23 errors / 57 warnings・新規指摘ゼロ）
- `npm run typecheck` — アプリ側エラーなし
- `npm run test` — 3426 passed（新規6件）
- `npm run build -- --webpack` — 成功

## 補足

このPRはコード変更のみで、マイグレーションはありません。バックフィットは実行済みなので、マージ後の作業はありません。

クライアント側（`AvatarUpload.tsx`）の切り抜き出力を小さくすればアップロードの転送量も減らせますが、サーバー側で確実に縮める方が全クライアントに効くため、今回はサーバー側のみとしています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mmqeUvT5TbjAMPNo6Pxsn
