### PR TITLE
fix(admin): インプレッションカードの読み違えを防ぐ4点を修正

### DIFF
--- a/features/admin-dashboard/components/AdminImpressionSection.tsx
+++ b/features/admin-dashboard/components/AdminImpressionSection.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { Eye } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { AdminImpressionTrendChartPanel } from "./AdminImpressionTrendChartPanel";
+import { formatImpressionShare } from "../lib/build-impression-stats";
 import type { PostImpressionStats } from "../lib/get-post-impression-stats";
 
 interface AdminImpressionSectionProps {
@@ -66,7 +67,7 @@ function BreakdownRow({
               {item.value.toLocaleString("ja-JP")}
             </span>
             <span className="text-slate-500">
-              {total > 0 ? `${Math.round((item.value / total) * 100)}%` : "0%"}
+              {formatImpressionShare(item.value, total)}
             </span>
           </span>
         ))}
@@ -93,6 +94,14 @@ export function AdminImpressionSection({ stats }: AdminImpressionSectionProps) {
             <p className="mt-1 text-sm text-slate-600">
               可視50%×1秒で1件。同じ人・同じ投稿は30分に1回まで数えます。
             </p>
+            {/*
+              2026-08-12 に重複除外を「1日1回」から「30分に1回」へ変えた。
+              書いておかないと、日別チャートの段差をアクセス増と読み違える。
+            */}
+            <p className="mt-1 text-xs text-slate-500">
+              2026-08-12 より前は「1日1回」で集計しています（同じ日を境に数え方が
+              変わるため、チャートの段差は増加ではありません）。
+            </p>
           </div>
         </div>
       </CardHeader>
@@ -105,7 +114,12 @@ export function AdminImpressionSection({ stats }: AdminImpressionSectionProps) {
           <SummaryCell
             label="ユニーク視聴者"
             value={totals.uniqueViewers.toLocaleString("ja-JP")}
-            hint="期間内の実人数(日次の合計ではありません)"
+            /*
+              「実人数」と書くと過信される。ゲストは IP ハッシュで識別するため、
+              モバイルで IP が変わるたびに別人として数えられ、期間が長いほど
+              膨らむ。実態に近いのは日別チャートの方。
+            */
+            hint="日次の合計ではありません。ゲストはIPで識別するため、期間が長いほど多めに出ます"
           />
           <SummaryCell
             label="見られた投稿"
@@ -180,62 +194,53 @@ export function AdminImpressionSection({ stats }: AdminImpressionSectionProps) {
                 よく見られた投稿
               </h3>
               <p className="mt-1 text-xs text-slate-500">
-                この期間のインプレッション上位。サムネイルから投稿詳細へ移動できます。
+                この期間のインプレッション上位（上段）とユニーク視聴者（下段）。
+                タップで投稿詳細へ移動できます。
               </p>
             </div>
-            <div className="overflow-x-auto">
-              <table className="w-full min-w-[520px] text-sm">
-                <thead>
-                  <tr className="border-b border-slate-200 text-left text-xs text-slate-500">
-                    <th className="pb-2 font-medium">投稿</th>
-                    <th className="pb-2 text-right font-medium">
-                      インプレッション
-                    </th>
-                    <th className="pb-2 text-right font-medium">
-                      ユニーク視聴者
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {topPosts.map((post) => (
-                    <tr
-                      key={post.imageId}
-                      className="border-b border-slate-100 last:border-0"
-                    >
-                      <td className="py-2">
-                        <Link
-                          href={`/posts/${post.imageId}`}
-                          className="flex items-center gap-3 hover:underline"
-                          target="_blank"
-                        >
-                          <span className="relative h-10 w-10 shrink-0 overflow-hidden rounded-lg bg-slate-100">
-                            {post.thumbUrl ? (
-                              <Image
-                                src={post.thumbUrl}
-                                alt=""
-                                fill
-                                sizes="40px"
-                                className="object-cover"
-                                unoptimized
-                              />
-                            ) : null}
-                          </span>
-                          <span className="truncate text-slate-700">
-                            {post.authorName}
-                          </span>
-                        </Link>
-                      </td>
-                      <td className="py-2 text-right font-semibold text-slate-900">
-                        {post.impressions.toLocaleString("ja-JP")}
-                      </td>
-                      <td className="py-2 text-right text-slate-600">
-                        {post.uniqueViewers.toLocaleString("ja-JP")}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+            {/*
+              表(min-width + 横スクロール)にすると、スマホでは肝心の数値が画面外に
+              出てランキングとして機能しない。管理画面はスマホから見ることが多い
+              ため、どの幅でも横スクロールなしで数値まで読める並びにする。
+            */}
+            <ul className="text-sm">
+              {topPosts.map((post) => (
+                <li
+                  key={post.imageId}
+                  className="flex items-center gap-3 border-b border-slate-100 py-2 last:border-0"
+                >
+                  <Link
+                    href={`/posts/${post.imageId}`}
+                    className="flex min-w-0 flex-1 items-center gap-3 hover:underline"
+                    target="_blank"
+                  >
+                    <span className="relative h-10 w-10 shrink-0 overflow-hidden rounded-lg bg-slate-100">
+                      {post.thumbUrl ? (
+                        <Image
+                          src={post.thumbUrl}
+                          alt=""
+                          fill
+                          sizes="40px"
+                          className="object-cover"
+                          unoptimized
+                        />
+                      ) : null}
+                    </span>
+                    <span className="truncate text-slate-700">
+                      {post.authorName}
+                    </span>
+                  </Link>
+                  <div className="shrink-0 text-right">
+                    <p className="font-semibold text-slate-900">
+                      {post.impressions.toLocaleString("ja-JP")}
+                    </p>
+                    <p className="text-xs text-slate-500">
+                      {post.uniqueViewers.toLocaleString("ja-JP")}人が視聴
+                    </p>
+                  </div>
+                </li>
+              ))}
+            </ul>
           </div>
         ) : null}
       </CardContent>

--- a/features/admin-dashboard/lib/build-impression-stats.ts
+++ b/features/admin-dashboard/lib/build-impression-stats.ts
@@ -68,6 +68,21 @@ function toCount(value: unknown): number {
     : 0;
 }
 
+/**
+ * 内訳の比率表示。
+ *
+ * 単純な四捨五入だと「フィード 3件 → 0%」のように、件数があるのに 0% と出て
+ * 壊れて見える。表示形式の記録は途中から始めたので、しばらく分母(不明)が
+ * 大きいままになる。0 でないのに 0% になる場合は「1%未満」と出す。
+ */
+export function formatImpressionShare(value: number, total: number): string {
+  if (total <= 0 || value <= 0) {
+    return "0%";
+  }
+  const rounded = Math.round((value / total) * 100);
+  return rounded === 0 ? "1%未満" : `${rounded}%`;
+}
+
 /** "2026-08-12" → "8/12"。文字列から切り出す(Date を通すとタイムゾーンでずれる)。 */
 export function formatImpressionDateLabel(date: string): string {
   const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);

--- a/tests/unit/features/admin-dashboard/build-impression-stats.test.ts
+++ b/tests/unit/features/admin-dashboard/build-impression-stats.test.ts
@@ -9,6 +9,7 @@
 
 import {
   formatImpressionDateLabel,
+  formatImpressionShare,
   parseImpressionStats,
 } from "@/features/admin-dashboard/lib/build-impression-stats";
 
@@ -136,6 +137,30 @@ describe("parseImpressionStats", () => {
       uniqueViewers: 0,
       grid: 0,
     });
+  });
+});
+
+describe("formatImpressionShare", () => {
+  test("件数があるのに0%と出さない(1%未満にする)", () => {
+    /*
+      表示形式の記録は途中から始めたので、しばらく分母(不明)が大きいまま。
+      単純な四捨五入だと「フィード 3件 → 0%」になり、壊れて見える。
+    */
+    expect(formatImpressionShare(3, 10979)).toBe("1%未満");
+    expect(formatImpressionShare(36, 10979)).toBe("1%未満");
+  });
+
+  test("四捨五入で1%以上になるものは通常表示", () => {
+    // 0.5% は四捨五入で 1% になるので「1%未満」にはしない
+    expect(formatImpressionShare(5, 1000)).toBe("1%");
+    expect(formatImpressionShare(300, 1000)).toBe("30%");
+    expect(formatImpressionShare(1000, 1000)).toBe("100%");
+  });
+
+  test("0件・分母0は0%", () => {
+    expect(formatImpressionShare(0, 1000)).toBe("0%");
+    expect(formatImpressionShare(10, 0)).toBe("0%");
+    expect(formatImpressionShare(0, 0)).toBe("0%");
   });
 });
 


