### PR TITLE
fix(worker): 応答が失われただけの完了RPCで画像を消さないようにする

### DIFF
--- a/supabase/functions/image-gen-worker/index.ts
+++ b/supabase/functions/image-gen-worker/index.ts
@@ -2996,61 +2996,104 @@ Deno.serve(async () => {
           };
 
           /**
-           * 完了 RPC がエラーを返したとき、**本当に失敗したのか**を DB に問い合わせる。
+           * 完了 RPC がエラーを返したときの「本当の結果」。
            *
-           * 520 / タイムアウト / 切断は「結果が不明」であって「失敗」ではない。
-           * RPC 側はコミット済みなのに応答だけが失われることがあり、そこで
-           * cleanupUploadedImages を走らせると **コミット済みの行が参照している
-           * 画像を消してしまう**(= 一覧に壊れた画像が出る)。
+           * ここを2値(成功/失敗)で扱うと危険。520・切断・タイムアウトは
+           * **結果が不明**であり、元トランザクションがまだ実行中の可能性がある。
+           * complete_image_job_with_prompt_secrets は job 行を FOR UPDATE した後に
+           * 画像を INSERT し、**最後に** status='succeeded' へ更新するため、
+           * 実行中に通常 SELECT すると旧値(processing)が見える。
+           * それを「未コミット」と決めつけて削除すると、直後にコミットされた瞬間に
+           * 「DB行あり・Storage実体なし」が再発する。
            *
-           * 実際に 2026-08-17 に発生している:
-           *   uploading 完了 → RPC が 65 秒かかる → Cloudflare 520 →
-           *   ワーカーが失敗と判断 → 画像を削除。しかし RPC は 211ms 前に
-           *   コミット済みで、image_jobs=succeeded / generated_images の行も存在した。
-           *
-           * ジョブが succeeded かつ行が存在すれば「応答が失われただけ」なので、
-           * RPC が返すはずだった形(id / storage_path)を復元して成功経路に合流させる。
-           * 判定できない場合は null を返し、従来どおり後始末して失敗させる。
+           * 方針: **迷ったら消さない**。
+           * 孤児は後から安全に掃除できるが、コミット済み行の参照先は復旧できない。
            */
-          const recoverCommittedImageRecords = async (): Promise<
+          type CompletionOutcome =
+            | { kind: "committed"; records: Array<{ id: string; storage_path: string }> }
+            | { kind: "failed" }
+            | { kind: "unknown" };
+
+          /**
+           * エラーが「サーバに届いて拒否された」ものかを見分ける。
+           *
+           * PostgREST / Postgres の構造化エラーは code を持つ(23505 / P0001 /
+           * 57014=statement timeout 等)。いずれもトランザクションは巻き戻っており、
+           * 後始末してよい。一方 520 はゲートウェイが HTML を返すため code が無く、
+           * 元トランザクションの生死が分からない。
+           */
+          const isRejectedByServer = (error: unknown): boolean => {
+            const code = (error as { code?: unknown } | null)?.code;
+            return typeof code === "string" && code.length > 0;
+          };
+
+          /** コミット済みなら RPC が返すはずだった形を復元する。未確定なら null。 */
+          const readCommittedImageRecords = async (): Promise<
             Array<{ id: string; storage_path: string }> | null
           > => {
-            try {
-              const { data: jobRow, error: jobError } = await supabase
-                .from("image_jobs")
-                .select("status")
-                .eq("id", jobId)
-                .maybeSingle();
-              if (jobError || jobRow?.status !== "succeeded") {
-                return null;
-              }
-
-              const { data: rows, error: rowsError } = await supabase
-                .from("generated_images")
-                .select("id, storage_path")
-                .eq("image_job_id", jobId);
-              if (rowsError || !rows || rows.length === 0) {
-                return null;
-              }
-
-              return rows
-                .map((row) => ({
-                  id: typeof row?.id === "string" ? row.id : null,
-                  storage_path:
-                    typeof row?.storage_path === "string" ? row.storage_path : null,
-                }))
-                .filter(
-                  (row): row is { id: string; storage_path: string } =>
-                    row.id !== null && row.storage_path !== null,
-                );
-            } catch (error) {
-              // 確認そのものが失敗したら「不明」として扱い、従来の後始末に委ねる
-              console.warn("[Worker] failed to verify committed persistence", {
-                jobId,
-                error,
-              });
+            const { data: jobRow, error: jobError } = await supabase
+              .from("image_jobs")
+              .select("status")
+              .eq("id", jobId)
+              .maybeSingle();
+            if (jobError || jobRow?.status !== "succeeded") {
               return null;
             }
+
+            const { data: rows, error: rowsError } = await supabase
+              .from("generated_images")
+              .select("id, storage_path")
+              .eq("image_job_id", jobId);
+            if (rowsError || !rows || rows.length === 0) {
+              return null;
+            }
+
+            const records = rows
+              .map((row) => ({
+                id: typeof row?.id === "string" ? row.id : null,
+                storage_path:
+                  typeof row?.storage_path === "string" ? row.storage_path : null,
+              }))
+              .filter(
+                (row): row is { id: string; storage_path: string } =>
+                  row.id !== null && row.storage_path !== null,
+              );
+            return records.length > 0 ? records : null;
+          };
+
+          /**
+           * 完了 RPC のエラーを 3 状態に分類する。
+           *
+           * コミットは応答が返った後に完了することがあるため、少しだけ待って
+           * 数回見に行く(bounded polling)。それでも掴めなければ unknown とし、
+           * 呼び出し側は**削除せずに**失敗させる。ジョブは再試行され、
+           * 完了 RPC は冪等なので、元トランザクションが後からコミットしていれば
+           * 再試行時に既存行が返り、そこで今回の孤児だけが掃除される。
+           */
+          const classifyCompletionOutcome = async (
+            error: unknown,
+          ): Promise<CompletionOutcome> => {
+            const attempts = 4;
+            for (let i = 0; i < attempts; i += 1) {
+              try {
+                const records = await readCommittedImageRecords();
+                if (records) {
+                  return { kind: "committed", records };
+                }
+              } catch (checkError) {
+                // 確認そのものの失敗は「未コミットの証拠」にはならない
+                console.warn("[Worker] failed to verify completion state", {
+                  jobId,
+                  checkError,
+                });
+                return { kind: "unknown" };
+              }
+              if (i < attempts - 1) {
+                await new Promise((resolve) => setTimeout(resolve, 750));
+              }
+            }
+            // サーバに届いて拒否されたことが分かっている場合だけ「失敗」と断定する
+            return isRejectedByServer(error) ? { kind: "failed" } : { kind: "unknown" };
           };
 
           /** 完了 RPC の返り値から storage_path を取り出す。 */
@@ -3167,17 +3210,26 @@ Deno.serve(async () => {
 
                 if (completeJobError) {
                   console.error("OpenAI batch completion RPC error:", completeJobError);
-                  // 応答が失われただけでコミット済みの可能性がある。消す前に確かめる。
-                  const recovered = await recoverCommittedImageRecords();
-                  if (!recovered) {
-                    await cleanupUploadedImages("persistence failure");
+                  const outcome = await classifyCompletionOutcome(completeJobError);
+                  if (outcome.kind === "committed") {
+                    console.warn(
+                      "[Worker] completion RPC response lost but the transaction was committed; keeping uploads",
+                      { jobId, images: outcome.records.length },
+                    );
+                    imageRecords = outcome.records;
+                  } else {
+                    if (outcome.kind === "failed") {
+                      // サーバに届いて拒否された = 巻き戻り済み。後始末してよい
+                      await cleanupUploadedImages("persistence failure");
+                    } else {
+                      // 結果が不明。消すと参照先を壊しうるので残す(孤児は後から掃除できる)
+                      console.warn(
+                        "[Worker] completion RPC outcome unknown; keeping uploads for reconciliation",
+                        { jobId },
+                      );
+                    }
                     throw new Error(`画像メタデータの保存に失敗しました: ${completeJobError.message}`);
                   }
-                  console.warn(
-                    "[Worker] completion RPC failed but the transaction was committed; keeping uploads",
-                    { jobId, images: recovered.length },
-                  );
-                  imageRecords = recovered;
                 }
 
                 const rpcImageRecordIds = Array.isArray(imageRecords)
@@ -3248,20 +3300,28 @@ Deno.serve(async () => {
                   "Failed to complete image job atomically:",
                   geminiCompleteError,
                 );
-                // 応答が失われただけでコミット済みの可能性がある。消す前に確かめる。
-                const recovered = await recoverCommittedImageRecords();
-                if (!recovered) {
-                  // DB に紐づかなかったアップロードを孤児にしない
-                  await cleanupUploadedImages("persistence failure");
+                const outcome = await classifyCompletionOutcome(geminiCompleteError);
+                if (outcome.kind === "committed") {
+                  console.warn(
+                    "[Worker] completion RPC response lost but the transaction was committed; keeping uploads",
+                    { jobId, images: outcome.records.length },
+                  );
+                  geminiImageRecords = outcome.records;
+                } else {
+                  if (outcome.kind === "failed") {
+                    // サーバに届いて拒否された = 巻き戻り済み。孤児にしないため消す
+                    await cleanupUploadedImages("persistence failure");
+                  } else {
+                    // 結果が不明。消すと参照先を壊しうるので残す
+                    console.warn(
+                      "[Worker] completion RPC outcome unknown; keeping uploads for reconciliation",
+                      { jobId },
+                    );
+                  }
                   throw new Error(
                     `画像メタデータの保存に失敗しました: ${geminiCompleteError.message}`,
                   );
                 }
-                console.warn(
-                  "[Worker] completion RPC failed but the transaction was committed; keeping uploads",
-                  { jobId, images: recovered.length },
-                );
-                geminiImageRecords = recovered;
               }
 
               const geminiRecordIds = Array.isArray(geminiImageRecords)

--- a/supabase/functions/image-gen-worker/index.ts
+++ b/supabase/functions/image-gen-worker/index.ts
@@ -2995,6 +2995,64 @@ Deno.serve(async () => {
             }
           };
 
+          /**
+           * 完了 RPC がエラーを返したとき、**本当に失敗したのか**を DB に問い合わせる。
+           *
+           * 520 / タイムアウト / 切断は「結果が不明」であって「失敗」ではない。
+           * RPC 側はコミット済みなのに応答だけが失われることがあり、そこで
+           * cleanupUploadedImages を走らせると **コミット済みの行が参照している
+           * 画像を消してしまう**(= 一覧に壊れた画像が出る)。
+           *
+           * 実際に 2026-08-17 に発生している:
+           *   uploading 完了 → RPC が 65 秒かかる → Cloudflare 520 →
+           *   ワーカーが失敗と判断 → 画像を削除。しかし RPC は 211ms 前に
+           *   コミット済みで、image_jobs=succeeded / generated_images の行も存在した。
+           *
+           * ジョブが succeeded かつ行が存在すれば「応答が失われただけ」なので、
+           * RPC が返すはずだった形(id / storage_path)を復元して成功経路に合流させる。
+           * 判定できない場合は null を返し、従来どおり後始末して失敗させる。
+           */
+          const recoverCommittedImageRecords = async (): Promise<
+            Array<{ id: string; storage_path: string }> | null
+          > => {
+            try {
+              const { data: jobRow, error: jobError } = await supabase
+                .from("image_jobs")
+                .select("status")
+                .eq("id", jobId)
+                .maybeSingle();
+              if (jobError || jobRow?.status !== "succeeded") {
+                return null;
+              }
+
+              const { data: rows, error: rowsError } = await supabase
+                .from("generated_images")
+                .select("id, storage_path")
+                .eq("image_job_id", jobId);
+              if (rowsError || !rows || rows.length === 0) {
+                return null;
+              }
+
+              return rows
+                .map((row) => ({
+                  id: typeof row?.id === "string" ? row.id : null,
+                  storage_path:
+                    typeof row?.storage_path === "string" ? row.storage_path : null,
+                }))
+                .filter(
+                  (row): row is { id: string; storage_path: string } =>
+                    row.id !== null && row.storage_path !== null,
+                );
+            } catch (error) {
+              // 確認そのものが失敗したら「不明」として扱い、従来の後始末に委ねる
+              console.warn("[Worker] failed to verify committed persistence", {
+                jobId,
+                error,
+              });
+              return null;
+            }
+          };
+
           /** 完了 RPC の返り値から storage_path を取り出す。 */
           const extractPersistedPaths = (rows: unknown): string[] =>
             Array.isArray(rows)
@@ -3085,7 +3143,7 @@ Deno.serve(async () => {
               });
 
               if (isOpenAIImageModel(dbModel)) {
-                const { data: imageRecords, error: completeJobError } = await supabase.rpc(
+                const { data: rpcImageRecords, error: completeJobError } = await supabase.rpc(
                   // 画像行・author secret・job 成功更新を同一トランザクションで
                   // 確定する。旧 complete_image_job_with_generated_images は
                   // 空になった prompt_text をコピーするだけで author secret を
@@ -3104,10 +3162,22 @@ Deno.serve(async () => {
                   }
                 );
 
+                // エラー時に「実際はコミット済みだった」行で差し替えるため let
+                let imageRecords: unknown = rpcImageRecords;
+
                 if (completeJobError) {
                   console.error("OpenAI batch completion RPC error:", completeJobError);
-                  await cleanupUploadedImages("persistence failure");
-                  throw new Error(`画像メタデータの保存に失敗しました: ${completeJobError.message}`);
+                  // 応答が失われただけでコミット済みの可能性がある。消す前に確かめる。
+                  const recovered = await recoverCommittedImageRecords();
+                  if (!recovered) {
+                    await cleanupUploadedImages("persistence failure");
+                    throw new Error(`画像メタデータの保存に失敗しました: ${completeJobError.message}`);
+                  }
+                  console.warn(
+                    "[Worker] completion RPC failed but the transaction was committed; keeping uploads",
+                    { jobId, images: recovered.length },
+                  );
+                  imageRecords = recovered;
                 }
 
                 const rpcImageRecordIds = Array.isArray(imageRecords)
@@ -3153,7 +3223,9 @@ Deno.serve(async () => {
               // source_image_stock_id は RPC 内で FOR UPDATE 付きに読み直した
               // ジョブの値を使う。生成中にユーザーがストック保存した場合の
               // 後追い更新も、Worker 起動時の古い値ではなく最新が反映される。
-              const { data: geminiImageRecords, error: geminiCompleteError } =
+              // エラー時に「実際はコミット済みだった」行で差し替えるため let
+              let geminiImageRecords: unknown;
+              const { data: rpcGeminiImageRecords, error: geminiCompleteError } =
                 await supabase.rpc("complete_image_job_with_prompt_secrets", {
                   p_job_id: jobId,
                   p_images: [
@@ -3169,17 +3241,27 @@ Deno.serve(async () => {
                   p_model: dbModel,
                   p_background_mode: backgroundMode,
                 });
+              geminiImageRecords = rpcGeminiImageRecords;
 
               if (geminiCompleteError) {
                 console.error(
                   "Failed to complete image job atomically:",
                   geminiCompleteError,
                 );
-                // DB に紐づかなかったアップロードを孤児にしない
-                await cleanupUploadedImages("persistence failure");
-                throw new Error(
-                  `画像メタデータの保存に失敗しました: ${geminiCompleteError.message}`,
+                // 応答が失われただけでコミット済みの可能性がある。消す前に確かめる。
+                const recovered = await recoverCommittedImageRecords();
+                if (!recovered) {
+                  // DB に紐づかなかったアップロードを孤児にしない
+                  await cleanupUploadedImages("persistence failure");
+                  throw new Error(
+                    `画像メタデータの保存に失敗しました: ${geminiCompleteError.message}`,
+                  );
+                }
+                console.warn(
+                  "[Worker] completion RPC failed but the transaction was committed; keeping uploads",
+                  { jobId, images: recovered.length },
                 );
+                geminiImageRecords = recovered;
               }
 
               const geminiRecordIds = Array.isArray(geminiImageRecords)


### PR DESCRIPTION
生成した画像が一覧で壊れて表示される事象の原因が特定できたので、その修正です。

## 起きたこと（2026-08-17 04:14 UTC・本番）

Edge Function のログから、ステージごとの所要時間が取れました。

```
charging   0.47s  ✓
generating 30.63s ✓ (OpenAI 24.73s)
uploading  2.37s  ✓ Storage 保存 完了
persisting 65.34s ✗ Cloudflare 520 (Ray ID a2c5d86f8910c981)
```

完了RPCが **65秒** かかり、Cloudflare がゲートウェイ側でタイムアウトして 520 を返しました。ワーカーはこれを失敗と判断し `cleanupUploadedImages` を実行、**直前にアップロードした画像を削除**しました。

**しかし RPC は 211ms 前にコミット済みでした。**

| 時刻 (UTC) | 出来事 |
|---|---|
| 04:14:23.548 | **RPC がコミット**（`image_jobs`=succeeded / `generated_images` に行） |
| 04:14:23.753 | ワーカーが `cleaned up 1 unpersisted uploads` を実行 |

結果、**DBは「成功」・ストレージは「空」**となり、一覧に壊れた画像が出ました。直近14日の 807件中 1件（0.12%）です。

## 原因

**「応答が返らない」を「失敗した」として扱っていました。**

520・タイムアウト・切断はいずれも**結果が不明**であり、そこで削除という取り返しのつかない補償動作を実行すると、コミット済みのデータを壊します。**再発条件は「RPCが遅いこと」だけ**なので、負荷が上がればまとめて起こり得ます。

## 対処

削除する前に、本当に失敗したのかを **DBに問い合わせます**（`recoverCommittedImageRecords`）。

```
完了RPCがエラー
  ├ ジョブが succeeded かつ generated_images に行がある
  │   → 応答が失われただけ。RPC が返すはずだった形（id / storage_path）を
  │     復元して成功経路へ合流。画像は消さない
  └ それ以外（succeeded でない・行が無い・確認自体が失敗）
      → 従来どおり後始末して失敗（安全側）
```

OpenAI経路と Gemini経路の両方に入れました。

復元した値は下流の `extractPersistedPaths` にも渡るので、**stale競合（別ワーカーが先に完了）のときは従来どおり自分のアップロードだけを消します**。復元行の `storage_path` が今回のパスと一致する通常ケースでは `keep` に入り、削除されません。

## 検証

今回の事象データ（`job d04fe1b3`）で確認しました。

| | |
|---|---|
| `image_jobs.status` | `succeeded` |
| `generated_images` の行 | 1件（`storage_path` あり） |

→ 修正後は復元側に入り、**削除されません**。

- `npm run test` — 3,534 passed
- `npm run build -- --webpack` — 成功
- Worker の型チェック — main と同じ2件のみ（`--noResolve` の副作用で、本変更由来ではありません）

## レビューで見ていただきたい点

1. **`let` への変更**。`imageRecords` / `geminiImageRecords` を `const` から `let` にして、エラー時に復元行で差し替えています。下流の `extractPersistedPaths` / `rpcImageRecordIds` が復元後の値を見ていることを確認してください。
2. **復元の判定条件**（`status === "succeeded"` かつ行が1件以上）が十分か。これで「コミット済み」と断定してよいか。
3. **stale競合との干渉**。別ワーカーが先に完了していた場合、復元行は相手の行になります。その状態で `cleanupUploadedImages("atomic completion", ...)` に渡すと自分のアップロードだけが消えます。これが意図どおりか。
4. **返金の噛み合わせ**。今回のケースでは 10ペルコインが返っていません（ワーカーは失敗と判断したのにジョブは成功でコミット済み）。修正後は成功として扱うので消費が正になりますが、**逆パターン（本当に失敗したのに返金されない）が無いか**は本PRの範囲外です。

## 未対応

- **RPCが65秒かかった原因は未解明**です。本修正は「遅くなっても壊れない」ようにするもので、遅さ自体は残ります。ユーザーは今回117秒待っています
- **Worker に自動テストがありません**（Deno側にテストファイルなし）。520 を再現する手段も無く、最終確認は本番になります

## デプロイ

`supabase functions deploy image-gen-worker` が必要です。マージ後にご一緒に行います。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mmqeUvT5TbjAMPNo6Pxsn