### PR TITLE
fix(collections): 終了した企画の解放お知らせを出さないようにする

### DIFF
--- a/features/collections/lib/collection-unlock-announcement.ts
+++ b/features/collections/lib/collection-unlock-announcement.ts
@@ -1,5 +1,6 @@
 import type { StylePresetPublicSummary } from "@/features/style-presets/lib/schema";
 import { computeUnlockedCount, sequentialBatchSize } from "./collection-unlock";
+import { isCollectionDisplayPeriodActive } from "./collection-display-period";
 import type { CollectionUnlockContext } from "./collection-unlock-gating";
 
 /**
@@ -63,13 +64,16 @@ export interface CollectionUnlockAnnouncement {
  *
  * 対象は「解放ゲート付き(unlockPrerequisiteKey != null)かつ前提カテゴリ完走済み」かつ
  * 解放数が 1 以上のカテゴリのみ。前提未完走・ゲートなしカテゴリは対象外(空配列に寄与しない)。
+ * さらに**開催期間内**であることを要求する(終了した企画は告知しない)。
  *
  * @param presets サーバーで取得したプリセット一覧(sort_order 昇順)。locked 付与前でよい。
  * @param context resolveCollectionUnlockContext の結果。
+ * @param now 開催期間の判定に使う時刻(テスト用に注入可能)。
  */
 export function buildCollectionUnlockAnnouncements(
   presets: readonly StylePresetPublicSummary[],
   context: CollectionUnlockContext,
+  now: Date = new Date(),
 ): CollectionUnlockAnnouncement[] {
   // 告知対象を sort_order 昇順で集約する。対象は2系統:
   //  - 前提カテゴリ付き(例: ぷち神): 前提カテゴリ完走済みのときのみ。解放順は末尾(sort_order最大)から。
@@ -77,6 +81,28 @@ export function buildCollectionUnlockAnnouncements(
   const itemsByCategoryKey = new Map<string, StylePresetPublicSummary[]>();
   for (const preset of presets) {
     const cat = preset.category;
+    /*
+      終了した企画は告知しない。
+
+      これが無いと、開催期間を過ぎたカテゴリでも sequential/前提の条件だけで
+      対象に残り続ける。既読は localStorage(端末単位)なので、端末を変えた人・
+      ストレージを消した人・シークレットウィンドウの人には、**終了済みの企画の
+      解放モーダルが出てしまう**(実際にイタリア旅行で発生した)。
+      新しい企画の開始直後に前の企画のモーダルが混ざるのも避けたい。
+
+      期間未設定(NULL/NULL)は「常設のコラボ企画」として通す
+      (isCollectionDisplayPeriodActive の NULL=制限なし判定に合わせる)。
+      復刻で期間を開催中に戻せば、また対象に戻る。そのとき既に完走済みの人には
+      「前回見た解放数」と一致するので出ない(decideUnlockAnnouncement)。
+    */
+    if (
+      !isCollectionDisplayPeriodActive({
+        collectionDisplayStartsAt: cat.collectionDisplayStartsAt,
+        collectionDisplayEndsAt: cat.collectionDisplayEndsAt,
+      }, now)
+    ) {
+      continue;
+    }
     const prerequisite = cat.unlockPrerequisiteKey;
     const sequential = cat.sequentialUnlock === true;
     if (prerequisite) {

--- a/tests/unit/features/collections/collection-unlock-announcement.test.ts
+++ b/tests/unit/features/collections/collection-unlock-announcement.test.ts
@@ -275,3 +275,134 @@ describe("buildCollectionUnlockAnnouncements", () => {
     });
   });
 });