### PR DESCRIPTION
#511 のインプレッションカードを実機（スマホ）で確認して見つかった4点です。**すべてUI側のみで、マイグレーションもデータ変更もありません。**

## 1. 件数があるのに「0%」と出る 🐛

`フィード 3 0%` / `グリッド 36 0%` と表示されていました。件数があるのに0%なので、壊れているように見えます。

表示形式の記録は 2026-08-12 開始なので、**しばらく分母（不明）が大きいまま**です。3/10979 も 36/10979 も四捨五入で0%になります。

→ 0でないのに0%になる場合は **「1%未満」** と出すようにしました。0.5%は四捨五入で1%になるので、そこは通常表示のままです。

## 2. 「ユニーク視聴者」を実人数と書いていた

補足が「期間内の実人数（日次の合計ではありません）」でしたが、**実人数ではありません**。ゲストは IP ハッシュで識別しているため、モバイルで IP が変わるたびに別人として数えられます。

実データでも 30日で **179**（日次だと 17 前後）と、期間が長いほど膨らんでいました。実態に近いのは日別チャートの方です。

→ 「日次の合計ではありません。ゲストはIPで識別するため、期間が長いほど多めに出ます」に書き換えました。

## 3. スマホでランキングの数値が読めない 🐛

`min-width` + 横スクロールの表にしていたため、スマホでは**数値が1つも画面に入らず**、ランキングとして機能していませんでした。管理画面はスマホから見ることが多いので実害があります。

→ 表をやめ、**どの幅でも横スクロールなしで数値まで読める縦並び**にしました（インプレッションの下にユニーク視聴者）。

## 4. 数え方が変わったことが画面上に無かった

2026-08-12 に重複除外を「1日1回」→「30分に1回」へ変えたので、**日別チャートに段差ができます**。書いておかないと、数ヶ月後に見返したときアクセス急増と読み違えます。

→ カードの説明に「2026-08-12 より前は『1日1回』で集計しています（チャートの段差は増加ではありません）」を追加しました。

## 確認したこと

- `npm run lint` — **23 errors / 57 warnings**（main の既存baselineと同数・新規指摘なし）
- `npx tsc --noEmit` — アプリコードのエラー0
- `npm run test` — **346 suites / 3481 tests すべてパス**（+3件は比率表示の回帰テスト）
- `npm run build -- --webpack` — 成功

## 実機で見てほしいところ

1. スマホの `/admin` で「よく見られた投稿」の**数値が横スクロールなしで読めるか**
2. 「どこで見られたか」の フィード / グリッド が **「1%未満」** になっているか

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mmqeUvT5TbjAMPNo6Pxsn