### PR TITLE
fix(posts): 本人が自分の非公開プロンプトをコピーできないのを直す

### DIFF
--- a/app/api/posts/[id]/prompt-text/route.ts
+++ b/app/api/posts/[id]/prompt-text/route.ts
@@ -24,11 +24,16 @@ import { postsRouteCopy } from "@/features/posts/lib/route-copy";
  * - `validate_derived_prompt_source` が false（削除・投稿取消・公開停止・
  *   free でない・root でない・secret 無し・原作者が利用不可・未フォロー・
  *   双方向いずれかのブロック）
- * - **原作が非公開プロンプト**
+ * - **原作が非公開プロンプト**（ただし**原作者本人は除く**）
  *
- * 非公開を弾くのがこの経路の要点である。`resolve_derived_prompt_source` は
- * 本文を返す唯一の RPC で、Worker が provider 送信直前に使うためのもの。
- * ここから非公開の本文が出ると、機能そのものが成立しなくなる。
+ * 非公開を第三者へ出さないのがこの経路の要点である。`resolve_derived_prompt_source`
+ * は本文を返す唯一の RPC で、Worker が provider 送信直前に使うためのもの。
+ * ここから非公開の本文が第三者へ出ると、機能そのものが成立しなくなる。
+ *
+ * 一方で**本人は自分の非公開プロンプトを取り出せる**。非公開は「第三者へ渡さない」
+ * 設定であって、自分の資産を自分から遠ざけるものではない。本人は投稿詳細で本文を
+ * そのまま読めるので、ここで拒否しても秘匿にはならず、コピーだけができない状態に
+ * なる（参照カードは本人にコピーボタンを出すため、UI と条件が食い違っていた）。
  *
  * 理由は返さない。どの条件で落ちても同じ 404 にする。区別できると原作の
  * 状態を推測できてしまう（ADR-005）。
@@ -83,11 +88,17 @@ export async function GET(
       return jsonUnavailable(copy.promptTextUnavailable);
     }
 
-    // 非公開の本文はこの経路から絶対に出さない。
-    // validate は公開・非公開のどちらも通すため、ここで明示的に絞る。
+    /*
+      非公開の本文を第三者へ出さない。validate は公開・非公開のどちらも通すため、
+      ここで明示的に絞る。
+
+      ただし**原作者本人には出す**。本人は投稿詳細で本文をそのまま読めるので、
+      ここで拒否しても秘匿にならず「見えているのにコピーできない」だけになる。
+      参照カードは本人にコピーボタンを出しており、UI と条件が食い違っていた。
+    */
     const { data: originRow, error: originError } = await supabase
       .from("generated_images")
-      .select("prompt_visibility")
+      .select("prompt_visibility, user_id")
       .eq("id", validated.root_post_id)
       .maybeSingle();
 
@@ -95,7 +106,13 @@ export async function GET(
       return jsonUnavailable(copy.promptTextUnavailable);
     }
 
