### PR TITLE
feat(analytics): シェアURL経由の新規登録を計測できるようにする

### DIFF
--- a/.cursor/rules/database-design.mdc
+++ b/.cursor/rules/database-design.mdc
@@ -251,7 +251,7 @@ alwaysApply: false
 - 主キー: `id`
 - 主要カラム: `user_id`, `nickname`, `bio`, `avatar_url`, `website_url`, `subscription_plan`, `signup_source`, `last_daily_post_bonus_at`, `last_streak_login_at`, `streak_days`, `referral_code`, `last_coordinate_toast_ack_at`, `coordinate_stocks_tab_seen_at`, `deactivation_requested_at`, `deletion_scheduled_at`, `deactivated_at`, `reactivated_at`, `created_at`, `updated_at`
 - 外部キー: `id -> auth.users.id`, `user_id -> auth.users.id`
-- 制約: `user_id` UNIQUE、`referral_code` UNIQUE、`signup_source` は `style` / `wardrobe` のみ
+- 制約: `user_id` UNIQUE、`referral_code` UNIQUE、`signup_source` は書式のみ `^[a-z0-9_-]{1,40}$`（`style` / `wardrobe` に加え、企画キー等の任意タグを保持する）
 - RLS: 公開 `SELECT`、`INSERT/UPDATE` は本人のみ
 
 ### 管理・モデレーション・運用

