### PR TITLE
fix(posts): iOS でプロンプトのコピーが必ず失敗するのを直す

### DIFF
--- a/features/posts/components/SourcePromptReferenceCard.tsx
+++ b/features/posts/components/SourcePromptReferenceCard.tsx
@@ -26,7 +26,7 @@ import {
   isLandscapeRatio,
 } from "./BeforeAfterFrame";
 import { shouldShowUsageCount } from "../lib/constants";
-import { copyTextToClipboard } from "../lib/copy-to-clipboard";
+import { copyTextFromPromise } from "@/lib/clipboard";
 import { trackPromptUseTapped } from "../lib/home-view-events";
 import { fetchSourcePromptText } from "../lib/source-prompt-text-api";
 import type { SubscriptionPlan } from "@/features/subscription/subscription-config";
@@ -187,8 +187,13 @@ export function SourcePromptReferenceCard({
   */
   const handleCopyPrompt = async () => {
     try {
-      const promptText = await fetchSourcePromptText(reference.postId);
-      await copyTextToClipboard(promptText);
+      /*
+        本文の取得を await してから copyTextToClipboard を呼ぶと、iOS Safari では
+        通信のあいだにユーザー操作の権限が切れてコピーが必ず拒否される
+        (同期的にテキストを持っている他のコピーは動く)。
+        Promise を渡せる形にして、押した瞬間の権限を保つ。
+      */
+      await copyTextFromPromise(fetchSourcePromptText(reference.postId));
       setIsCopied(true);
       toast({ title: t("sourcePromptCopied") });
       setTimeout(() => setIsCopied(false), 2000);

--- a/lib/clipboard.ts
+++ b/lib/clipboard.ts
@@ -46,3 +46,44 @@ export async function copyTextToClipboard(text: string): Promise<void> {
 
   throw new Error("Failed to copy to clipboard");
 }
+
+/**
+ * 「押してから通信でテキストを取ってコピーする」ためのコピー。
+ *
+ * iOS Safari は `await` を挟むとユーザー操作の権限が切れ、その後の
+ * `clipboard.writeText` が拒否される。textarea + execCommand のフォールバックも
+ * 権限が切れた後では効かないため、通信してから copyTextToClipboard を呼ぶ形だと
+ * iOS では必ず失敗する（同期的にテキストを持っている他のコピーは動く）。
+ *
+ * `ClipboardItem` には **Promise を渡せる**。こうすると中身が後から解決しても
+ * 押した瞬間の権限が保たれる。Safari が用意している正攻法。
+ *
+ * **クリックハンドラから同期的に呼ぶこと**（先に await すると意味がない）。
+ *
+ * @param textPromise コピーするテキストの Promise
+ * @throws テキストの取得に失敗した場合、またはコピーできなかった場合
+ */
+export async function copyTextFromPromise(
+  textPromise: Promise<string>
+): Promise<void> {
+  if (
+    typeof ClipboardItem !== "undefined" &&
+    navigator.clipboard &&
+    typeof navigator.clipboard.write === "function"
+  ) {
+    try {
+      await navigator.clipboard.write([
+        new ClipboardItem({
+          "text/plain": textPromise.then(
+            (text) => new Blob([text], { type: "text/plain" })
+          ),
+        }),
+      ]);
+      return;
+    } catch {
+      // 未対応・拒否された場合は従来経路へ倒す
+    }
+  }
+
+  await copyTextToClipboard(await textPromise);
+}

--- a/tests/unit/features/posts/source-prompt-reference-card.test.tsx
+++ b/tests/unit/features/posts/source-prompt-reference-card.test.tsx
@@ -95,8 +95,10 @@ jest.mock("@/components/ui/use-toast", () => ({
   useToast: () => ({ toast: jest.fn() }),
 }));
 
-jest.mock("@/features/posts/lib/copy-to-clipboard", () => ({
-  copyTextToClipboard: jest.fn().mockResolvedValue(undefined),
+jest.mock("@/lib/clipboard", () => ({
+  // 本文の取得を await してから呼ぶと iOS Safari で権限が切れるため、
+  // Promise を渡す形になっていることをここで固定する
+  copyTextFromPromise: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock("@/features/posts/lib/source-prompt-text-api", () => ({
@@ -607,9 +609,7 @@ describe("プロンプトのコピー", () => {
     const { fetchSourcePromptText } = jest.requireMock(
       "@/features/posts/lib/source-prompt-text-api"
     );
-    const { copyTextToClipboard } = jest.requireMock(
-      "@/features/posts/lib/copy-to-clipboard"
-    );
+    const { copyTextFromPromise } = jest.requireMock("@/lib/clipboard");
 
     renderCard({
       reference: buildReference({ promptVisibility: "public" }),
@@ -621,8 +621,12 @@ describe("プロンプトのコピー", () => {
 
     await waitFor(() => {
       expect(fetchSourcePromptText).toHaveBeenCalledWith(ORIGIN_POST_ID);
-      expect(copyTextToClipboard).toHaveBeenCalledWith("白いワンピースにして");
+      expect(copyTextFromPromise).toHaveBeenCalledTimes(1);
     });
+    // 解決済みの文字列ではなく Promise を渡していること(iOS の権限を保つため)
+    const passed = copyTextFromPromise.mock.calls[0][0];
+    expect(passed).toBeInstanceOf(Promise);
+    await expect(passed).resolves.toBe("白いワンピースにして");
   });
 });
 

--- a/tests/unit/lib/clipboard-from-promise.test.ts
+++ b/tests/unit/lib/clipboard-from-promise.test.ts
@@ -1,0 +1,94 @@
+/**
+ * 「押してから通信でテキストを取ってコピーする」経路のテスト。
+ *
+ * ここが誤ると iOS Safari でコピーが必ず失敗する。await を挟むと
+ * ユーザー操作の権限が切れ、writeText も execCommand も拒否されるため、
+ * ClipboardItem に Promise を渡す形でなければならない。
+ */
+
+import { copyTextFromPromise } from "@/lib/clipboard";
+
+describe("copyTextFromPromise", () => {
+  const originalClipboard = navigator.clipboard;
+  const originalClipboardItem = (globalThis as { ClipboardItem?: unknown })
+    .ClipboardItem;
+
+  function setClipboard(value: unknown) {
+    Object.defineProperty(navigator, "clipboard", {
+      value,
+      configurable: true,
+      writable: true,
+    });
+  }
+
+  function setClipboardItem(value: unknown) {
+    (globalThis as { ClipboardItem?: unknown }).ClipboardItem = value;
+  }
+
+  afterEach(() => {
+    setClipboard(originalClipboard);
+    setClipboardItem(originalClipboardItem);
+    jest.restoreAllMocks();
+  });
+
+  test("ClipboardItem には解決前の Promise を渡す(権限を保つため)", async () => {
+    let resolveText: ((value: string) => void) | undefined;
+    const textPromise = new Promise<string>((resolve) => {
+      resolveText = resolve;
+    });
+
+    const write = jest.fn().mockResolvedValue(undefined);
+    setClipboard({ write, writeText: jest.fn() });
+    const itemArgs: Record<string, unknown>[] = [];
+    setClipboardItem(
+      class {
+        constructor(items: Record<string, unknown>) {
+          itemArgs.push(items);
+        }
+      }
+    );
+
+    const copyPromise = copyTextFromPromise(textPromise);
+
+    // テキストが解決する前に ClipboardItem が作られていること
+    expect(itemArgs).toHaveLength(1);
+    expect(itemArgs[0]["text/plain"]).toBeInstanceOf(Promise);
+
+    resolveText?.("コピーされる本文");
+    await copyPromise;
+
+    expect(write).toHaveBeenCalledTimes(1);
+  });
+
+  test("ClipboardItem が無ければ従来の writeText へ倒す", async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    setClipboard({ writeText });
+    setClipboardItem(undefined);
+
+    await copyTextFromPromise(Promise.resolve("本文"));
+
+    expect(writeText).toHaveBeenCalledWith("本文");
+  });
+
+  test("ClipboardItem 経路が拒否されたら従来経路へ倒す", async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    setClipboard({
+      write: jest.fn().mockRejectedValue(new Error("NotAllowedError")),
+      writeText,
+    });
+    setClipboardItem(class {});
+
+    await copyTextFromPromise(Promise.resolve("本文"));
+
+    expect(writeText).toHaveBeenCalledWith("本文");
+  });
+
+  test("テキストの取得に失敗したら例外を投げる(呼び出し側がエラー表示できる)", async () => {
+    setClipboard({ writeText: jest.fn() });
+    setClipboardItem(undefined);
+
+    await expect(
+      copyTextFromPromise(Promise.reject(new Error("fetch failed")))
+    ).rejects.toThrow("fetch failed");
+  });
+});


### PR DESCRIPTION
投稿詳細の「プロンプトをコピーする」が iOS で必ず失敗する問題の修正です。

## 何が起きていたか

このボタンだけが、**押した後に API で本文を取ってから**コピーしていました。

```ts
const promptText = await fetchSourcePromptText(reference.postId);  // ← 通信
await copyTextToClipboard(promptText);                             // ← ここで拒否される
```

iOS Safari は `await` を挟むと**ユーザー操作の権限が切れます**。その後の `navigator.clipboard.writeText` は `NotAllowedError` で拒否され、用意してある textarea + `execCommand` のフォールバックも権限が切れた後では効きません。結果、必ず「コピーできませんでした」になっていました。

本文を props に載せず API 経由で取るのは、未フォロワーのブラウザへ届かせないための意図的な設計（PROMPT-SECRECY-001）です。設計は正しく、**コピーの呼び方だけが iOS に合っていませんでした**。

### 他のコピーが動いていた理由

アプリ内の他のコピーは、いずれも**テキストを同期的に持っています**。

| 箇所 | 呼び方 |
|---|---|
| 投稿詳細のプロンプト欄（`PostDetail.tsx:160`） | `copyTextToClipboard(displayPrompt)` |
| 生成結果（`GeneratedImageList.tsx:150`） | `copyTextToClipboard(prompt)` |
| 共有リンク（`ShareLinkButton.tsx:117`） | `copyTextToClipboard(resolveUrl())` |
| **参照カード（今回の不具合）** | **`await fetch(...)` してから** `copyTextToClipboard(...)` |

await を挟んでいるのはここだけでした。

## 変更内容

`lib/clipboard.ts` に `copyTextFromPromise` を追加しました。

`ClipboardItem` には **Promise を渡せます**。こうすると中身が後から解決しても、押した瞬間の権限が保たれます。Safari が非同期コピーのために用意している正攻法です。

```ts
await navigator.clipboard.write([
  new ClipboardItem({
    "text/plain": textPromise.then((text) => new Blob([text], { type: "text/plain" })),
  }),
]);
```

- 未対応・拒否された場合は、従来の `writeText` → `execCommand` へ倒します
- **クリックハンドラから同期的に呼ぶこと**が前提です（先に await すると意味がありません）。関数の JSDoc に明記しました
- 呼び出し側（`SourcePromptReferenceCard`）は `await fetch` をやめ、Promise をそのまま渡します

## テスト

- `copyTextFromPromise`: 解決前の Promise を `ClipboardItem` に渡していること／未対応時のフォールバック／拒否時のフォールバック／取得失敗時に例外を投げること（4件）
- 参照カードのテスト: 解決済みの文字列ではなく**Promise を渡していること**を固定（iOS の権限保持がここで守られる）

## 検証

- `npm run lint` — main と同数（23 errors / 57 warnings・新規指摘ゼロ）
- `npm run typecheck` — アプリ側エラーなし
- `npm run test` — 3430 passed（新規4件 + 既存1件を更新）
- `npm run build -- --webpack` — 成功

**実機（iOS Safari）での確認は未実施**です。マージ後にご確認ください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mmqeUvT5TbjAMPNo6Pxsn