-    if ((originRow as { prompt_visibility?: string }).prompt_visibility !== "public") {
+    const origin = originRow as {
+      prompt_visibility?: string;
+      user_id?: string | null;
+    };
+    const isOriginAuthor = !!origin.user_id && origin.user_id === user.id;
+
+    if (!isOriginAuthor && origin.prompt_visibility !== "public") {
       return jsonUnavailable(copy.promptTextUnavailable);
     }
 

--- a/tests/unit/app/api/posts/prompt-text-route.test.ts
+++ b/tests/unit/app/api/posts/prompt-text-route.test.ts
@@ -1,0 +1,175 @@
+/** @jest-environment node */
+
+/**
+ * GET /api/posts/[id]/prompt-text のテスト（PROMPT-SECRECY-001）。
+ *
+ * ここが誤ると (a) 非公開プロンプトの本文が第三者へ出る、
+ * (b) 本人が自分の本文をコピーできない、のどちらかが起きる。
+ * 実際に (b) が本番で起きていた（参照カードは本人にコピーボタンを出すのに、
+ * この API が非公開を一律で 404 にしていた）。
+ */
+
+jest.mock("@/lib/auth", () => ({
+  getUser: jest.fn(),
+}));
+
+jest.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: jest.fn(),
+}));
+
+import { NextRequest } from "next/server";
+import { GET } from "@/app/api/posts/[id]/prompt-text/route";
+import { getUser } from "@/lib/auth";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+const mockGetUser = getUser as jest.MockedFunction<typeof getUser>;
+const mockCreateAdminClient = createAdminClient as jest.MockedFunction<
+  typeof createAdminClient
+>;
+
+const POST_ID = "11111111-1111-4111-8111-111111111111";
+const OWNER_ID = "22222222-2222-4222-8222-222222222222";
+const FOLLOWER_ID = "33333333-3333-4333-8333-333333333333";
+const PROMPT = "白いワンピースにして";
+
+interface StubOptions {
+  isAvailable?: boolean;
+  promptVisibility?: "public" | "private";
+  originUserId?: string;
+  hasSecret?: boolean;
+}
+
+function mockSupabase(options: StubOptions = {}) {
+  mockCreateAdminClient.mockReturnValue({
+    rpc: jest.fn(() => ({
+      select: () => ({
+        maybeSingle: () =>
+          Promise.resolve({
+            data: {
+              is_available: options.isAvailable ?? true,
+              root_post_id: POST_ID,
+            },
+            error: null,
+          }),
+      }),
+    })),
+    from: jest.fn((table: string) => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: () =>
+            Promise.resolve({
+              data:
+                table === "generated_images"
+                  ? {
+                      prompt_visibility: options.promptVisibility ?? "private",
+                      user_id: options.originUserId ?? OWNER_ID,
+                    }
+                  : options.hasSecret === false
+                    ? null
+                    : { prompt: PROMPT },
+              error: null,
+            }),
+        }),
+      }),
+    })),
+  } as unknown as ReturnType<typeof createAdminClient>);
+}
+
+const params = Promise.resolve({ id: POST_ID });
+
+function request(): NextRequest {
+  return new NextRequest(`http://localhost/api/posts/${POST_ID}/prompt-text`);
+}
+
+describe("GET /api/posts/[id]/prompt-text", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("本人は自分の非公開プロンプトを取り出せる", async () => {
+    // 非公開は「第三者へ渡さない」設定であって、自分の資産を自分から
+    // 遠ざけるものではない。本人は投稿詳細で本文をそのまま読めている
+    mockGetUser.mockResolvedValue({ id: OWNER_ID } as never);
+    mockSupabase({ promptVisibility: "private", originUserId: OWNER_ID });
+
+    const response = await GET(request(), { params });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      postId: POST_ID,
+      prompt: PROMPT,
+    });
+  });
+
+  test("第三者には非公開プロンプトを出さない(秘匿の要)", async () => {
+    // validate は通る = フォロワー。それでも非公開は渡さない
+    mockGetUser.mockResolvedValue({ id: FOLLOWER_ID } as never);
+    mockSupabase({ promptVisibility: "private", originUserId: OWNER_ID });
+
+    const response = await GET(request(), { params });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      errorCode: "POSTS_PROMPT_TEXT_UNAVAILABLE",
+    });
+  });
+
+  test("公開プロンプトは第三者にも出す(validate を通ったフォロワー)", async () => {
+    mockGetUser.mockResolvedValue({ id: FOLLOWER_ID } as never);
+    mockSupabase({ promptVisibility: "public", originUserId: OWNER_ID });
+
+    const response = await GET(request(), { params });
+
+    expect(response.status).toBe(200);
+  });
+
+  test("本人でも validate が false なら出さない(投稿取消・公開停止など)", async () => {
+    mockGetUser.mockResolvedValue({ id: OWNER_ID } as never);
+    mockSupabase({
+      isAvailable: false,
+      promptVisibility: "private",
+      originUserId: OWNER_ID,
+    });
+
+    const response = await GET(request(), { params });
+
+    expect(response.status).toBe(404);
+  });
+
+  test("未ログインは 401", async () => {
+    mockGetUser.mockResolvedValue(null);
+    mockSupabase();
+
+    const response = await GET(request(), { params });
+
+    expect(response.status).toBe(401);
+  });
+
+  test("secret が無ければ出さない(本文の正本が無い)", async () => {
+    mockGetUser.mockResolvedValue({ id: OWNER_ID } as never);
+    mockSupabase({
+      promptVisibility: "private",
+      originUserId: OWNER_ID,
+      hasSecret: false,
+    });
+
+    const response = await GET(request(), { params });
+
+    expect(response.status).toBe(404);
+  });
+
+  test("落ちた理由は区別させない(どの条件でも同じ 404)", async () => {
+    mockGetUser.mockResolvedValue({ id: FOLLOWER_ID } as never);
+
+    mockSupabase({ promptVisibility: "private", originUserId: OWNER_ID });
+    const blockedByVisibility = await GET(request(), { params });
+
+    mockSupabase({ isAvailable: false, originUserId: OWNER_ID });
+    const blockedByValidation = await GET(request(), { params });
+
+    expect(blockedByVisibility.status).toBe(blockedByValidation.status);
+    await expect(blockedByVisibility.json()).resolves.toEqual(
+      await blockedByValidation.json()
+    );
+  });
+});


