### PR TITLE
chore(collections): オーストラリア旅行の会期を1週間ずらし、2段構成を案内する

### DIFF
--- a/features/collections/components/AustraliaTravelGuide.tsx
+++ b/features/collections/components/AustraliaTravelGuide.tsx
@@ -458,6 +458,49 @@ export function AustraliaTravelGuide({
             </div>
           </Reveal>
 
+          {/*
+            企画(スクラップブック)は 8/29 開始だが、その前の10日間は
+            コーデ用プロンプトを毎朝公開する(企画ではなく通常の共有)。
+            前半に来た人が「今は何をすればいいのか」で迷わないよう2段構成を示す。
+            旅程が10日間なので 8/19〜8/28 が Day1〜Day10 に対応する。
+          */}
+          <Reveal delay={230}>
+            <div className="mx-auto mt-5 w-full max-w-[330px] space-y-2 text-left">
+              <div
+                className="rounded-2xl border bg-white/85 px-4 py-3"
+                style={{ borderColor: "rgba(15,127,168,0.35)" }}
+              >
+                <p
+                  className="text-[11px] font-bold tracking-wide"
+                  style={{ color: AU_OCEAN, fontFamily: HEADING_FONT }}
+                >
+                  8/19(水)〜8/28(金) ・ 旅のあいだ
+                </p>
+                <p className="mt-0.5 text-xs leading-relaxed text-[#7a6a58]">
+                  オーストラリアをめぐる
+                  <strong className="font-bold text-[#4a3b2c]">コーデのプロンプトを毎朝公開</strong>
+                  。10日間の旅を楽しんでください。
+                </p>
+              </div>
+              <div
+                className="rounded-2xl border-2 bg-white px-4 py-3"
+                style={{ borderColor: AU_OCHRE }}
+              >
+                <p
+                  className="text-[11px] font-bold tracking-wide"
+                  style={{ color: AU_OCHRE, fontFamily: HEADING_FONT }}
+                >
+                  8/29(土)〜9/6(日) ・ 旅のあと
+                </p>
+                <p className="mt-0.5 text-xs leading-relaxed text-[#7a6a58]">
+                  思い出を振り返って、
+                  <strong className="font-bold text-[#4a3b2c]">めくれる旅行日記をつくる企画</strong>
+                  がはじまります。
+                </p>
+              </div>
+            </div>
+          </Reveal>
+
           <Reveal delay={240}>
             <p className="mt-4 text-sm leading-loose text-[#7a6a58]">
               うちの子と、オーストラリアをめぐる10日間。
@@ -478,7 +521,7 @@ export function AustraliaTravelGuide({
               </svg>
             </Link>
             <p className="mt-3 text-xs text-[#9a8a78]">
-              企画がスタートしたら対象の「オーストラリア旅行」シリーズが表示されます！
+              日記づくりの企画は 8/29(土) 8:00 から。それまでは毎朝のコーデプロンプトをお楽しみください！
             </p>
           </Reveal>
         </div>

--- a/features/collections/components/AustraliaTravelGuide.tsx
+++ b/features/collections/components/AustraliaTravelGuide.tsx
@@ -433,7 +433,7 @@ export function AustraliaTravelGuide({
                 style={{ fontFamily: HEADING_FONT }}
               >
                 <span>
-                  2026/8/22
+                  2026/8/29
                   <span className="text-[11px] font-medium text-[#9a8a78]">(土)</span>{" "}
                   8:00
                 </span>
@@ -450,7 +450,7 @@ export function AustraliaTravelGuide({
                   <path d="M5 12h14M13 6l6 6-6 6" />
                 </svg>
                 <span>
-                  8/30
+                  9/6
                   <span className="text-[11px] font-medium text-[#9a8a78]">(日)</span>{" "}
                   21:59
                 </span>


### PR DESCRIPTION
企画の構成を2段に変えたことに伴う日程変更と、その案内の追加です。

## 新しい構成

| 期間 | 内容 | 扱い |
|---|---|---|
| **8/19(水)〜8/28(金)** | オーストラリアをめぐるコーデのプロンプトを毎朝公開（10日間 = Day1〜Day10） | **企画ではない**（通常のプロンプト共有） |
| **8/29(土)〜9/6(日)** | 思い出を振り返って、めくれる旅行日記をつくる | **企画本体** |

## なぜこの順序にしたか

スクラップブックのプロンプトは、8本とも**振り返りとして書かれています**。

> 写真を見返しながら手作りした旅行日記の温かさを表現する

元の順序では「まだ行っていない旅行の思い出を先に書く」構造でした。前半でコーデを楽しんでもらってから日記に入ると、**素材の設計と一致します**。

あわせて 1日2回のプロンプト共有（朝=コーデ / 夜=企画）をやめ、朝1回に集約します。反応が良い時間に寄せつつ運営負荷を下げる狙いです。

前半10日は旅程そのもの（Day1 ケアンズ 〜 Day10 空港）で、後半の日記8枚は `Day1-2` / `Day6-7` / `Day8-9` を1枚に集約した構成に対応します。

## 変更内容

| | |
|---|---|
| ガイドページの会期表記 | `2026/8/22 → 8/30` を `2026/8/29 → 9/6` へ（**JSX直書き**でDBと同期しないため手動更新） |
| 2段構成の案内（新規） | ヒーロー内に「旅のあいだ」「旅のあと」の2枚を追加 |
| CTA直下の注記 | 前半に来た人向けの文言へ変更 |

色は旅程背景と揃えました（旅のあいだ=海の青 / 旅のあと=赤い大地のオーカー）。

### 2段構成の案内を入れた理由

企画は 8/29 開始ですが、**その前の10日間もXでプロンプトを共有します**。前半にXから来た人がページを見ても「企画がスタートしたら表示されます」としか書いておらず、**今は何をすればいいのかが分からない**状態でした。

前半と後半を1枚に並べることで「旅を楽しむ → その思い出を日記にする」という繋がりも伝わります。

## DB側（このPRには含まれません）

`preset_categories.travel_to_australia` の表示期間を **8/29 08:00 〜 9/6 21:59（JST）** に更新済みです。

なお**変更前のDBは開始が 8/16 08:00 になっており**、当初予定の 8/22 ともずれていました（秒も切られていたので admin 画面からの編集と思われます）。今回正しい値で入れ直しています。

## 付随して必要な運用判断（コード変更なし）

投稿ボーナス（ワンタップ20/フリー20）とクリエイター還元（2）は**「8月31日まで」と公言済み**です。そのままだと**企画期間の途中（9/1）でユーザーのペルコイン収入が変わります**。

コンプリートには最低80ペルコイン（8枚×10）が必要なため、**9/6 まで延長する方針で決定済み**です。告知は別途行います。

## 検証

- `npm run lint` — 変更ファイルは警告0
- `npm run typecheck` — エラー0
- `npm run test` — 3,534 passed / 347 suites
- `npm run build -- --webpack` — 成功
- 実機確認 — 会期表記・2段構成の案内・CTA注記がいずれも意図どおり表示されることを確認

## マージのタイミング

**前半が始まる 8/19 より前にマージしたいです。** 前半週にXから来る人へページの案内が効くようにするためです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mmqeUvT5TbjAMPNo6Pxsn