+
+describe("開催期間の判定", () => {
+  /*
+    終了した企画は告知しない。既読は localStorage(端末単位)なので、
+    これが無いと端末を変えた人・シークレットウィンドウの人に
+    終了済み企画の解放モーダルが出る(イタリア旅行で実際に発生した)。
+  */
+  const NOW = new Date("2026-08-17T12:00:00+09:00");
+
+  function sequentialCategory(
+    key: string,
+    period: { startsAt: string | null; endsAt: string | null },
+  ) {
+    return makeCategory(key, {
+      displayNameJa: key,
+      unlockPrerequisiteKey: null,
+      sequentialUnlock: true,
+      progressiveBatchSize: null,
+      isCollectionSeries: true,
+      completionThreshold: 3,
+      collectionDisplayStartsAt: period.startsAt,
+      collectionDisplayEndsAt: period.endsAt,
+    });
+  }
+
+  function contextFor(key: string, distinctGenerated: number): CollectionUnlockContext {
+    return {
+      prerequisiteCompletedKeys: new Set<string>(),
+      distinctGeneratedByCategoryKey: new Map([[key, distinctGenerated]]),
+      prerequisiteUniqueCountByKey: new Map(),
+    };
+  }
+
+  test("終了した企画は告知対象から外れる", () => {
+    const cat = sequentialCategory("ended", {
+      startsAt: "2026-07-03T19:00:00+09:00",
+      endsAt: "2026-07-12T21:59:00+09:00",
+    });
+    const presets = [makePreset("p1", cat), makePreset("p2", cat), makePreset("p3", cat)];
+
+    expect(
+      buildCollectionUnlockAnnouncements(presets, contextFor("ended", 3), NOW),
+    ).toEqual([]);
+  });
+
+  test("開始前の企画も告知しない", () => {
+    const cat = sequentialCategory("upcoming", {
+      startsAt: "2026-08-29T08:00:00+09:00",
+      endsAt: "2026-09-06T21:59:00+09:00",
+    });
+    const presets = [makePreset("p1", cat), makePreset("p2", cat), makePreset("p3", cat)];
+
+    expect(
+      buildCollectionUnlockAnnouncements(presets, contextFor("upcoming", 1), NOW),
+    ).toEqual([]);
+  });
+
+  test("開催中なら告知する", () => {
+    const cat = sequentialCategory("running", {
+      startsAt: "2026-08-15T08:00:00+09:00",
+      endsAt: "2026-08-30T21:59:00+09:00",
+    });
+    const presets = [makePreset("p1", cat), makePreset("p2", cat), makePreset("p3", cat)];
+
+    const result = buildCollectionUnlockAnnouncements(
+      presets,
+      contextFor("running", 1),
+      NOW,
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].categoryKey).toBe("running");
+  });
+
+  test("期間未設定は常設のコラボ企画として告知する", () => {
+    // NULL は「制限なし」。isCollectionDisplayPeriodActive の仕様に合わせる
+    const cat = sequentialCategory("evergreen", { startsAt: null, endsAt: null });
+    const presets = [makePreset("p1", cat), makePreset("p2", cat), makePreset("p3", cat)];
+
+    expect(
+      buildCollectionUnlockAnnouncements(presets, contextFor("evergreen", 1), NOW),
+    ).toHaveLength(1);
+  });
+
+  test("復刻(期間を開催中に戻す)で再び告知対象になる", () => {
+    const cat = sequentialCategory("revived", {
+      startsAt: "2026-08-16T08:00:00+09:00",
+      endsAt: "2026-08-25T21:59:00+09:00",
+    });
+    const presets = [makePreset("p1", cat), makePreset("p2", cat), makePreset("p3", cat)];
+
+    const result = buildCollectionUnlockAnnouncements(
+      presets,
+      contextFor("revived", 2),
+      NOW,
+    );
+    // 対象には戻る。実際に出すかは既読(localStorage)との比較で決まるため、
+    // 完走済みの人には decideUnlockAnnouncement 側で "none" になる
+    expect(result).toHaveLength(1);
+    expect(result[0].unlockedCount).toBe(3);
+  });
+
+  test("終了済みと開催中が混在しても、開催中だけが残る", () => {
+    const ended = sequentialCategory("ended", {
+      startsAt: "2026-07-03T19:00:00+09:00",
+      endsAt: "2026-07-12T21:59:00+09:00",
+    });
+    const running = sequentialCategory("running", {
+      startsAt: "2026-08-15T08:00:00+09:00",
+      endsAt: "2026-08-30T21:59:00+09:00",
+    });
+    const presets = [
+      makePreset("e1", ended),
+      makePreset("e2", ended),
+      makePreset("e3", ended),
+      makePreset("r1", running),
+      makePreset("r2", running),
+      makePreset("r3", running),
+    ];
+    const context: CollectionUnlockContext = {
+      prerequisiteCompletedKeys: new Set<string>(),
+      distinctGeneratedByCategoryKey: new Map([
+        ["ended", 3],
+        ["running", 1],
+      ]),
+      prerequisiteUniqueCountByKey: new Map(),
+    };
+
+    const result = buildCollectionUnlockAnnouncements(presets, context, NOW);
+    expect(result.map((a) => a.categoryKey)).toEqual(["running"]);
+  });
+});