### PR DESCRIPTION
自分の非公開プロンプトがコピーできない不具合の修正です。

## 何が起きていたか

**UI と API で条件が食い違っていました。**

| | 条件 |
|---|---|
| コピーボタンを出す条件（`SourcePromptReferenceCard`） | **本人 または 公開** |
| 本文を返す条件（`/api/posts/[id]/prompt-text`） | **公開のみ** |

そのため、**本人の非公開プロンプトではボタンが出るのに API が 404 を返し**、画面には「コピーできませんでした」とだけ表示されていました。

本番データでも確認しています（`generation_type='free'` / `source_post_id IS NULL` の直近投稿は `prompt_visibility='private'` が多数）。

### いつ壊れたか

`/free` のプロンプト秘匿対応（#464-476）で、本文を投稿詳細の props から `/api/posts/[id]/prompt-text` 経由へ移したときです。そのとき **UI 側だけ**「本人は自分のプロンプトを常にコピーできる」に直され、API 側が追随していませんでした。

`SourcePromptReferenceCard` のコメントにも意図が明記されています。

> 非公開はフォロワーにも渡さないが、**本人は自分のプロンプトを常にコピーできる**。非公開は「第三者へ渡さない」設定であって、自分の資産を自分から遠ざけるものではない。

## 変更内容

原作者本人には、非公開でも本文を返します。

```ts
const isOriginAuthor = !!origin.user_id && origin.user_id === user.id;
if (!isOriginAuthor && origin.prompt_visibility !== "public") {
  return jsonUnavailable(...);
}
```

**第三者への秘匿（この経路の要点）は変えていません。** `validate_derived_prompt_source` を通ったフォロワーであっても、非公開の本文は従来どおり返しません。

本人に返すことが秘匿を弱めない理由は、**本人は投稿詳細で本文をそのまま読めている**ためです。ここで拒否しても秘匿にはならず、「見えているのにコピーだけできない」状態になるだけでした。

## テスト（新規7件）

このルートにはテストがなかったので追加しました。

- 本人は自分の**非公開**プロンプトを取り出せる
- **第三者には非公開を出さない**（validate を通ったフォロワーでも）
- 公開プロンプトは第三者にも出す
- 本人でも validate が false なら出さない（投稿取消・公開停止など）
- 未ログインは 401
- secret が無ければ出さない
- **落ちた理由は区別させない**（どの条件でも同じ 404。ADR-005）

## 検証

- `npm run lint` — main と同数（23 errors / 57 warnings・新規指摘ゼロ）
- `npm run typecheck` — アプリ側エラーなし
- `npm run test` — 3437 passed（新規7件）
- `npm run build -- --webpack` — 成功

## 補足

先にマージした #508（iOS で await を挟むとコピーの権限が切れる件）は**別の実在する問題**の修正で、公開プロンプトを他人がコピーする経路には引き続き必要です。ただし**今回の症状の原因ではありませんでした**。API を最後まで読まずに進めたのが原因です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mmqeUvT5TbjAMPNo6Pxsn
