### PR TITLE
feat(impressions): 計測窓を30分にし、表示形式別の内訳をadminに追加

### DIFF
--- a/app/(app)/admin/page.tsx
+++ b/app/(app)/admin/page.tsx
@@ -9,6 +9,7 @@ import { parseAdminDashboardTab } from "@/features/admin-dashboard/lib/dashboard
 import { listPresetCategories } from "@/features/style-presets/lib/preset-category-repository";
 import { getAdminDashboardData } from "@/features/admin-dashboard/lib/get-admin-dashboard-data";
 import { getAiCostActuals } from "@/features/admin-dashboard/lib/get-ai-cost-actuals";
+import { getPostImpressionStats } from "@/features/admin-dashboard/lib/get-post-impression-stats";
 import {
   formatAdminDateTimeLabel,
   getCustomDashboardRangeBounds,
@@ -117,6 +118,7 @@ export default async function AdminDashboardPage({
           loginMethodMix={data.loginMethodMix}
           aiCostEstimate={data.aiCostEstimate}
           aiCostActualsPromise={getAiCostActuals(range)}
+          impressionsPromise={getPostImpressionStats(range)}
         />
       )}
     </AdminDashboardView>

--- a/app/api/posts/[id]/view/route.ts
+++ b/app/api/posts/[id]/view/route.ts
@@ -16,7 +16,7 @@ import { postsRouteCopy } from "@/features/posts/lib/route-copy";
  * フラグON時は、詳細到達も viewable インプレッションとして計上する
  * (docs/planning/post-impressions-implementation-plan.md の v1.1 拡張)。
  * フィード計測と同じ record_post_impressions RPC / dedup を共有するため、
- * 「フィードでも詳細でも、同一投稿×同一視聴者×同一日は1回」となり二重カウントしない。
+ * 「フィードでも詳細でも、同一投稿×同一視聴者×同一30分枠は1回」となり二重カウントしない。
  */
 export async function POST(
   _request: NextRequest,
@@ -68,6 +68,7 @@ export async function POST(
           const { error } = await supabase.rpc("record_post_impressions", {
             p_image_ids: [id],
             p_viewer_key: viewerKey,
+            p_view_mode: "detail",
           });
           if (error) {
             console.error("[posts view] impression record failed:", error);

--- a/app/api/posts/impressions/batch/route.ts
+++ b/app/api/posts/impressions/batch/route.ts
@@ -23,6 +23,9 @@ import { getPopupBannerClientIpHash } from "@/features/popup-banners/lib/popup-b
 
 const bodySchema = z.object({
   image_ids: z.array(z.string().uuid()).min(1).max(100),
+  // どこで見られたか。表示形式別の内訳を出すための補助情報で、認可には使わない。
+  // 古いクライアントは送ってこないため任意(その場合は DB 側で NULL=不明)。
+  view_mode: z.enum(["grid", "feed", "detail"]).optional(),
 });
 
 function noop(): NextResponse {
@@ -86,6 +89,7 @@ export async function POST(request: NextRequest) {
     const { data, error } = await supabase.rpc("record_post_impressions", {
       p_image_ids: parsed.image_ids,
       p_viewer_key: viewerKey,
+      p_view_mode: parsed.view_mode ?? null,
     });
 
     if (error) {

--- a/features/admin-dashboard/components/AdminImpressionSection.tsx
+++ b/features/admin-dashboard/components/AdminImpressionSection.tsx
@@ -1,0 +1,244 @@
+import Image from "next/image";
+import Link from "next/link";
+import { Eye } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { AdminImpressionTrendChartPanel } from "./AdminImpressionTrendChartPanel";
+import type { PostImpressionStats } from "../lib/get-post-impression-stats";
+
+interface AdminImpressionSectionProps {
+  stats: PostImpressionStats;
+}
+
+const HEADING_FONT = {
+  fontFamily: "var(--font-admin-heading), ui-monospace, monospace",
+};
+
+function SummaryCell({
+  label,
+  value,
+  hint,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+}) {
+  return (
+    <div className="rounded-xl border border-violet-100 bg-violet-50/40 p-4">
+      <p className="text-xs font-medium text-slate-600">{label}</p>
+      <p className="mt-1 text-2xl font-bold text-slate-900" style={HEADING_FONT}>
+        {value}
+      </p>
+      {hint ? <p className="mt-1 text-xs text-slate-500">{hint}</p> : null}
+    </div>
+  );
+}
+
+function BreakdownRow({
+  label,
+  items,
+  total,
+}: {
+  label: string;
+  items: Array<{ key: string; label: string; value: number; color: string }>;
+  total: number;
+}) {
+  const visible = items.filter((item) => item.value > 0);
+  if (visible.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="text-xs font-medium text-slate-600">{label}</p>
+      <div className="flex flex-wrap gap-2">
+        {visible.map((item) => (
+          <span
+            key={item.key}
+            className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1 text-xs text-slate-700"
+          >
+            <span
+              className="h-2 w-2 rounded-full"
+              style={{ backgroundColor: item.color }}
+              aria-hidden
+            />
+            {item.label}
+            <span className="font-semibold text-slate-900">
+              {item.value.toLocaleString("ja-JP")}
+            </span>
+            <span className="text-slate-500">
+              {total > 0 ? `${Math.round((item.value / total) * 100)}%` : "0%"}
+            </span>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function AdminImpressionSection({ stats }: AdminImpressionSectionProps) {
+  const { totals, daily, topPosts } = stats;
+
+  return (
+    <Card className="border-violet-200/60 bg-white/95 shadow-sm">
+      <CardHeader className="pb-4">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <CardTitle
+              className="flex items-center gap-2 text-lg text-slate-900"
+              style={HEADING_FONT}
+            >
+              <Eye className="h-5 w-5 text-violet-600" aria-hidden />
+              インプレッション
+            </CardTitle>
+            <p className="mt-1 text-sm text-slate-600">
+              可視50%×1秒で1件。同じ人・同じ投稿は30分に1回まで数えます。
+            </p>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          <SummaryCell
+            label="インプレッション"
+            value={totals.impressions.toLocaleString("ja-JP")}
+          />
+          <SummaryCell
+            label="ユニーク視聴者"
+            value={totals.uniqueViewers.toLocaleString("ja-JP")}
+            hint="期間内の実人数(日次の合計ではありません)"
+          />
+          <SummaryCell
+            label="見られた投稿"
+            value={totals.uniquePosts.toLocaleString("ja-JP")}
+          />
+          <SummaryCell
+            label="1投稿あたり平均"
+            value={totals.averagePerPost.toLocaleString("ja-JP")}
+          />
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <BreakdownRow
+            label="どこで見られたか"
+            total={totals.impressions}
+            items={[
+              {
+                key: "feed",
+                label: "フィード",
+                value: totals.feed,
+                color: "#2563EB",
+              },
+              {
+                key: "grid",
+                label: "グリッド",
+                value: totals.grid,
+                color: "#7C3AED",
+              },
+              {
+                key: "detail",
+                label: "投稿詳細",
+                value: totals.detail,
+                color: "#059669",
+              },
+              {
+                key: "unknown",
+                label: "不明(計測前)",
+                value: totals.unknown,
+                color: "#CBD5E1",
+              },
+            ]}
+          />
+          <BreakdownRow
+            label="誰が見たか"
+            total={totals.impressions}
+            items={[
+              {
+                key: "authenticated",
+                label: "ログイン",
+                value: totals.authenticated,
+                color: "#0F766E",
+              },
+              {
+                key: "guest",
+                label: "ゲスト",
+                value: totals.guest,
+                color: "#D97706",
+              },
+            ]}
+          />
+        </div>
+
+        <AdminImpressionTrendChartPanel data={daily} />
+
+        {topPosts.length > 0 ? (
+          <div className="space-y-3">
+            <div>
+              <h3
+                className="text-sm font-semibold text-slate-900"
+                style={HEADING_FONT}
+              >
+                よく見られた投稿
+              </h3>
+              <p className="mt-1 text-xs text-slate-500">
+                この期間のインプレッション上位。サムネイルから投稿詳細へ移動できます。
+              </p>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[520px] text-sm">
+                <thead>
+                  <tr className="border-b border-slate-200 text-left text-xs text-slate-500">
+                    <th className="pb-2 font-medium">投稿</th>
+                    <th className="pb-2 text-right font-medium">
+                      インプレッション
+                    </th>
+                    <th className="pb-2 text-right font-medium">
+                      ユニーク視聴者
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {topPosts.map((post) => (
+                    <tr
+                      key={post.imageId}
+                      className="border-b border-slate-100 last:border-0"
+                    >
+                      <td className="py-2">
+                        <Link
+                          href={`/posts/${post.imageId}`}
+                          className="flex items-center gap-3 hover:underline"
+                          target="_blank"
+                        >
+                          <span className="relative h-10 w-10 shrink-0 overflow-hidden rounded-lg bg-slate-100">
+                            {post.thumbUrl ? (
+                              <Image
+                                src={post.thumbUrl}
+                                alt=""
+                                fill
+                                sizes="40px"
+                                className="object-cover"
+                                unoptimized
+                              />
+                            ) : null}
+                          </span>
+                          <span className="truncate text-slate-700">
+                            {post.authorName}
+                          </span>
+                        </Link>
+                      </td>
+                      <td className="py-2 text-right font-semibold text-slate-900">
+                        {post.impressions.toLocaleString("ja-JP")}
+                      </td>
+                      <td className="py-2 text-right text-slate-600">
+                        {post.uniqueViewers.toLocaleString("ja-JP")}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/features/admin-dashboard/components/AdminImpressionTrendChart.tsx
+++ b/features/admin-dashboard/components/AdminImpressionTrendChart.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import {
+  Bar,
+  CartesianGrid,
+  ComposedChart,
+  Legend,
+  Line,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { ImpressionDailyPoint } from "../lib/build-impression-stats";
+
+interface AdminImpressionTrendChartProps {
+  data: ImpressionDailyPoint[];
+}
+
+function CustomTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean;
+  payload?: Array<{ name?: string; value?: number | string; color?: string }>;
+  label?: string;
+}) {
+  if (!active || !payload?.length) {
+    return null;
+  }
+
+  const total = payload
+    .filter((item) => item.name !== "ユニーク視聴者")
+    .reduce(
+      (sum, item) => sum + (typeof item.value === "number" ? item.value : 0),
+      0
+    );
+
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-3 shadow-lg">
+      <p className="text-sm font-semibold text-slate-900">{label}</p>
+      <div className="mt-2 space-y-1 text-sm text-slate-600">
+        {payload.map((item) => (
+          <p key={String(item.name)} style={{ color: item.color }}>
+            {item.name}:{" "}
+            {typeof item.value === "number"
+              ? item.value.toLocaleString("ja-JP")
+              : item.value}
+          </p>
+        ))}
+        <p className="border-t border-slate-100 pt-1 font-semibold text-slate-900">
+          合計: {total.toLocaleString("ja-JP")}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default function AdminImpressionTrendChart({
+  data,
+}: AdminImpressionTrendChartProps) {
+  if (data.length === 0) {
+    return (
+      <div className="flex h-[260px] items-center justify-center rounded-xl border border-dashed border-slate-200 bg-slate-50/70 text-sm text-slate-500 sm:h-[320px]">
+        この期間のデータはありません。
+      </div>
+    );
+  }
+
+  // 表示形式の記録は 2026-08-12 開始。それ以前の行しかない期間で
+  // 「不明」だけの積み上げを出しても意味がないので、0 のときは凡例ごと消す。
+  const hasUnknown = data.some((point) => point.unknown > 0);
+
+  return (
+    <div className="h-[260px] w-full sm:h-[320px]">
+      <ResponsiveContainer width="100%" height="100%">
+        <ComposedChart
+          data={data}
+          margin={{ top: 12, right: 12, left: 0, bottom: 0 }}
+          title="インプレッションの日別推移"
+        >
+          <CartesianGrid stroke="#E2E8F0" strokeDasharray="3 3" />
+          <XAxis
+            dataKey="label"
+            tickLine={false}
+            axisLine={false}
+            tick={{ fill: "#64748B", fontSize: 12 }}
+            minTickGap={24}
+            tickMargin={10}
+          />
+          <YAxis
+            tickLine={false}
+            axisLine={false}
+            tick={{ fill: "#64748B", fontSize: 12 }}
+            width={40}
+          />
+          <Tooltip content={<CustomTooltip />} />
+          <Legend />
+          <Bar
+            dataKey="feed"
+            name="フィード"
+            stackId="impressions"
+            fill="#2563EB"
+            radius={[0, 0, 0, 0]}
+          />
+          <Bar
+            dataKey="grid"
+            name="グリッド"
+            stackId="impressions"
+            fill="#7C3AED"
+            radius={[0, 0, 0, 0]}
+          />
+          <Bar
+            dataKey="detail"
+            name="投稿詳細"
+            stackId="impressions"
+            fill="#059669"
+            radius={[0, 0, 0, 0]}
+          />
+          {hasUnknown ? (
+            <Bar
+              dataKey="unknown"
+              name="不明(計測前)"
+              stackId="impressions"
+              fill="#CBD5E1"
+              radius={[4, 4, 0, 0]}
+            />
+          ) : null}
+          <Line
+            type="monotone"
+            dataKey="uniqueViewers"
+            name="ユニーク視聴者"
+            stroke="#E11D48"
+            strokeWidth={2.5}
+            dot={false}
+            activeDot={{ r: 5 }}
+          />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/features/admin-dashboard/components/AdminImpressionTrendChartPanel.tsx
+++ b/features/admin-dashboard/components/AdminImpressionTrendChartPanel.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { Loader2 } from "lucide-react";
+import type { ImpressionDailyPoint } from "../lib/build-impression-stats";
+
+const AdminImpressionTrendChart = dynamic(
+  () => import("./AdminImpressionTrendChart"),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex h-[320px] items-center justify-center rounded-xl border border-dashed border-slate-200 bg-slate-50/70 text-sm text-slate-500">
+        <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden />
+        チャートを読み込み中...
+      </div>
+    ),
+  }
+);
+
+interface AdminImpressionTrendChartPanelProps {
+  data: ImpressionDailyPoint[];
+}
+
+export function AdminImpressionTrendChartPanel({
+  data,
+}: AdminImpressionTrendChartPanelProps) {
+  return (
+    <div className="overflow-x-auto pb-2 [-ms-overflow-style:none] [scrollbar-width:thin] [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-violet-200 [&::-webkit-scrollbar-track]:bg-transparent md:overflow-visible md:pb-0">
+      <div className="min-w-[680px] md:min-w-0">
+        <AdminImpressionTrendChart data={data} />
+      </div>
+    </div>
+  );
+}

--- a/features/admin-dashboard/components/AdminPageAnalyticsSectionServer.tsx
+++ b/features/admin-dashboard/components/AdminPageAnalyticsSectionServer.tsx
@@ -1,7 +1,10 @@
 import { Suspense } from "react";
+import { Loader2 } from "lucide-react";
 import type { Ga4DashboardData } from "@/features/analytics/lib/ga4-types";
 import type { AiCostActuals } from "../lib/ai-cost-actual-types";
+import type { PostImpressionStats } from "../lib/get-post-impression-stats";
 import { AdminAiCostActualRow } from "./AdminAiCostActualRow";
+import { AdminImpressionSection } from "./AdminImpressionSection";
 import type {
   DashboardAiCostEstimate,
   DashboardFunnelStep,
@@ -27,6 +30,7 @@ interface AdminPageAnalyticsSectionServerProps {
   loginMethodMix: DashboardLoginMethodMixItem[];
   aiCostEstimate: DashboardAiCostEstimate;
   aiCostActualsPromise: Promise<AiCostActuals>;
+  impressionsPromise: Promise<PostImpressionStats>;
 }
 
 interface AdminGa4SectionLoaderProps {
@@ -40,6 +44,24 @@ async function AdminAiCostActualLoader({
 }) {
   const actuals = await actualsPromise;
   return <AdminAiCostActualRow actuals={actuals} />;
+}
+
+async function AdminImpressionSectionLoader({
+  impressionsPromise,
+}: {
+  impressionsPromise: Promise<PostImpressionStats>;
+}) {
+  const stats = await impressionsPromise;
+  return <AdminImpressionSection stats={stats} />;
+}
+
+function AdminImpressionSectionSkeleton() {
+  return (
+    <div className="flex h-[420px] items-center justify-center rounded-xl border border-dashed border-slate-200 bg-slate-50/70 text-sm text-slate-500">
+      <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden />
+      インプレッションを集計中...
+    </div>
+  );
 }
 
 async function AdminPageAnalyticsAccessSectionLoader({
@@ -65,11 +87,19 @@ export function AdminPageAnalyticsSectionServer({
   loginMethodMix,
   aiCostEstimate,
   aiCostActualsPromise,
+  impressionsPromise,
 }: AdminPageAnalyticsSectionServerProps) {
   return (
     <section className="space-y-4">
       <Suspense fallback={<AdminPageAnalyticsAccessSectionSkeleton />}>
         <AdminPageAnalyticsAccessSectionLoader ga4Promise={ga4Promise} />
+      </Suspense>
+      {/*
+        インプレッションは post_impressions を SQL で畳んで出す(GA4 とは別系統)。
+        集計に時間がかかっても他のカードの表示を止めないよう Suspense で切る。
+      */}
+      <Suspense fallback={<AdminImpressionSectionSkeleton />}>
+        <AdminImpressionSectionLoader impressionsPromise={impressionsPromise} />
       </Suspense>
       <AdminTrendAndFunnelSection
         trend={trend}

--- a/features/admin-dashboard/lib/build-impression-stats.ts
+++ b/features/admin-dashboard/lib/build-impression-stats.ts
@@ -1,0 +1,156 @@
+/**
+ * インプレッション集計RPC(`get_post_impression_stats`)の戻り値を整形する純ロジック。
+ *
+ * SQL 側は jsonb を返すため型が付かない。ここで形を検証して落とし、
+ * 想定外の値が入っても画面が落ちないようにする(admin は運営の目であって、
+ * 数値が1つ欠けたくらいで真っ白になる方が困る)。
+ */
+
+export interface ImpressionDailyPoint {
+  /** JST の日付 (YYYY-MM-DD) */
+  date: string;
+  /** チャートのX軸ラベル (M/D) */
+  label: string;
+  impressions: number;
+  uniqueViewers: number;
+  uniquePosts: number;
+  grid: number;
+  feed: number;
+  detail: number;
+  /** 表示形式の記録を始める前(2026-08-12以前)の行 */
+  unknown: number;
+  authenticated: number;
+  guest: number;
+}
+
+export interface ImpressionTotals {
+  impressions: number;
+  uniqueViewers: number;
+  uniquePosts: number;
+  grid: number;
+  feed: number;
+  detail: number;
+  unknown: number;
+  authenticated: number;
+  guest: number;
+  /** 1投稿あたりの平均インプレッション */
+  averagePerPost: number;
+}
+
+export interface ImpressionTopPostRef {
+  imageId: string;
+  impressions: number;
+  uniqueViewers: number;
+}
+
+export interface ParsedImpressionStats {
+  daily: ImpressionDailyPoint[];
+  totals: ImpressionTotals;
+  topPostRefs: ImpressionTopPostRef[];
+}
+
+const EMPTY_TOTALS: ImpressionTotals = {
+  impressions: 0,
+  uniqueViewers: 0,
+  uniquePosts: 0,
+  grid: 0,
+  feed: 0,
+  detail: 0,
+  unknown: 0,
+  authenticated: 0,
+  guest: 0,
+  averagePerPost: 0,
+};
+
+function toCount(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : 0;
+}
+
+/** "2026-08-12" → "8/12"。文字列から切り出す(Date を通すとタイムゾーンでずれる)。 */
+export function formatImpressionDateLabel(date: string): string {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+  if (!match) {
+    return date;
+  }
+  return `${Number(match[2])}/${Number(match[3])}`;
+}
+
+export function parseImpressionStats(raw: unknown): ParsedImpressionStats {
+  if (!raw || typeof raw !== "object") {
+    return { daily: [], totals: EMPTY_TOTALS, topPostRefs: [] };
+  }
+
+  const source = raw as Record<string, unknown>;
+
+  const dailyRaw = Array.isArray(source.daily) ? source.daily : [];
+  const daily: ImpressionDailyPoint[] = dailyRaw.flatMap((entry) => {
+    if (!entry || typeof entry !== "object") {
+      return [];
+    }
+    const row = entry as Record<string, unknown>;
+    const date = typeof row.date === "string" ? row.date : null;
+    if (!date) {
+      return [];
+    }
+    return [
+      {
+        date,
+        label: formatImpressionDateLabel(date),
+        impressions: toCount(row.impressions),
+        uniqueViewers: toCount(row.unique_viewers),
+        uniquePosts: toCount(row.unique_posts),
+        grid: toCount(row.grid),
+        feed: toCount(row.feed),
+        detail: toCount(row.detail),
+        unknown: toCount(row.unknown),
+        authenticated: toCount(row.authenticated),
+        guest: toCount(row.guest),
+      },
+    ];
+  });
+
+  const totalsRaw =
+    source.totals && typeof source.totals === "object"
+      ? (source.totals as Record<string, unknown>)
+      : {};
+  const impressions = toCount(totalsRaw.impressions);
+  const uniquePosts = toCount(totalsRaw.unique_posts);
+
+  const totals: ImpressionTotals = {
+    impressions,
+    uniqueViewers: toCount(totalsRaw.unique_viewers),
+    uniquePosts,
+    grid: toCount(totalsRaw.grid),
+    feed: toCount(totalsRaw.feed),
+    detail: toCount(totalsRaw.detail),
+    unknown: toCount(totalsRaw.unknown),
+    authenticated: toCount(totalsRaw.authenticated),
+    guest: toCount(totalsRaw.guest),
+    // 0除算をここで潰す(投稿が1件も見られていない期間は 0 でよい)
+    averagePerPost:
+      uniquePosts > 0 ? Math.round((impressions / uniquePosts) * 10) / 10 : 0,
+  };
+
+  const topRaw = Array.isArray(source.topPosts) ? source.topPosts : [];
+  const topPostRefs: ImpressionTopPostRef[] = topRaw.flatMap((entry) => {
+    if (!entry || typeof entry !== "object") {
+      return [];
+    }
+    const row = entry as Record<string, unknown>;
+    const imageId = typeof row.image_id === "string" ? row.image_id : null;
+    if (!imageId) {
+      return [];
+    }
+    return [
+      {
+        imageId,
+        impressions: toCount(row.impressions),
+        uniqueViewers: toCount(row.unique_viewers),
+      },
+    ];
+  });
+
+  return { daily, totals, topPostRefs };
+}

--- a/features/admin-dashboard/lib/get-post-impression-stats.ts
+++ b/features/admin-dashboard/lib/get-post-impression-stats.ts
@@ -1,0 +1,161 @@
+import "server-only";
+
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getPostThumbUrl } from "@/features/posts/lib/utils";
+import {
+  parseImpressionStats,
+  type ImpressionDailyPoint,
+  type ImpressionTotals,
+} from "./build-impression-stats";
+import { getRangeBounds, type DashboardRange } from "./dashboard-range";
+
+/**
+ * 投稿インプレッションの期間集計を取る。
+ *
+ * 集計は SQL の `get_post_impression_stats` に寄せている。90日分だと数万行になり、
+ * PostgREST の行上限に当たるうえ、期間のユニーク視聴者数は日次の合計では出せない
+ * (同じ人が複数日に跨るため)。行を引いて TS で畳む形にはしない。
+ *
+ * `post_impressions` は RLS 全拒否なので service role で読む。
+ */
+
+export interface ImpressionTopPost {
+  imageId: string;
+  impressions: number;
+  uniqueViewers: number;
+  thumbUrl: string;
+  authorName: string;
+  postedAt: string | null;
+}
+
+export interface PostImpressionStats {
+  totals: ImpressionTotals;
+  daily: ImpressionDailyPoint[];
+  topPosts: ImpressionTopPost[];
+}
+
+const EMPTY_STATS: PostImpressionStats = {
+  totals: {
+    impressions: 0,
+    uniqueViewers: 0,
+    uniquePosts: 0,
+    grid: 0,
+    feed: 0,
+    detail: 0,
+    unknown: 0,
+    authenticated: 0,
+    guest: 0,
+    averagePerPost: 0,
+  },
+  daily: [],
+  topPosts: [],
+};
+
+const TOP_POST_LIMIT = 10;
+
+export async function getPostImpressionStats(
+  range: DashboardRange
+): Promise<PostImpressionStats> {
+  try {
+    const bounds = getRangeBounds(range);
+    const supabase = createAdminClient();
+
+    const { data, error } = await supabase.rpc("get_post_impression_stats", {
+      p_from: bounds.currentStartIso,
+      p_to: bounds.nowIso,
+      p_top_limit: TOP_POST_LIMIT,
+    });
+
+    if (error) {
+      console.error("[admin impression stats] RPC failed:", error);
+      return EMPTY_STATS;
+    }
+
+    const { daily, totals, topPostRefs } = parseImpressionStats(data);
+
+    if (topPostRefs.length === 0) {
+      return { totals, daily, topPosts: [] };
+    }
+
+    // サムネイルと作者名は集計とは別に引く。URL 生成を SQL に写すと
+    // getPostThumbUrl のフォールバック(thumb→display→原本)と二重管理になる。
+    const imageIds = topPostRefs.map((ref) => ref.imageId);
+    const { data: imageRows, error: imageError } = await supabase
+      .from("generated_images")
+      .select(
+        "id, user_id, posted_at, storage_path_thumb, storage_path, image_url"
+      )
+      .in("id", imageIds);
+
+    if (imageError) {
+      console.error("[admin impression stats] image fetch failed:", imageError);
+      return { totals, daily, topPosts: [] };
+    }
+
+    const imageMap = new Map(
+      ((imageRows ?? []) as Array<{
+        id: string;
+        user_id: string | null;
+        posted_at: string | null;
+        storage_path_thumb: string | null;
+        storage_path: string | null;
+        image_url: string | null;
+      }>).map((row) => [row.id, row] as const)
+    );
+
+    const userIds = Array.from(
+      new Set(
+        Array.from(imageMap.values())
+          .map((row) => row.user_id)
+          .filter((value): value is string => Boolean(value))
+      )
+    );
+
+    const profilesResult =
+      userIds.length > 0
+        ? await supabase
+            .from("profiles")
+            .select("user_id, nickname")
+            .in("user_id", userIds)
+        : { data: [], error: null };
+
+    if (profilesResult.error) {
+      console.error(
+        "[admin impression stats] profile fetch failed:",
+        profilesResult.error
+      );
+    }
+
+    const nicknameMap = new Map<string, string | null>(
+      ((profilesResult.data ?? []) as Array<{
+        user_id: string;
+        nickname: string | null;
+      }>).map((profile) => [profile.user_id, profile.nickname ?? null] as const)
+    );
+
+    const topPosts: ImpressionTopPost[] = topPostRefs.flatMap((ref) => {
+      const image = imageMap.get(ref.imageId);
+      // 集計後に削除された投稿は落とす(数字だけ残っても辿れない)
+      if (!image) {
+        return [];
+      }
+      const nickname = image.user_id ? nicknameMap.get(image.user_id) : null;
+      return [
+        {
+          imageId: ref.imageId,
+          impressions: ref.impressions,
+          uniqueViewers: ref.uniqueViewers,
+          thumbUrl: getPostThumbUrl(image),
+          authorName: nickname || image.user_id?.slice(0, 8) || "不明",
+          postedAt: image.posted_at,
+        },
+      ];
+    });
+
+    return { totals, daily, topPosts };
+  } catch (error) {
+    // ダッシュボード全体を落とさない。ここが欠けても他のKPIは見たい
+    console.error("[admin impression stats] unexpected error:", error);
+    return EMPTY_STATS;
+  }
+}

--- a/features/posts/components/PostCard.tsx
+++ b/features/posts/components/PostCard.tsx
@@ -61,7 +61,7 @@ export function PostCard({
       return;
     }
     const timer = window.setTimeout(() => {
-      queuePostImpression(postId);
+      queuePostImpression(postId, "grid");
     }, 1000);
     return () => window.clearTimeout(timer);
   }, [impressionsActive, impressionInView, postId]);

--- a/features/posts/components/PostFeedCard.tsx
+++ b/features/posts/components/PostFeedCard.tsx
@@ -117,7 +117,7 @@ export function PostFeedCard({
       return;
     }
     const timer = window.setTimeout(() => {
-      queuePostImpression(postId);
+      queuePostImpression(postId, "feed");
     }, 1000);
     return () => window.clearTimeout(timer);
   }, [impressionsActive, impressionInView, postId]);

--- a/features/posts/lib/impressions-client.ts
+++ b/features/posts/lib/impressions-client.ts
@@ -7,10 +7,11 @@
  * ページ離脱時(visibilitychange: hidden / pagehide)は sendBeacon で flush する。
  *
  * 過剰加算ガード(ADR-002/003):
- * - sessionStorage(`post-impressions-sent-v1`)に「最後に送った時刻」を持ち、
- *   30分経つまで同じ投稿を再送しない。キュー投入時点で記録するため、
- *   StrictMode 二重実行・BFCache 復帰・再マウントでも二重送信しない
- *   (送信失敗時の取りこぼしは DB dedup と次の窓に委ねる)。
+ * - 「最後に送った時刻」をモジュール内 Map に持ち、30分経つまで同じ投稿を
+ *   再送しない。キュー投入時点で記録するため、StrictMode 二重実行・
+ *   BFCache 復帰・再マウントでも二重送信しない。
+ * - sessionStorage(`post-impressions-sent-v1`)はリロードをまたぐ引き継ぎ層。
+ *   **抑止の正本ではない**(読めない環境があるため)。
  * - サーバ側でも (image_id, viewer_key, window_start) UNIQUE が最終防波堤。
  *
  * ここの抑止(前回送信から30分)は DB の固定枠より厳しい。緩い側にすると
@@ -31,60 +32,69 @@ const MAX_BATCH_SIZE = 100;
 /** 再送を許すまでの間隔。SQL 側の 30分固定枠(floor(epoch/1800))と対になる。 */
 export const IMPRESSION_WINDOW_MS = 30 * 60 * 1000;
 
-type SentMap = Record<string, number>;
+/**
+ * 「この投稿を最後に送った時刻」。**抑止の正本はこのメモリ側**。
+ *
+ * sessionStorage はプロパティアクセス自体が SecurityError を投げ得る
+ * (Cookie無効設定・一部のプライベートモード等)。そこに依存すると、
+ * 読めない環境で30分の抑止がまるごと外れる。DB 側は30分の固定枠なので、
+ * 10:29 と 10:31 が別枠になり、2分しか経っていなくても2回加算されてしまう。
+ * (窓が1日だった頃は DB 側が受け止めていたが、30分にした以上ここが要る)
+ */
+const sentMemory = new Map<string, number>();
+let hydrated = false;
 
-function readSentMap(): SentMap {
-  if (typeof window === "undefined") {
-    return {};
+/**
+ * sessionStorage の内容をメモリへ取り込む(リロード・BFCache 復帰の引き継ぎ)。
+ * sessionStorage はタブ単位でこのモジュールしか書かないため、1回で足りる。
+ */
+function hydrateFromSession(now: number): void {
+  if (hydrated || typeof window === "undefined") {
+    return;
   }
-  // sessionStorage はプロパティアクセス自体が SecurityError を投げ得る
-  // (Cookie無効設定・一部のプライベートモード等)ため、全体を try-catch で守る。
-  // 読めない環境では空(=セッションdedupなし)にフォールバックし、
-  // 整合性は DB の UNIQUE(最終防波堤)に委ねる。
+  hydrated = true;
   try {
     const raw = window.sessionStorage.getItem(SESSION_KEY);
     if (!raw) {
-      return {};
+      return;
     }
     const parsed = JSON.parse(raw) as unknown;
     // 旧形式(ID の配列)は送信時刻を持たないので捨てる。デプロイをまたいだ
     // セッションで1投稿につき最大1回多く送るだけで、DB dedup が吸収する。
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return {};
+      return;
     }
-    const result: SentMap = {};
     for (const [id, at] of Object.entries(parsed as Record<string, unknown>)) {
-      if (typeof at === "number" && Number.isFinite(at)) {
-        result[id] = at;
+      if (typeof at === "number" && Number.isFinite(at) && now - at < IMPRESSION_WINDOW_MS) {
+        sentMemory.set(id, at);
       }
     }
-    return result;
   } catch {
-    return {};
+    // 読めない環境ではメモリだけで抑止する(このページロード中は同じ精度)
   }
 }
 
-function writeSentMap(map: SentMap): void {
+function persistToSession(): void {
   if (typeof window === "undefined") {
     return;
   }
   try {
-    window.sessionStorage.setItem(SESSION_KEY, JSON.stringify(map));
+    window.sessionStorage.setItem(
+      SESSION_KEY,
+      JSON.stringify(Object.fromEntries(sentMemory))
+    );
   } catch {
-    // sessionStorage 不可(プライベートモード等)でも計測は継続する
-    // (このセッション中の dedup はモジュール内 Map が担う)。
+    // 書けなくても計測は継続する(抑止は sentMemory が担う)
   }
 }
 
 /** 期限切れの記録を落とす(長時間セッションで際限なく肥大化させない)。 */
-function pruneExpired(map: SentMap, now: number): SentMap {
-  const pruned: SentMap = {};
-  for (const [id, at] of Object.entries(map)) {
-    if (now - at < IMPRESSION_WINDOW_MS) {
-      pruned[id] = at;
+function pruneExpired(now: number): void {
+  for (const [id, at] of sentMemory) {
+    if (now - at >= IMPRESSION_WINDOW_MS) {
+      sentMemory.delete(id);
     }
   }
-  return pruned;
 }
 
 // モジュールスコープの送信バッファ(ホーム滞在中に跨って共有)。
@@ -181,15 +191,16 @@ export function queuePostImpression(
   }
 
   const now = Date.now();
-  const sent = readSentMap();
-  const lastSentAt = sent[imageId];
-  if (typeof lastSentAt === "number" && now - lastSentAt < IMPRESSION_WINDOW_MS) {
+  hydrateFromSession(now);
+
+  const lastSentAt = sentMemory.get(imageId);
+  if (lastSentAt !== undefined && now - lastSentAt < IMPRESSION_WINDOW_MS) {
     return;
   }
   // キュー投入時点で「送信済み」として記録する(二重送信防止を最優先)。
-  const next = pruneExpired(sent, now);
-  next[imageId] = now;
-  writeSentMap(next);
+  pruneExpired(now);
+  sentMemory.set(imageId, now);
+  persistToSession();
 
   pending.set(imageId, viewMode);
   registerLifecycleFlush();

--- a/features/posts/lib/impressions-client.ts
+++ b/features/posts/lib/impressions-client.ts
@@ -2,18 +2,25 @@
  * 投稿インプレッションのクライアント送信バッファ
  * (計画書: docs/planning/post-impressions-implementation-plan.md)
  *
- * PostCard が viewable(可視50%×1秒)を達成した image_id をここに積み、
+ * PostCard / PostFeedCard が viewable(可視50%×1秒)を達成した image_id をここに積み、
  * デバウンスで `POST /api/posts/impressions/batch` へまとめて送る。
  * ページ離脱時(visibilitychange: hidden / pagehide)は sendBeacon で flush する。
  *
  * 過剰加算ガード(ADR-002/003):
- * - sessionStorage(`post-impressions-sent-v1`)で「このセッションで送信済み」を抑止。
- *   キュー投入時点で記録するため、StrictMode 二重実行・BFCache 復帰・再マウントでも
- *   二重送信しない(送信失敗時の取りこぼしは DB 日次 dedup と翌セッションに委ねる)。
- * - サーバ側でも (image_id, viewer_key, event_date) UNIQUE が最終防波堤。
+ * - sessionStorage(`post-impressions-sent-v1`)に「最後に送った時刻」を持ち、
+ *   30分経つまで同じ投稿を再送しない。キュー投入時点で記録するため、
+ *   StrictMode 二重実行・BFCache 復帰・再マウントでも二重送信しない
+ *   (送信失敗時の取りこぼしは DB dedup と次の窓に委ねる)。
+ * - サーバ側でも (image_id, viewer_key, window_start) UNIQUE が最終防波堤。
+ *
+ * ここの抑止(前回送信から30分)は DB の固定枠より厳しい。緩い側にすると
+ * 枠をまたいだ瞬間に連続で送れてしまうため、意図的にこの向きにしている。
  */
 
 import { isPostImpressionsEnabled } from "@/lib/env";
+
+/** どこで見られたか。DB の post_impressions.view_mode と対応する。 */
+export type ImpressionViewMode = "grid" | "feed" | "detail";
 
 const SESSION_KEY = "post-impressions-sent-v1";
 const BATCH_ENDPOINT = "/api/posts/impressions/batch";
@@ -21,46 +28,77 @@ const BATCH_ENDPOINT = "/api/posts/impressions/batch";
 const FLUSH_DEBOUNCE_MS = 1500;
 /** API/RPC の上限(100)に合わせた1回あたりの最大送信件数。 */
 const MAX_BATCH_SIZE = 100;
+/** 再送を許すまでの間隔。SQL 側の 30分固定枠(floor(epoch/1800))と対になる。 */
+export const IMPRESSION_WINDOW_MS = 30 * 60 * 1000;
 
-function readSentIds(): Set<string> {
+type SentMap = Record<string, number>;
+
+function readSentMap(): SentMap {
   if (typeof window === "undefined") {
-    return new Set<string>();
+    return {};
   }
   // sessionStorage はプロパティアクセス自体が SecurityError を投げ得る
   // (Cookie無効設定・一部のプライベートモード等)ため、全体を try-catch で守る。
-  // 読めない環境では空Set(=セッションdedupなし)にフォールバックし、
-  // 整合性は DB 日次 UNIQUE(最終防波堤)に委ねる。
+  // 読めない環境では空(=セッションdedupなし)にフォールバックし、
+  // 整合性は DB の UNIQUE(最終防波堤)に委ねる。
   try {
     const raw = window.sessionStorage.getItem(SESSION_KEY);
     if (!raw) {
-      return new Set<string>();
+      return {};
     }
-    const parsed = JSON.parse(raw) as string[];
-    return new Set(Array.isArray(parsed) ? parsed : []);
+    const parsed = JSON.parse(raw) as unknown;
+    // 旧形式(ID の配列)は送信時刻を持たないので捨てる。デプロイをまたいだ
+    // セッションで1投稿につき最大1回多く送るだけで、DB dedup が吸収する。
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    const result: SentMap = {};
+    for (const [id, at] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof at === "number" && Number.isFinite(at)) {
+        result[id] = at;
+      }
+    }
+    return result;
   } catch {
-    return new Set<string>();
+    return {};
   }
 }
 
-function writeSentIds(ids: Set<string>): void {
+function writeSentMap(map: SentMap): void {
   if (typeof window === "undefined") {
     return;
   }
   try {
-    window.sessionStorage.setItem(SESSION_KEY, JSON.stringify(Array.from(ids)));
+    window.sessionStorage.setItem(SESSION_KEY, JSON.stringify(map));
   } catch {
     // sessionStorage 不可(プライベートモード等)でも計測は継続する
-    // (このセッション中の dedup はモジュール内 Set が担う)。
+    // (このセッション中の dedup はモジュール内 Map が担う)。
   }
 }
 
+/** 期限切れの記録を落とす(長時間セッションで際限なく肥大化させない)。 */
+function pruneExpired(map: SentMap, now: number): SentMap {
+  const pruned: SentMap = {};
+  for (const [id, at] of Object.entries(map)) {
+    if (now - at < IMPRESSION_WINDOW_MS) {
+      pruned[id] = at;
+    }
+  }
+  return pruned;
+}
+
 // モジュールスコープの送信バッファ(ホーム滞在中に跨って共有)。
-const pending = new Set<string>();
+// 表示形式を切り替えた直後は grid と feed が混ざり得るので、投稿ごとに保持する。
+const pending = new Map<string, ImpressionViewMode>();
 let flushTimer: number | null = null;
 let lifecycleRegistered = false;
 
-function sendBatch(imageIds: string[], useBeacon: boolean): void {
-  const payload = JSON.stringify({ image_ids: imageIds });
+function sendBatch(
+  imageIds: string[],
+  viewMode: ImpressionViewMode,
+  useBeacon: boolean
+): void {
+  const payload = JSON.stringify({ image_ids: imageIds, view_mode: viewMode });
 
   if (useBeacon && typeof navigator !== "undefined" && navigator.sendBeacon) {
     const ok = navigator.sendBeacon(
@@ -91,10 +129,23 @@ export function flushPostImpressions(useBeacon = false): void {
   if (pending.size === 0) {
     return;
   }
-  const ids = Array.from(pending);
+
+  // 表示形式ごとに分けて送る(1リクエスト1 view_mode)。
+  const byMode = new Map<ImpressionViewMode, string[]>();
+  for (const [imageId, viewMode] of pending) {
+    const ids = byMode.get(viewMode);
+    if (ids) {
+      ids.push(imageId);
+    } else {
+      byMode.set(viewMode, [imageId]);
+    }
+  }
   pending.clear();
-  for (let i = 0; i < ids.length; i += MAX_BATCH_SIZE) {
-    sendBatch(ids.slice(i, i + MAX_BATCH_SIZE), useBeacon);
+
+  for (const [viewMode, ids] of byMode) {
+    for (let i = 0; i < ids.length; i += MAX_BATCH_SIZE) {
+      sendBatch(ids.slice(i, i + MAX_BATCH_SIZE), viewMode, useBeacon);
+    }
   }
 }
 
@@ -115,10 +166,13 @@ function registerLifecycleFlush(): void {
 }
 
 /**
- * viewable 達成した投稿をバッファに積む(セッション内で未送信のもののみ)。
+ * viewable 達成した投稿をバッファに積む(前回送信から30分経ったもののみ)。
  * デバウンス後にまとめて送信される。
  */
-export function queuePostImpression(imageId: string): void {
+export function queuePostImpression(
+  imageId: string,
+  viewMode: ImpressionViewMode
+): void {
   if (typeof window === "undefined" || !isPostImpressionsEnabled()) {
     return;
   }
@@ -126,15 +180,18 @@ export function queuePostImpression(imageId: string): void {
     return;
   }
 
-  const sent = readSentIds();
-  if (sent.has(imageId)) {
+  const now = Date.now();
+  const sent = readSentMap();
+  const lastSentAt = sent[imageId];
+  if (typeof lastSentAt === "number" && now - lastSentAt < IMPRESSION_WINDOW_MS) {
     return;
   }
   // キュー投入時点で「送信済み」として記録する(二重送信防止を最優先)。
-  sent.add(imageId);
-  writeSentIds(sent);
+  const next = pruneExpired(sent, now);
+  next[imageId] = now;
+  writeSentMap(next);
 
-  pending.add(imageId);
+  pending.set(imageId, viewMode);
   registerLifecycleFlush();
 
   if (flushTimer === null) {

--- a/supabase/migrations/20260812100000_change_post_impression_window_and_add_view_mode.sql
+++ b/supabase/migrations/20260812100000_change_post_impression_window_and_add_view_mode.sql
@@ -15,6 +15,19 @@
 -- グリッド由来かフィード由来かを切り分けられないと、ホーム既定をフィードへ
 -- 切り替える判断の材料が作れない(home_view_events は「タップ」しか見ていない)。
 -- 既存行は切替前で判別不能なため NULL のままにする。grid/feed に割り振ると嘘になる。
+--
+-- ## 適用順序
+--
+-- record_post_impressions の引数が 2 → 3 に増える。p_view_mode に DEFAULT NULL を
+-- 付けてあるので「migration適用 → デプロイ」の順なら旧アプリ(2引数)も動く。
+-- 逆順(デプロイが先)にすると3引数の呼び出しが解決先を失い、計測だけが静かに
+-- 止まる(アプリは落ちない)。必ずこの順で適用すること。
+--
+-- 全体を1トランザクションに包む。UNIQUE の差し替えと DROP/CREATE FUNCTION を
+-- 跨いで失敗すると、dedup制約なし(重複加算)または RPC なし(計測停止)の状態が
+-- 本番に残る。DROP と CREATE の間に来た呼び出しも、未コミットなら外から見えない。
+
+BEGIN;
 
 -- 1) 30分枠の列。既存行は event_date の JST 0時に置く
 --    (旧 UNIQUE が (image_id, viewer_key, event_date) だったので、
@@ -228,3 +241,5 @@ REVOKE ALL ON FUNCTION public.get_post_impression_stats(timestamptz, timestamptz
 REVOKE ALL ON FUNCTION public.get_post_impression_stats(timestamptz, timestamptz, integer) FROM anon;
 REVOKE ALL ON FUNCTION public.get_post_impression_stats(timestamptz, timestamptz, integer) FROM authenticated;
 GRANT EXECUTE ON FUNCTION public.get_post_impression_stats(timestamptz, timestamptz, integer) TO service_role;
+
+COMMIT;

--- a/supabase/migrations/20260812100000_change_post_impression_window_and_add_view_mode.sql
+++ b/supabase/migrations/20260812100000_change_post_impression_window_and_add_view_mode.sql
@@ -1,0 +1,230 @@
+-- インプレッションの重複除外を「1日1回」から「30分に1回」へ変更し、表示形式を記録する
+--
+-- ## なぜ変えるか
+--
+-- 直近14日・222投稿の分布が p10=15 / 中央値=24 / p90=29 と極端に潰れていた。
+-- 上限がその日のアクティブ人数で決まるため、どの投稿もほぼ同じ数字になり、
+-- 投稿者にとって「見られた」の手応えにならない。窓を縮めて数字を動かす。
+--
+-- 固定枠(floor(epoch/1800))にするのは、`ON CONFLICT DO NOTHING` の原子性を保つため。
+-- 「前回から30分経過したか」で判定すると読み取り→条件付き書き込みになり、
+-- 同時実行で二重加算しうる。10:29 と 10:31 が別枠になる粗さは許容する。
+--
+-- ## view_mode を足す理由
+--
+-- グリッド由来かフィード由来かを切り分けられないと、ホーム既定をフィードへ
+-- 切り替える判断の材料が作れない(home_view_events は「タップ」しか見ていない)。
+-- 既存行は切替前で判別不能なため NULL のままにする。grid/feed に割り振ると嘘になる。
+
+-- 1) 30分枠の列。既存行は event_date の JST 0時に置く
+--    (旧 UNIQUE が (image_id, viewer_key, event_date) だったので、
+--     この詰め方なら新 UNIQUE も必ず満たす)
+ALTER TABLE public.post_impressions
+  ADD COLUMN window_start timestamptz;
+
+UPDATE public.post_impressions
+SET window_start = (event_date::timestamp AT TIME ZONE 'Asia/Tokyo')
+WHERE window_start IS NULL;
+
+ALTER TABLE public.post_impressions
+  ALTER COLUMN window_start SET NOT NULL;
+
+COMMENT ON COLUMN public.post_impressions.window_start IS
+  '重複除外の30分固定枠の開始時刻(floor(epoch/1800)*1800)。切替前の行は event_date の JST 0時';
+
+-- 2) 表示形式。切替前の行は判別不能なので NULL 許容
+ALTER TABLE public.post_impressions
+  ADD COLUMN view_mode text
+  CHECK (view_mode IS NULL OR view_mode IN ('grid', 'feed', 'detail'));
+
+COMMENT ON COLUMN public.post_impressions.view_mode IS
+  'どこで見られたか。grid/feed=ホームの表示形式、detail=投稿詳細。NULL は切替前(2026-08-12以前)で判別不能';
+
+-- 3) 重複除外を 日 → 30分枠 へ差し替え
+ALTER TABLE public.post_impressions
+  DROP CONSTRAINT post_impressions_dedup_unique;
+
+ALTER TABLE public.post_impressions
+  ADD CONSTRAINT post_impressions_dedup_unique
+  UNIQUE (image_id, viewer_key, window_start);
+
+-- 4) admin の期間集計用。既存の (image_id, event_date DESC) は投稿単位の索きで、
+--    「期間で絞って日次に畳む」問い合わせには効かない
+CREATE INDEX idx_post_impressions_created_at
+  ON public.post_impressions (created_at DESC);
+
+COMMENT ON TABLE public.post_impressions IS
+  '投稿インプレッションの重複除外表(30分枠×視聴者×投稿)。viewer_key: 認証 u:<user_id> / ゲスト g:<ip_hash>。公開SELECT禁止(service role専用)';
+
+COMMENT ON COLUMN public.generated_images.impression_count IS
+  '公開閲覧数(viewableインプレッション)。可視50%×1秒で加算し、同一視聴者は30分に1回まで。view_count(詳細到達・重複除外なし)は内部分析用に併存';
+
+-- 5) 記録RPC: 30分枠 + view_mode
+--    p_view_mode は既定 NULL。マイグレーションを先に当ててもデプロイ前の
+--    アプリ(2引数呼び出し)がそのまま動くようにするため。
+--    引数の数が変わるため CREATE OR REPLACE では旧版が残る(オーバーロードになり、
+--    2引数の呼び出しが旧版へ解決される)。必ず DROP してから作り直す。
+DROP FUNCTION IF EXISTS public.record_post_impressions(uuid[], text);
+
+CREATE FUNCTION public.record_post_impressions(
+  p_image_ids uuid[],
+  p_viewer_key text,
+  p_view_mode text DEFAULT NULL
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_event_date date := timezone('Asia/Tokyo', now())::date;
+  -- 30分の固定枠。クライアント側の抑止(前回送信から30分)より DB の方が緩いので、
+  -- 二重計上にはならない(クライアントが送ってこない限り増えない)。
+  v_window_start timestamptz := to_timestamp(floor(extract(epoch from now()) / 1800) * 1800);
+  v_view_mode text := p_view_mode;
+  v_inserted integer := 0;
+BEGIN
+  IF p_viewer_key IS NULL OR length(p_viewer_key) = 0 OR length(p_viewer_key) > 128 THEN
+    RAISE EXCEPTION 'Invalid viewer key';
+  END IF;
+  IF p_image_ids IS NULL OR array_length(p_image_ids, 1) IS NULL THEN
+    RETURN 0;
+  END IF;
+  IF array_length(p_image_ids, 1) > 100 THEN
+    RAISE EXCEPTION 'Too many image ids in one batch (max 100)';
+  END IF;
+  -- 想定外の値は落とさず NULL(不明)に倒す。表示形式は集計のための補助情報であり、
+  -- ここで例外にすると計測そのものが止まってしまう
+  IF v_view_mode IS NOT NULL AND v_view_mode NOT IN ('grid', 'feed', 'detail') THEN
+    v_view_mode := NULL;
+  END IF;
+
+  WITH candidate AS (
+    -- 公開中の投稿のみ対象(存在しないIDはここで消え、FK違反も起きない)
+    SELECT gi.id AS image_id
+    FROM public.generated_images gi
+    WHERE gi.id = ANY (p_image_ids)
+      AND gi.is_posted = true
+      AND gi.moderation_status = 'visible'
+  ),
+  inserted AS (
+    INSERT INTO public.post_impressions (
+      image_id, viewer_key, event_date, window_start, view_mode
+    )
+    SELECT DISTINCT c.image_id, p_viewer_key, v_event_date, v_window_start, v_view_mode
+    FROM candidate c
+    ON CONFLICT (image_id, viewer_key, window_start) DO NOTHING
+    RETURNING image_id
+  ),
+  bumped AS (
+    UPDATE public.generated_images gi
+    SET impression_count = gi.impression_count + 1
+    FROM inserted i
+    WHERE gi.id = i.image_id
+    RETURNING gi.id
+  )
+  SELECT count(*) INTO v_inserted FROM bumped;
+
+  RETURN v_inserted;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.record_post_impressions(uuid[], text, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.record_post_impressions(uuid[], text, text) FROM anon;
+REVOKE ALL ON FUNCTION public.record_post_impressions(uuid[], text, text) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.record_post_impressions(uuid[], text, text) TO service_role;
+
+-- 6) admin ダッシュボード用の集計RPC
+--    行をそのまま引くと 90日で数万件になり PostgREST の上限に当たるため、SQL 側で畳む。
+--    期間のユニーク視聴者数は日次の合計ではないので、daily と totals を別々に出す。
+CREATE OR REPLACE FUNCTION public.get_post_impression_stats(
+  p_from timestamptz,
+  p_to timestamptz,
+  p_top_limit integer DEFAULT 20
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_limit integer := least(greatest(coalesce(p_top_limit, 20), 1), 100);
+  v_daily jsonb;
+  v_totals jsonb;
+  v_top jsonb;
+BEGIN
+  IF p_from IS NULL OR p_to IS NULL OR p_from >= p_to THEN
+    RAISE EXCEPTION 'Invalid range';
+  END IF;
+
+  WITH scoped AS (
+    SELECT event_date, viewer_key, image_id, view_mode
+    FROM public.post_impressions
+    WHERE created_at >= p_from
+      AND created_at < p_to
+  )
+  SELECT
+    coalesce(
+      jsonb_agg(row_to_json(d)::jsonb ORDER BY d.date),
+      '[]'::jsonb
+    )
+  INTO v_daily
+  FROM (
+    SELECT
+      event_date::text AS date,
+      count(*)::integer AS impressions,
+      count(DISTINCT viewer_key)::integer AS unique_viewers,
+      count(DISTINCT image_id)::integer AS unique_posts,
+      count(*) FILTER (WHERE view_mode = 'grid')::integer AS grid,
+      count(*) FILTER (WHERE view_mode = 'feed')::integer AS feed,
+      count(*) FILTER (WHERE view_mode = 'detail')::integer AS detail,
+      count(*) FILTER (WHERE view_mode IS NULL)::integer AS unknown,
+      count(*) FILTER (WHERE viewer_key LIKE 'u:%')::integer AS authenticated,
+      count(*) FILTER (WHERE viewer_key LIKE 'g:%')::integer AS guest
+    FROM scoped
+    GROUP BY event_date
+  ) d;
+
+  WITH scoped AS (
+    SELECT viewer_key, image_id, view_mode
+    FROM public.post_impressions
+    WHERE created_at >= p_from
+      AND created_at < p_to
+  )
+  SELECT jsonb_build_object(
+    'impressions', count(*)::integer,
+    'unique_viewers', count(DISTINCT viewer_key)::integer,
+    'unique_posts', count(DISTINCT image_id)::integer,
+    'grid', count(*) FILTER (WHERE view_mode = 'grid')::integer,
+    'feed', count(*) FILTER (WHERE view_mode = 'feed')::integer,
+    'detail', count(*) FILTER (WHERE view_mode = 'detail')::integer,
+    'unknown', count(*) FILTER (WHERE view_mode IS NULL)::integer,
+    'authenticated', count(*) FILTER (WHERE viewer_key LIKE 'u:%')::integer,
+    'guest', count(*) FILTER (WHERE viewer_key LIKE 'g:%')::integer
+  )
+  INTO v_totals
+  FROM scoped;
+
+  SELECT coalesce(jsonb_agg(row_to_json(t)::jsonb ORDER BY t.impressions DESC), '[]'::jsonb)
+  INTO v_top
+  FROM (
+    SELECT
+      image_id::text AS image_id,
+      count(*)::integer AS impressions,
+      count(DISTINCT viewer_key)::integer AS unique_viewers
+    FROM public.post_impressions
+    WHERE created_at >= p_from
+      AND created_at < p_to
+    GROUP BY image_id
+    ORDER BY count(*) DESC
+    LIMIT v_limit
+  ) t;
+
+  RETURN jsonb_build_object('daily', v_daily, 'totals', v_totals, 'topPosts', v_top);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_post_impression_stats(timestamptz, timestamptz, integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.get_post_impression_stats(timestamptz, timestamptz, integer) FROM anon;
+REVOKE ALL ON FUNCTION public.get_post_impression_stats(timestamptz, timestamptz, integer) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.get_post_impression_stats(timestamptz, timestamptz, integer) TO service_role;

--- a/tests/unit/app/api/posts/impressions-batch-route.test.ts
+++ b/tests/unit/app/api/posts/impressions-batch-route.test.ts
@@ -114,7 +114,37 @@ describe("POST /api/posts/impressions/batch", () => {
     expect(rpc).toHaveBeenCalledWith("record_post_impressions", {
       p_image_ids: [IMAGE_ID],
       p_viewer_key: "u:user-1",
+      // 送られてこなければ NULL(=不明)。古いクライアントを弾かない
+      p_view_mode: null,
     });
+  });
+
+  test("view_mode はそのままRPCへ渡す(表示形式別の内訳の元になる)", async () => {
+    mockGetUser.mockResolvedValue({ id: "user-1" } as Awaited<
+      ReturnType<typeof getUser>
+    >);
+    const rpc = mockRpc(1);
+    const res = await POST(
+      createRequest({ image_ids: [IMAGE_ID], view_mode: "feed" }),
+    );
+    expect(res.status).toBe(200);
+    expect(rpc).toHaveBeenCalledWith("record_post_impressions", {
+      p_image_ids: [IMAGE_ID],
+      p_viewer_key: "u:user-1",
+      p_view_mode: "feed",
+    });
+  });
+
+  test("未知の view_mode は400(集計に想定外の値を混ぜない)", async () => {
+    mockGetUser.mockResolvedValue({ id: "user-1" } as Awaited<
+      ReturnType<typeof getUser>
+    >);
+    const rpc = mockRpc(1);
+    const res = await POST(
+      createRequest({ image_ids: [IMAGE_ID], view_mode: "carousel" }),
+    );
+    expect(res.status).toBe(400);
+    expect(rpc).not.toHaveBeenCalled();
   });
 
   test("ゲストは g:<ip_hash> でRPCを呼ぶ", async () => {
@@ -125,6 +155,7 @@ describe("POST /api/posts/impressions/batch", () => {
     expect(rpc).toHaveBeenCalledWith("record_post_impressions", {
       p_image_ids: [IMAGE_ID],
       p_viewer_key: "g:abcdef",
+      p_view_mode: null,
     });
   });
 

--- a/tests/unit/app/api/posts/view-route-impressions.test.ts
+++ b/tests/unit/app/api/posts/view-route-impressions.test.ts
@@ -113,6 +113,8 @@ describe("POST /api/posts/[id]/view のインプレッション計上", () => {
     expect(rpc).toHaveBeenCalledWith("record_post_impressions", {
       p_image_ids: [POST_ID],
       p_viewer_key: "u:user-1",
+      // 詳細到達はフィード/グリッドと同じ枠で数えるが、内訳では区別する
+      p_view_mode: "detail",
     });
   });
 
@@ -122,6 +124,7 @@ describe("POST /api/posts/[id]/view のインプレッション計上", () => {
     expect(rpc).toHaveBeenCalledWith("record_post_impressions", {
       p_image_ids: [POST_ID],
       p_viewer_key: "g:hash123",
+      p_view_mode: "detail",
     });
   });
 

--- a/tests/unit/features/admin-dashboard/build-impression-stats.test.ts
+++ b/tests/unit/features/admin-dashboard/build-impression-stats.test.ts
@@ -1,0 +1,151 @@
+/**
+ * インプレッション集計RPCの戻り値を整形する純ロジックのテスト。
+ *
+ * ここが誤ると admin の数字が黙って狂う。特に「期間のユニーク視聴者数」を
+ * 日次の合計と取り違えると、同じ人が複数日見ただけで人数が水増しされる。
+ * SQL 側で totals を別に出しているのはそのためで、ここでは totals を
+ * 日次から作り直さないことを固定する。
+ */
+
+import {
+  formatImpressionDateLabel,
+  parseImpressionStats,
+} from "@/features/admin-dashboard/lib/build-impression-stats";
+
+const RAW = {
+  daily: [
+    {
+      date: "2026-08-11",
+      impressions: 100,
+      unique_viewers: 20,
+      unique_posts: 40,
+      grid: 60,
+      feed: 30,
+      detail: 10,
+      unknown: 0,
+      authenticated: 70,
+      guest: 30,
+    },
+    {
+      date: "2026-08-12",
+      impressions: 50,
+      unique_viewers: 15,
+      unique_posts: 25,
+      grid: 20,
+      feed: 20,
+      detail: 10,
+      unknown: 0,
+      authenticated: 40,
+      guest: 10,
+    },
+  ],
+  totals: {
+    impressions: 150,
+    // 2日間の実人数。日次の合計(35)ではない
+    unique_viewers: 24,
+    unique_posts: 50,
+    grid: 80,
+    feed: 50,
+    detail: 20,
+    unknown: 0,
+    authenticated: 110,
+    guest: 40,
+  },
+  topPosts: [
+    { image_id: "img-1", impressions: 30, unique_viewers: 18 },
+    { image_id: "img-2", impressions: 12, unique_viewers: 9 },
+  ],
+};
+
+describe("parseImpressionStats", () => {
+  test("日次・合計・上位投稿をそのまま取り出す", () => {
+    const result = parseImpressionStats(RAW);
+
+    expect(result.daily).toHaveLength(2);
+    expect(result.daily[0]).toMatchObject({
+      date: "2026-08-11",
+      label: "8/11",
+      impressions: 100,
+      uniqueViewers: 20,
+      grid: 60,
+      feed: 30,
+      detail: 10,
+      authenticated: 70,
+      guest: 30,
+    });
+
+    // 日次の合計(20+15=35)で上書きしない
+    expect(result.totals.uniqueViewers).toBe(24);
+    expect(result.totals.impressions).toBe(150);
+
+    expect(result.topPostRefs).toEqual([
+      { imageId: "img-1", impressions: 30, uniqueViewers: 18 },
+      { imageId: "img-2", impressions: 12, uniqueViewers: 9 },
+    ]);
+  });
+
+  test("1投稿あたり平均は小数第1位まで、投稿0件なら0(0除算にしない)", () => {
+    expect(parseImpressionStats(RAW).totals.averagePerPost).toBe(3);
+
+    const empty = parseImpressionStats({
+      daily: [],
+      totals: { impressions: 10, unique_posts: 0 },
+      topPosts: [],
+    });
+    expect(empty.totals.averagePerPost).toBe(0);
+
+    const rounded = parseImpressionStats({
+      daily: [],
+      totals: { impressions: 10, unique_posts: 3 },
+      topPosts: [],
+    });
+    expect(rounded.totals.averagePerPost).toBe(3.3);
+  });
+
+  test("null/壊れた形でも落ちず空を返す(admin を真っ白にしない)", () => {
+    for (const raw of [null, undefined, "oops", 42, {}]) {
+      const result = parseImpressionStats(raw);
+      expect(result.daily).toEqual([]);
+      expect(result.topPostRefs).toEqual([]);
+      expect(result.totals.impressions).toBe(0);
+    }
+  });
+
+  test("date や image_id を欠く行は落とす", () => {
+    const result = parseImpressionStats({
+      daily: [{ impressions: 5 }, { date: "2026-08-12", impressions: 5 }],
+      totals: {},
+      topPosts: [{ impressions: 3 }, { image_id: "img-9", impressions: 3 }],
+    });
+
+    expect(result.daily.map((d) => d.date)).toEqual(["2026-08-12"]);
+    expect(result.topPostRefs.map((t) => t.imageId)).toEqual(["img-9"]);
+  });
+
+  test("負数・非数値は0として扱う", () => {
+    const result = parseImpressionStats({
+      daily: [
+        { date: "2026-08-12", impressions: -5, unique_viewers: "many", grid: null },
+      ],
+      totals: {},
+      topPosts: [],
+    });
+
+    expect(result.daily[0]).toMatchObject({
+      impressions: 0,
+      uniqueViewers: 0,
+      grid: 0,
+    });
+  });
+});
+
+describe("formatImpressionDateLabel", () => {
+  test("YYYY-MM-DD を M/D にする(ゼロ埋めを外す)", () => {
+    expect(formatImpressionDateLabel("2026-08-12")).toBe("8/12");
+    expect(formatImpressionDateLabel("2026-01-05")).toBe("1/5");
+  });
+
+  test("想定外の形式はそのまま返す", () => {
+    expect(formatImpressionDateLabel("2026/08/12")).toBe("2026/08/12");
+  });
+});

--- a/tests/unit/features/posts/impressions-client.test.ts
+++ b/tests/unit/features/posts/impressions-client.test.ts
@@ -210,6 +210,47 @@ describe("impressions-client", () => {
     expect(beaconMock).toHaveBeenCalledTimes(1);
   });
 
+  it("sessionStorageが使えなくても30分の抑止は効く(固定枠の境界を跨がせない)", () => {
+    /*
+      DB 側は30分の固定枠なので、10:29 と 10:31 は別枠になる。
+      storage が読めない環境で抑止が外れると、2分しか経っていなくても
+      2回加算されてしまう(窓が1日だった頃は DB が受け止めていた)。
+      抑止の正本をモジュール内 Map に置いているのはこのため。
+    */
+    const original = Object.getOwnPropertyDescriptor(window, "sessionStorage");
+    Object.defineProperty(window, "sessionStorage", {
+      configurable: true,
+      get() {
+        throw new Error("SecurityError: access denied");
+      },
+    });
+    try {
+      const { queuePostImpression } = loadModule();
+
+      queuePostImpression(ID_A, "feed");
+      jest.advanceTimersByTime(1500);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      // 2分後(枠は跨ぐが30分は経っていない)に見直しても送らない
+      jest.advanceTimersByTime(2 * 60 * 1000);
+      queuePostImpression(ID_A, "feed");
+      jest.advanceTimersByTime(1500);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      // 30分経てば送る
+      jest.advanceTimersByTime(WINDOW_MS);
+      queuePostImpression(ID_A, "feed");
+      jest.advanceTimersByTime(1500);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      if (original) {
+        Object.defineProperty(window, "sessionStorage", original);
+      } else {
+        delete (window as { sessionStorage?: unknown }).sessionStorage;
+      }
+    }
+  });
+
   it("sessionStorageアクセスが例外を投げる環境でもクラッシュせず送信できる", () => {
     // Cookie無効設定等では window.sessionStorage への「プロパティアクセス自体」が
     // SecurityError を投げる。dedupは諦めて(DBのUNIQUEに委ねて)送信は継続する。

--- a/tests/unit/features/posts/impressions-client.test.ts
+++ b/tests/unit/features/posts/impressions-client.test.ts
@@ -3,9 +3,13 @@
  * (docs/planning/post-impressions-implementation-plan.md EARS-01/05, ADR-002/003)
  *
  * - queue → デバウンス(1.5s)後に1回のバッチ fetch にまとまる
- * - sessionStorage(post-impressions-sent-v1)でセッション内の二重送信を抑止
+ * - sessionStorage(post-impressions-sent-v1)で「前回送信から30分」を抑止
+ * - 表示形式(grid/feed)は混ざらないようリクエストを分ける
  * - 離脱 flush は sendBeacon を優先
  * - フラグOFFでは何もしない
+ *
+ * 30分の抑止はここが本体。DB 側は固定枠(floor(epoch/1800))で緩いため、
+ * クライアントが送ってしまうと枠をまたいだ瞬間に加算されてしまう。
  *
  * モジュールスコープの状態(バッファ/タイマー/リスナー登録)を持つため、
  * jest.resetModules + require で各テスト独立のモジュールインスタンスを使う
@@ -27,6 +31,7 @@ type Mod = typeof import("@/features/posts/lib/impressions-client");
 const SESSION_KEY = "post-impressions-sent-v1";
 const ID_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
 const ID_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const WINDOW_MS = 30 * 60 * 1000;
 
 function loadModule(): Mod {
   let mod: Mod;
@@ -36,6 +41,13 @@ function loadModule(): Mod {
     mod = require("@/features/posts/lib/impressions-client") as Mod;
   });
   return mod!;
+}
+
+function parseBody(call: [string, RequestInit]) {
+  return JSON.parse(call[1].body as string) as {
+    image_ids: string[];
+    view_mode?: string;
+  };
 }
 
 describe("impressions-client", () => {
@@ -63,8 +75,8 @@ describe("impressions-client", () => {
 
   it("queue後、デバウンスで1回のバッチfetchにまとまり、sessionStorageに記録される", () => {
     const { queuePostImpression } = loadModule();
-    queuePostImpression(ID_A);
-    queuePostImpression(ID_B);
+    queuePostImpression(ID_A, "grid");
+    queuePostImpression(ID_B, "grid");
 
     expect(fetchMock).not.toHaveBeenCalled();
 
@@ -75,36 +87,105 @@ describe("impressions-client", () => {
     expect(url).toBe("/api/posts/impressions/batch");
     expect(JSON.parse((init as RequestInit).body as string)).toEqual({
       image_ids: [ID_A, ID_B],
+      view_mode: "grid",
     });
     expect((init as RequestInit).keepalive).toBe(true);
 
-    const sent = JSON.parse(window.sessionStorage.getItem(SESSION_KEY) ?? "[]");
-    expect(sent).toEqual([ID_A, ID_B]);
+    // 記録は「ID → 最終送信時刻」。時刻を持たないと30分の判定ができない
+    const sent = JSON.parse(window.sessionStorage.getItem(SESSION_KEY) ?? "{}");
+    expect(Object.keys(sent).sort()).toEqual([ID_A, ID_B].sort());
+    expect(typeof sent[ID_A]).toBe("number");
   });
 
-  it("同一IDの再queueは送信されない(セッション内dedup)", () => {
+  it("表示形式が混ざるとリクエストを分ける(grid と feed を同じ body に入れない)", () => {
     const { queuePostImpression } = loadModule();
-    queuePostImpression(ID_A);
+    queuePostImpression(ID_A, "grid");
+    queuePostImpression(ID_B, "feed");
+
+    jest.advanceTimersByTime(1500);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const bodies = fetchMock.mock.calls.map((call) =>
+      parseBody(call as [string, RequestInit])
+    );
+    expect(bodies).toEqual(
+      expect.arrayContaining([
+        { image_ids: [ID_A], view_mode: "grid" },
+        { image_ids: [ID_B], view_mode: "feed" },
+      ])
+    );
+  });
+
+  it("30分未満の再queueは送信されない", () => {
+    const { queuePostImpression } = loadModule();
+    queuePostImpression(ID_A, "grid");
     jest.advanceTimersByTime(1500);
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
-    // 送信済みIDを再queueしても新たな送信は発生しない
-    queuePostImpression(ID_A);
+    // あと1msで窓が開ける、というところまで進めても送らない
+    jest.advanceTimersByTime(WINDOW_MS - 1500 - 1);
+    queuePostImpression(ID_A, "grid");
     jest.advanceTimersByTime(3000);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it("sessionStorageに既送信のIDはqueueされない(BFCache/StrictMode吸収)", () => {
-    window.sessionStorage.setItem(SESSION_KEY, JSON.stringify([ID_A]));
+  it("30分経過後の再queueは送信される(数字が動くのはここ)", () => {
     const { queuePostImpression } = loadModule();
-    queuePostImpression(ID_A);
+    queuePostImpression(ID_A, "grid");
+    jest.advanceTimersByTime(1500);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(WINDOW_MS);
+    queuePostImpression(ID_A, "grid");
+    jest.advanceTimersByTime(1500);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(parseBody(fetchMock.mock.calls[1] as [string, RequestInit])).toEqual({
+      image_ids: [ID_A],
+      view_mode: "grid",
+    });
+  });
+
+  it("sessionStorageに30分以内の記録があればqueueされない(BFCache/StrictMode吸収)", () => {
+    window.sessionStorage.setItem(
+      SESSION_KEY,
+      JSON.stringify({ [ID_A]: Date.now() })
+    );
+    const { queuePostImpression } = loadModule();
+    queuePostImpression(ID_A, "feed");
     jest.advanceTimersByTime(3000);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("旧形式(IDの配列)の記録は捨てて送信する(デプロイをまたいだセッション)", () => {
+    // 送信時刻を持たないため窓の判定ができない。DB dedup に任せて1回多く送る
+    window.sessionStorage.setItem(SESSION_KEY, JSON.stringify([ID_A]));
+    const { queuePostImpression } = loadModule();
+    queuePostImpression(ID_A, "feed");
+    jest.advanceTimersByTime(1500);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("期限切れの記録は保存時に捨てる(長時間セッションで肥大化させない)", () => {
+    const { queuePostImpression } = loadModule();
+    queuePostImpression(ID_A, "grid");
+    jest.advanceTimersByTime(1500);
+
+    jest.advanceTimersByTime(WINDOW_MS);
+    queuePostImpression(ID_B, "grid");
+
+    const sent = JSON.parse(window.sessionStorage.getItem(SESSION_KEY) ?? "{}");
+    expect(Object.keys(sent)).toEqual([ID_B]);
+
+    // このテストのモジュールインスタンスが登録した visibilitychange リスナーは
+    // window に残り続ける(jsdom の window はファイル内で共有)。バッファを空に
+    // しておかないと、後続テストの離脱 flush に ID_B が混ざる。
+    jest.advanceTimersByTime(1500);
+  });
+
   it("flushPostImpressions(true) は sendBeacon を優先して即時送信する", () => {
     const { queuePostImpression, flushPostImpressions } = loadModule();
-    queuePostImpression(ID_A);
+    queuePostImpression(ID_A, "grid");
     flushPostImpressions(true);
 
     expect(beaconMock).toHaveBeenCalledTimes(1);
@@ -118,7 +199,7 @@ describe("impressions-client", () => {
 
   it("visibilitychange(hidden) で未送信分が beacon flush される(EARS-05)", () => {
     const { queuePostImpression } = loadModule();
-    queuePostImpression(ID_A);
+    queuePostImpression(ID_A, "grid");
 
     Object.defineProperty(document, "visibilityState", {
       value: "hidden",
@@ -131,7 +212,7 @@ describe("impressions-client", () => {
 
   it("sessionStorageアクセスが例外を投げる環境でもクラッシュせず送信できる", () => {
     // Cookie無効設定等では window.sessionStorage への「プロパティアクセス自体」が
-    // SecurityError を投げる。dedupは諦めて(DB日次UNIQUEに委ねて)送信は継続する。
+    // SecurityError を投げる。dedupは諦めて(DBのUNIQUEに委ねて)送信は継続する。
     const original = Object.getOwnPropertyDescriptor(window, "sessionStorage");
     Object.defineProperty(window, "sessionStorage", {
       configurable: true,
@@ -141,12 +222,12 @@ describe("impressions-client", () => {
     });
     try {
       const { queuePostImpression } = loadModule();
-      expect(() => queuePostImpression(ID_A)).not.toThrow();
+      expect(() => queuePostImpression(ID_A, "feed")).not.toThrow();
       jest.advanceTimersByTime(1500);
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(
         JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string),
-      ).toEqual({ image_ids: [ID_A] });
+      ).toEqual({ image_ids: [ID_A], view_mode: "feed" });
     } finally {
       if (original) {
         Object.defineProperty(window, "sessionStorage", original);
@@ -162,7 +243,7 @@ describe("impressions-client", () => {
   it("フラグOFFでは何もしない", () => {
     mockFlag.mockReturnValue(false);
     const { queuePostImpression } = loadModule();
-    queuePostImpression(ID_A);
+    queuePostImpression(ID_A, "grid");
     jest.advanceTimersByTime(3000);
     expect(fetchMock).not.toHaveBeenCalled();
     expect(window.sessionStorage.getItem(SESSION_KEY)).toBeNull();

--- a/tests/unit/features/posts/post-card-impressions.test.tsx
+++ b/tests/unit/features/posts/post-card-impressions.test.tsx
@@ -100,7 +100,8 @@ describe("PostCard の viewable 計測", () => {
       jest.advanceTimersByTime(1);
     });
     expect(queueSpy).toHaveBeenCalledTimes(1);
-    expect(queueSpy).toHaveBeenCalledWith(POST_ID);
+    // グリッドのカードは "grid" で記録する(フィードと内訳を分けるため)
+    expect(queueSpy).toHaveBeenCalledWith(POST_ID, "grid");
   });
 
   it("1秒未満で画面外に出たらキャンセルされる(高速スクロール)", () => {

--- a/tests/unit/features/posts/post-feed-card.test.tsx
+++ b/tests/unit/features/posts/post-feed-card.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { PostFeedCard } from "@/features/posts/components/PostFeedCard";
 import type { Post } from "@/features/posts/types";
 
@@ -45,8 +45,11 @@ jest.mock("next/image", () => ({
     }),
 }));
 
+// 既定は「見えていない」。インプレッション計測のテストだけ true にする
+// (jest.mock のファクトリから参照するため mock 接頭辞が要る)
+let mockInView = false;
 jest.mock("react-intersection-observer", () => ({
-  useInView: () => ({ ref: jest.fn(), inView: false }),
+  useInView: () => ({ ref: jest.fn(), inView: mockInView }),
 }));
 
 const fullscreenSpy = jest.fn();
@@ -120,12 +123,14 @@ function ctaProps(): { isFollowingAuthor?: boolean } {
   return ctaSpy.mock.calls[ctaSpy.mock.calls.length - 1][0];
 }
 
+let mockImpressionsEnabled = false;
 jest.mock("@/lib/env", () => ({
-  isPostImpressionsEnabled: () => false,
+  isPostImpressionsEnabled: () => mockImpressionsEnabled,
 }));
 
+const mockQueueImpression = jest.fn();
 jest.mock("@/features/posts/lib/impressions-client", () => ({
-  queuePostImpression: jest.fn(),
+  queuePostImpression: (...args: unknown[]) => mockQueueImpression(...args),
 }));
 
 function createPost(overrides: Partial<Post> = {}): Post {
@@ -151,6 +156,50 @@ function createPost(overrides: Partial<Post> = {}): Post {
 describe("PostFeedCard", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockInView = false;
+    mockImpressionsEnabled = false;
+  });
+
+  describe("インプレッション計測", () => {
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    test("可視50%が1秒続いたら feed として記録する", () => {
+      /*
+        グリッド(PostCard)と条件は同じにするが、記録する表示形式が違う。
+        ここが grid のままだと内訳が全部グリッドに寄り、フィード既定化の
+        判断材料にならない。
+      */
+      jest.useFakeTimers();
+      mockInView = true;
+      mockImpressionsEnabled = true;
+
+      render(<PostFeedCard post={createPost()} trackImpressions />);
+
+      act(() => {
+        jest.advanceTimersByTime(999);
+      });
+      expect(mockQueueImpression).not.toHaveBeenCalled();
+
+      act(() => {
+        jest.advanceTimersByTime(1);
+      });
+      expect(mockQueueImpression).toHaveBeenCalledWith("post-1", "feed");
+    });
+
+    test("trackImpressions を渡さなければ計測しない", () => {
+      jest.useFakeTimers();
+      mockInView = true;
+      mockImpressionsEnabled = true;
+
+      render(<PostFeedCard post={createPost()} />);
+
+      act(() => {
+        jest.advanceTimersByTime(2000);
+      });
+      expect(mockQueueImpression).not.toHaveBeenCalled();
+    });
   });
 
   describe("Before / After", () => {


### PR DESCRIPTION
## なぜ

インプレッションの数字が **投稿ごとにほとんど差が出ていません**。

直近14日・222投稿の分布:

| | 値 |
|---|---|
| 最小 | 1 |
| 下位10% | 15 |
| **中央値** | **24** |
| 上位10% | 29 |
| 最大 | 35 |

8割が 15〜29 に収まっています。重複除外が「1日1回」なので**上限がその日のアクティブ人数(20〜24人)で決まり**、ホームに出た投稿はほぼ全部が天井に張り付くためです。会心の一枚も軽く出した一枚も同じ「24」では、投稿者の手応えになりません。

あわせて、**グリッド由来かフィード由来かを切り分けられない**ことも問題でした。`post_impressions` に表示形式の列がなく、ホーム既定をフィードへ切り替える判断の材料が作れない状態です(`home_view_events` は「タップ」しか見ていません)。

## 変更

### ① 重複除外を「1日1回」→「30分に1回」

- `post_impressions` に `window_start` を追加し、UNIQUE を `(image_id, viewer_key, window_start)` へ差し替え
- 枠は**固定枠**(`floor(epoch/1800)`)。「前回から30分経過したか」で判定すると読み取り→条件付き書き込みになり `ON CONFLICT DO NOTHING` の原子性が崩れるため
- `event_date` は残しています(admin の日次集計にそのまま使うため)

**クライアント側も同時に直しています。** `sessionStorage` が「送ったIDの集合」を無期限で保持していたので、**DBだけ緩めても同じタブに居るユーザーからは2回目が送られてきません**(no-op になります)。「ID → 最終送信時刻」に変え、30分で失効するようにしました。

クライアントの抑止(前回送信から30分・スライド)は DB の固定枠より**厳しい**側に倒しています。緩いと枠をまたいだ瞬間に連続で送れてしまうためです。

### ② 表示形式(`view_mode`)の記録

`grid` / `feed` / `detail` を記録します。既存行は判別不能なので **NULL(不明)**。grid/feed に割り振ると嘘になります。

RPC の引数追加は `DEFAULT NULL` にしてあるので、**マイグレーションを先に当ててもデプロイ前のアプリ(2引数呼び出し)がそのまま動きます**。引数の数が変わるため `CREATE OR REPLACE` では旧版がオーバーロードとして残ってしまうので、`DROP` してから作り直しています。

### ③ admin ダッシュボードにインプレッションを追加

「すべて」タブに新しいカードを追加しました(既存の期間タブ 24h/7d/30d/90d に連動)。

- **サマリ**: インプレッション / ユニーク視聴者(期間内の実人数) / 見られた投稿 / 1投稿あたり平均
- **どこで見られたか**: フィード / グリッド / 投稿詳細 / 不明(計測前) の件数と比率
- **誰が見たか**: ログイン / ゲスト(現状ゲストは約31%)
- **日別の推移**: 表示形式で積み上げた棒 + ユニーク視聴者の折れ線
- **よく見られた投稿 トップ10**: サムネ・作者・数値。タップで投稿詳細へ

集計は SQL の `get_post_impression_stats` に寄せました。90日分だと数万行になり PostgREST の行上限に当たるうえ、**期間のユニーク視聴者数は日次の合計では出せない**(同じ人が複数日に跨るため)からです。

## 決めたこと

- **投稿者本人の閲覧は今回も数えます**(現状 全体の5.3%)。窓を緩めると自分でスクロールして増やせる余地は広がりますが、異常値が出てから対応する判断です
- **切替で過去の投稿が見劣りする件は受け入れます**。新規投稿だけ数字が伸び、既存投稿は止まりますが、閲覧者は他人の最新投稿としか比べないため。切替日の記録もしません

## 期待値について

数字は上がります(おそらく2〜3倍)。ただし**投稿間のバラつきはあまり改善しない見込み**です。倍率を決めるのは「その人が1日に何回アプリを開くか」であって投稿の良し悪しではないため、分布の形は変わらず水準だけ上がる、というのがいちばんありそうな結果です。差がつくのは「わざわざ戻ってきて見られた投稿」だけです。

## 確認したこと

- `npm run lint` — **23 errors / 57 warnings**(main の既存baselineと同数・新規指摘なし)
- `npx tsc --noEmit` — アプリコードのエラー0(`tests/**` の既存赤は据え置き)
- `npm run test` — **346 suites / 3477 tests すべてパス**
- `npm run build -- --webpack` — 成功

## 実機で見てほしいところ

1. `/admin` の「インプレッション」カード(期間タブを切り替えて数字が動くか)
2. ホームでグリッド↔フィードを切り替えて、内訳が分かれて記録されるか
3. 同じ投稿を30分以内に見直しても増えず、30分後には増えるか

## マイグレーション

`20260812100000_change_post_impression_window_and_add_view_mode.sql`

**本番適用はマージ後にご一緒に**。既存行の `window_start` は `event_date` の JST 0時で埋めるので、旧 UNIQUE を満たしていた行は新 UNIQUE も必ず満たします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mmqeUvT5TbjAMPNo6Pxsn