### PR DESCRIPTION
シークレットウィンドウでオーストラリア企画をテスト中に、**7/12 に終了したイタリア旅行の解放モーダル**が表示された件の修正です。

## 起きたこと

「新たに解放！ 次の1日が解放されました！つづきを生成して旅を進めよう。」というモーダルに、イタリアの `Day1 旅行日記` 〜 `Day8 旅行日記` のサムネイルが並んで表示されました。

## 原因は2つの重なりです

### ① 対象判定に開催期間が無かった

`buildCollectionUnlockAnnouncements` のフィルタは**2条件だけ**でした。

```
・前提カテゴリ付き かつ 前提を完走済み
・または sequential_unlock = true
```

**表示期間も visibility も見ていません。** イタリアは `sequential_unlock = true` / `visibility = public` のままなので、**終了後も告知対象として生き続けていました。**

### ② 既読が端末単位

「前回見た解放数」は localStorage（`persta:collection-unlock-seen-v1`）で**端末・ブラウザ単位**です。シークレットウィンドウでは未記録なので初回扱いになります。

当該ユーザーはイタリアを**9種すべて生成済み**（`unlockedCount = 9`、基準値1）だったため条件を満たし、表示されました。

**テスト固有の事象ではありません。** 端末を買い替えた人・ストレージを消した人にも同様に起こります。さらに **8/29 のオーストラリア公開時に、前の企画のモーダルが混ざります。**

## 対処

対象判定に開催期間の条件（`isCollectionDisplayPeriodActive`）を足しました。期間未設定（NULL/NULL）は「常設のコラボ企画」として通す既存仕様に合わせています。

### 本番データでの効果（実測）

| カテゴリ | 修正後 |
|---|---|
| ぷち神 / イタリア / ことわざ上巻 / ことわざ下巻 / ファッション雑誌 | **いずれも終了済みなので告知されなくなる** |
| オーストラリア | 開催中なので告知される |

## 復刻したときの挙動

期間を開催中に戻せば再び対象に戻ります。そのうえで実際に出すかは `decideUnlockAnnouncement` が localStorage の既読と比べて決めます。

| 状況 | 結果 |
|---|---|
| 完走済み（既読9 / 現在9） | `none` → **出ない** |
| 途中（既読3 / 現在4） | `drip` → 出る（正しい） |
| プリセットを足して復刻（総数増） | `drip` → 出る（正しい） |

**「復刻したら、もう全部持っている人にまた出る」は起きません。**

## レビューで見ていただきたい点

1. **期間未設定（NULL/NULL）を「告知する」に倒した判断**。`isCollectionDisplayPeriodActive` の「NULL = 制限なし」に合わせましたが、`hasCollectionDisplayPeriod`（NULL = イベントではない）という別の見方もあります。ホームの企画棚は後者を使っています。告知はどちらの意味が正しいか。
2. **`visibility` を見ていない点**。期間だけを条件にしました。`admin_only` のカテゴリは `getPublishedStylePresets({ includeAdminOnly: isAdmin })` の段階で一般ユーザーには渡らないため二重に見る必要はない、という判断です。
3. **`now` を第3引数（既定 `new Date()`）で追加**しました。呼び出し3箇所（`unlock-announcements/route.ts`、`CachedHomeStylePresetSection`、`HomePetitUnlickPreview`）は引数を渡していないので挙動は変わりません。サーバー側の時刻を使う点で問題がないか。

## 未対応（意図的）

**既読が localStorage（端末単位）である制約は残ります。** 端末を買い替えた人には、**開催中の**企画の初回モーダルが出ます。以前「修正は見送り」と判断された件で、本PRの範囲外としました。

## 検証

- `npm run lint` — 変更ファイルは警告0
- `npm run typecheck` — エラー0
- `npm run test` — **3,540 passed**（テスト6件追加: 終了済み / 開始前 / 開催中 / 期間未設定 / 復刻 / 混在）
- `npm run build -- --webpack` — 成功
- 本番データに対して、告知対象の6カテゴリがどう変わるかをSQLで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mmqeUvT5TbjAMPNo6Pxsn