--- a/app/m/[token]/book/page.tsx
+++ b/app/m/[token]/book/page.tsx
@@ -97,6 +97,7 @@ export default async function CollectionBookPage({
       pages={pages}
       isOwner={isOwner}
       completionId={token}
+      categoryKey={book.categoryKey}
       rewardGranted={rewardGranted}
       coverOverlay={book.coverOverlay}
       backCoverImageUrl={backCoverImageUrl}

--- a/app/m/[token]/page.tsx
+++ b/app/m/[token]/page.tsx
@@ -18,6 +18,7 @@ import { CompletionFeedPostButton } from "@/features/collections/components/Comp
 
 interface PublicMountPageProps {
   params: Promise<{ token: string }>;
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
 }
 
 // 注: i18n は Phase 7 で整える。当面は企画(JP)向けに日本語コピーを用いる。
@@ -106,14 +107,27 @@ export async function generateMetadata({
 
 export default async function PublicMountPage({
   params,
+  searchParams,
 }: PublicMountPageProps) {
   await connection();
   const { token } = await params;
+  const query = (await searchParams) ?? {};
 
   // book(めくれる日記帳)完走は没入の本リーダーへ。/m/<id> への既存導線を全てカバーする。
   const book = await getCollectionBookByToken(token);
   if (book) {
-    redirect(`/m/${token}/book`);
+    /*
+      signup_source は引き継ぐ。落とすと、mount 形式で共有された URL から
+      book 完走へリダイレクトされた人の流入元が失われる
+      (client の SignupSourceCapture はリダイレクト先でしか走らないため)。
+    */
+    const source = query.signup_source;
+    const value = Array.isArray(source) ? source[0] : source;
+    redirect(
+      value
+        ? `/m/${token}/book?signup_source=${encodeURIComponent(value)}`
+        : `/m/${token}/book`,
+    );
   }
 
   const mount = await getPublicMountByToken(token);

--- a/app/m/[token]/page.tsx
+++ b/app/m/[token]/page.tsx
@@ -168,6 +168,7 @@ export default async function PublicMountPage({
           <MountShareButton
             completionId={mount.completionId}
             mountImageUrl={mount.mountImageUrl}
+            categoryKey={mount.categoryKey}
           />
           <CompletionFeedPostButton
             completionId={mount.completionId}

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -65,7 +65,18 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   }, [isAdmin]);
 
   if (shouldBypassAppShell) {
-    return <>{children}</>;
+    /*
+      共通 chrome は出さないが、SignupSourceCapture だけは描く。
+      これを外すと、没入ビュー(/m/<token>/book 等)へ直接着地した人の
+      ?signup_source= が cookie に入らず、シェア経由の登録が計測できない。
+      表示は何も持たない(null を返す)ので chrome を出さない方針とは両立する。
+    */
+    return (
+      <>
+        <SignupSourceCapture />
+        {children}
+      </>
+    );
   }
 
   return (

--- a/features/campaigns/components/XLotteryEntryButton.tsx
+++ b/features/campaigns/components/XLotteryEntryButton.tsx
@@ -62,8 +62,8 @@ export function XLotteryEntryButton({
   const handleClick = () => {
     const shareUrl =
       view === "book"
-        ? buildPublicBookUrl(completionId)
-        : buildPublicMountUrl(completionId, mountImageUrl);
+        ? buildPublicBookUrl(completionId, categoryKey)
+        : buildPublicMountUrl(completionId, mountImageUrl, categoryKey);
     const intentUrl = buildXLotteryIntentUrl(copy, shareUrl);
     // 応募=シェアなので既存の共有計測も呼ぶ(best-effort)。
     trackMountShareEvent(completionId);

--- a/features/collections/components/CollectionProgressModal.tsx
+++ b/features/collections/components/CollectionProgressModal.tsx
@@ -631,7 +631,13 @@ export function CollectionProgressModal({
               /* posts / /m と同じ共有 UI(モバイル=シェアシート、PC=コピー/Web Share
                  メニュー)。成功時に share-event を計測する。 */
               <ShareLinkButton
-                url={() => buildPublicMountUrl(completionId, mountImageUrl)}
+                url={() =>
+                  buildPublicMountUrl(
+                    completionId,
+                    mountImageUrl,
+                    celebration.categoryKey,
+                  )
+                }
                 messages={MOUNT_SHARE_MESSAGES}
                 onShared={() => trackMountShareEvent(completionId)}
                 className="h-auto w-full rounded-full border-2 border-amber-300 bg-white px-6 py-3 text-base font-bold text-amber-600 transition-colors hover:bg-amber-50"

--- a/features/collections/components/MountShareButton.tsx
+++ b/features/collections/components/MountShareButton.tsx
@@ -17,9 +17,12 @@ import { buildPublicMountUrl, trackMountShareEvent } from "../lib/share-mount";
 export function MountShareButton({
   completionId,
   mountImageUrl,
+  categoryKey,
 }: {
   completionId: string;
   mountImageUrl: string;
+  /** シェアURLに流入元タグを付けるために使う(どの企画経由の登録かを取る)。 */
+  categoryKey?: string | null;
 }) {
   const [downloading, setDownloading] = useState(false);
   const { toast } = useToast();
@@ -54,7 +57,9 @@ export function MountShareButton({
   return (
     <div className="flex flex-wrap justify-center gap-3">
       <ShareLinkButton
-        url={() => buildPublicMountUrl(completionId, mountImageUrl)}
+        url={() =>
+          buildPublicMountUrl(completionId, mountImageUrl, categoryKey)
+        }
         messages={MOUNT_SHARE_MESSAGES}
         onShared={() => trackMountShareEvent(completionId)}
         className="px-5"

--- a/features/collections/components/ScrapbookReader.tsx
+++ b/features/collections/components/ScrapbookReader.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { X, Share2, Maximize2, Minimize2, ChevronUp } from "lucide-react";
+import { buildPublicBookUrl } from "../lib/share-mount";
 import { CatalogBookView } from "@/features/catalog/components/CatalogBookView";
 import type { CatalogPageData } from "@/features/catalog/components/CatalogPage";
 import { CompletionFeedPostButton } from "@/features/collections/components/CompletionFeedPostButton";
@@ -31,6 +32,7 @@ export function ScrapbookReader({
   backCoverImageUrl = null,
   pageAspectRatio = null,
   lottery = null,
+  categoryKey = null,
 }: {
   title: string;
   coverImageUrl: string | null;
@@ -59,6 +61,12 @@ export function ScrapbookReader({
     entryStartsAt: string | null;
     entryEndsAt: string | null;
   } | null;
+  /**
+   * シェアURLに付ける流入元タグ用。**lottery とは独立して渡すこと**。
+   * lottery は抽選対象のカテゴリにしか入らないため、そこから取ると
+   * イタリア旅行のような抽選なしの book でタグが欠ける。
+   */
+  categoryKey?: string | null;
 }) {
   const router = useRouter();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -157,7 +165,17 @@ export function ScrapbookReader({
   };
 
   const handleShare = async () => {
-    const url = typeof window !== "undefined" ? window.location.href : "";
+    /*
+      window.location.href をそのまま共有すると、所有者が内部導線から開いた
+      タグ無しURLがそのまま出回り、シェア経由の登録が計測できない。
+      completionId があるときは必ずタグ付きURLを組み立て直す。
+    */
+    const url =
+      completionId
+        ? buildPublicBookUrl(completionId, categoryKey)
+        : typeof window !== "undefined"
+          ? window.location.href
+          : "";
     try {
       if (navigator.share) {
         await navigator.share({ title, url });

--- a/features/collections/lib/share-mount.ts
+++ b/features/collections/lib/share-mount.ts
@@ -1,3 +1,5 @@
+import { parseSignupSource } from "@/features/auth/lib/signup-source";
+
 /**
  * 台紙ストレージURLから「mount-{timestamp}」のタイムスタンプ部分だけ抜く。
  * 古い台紙(タイムスタンプ前の固定パス)は null を返す。
@@ -11,20 +13,44 @@ export function extractMountVersionFromUrl(url: string | null | undefined): stri
 }
 
 /**
+ * シェアURLに付ける流入元タグを作る。
+ *
+ * カテゴリ key をそのまま使う(例: `travel_to_australia`)。接頭辞は付けない。
+ * `parseSignupSource` の書式は 1..40 文字なので、接頭辞を足すと
+ * 長い key(現状の最長は `collectible_wafer_sticker_god_petit_6p` = 38文字)で
+ * 上限に張り付き、将来の企画で無言で欠落する。
+ *
+ * 書式に合わない場合は null を返し、呼び出し側はパラメータごと省略する。
+ */
+function buildCollectionSignupSource(
+  categoryKey: string | null | undefined,
+): string | null {
+  return parseSignupSource(categoryKey);
+}
+
+/**
  * 台紙の公開ページURL(/m/{completionId}?v={ts})を組み立てる(client 用)。
  *
  * mountImageUrl を渡すと、台紙更新ごとに ?v=...が付き、SNS(X/Facebook 等)の
  * カードキャッシュが新しい URL として扱われ即時に新しい OGP が反映される。
  * 引数省略時はバージョン無しの旧形式 URL を出す(後方互換)。
+ *
+ * categoryKey を渡すと `?signup_source=<key>` が付く。着地時に
+ * SignupSourceCapture が first-touch で cookie に保存し、登録まで到達すると
+ * profiles.signup_source に残る = 「どの企画のシェア経由で登録したか」が取れる。
  */
 export function buildPublicMountUrl(
   completionId: string,
   mountImageUrl?: string | null,
+  categoryKey?: string | null,
 ): string {
   const version = extractMountVersionFromUrl(mountImageUrl);
-  const path = version
-    ? `/m/${completionId}?v=${version}`
-    : `/m/${completionId}`;
+  const params = new URLSearchParams();
+  if (version) params.set("v", version);
+  const source = buildCollectionSignupSource(categoryKey);
+  if (source) params.set("signup_source", source);
+  const query = params.toString();
+  const path = query ? `/m/${completionId}?${query}` : `/m/${completionId}`;
   return `${window.location.origin}${path}`;
 }
 
@@ -33,8 +59,13 @@ export function buildPublicMountUrl(
  * mount と違い、OGP画像は book ページの metadata がバージョン付きURLで返すため
  * キャッシュバスターのクエリは持たない。
  */
-export function buildPublicBookUrl(completionId: string): string {
-  return `${window.location.origin}/m/${completionId}/book`;
+export function buildPublicBookUrl(
+  completionId: string,
+  categoryKey?: string | null,
+): string {
+  const source = buildCollectionSignupSource(categoryKey);
+  const query = source ? `?signup_source=${encodeURIComponent(source)}` : "";
+  return `${window.location.origin}/m/${completionId}/book${query}`;
 }
 
 /**

--- a/supabase/migrations/20260817100000_relax_handle_new_user_signup_source.sql
+++ b/supabase/migrations/20260817100000_relax_handle_new_user_signup_source.sql
@@ -1,0 +1,123 @@
+-- handle_new_user() が signup_source を 'style' / 'wardrobe' 以外すべて捨てていた問題の是正。
+--
+-- 背景:
+--   CHECK 制約は 20260627100000 で書式チェック(^[a-z0-9_-]{1,40}$)へ緩和済みだが、
+--   トリガー側のハードコードされた許可リストが残ったままだった。
+--   このため外部チャネルのタグ(x_profile / 企画キー 等)は届いた瞬間に NULL にされ、
+--   本番の profiles は 193人中185人(96%)が signup_source IS NULL になっていた。
+--   神コレ・イタリア旅行で「シェア経由の流入」を数えられなかった直接の原因。
+--
+-- この migration:
+--   許可リストを外し、CHECK と同じ書式チェックだけに置き換える。
+--   書式に合わない値は NULL に落とす(= INSERT を失敗させない)。
+--   これは重要で、profiles の INSERT が CHECK 違反で落ちると
+--   関数末尾の EXCEPTION ハンドラが握りつぶし、**プロフィールが作られないまま
+--   ユーザーが登録完了してしまう**。書式検証をトリガー側にも残す理由。
+--
+-- 関数本体は signup_source の判定以外いっさい変えていない
+-- (登録ボーナス付与・無料枠バッチ・通知・紹介コード生成はそのまま)。
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'extensions'
+AS $function$
+DECLARE
+  v_default_nickname text;
+  v_signup_bonus integer;
+  v_tx_id uuid;
+  v_expire_at timestamptz;
+  v_signup_source text;
+BEGIN
+  v_signup_bonus := get_percoin_bonus_default('signup_bonus');
+
+  IF NEW.email IS NOT NULL THEN
+    v_default_nickname := split_part(NEW.email, '@', 1);
+    IF length(v_default_nickname) > 20 THEN
+      v_default_nickname := left(v_default_nickname, 20);
+    END IF;
+  END IF;
+
+  -- 書式は profiles_signup_source_check と一致させること。
+  -- 値の許可リストは持たない(企画キー等の任意タグを受け入れるため)。
+  v_signup_source := NULLIF(NEW.raw_user_meta_data->>'signup_source', '');
+  IF v_signup_source IS NOT NULL
+     AND v_signup_source !~ '^[a-z0-9_-]{1,40}$' THEN
+    v_signup_source := NULL;
+  END IF;
+
+  INSERT INTO public.profiles (id, user_id, nickname, signup_source)
+  VALUES (NEW.id, NEW.id, v_default_nickname, v_signup_source)
+  ON CONFLICT (user_id) DO NOTHING;
+
+  v_expire_at := (
+    date_trunc('month', now() AT TIME ZONE 'Asia/Tokyo')
+    + interval '7 months' - interval '1 second'
+  ) AT TIME ZONE 'Asia/Tokyo';
+
+  INSERT INTO public.credit_transactions (user_id, amount, transaction_type, metadata)
+  VALUES (
+    NEW.id,
+    v_signup_bonus,
+    'signup_bonus',
+    jsonb_build_object('bucket', 'promo')
+  )
+  RETURNING id INTO v_tx_id;
+
+  INSERT INTO public.free_percoin_batches (user_id, amount, remaining_amount, granted_at, expire_at, source, credit_transaction_id)
+  VALUES (NEW.id, v_signup_bonus, v_signup_bonus, now(), v_expire_at, 'signup_bonus', v_tx_id);
+
+  INSERT INTO public.user_credits (user_id, balance, paid_balance)
+  VALUES (NEW.id, v_signup_bonus, 0)
+  ON CONFLICT (user_id) DO UPDATE
+  SET balance = user_credits.balance + v_signup_bonus, updated_at = NOW();
+
+  BEGIN
+    INSERT INTO public.notifications (
+      recipient_id,
+      actor_id,
+      type,
+      entity_type,
+      entity_id,
+      title,
+      body,
+      data,
+      is_read,
+      created_at
+    ) VALUES (
+      NEW.id,
+      NEW.id,
+      'bonus',
+      'user',
+      NEW.id,
+      '新規登録ボーナス獲得！',
+      '新規登録特典として' || v_signup_bonus || 'ペルコインを獲得しました！',
+      jsonb_build_object(
+        'bonus_amount', v_signup_bonus,
+        'bonus_type', 'signup_bonus',
+        'granted_at', NOW()
+      ),
+      false,
+      NOW()
+    );
+  EXCEPTION WHEN others THEN
+    RAISE WARNING 'Error creating signup bonus notification: %', SQLERRM;
+  END;
+
+  BEGIN
+    PERFORM generate_referral_code(NEW.id);
+  EXCEPTION WHEN others THEN
+    RAISE WARNING 'Error generating referral code: %', SQLERRM;
+  END;
+
+  RETURN NEW;
+EXCEPTION WHEN others THEN
+  RAISE WARNING 'Error in handle_new_user trigger: %', SQLERRM;
+  RETURN NEW;
+END;
+$function$;
+
+COMMIT;

--- a/tests/unit/features/collections/book-share-attribution.test.ts
+++ b/tests/unit/features/collections/book-share-attribution.test.ts
@@ -1,0 +1,59 @@
+/**
+ * book(めくれる日記帳)完走の「シェア経由の登録」計測が3経路すべてで
+ * 成立することを固定するテスト。
+ *
+ * レビュー(PR #521)で、mount 系は計測できるのに book 系
+ * (= イタリア旅行・オーストラリア旅行)だけ流入元が NULL のままになる
+ * 経路が3つ見つかったため、その再発防止として置く。
+ *
+ *   1. 直接着地   /m/<id>/book?signup_source=... に外部から着地
+ *   2. リダイレクト /m/<id>?signup_source=... → /m/<id>/book
+ *   3. 通常シェア  book 画面の「シェア」ボタンが出すURL
+ *
+ * 1 と 2 は実装が別ファイル(AppShell / page.tsx)にあるため、
+ * ここでは「タグの持ち回りルール」を関数レベルで固定し、
+ * 経路の接続は下記コメントの根拠をもって担保する。
+ */
+
+import { buildPublicBookUrl } from "@/features/collections/lib/share-mount";
+import { parseSignupSource } from "@/features/auth/lib/signup-source";
+
+const origin = window.location.origin;
+
+describe("book シェアの流入元タグ", () => {
+  test("通常シェア: completionId と categoryKey からタグ付きURLを作る", () => {
+    // ScrapbookReader.handleShare が window.location.href をそのまま共有すると、
+    // 所有者が内部導線から開いたタグ無しURLが出回って計測が落ちる。
+    expect(buildPublicBookUrl("c1", "travel_to_australia")).toBe(
+      `${origin}/m/c1/book?signup_source=travel_to_australia`,
+    );
+  });
+
+  test("抽選なしの企画でもタグが付く(イタリア旅行)", () => {
+    /*
+      categoryKey は lottery prop からではなく独立して渡すこと。
+      lottery は抽選対象カテゴリにしか入らないため、そこから取ると
+      travel_to_italy のような抽選なしの book でタグが欠ける。
+    */
+    expect(buildPublicBookUrl("c1", "travel_to_italy")).toBe(
+      `${origin}/m/c1/book?signup_source=travel_to_italy`,
+    );
+  });
+
+  test("categoryKey が無ければタグを付けない(後方互換)", () => {
+    expect(buildPublicBookUrl("c1")).toBe(`${origin}/m/c1/book`);
+    expect(buildPublicBookUrl("c1", null)).toBe(`${origin}/m/c1/book`);
+  });
+
+  test("リダイレクトで引き継ぐ値は書式検証を通る(URLに不正値を載せない)", () => {
+    /*
+      /m/<id> → /m/<id>/book のリダイレクトはクエリを引き継ぐが、
+      値はユーザー入力由来なので、そのまま cookie/DB へ流れる前に
+      parseSignupSource(= DB の CHECK と同じ書式)で弾かれること。
+    */
+    expect(parseSignupSource("travel_to_australia")).toBe("travel_to_australia");
+    expect(parseSignupSource("Travel To AU")).toBeNull();
+    expect(parseSignupSource("a".repeat(41))).toBeNull();
+    expect(parseSignupSource("<script>")).toBeNull();
+  });
+});

--- a/tests/unit/features/collections/collection-progress-modal.test.tsx
+++ b/tests/unit/features/collections/collection-progress-modal.test.tsx
@@ -153,9 +153,11 @@ describe("CollectionProgressModal: 完了ビューのシェア (PC)", () => {
         "https://persta.ai/m/completion-1?v=42",
       );
     });
+    // 第3引数はシェアURLの流入元タグ(どの企画経由の登録かを取るため)
     expect(mockBuildPublicMountUrl).toHaveBeenCalledWith(
       "completion-1",
       completedCelebration.mountImageUrl,
+      completedCelebration.categoryKey,
     );
     await waitFor(() => {
       expect(mockToast).toHaveBeenCalledWith(

--- a/tests/unit/features/collections/mount-share-button.test.tsx
+++ b/tests/unit/features/collections/mount-share-button.test.tsx
@@ -227,10 +227,32 @@ describe("MountShareButton: シェアする (PC, posts と同一挙動)", () => 
         "https://persta.ai/m/completion-1?v=123",
       );
     });
+    // 第3引数はシェアURLの流入元タグ。ここでは未指定なので undefined
     expect(mockBuildPublicMountUrl).toHaveBeenCalledWith(
       "completion-1",
       defaultProps.mountImageUrl,
+      undefined,
     );
+  });
+
+  test("categoryKey を渡すとシェアURLの組立に流入元タグが伝わる", async () => {
+    /*
+      シェアURL → 訪問 → 新規登録 を繋ぐための first-touch タグ(計測①)。
+      /m ページから categoryKey が渡らないと、どの企画経由の登録か分からなくなる。
+    */
+    render(
+      <MountShareButton {...defaultProps} categoryKey="travel_to_australia" />,
+    );
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "リンクをコピー" }));
+
+    await waitFor(() => {
+      expect(mockBuildPublicMountUrl).toHaveBeenCalledWith(
+        "completion-1",
+        defaultProps.mountImageUrl,
+        "travel_to_australia",
+      );
+    });
     await waitFor(() => {
       expect(mockToast).toHaveBeenCalledWith(
         expect.objectContaining({ title: "URLをコピーしました" }),

--- a/tests/unit/features/collections/share-mount.test.ts
+++ b/tests/unit/features/collections/share-mount.test.ts
@@ -57,6 +57,71 @@ describe("buildPublicBookUrl", () => {
   test("book ビューの公開URLを組み立てる(キャッシュバスター無し)", () => {
     expect(buildPublicBookUrl("c1")).toBe(`${origin}/m/c1/book`);
   });
+
+  test("categoryKey を渡すと signup_source が付く", () => {
+    expect(buildPublicBookUrl("c1", "travel_to_australia")).toBe(
+      `${origin}/m/c1/book?signup_source=travel_to_australia`,
+    );
+  });
+});
+
+describe("シェアURLの流入元タグ(計測①)", () => {
+  /*
+    シェアURL → 訪問 → 新規登録 を繋ぐための first-touch タグ。
+    着地時に SignupSourceCapture が cookie へ保存し、登録時に
+    profiles.signup_source に残る。神コレ・イタリアで取れなかった指標。
+  */
+  test("バージョンとタグが両方付く", () => {
+    expect(
+      buildPublicMountUrl(
+        "c1",
+        "https://cdn.example.com/mounts/mount-1717999999999.png",
+        "fashion_magazine_summer",
+      ),
+    ).toBe(
+      `${origin}/m/c1?v=1717999999999&signup_source=fashion_magazine_summer`,
+    );
+  });
+
+  test("バージョンが無くてもタグだけ付く", () => {
+    expect(buildPublicMountUrl("c1", null, "travel_to_australia")).toBe(
+      `${origin}/m/c1?signup_source=travel_to_australia`,
+    );
+  });
+
+  test("categoryKey 省略時は従来どおりタグを付けない(後方互換)", () => {
+    expect(buildPublicMountUrl("c1", null)).toBe(`${origin}/m/c1`);
+    expect(buildPublicMountUrl("c1", null, null)).toBe(`${origin}/m/c1`);
+  });
+
+  test("書式に合わない key はタグごと省略する(不正な値を URL に載せない)", () => {
+    // DB の CHECK(^[a-z0-9_-]{1,40}$)と同じ書式。大文字・記号・41文字以上は落とす
+    expect(buildPublicMountUrl("c1", null, "Travel To Australia")).toBe(
+      `${origin}/m/c1`,
+    );
+    expect(buildPublicMountUrl("c1", null, "a".repeat(41))).toBe(
+      `${origin}/m/c1`,
+    );
+  });
+
+  test("実在するカテゴリ key はすべて書式を満たす", () => {
+    // 接頭辞を付けない設計の根拠。最長でも 38 文字で上限 40 に収まる
+    const keys = [
+      "travel_to_italy",
+      "travel_to_australia",
+      "fashion_magazine_summer",
+      "kotowaza_dictionary",
+      "kotowaza_dictionary_2",
+      "collectible_wafer_sticker",
+      "collectible_wafer_sticker_god_6p",
+      "collectible_wafer_sticker_god_petit_6p",
+    ];
+    for (const key of keys) {
+      expect(buildPublicMountUrl("c1", null, key)).toBe(
+        `${origin}/m/c1?signup_source=${key}`,
+      );
+    }
+  });
 });
 
 describe("trackMountShareEvent", () => {


### PR DESCRIPTION
企画の認知拡大を数値で語るための**計測①**です。「シェアURL → 訪問 → 新規登録」のうち、いちばん詰まっていた**登録時の流入元**を取れるようにします。

## 🔴 本丸: `handle_new_user()` が流入元を捨てていました

CHECK 制約は `20260627100000` で書式チェック（`^[a-z0-9_-]{1,40}$`）へ緩和済みでしたが、**トリガー側のハードコードされた許可リストが残ったまま**でした。

```sql
IF v_signup_source NOT IN ('style', 'wardrobe') THEN
  v_signup_source := NULL;   -- ← 外部チャネルのタグは全部ここで消えていた
END IF;
```

本番の実データがこれを裏付けています。

| `signup_source` | 件数 |
|---|---:|
| **(NULL)** | **185件** |
| wardrobe | 6件 |
| style | 2件 |

**193人中185人（96%）が NULL** です。神コレ・イタリア旅行で「シェア経由の流入」を数えられなかった直接の原因でした。

許可リストを外し、CHECK と同じ書式チェックだけに置き換えます。

## シェアURLに流入元タグを付ける

`buildPublicMountUrl` / `buildPublicBookUrl` に `categoryKey` を渡すと `?signup_source=<key>` が付きます。

着地時に **`SignupSourceCapture`（`AppShell` にマウント済み・first-touch・cookie 30日）** が拾い、登録時に `profiles.signup_source` へ落ちます。**既存の仕組みに乗るだけなので、新しい計測基盤は要りません。**

`/m/[token]` も `app/layout.tsx` → `LocaleShell` → `AppShell` の配下なので捕捉されます。

## 設計判断

**タグに接頭辞を付けず、カテゴリ key をそのまま使っています。** `c_` などを足すと最長 key（`collectible_wafer_sticker_god_petit_6p` = 38文字）が上限40に張り付き、将来の企画で無言で欠落するためです。書式に合わなければパラメータごと省略します。

**トリガー側にも書式検証を残しています。** `profiles` の INSERT が CHECK 違反で落ちると、関数末尾の `EXCEPTION` ハンドラが握りつぶし、**プロフィールが作られないままユーザーが登録完了**してしまいます。DB制約に任せきりにできません。

## 検証

本番DBに対して `BEGIN` 〜 `ROLLBACK` で dry-run し、関数が問題なく置き換わること、書式判定が期待どおりであることを確認済みです。

| 入力 | 結果 |
|---|---|
| `travel_to_australia` | 保持 |
| `style` | 保持（後方互換） |
| `Travel To AU` | NULL |
| 41文字 | NULL |

- `npm run lint` — 変更ファイルは警告0
- `npm run typecheck` — 変更ファイルはエラー0
- `npm run test` — 3,530 passed / 347 suites
- `npm run build -- --webpack` — 成功

## レビューで見ていただきたい点

1. **関数本体を丸ごと再定義しています。** `signup_source` の判定以外は本番の定義をそのまま写しました（登録ボーナス・無料枠バッチ・通知・紹介コード生成）。差分が判定部分だけになっているか確認してください。**登録の根幹を触るので、意図しない変更が混じっていないかが最重要**です。
2. **既存の `style` / `wardrobe` が壊れないこと** — 書式チェックを通るので保持されますが、後方互換の確認をお願いします。
3. **接頭辞なしのタグ設計**が妥当か。`profiles.signup_source` に `travel_to_australia` のような値が入ることになります。

## 未対応（計測①の残り）

**`/m/[token]` の訪問数そのものは取れません。** 訪問記録の実装が別途必要です。今回入るのは「**登録者がどの企画のシェア経由か**」までで、分母（訪問数）は次の段階になります。

計測②（ゲストの端末ID）・③（visit の企画別内訳）も未着手です。

## ⚠️ 適用について

**マイグレーションの本番適用は、マージ後にご一緒に行います。** 全ユーザーの登録経路を通るトリガーなので、適用タイミングを合わせたいためです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mmqeUvT5TbjAMPNo6Pxsn