### PR TITLE
fix(my-page): 画像を削除しても表示用WebPが残る取りこぼしを直す

### DIFF
--- a/app/api/internal/account-purge/route.ts
+++ b/app/api/internal/account-purge/route.ts
@@ -2,6 +2,10 @@ import { createHash, timingSafeEqual } from "node:crypto";
 import { connection, NextRequest, NextResponse } from "next/server";
 import { env } from "@/lib/env";
 import { createAdminClient } from "@/lib/supabase/admin";
+import {
+  collectGeneratedImageStoragePaths,
+  GENERATED_IMAGE_STORAGE_PATH_COLUMNS,
+} from "@/features/generation/lib/generated-image-storage-paths";
 
 const STORAGE_BUCKET = "generated-images";
 const STORAGE_REMOVE_CHUNK_SIZE = 100;
@@ -63,9 +67,7 @@ async function collectStoragePathsForUser(
   const [generatedResult, stockResult, profileResult] = await Promise.all([
     admin
       .from("generated_images")
-      .select(
-        "storage_path, storage_path_display, storage_path_thumb, pre_generation_storage_path"
-      )
+      .select(GENERATED_IMAGE_STORAGE_PATH_COLUMNS)
       .eq("user_id", userId),
     admin
       .from("source_image_stocks")
@@ -88,11 +90,10 @@ async function collectStoragePathsForUser(
     throw new Error(`profiles query failed: ${profileResult.error.message}`);
   }
 
-  for (const row of generatedResult.data ?? []) {
-    if (row.storage_path) paths.add(row.storage_path);
-    if (row.storage_path_display) paths.add(row.storage_path_display);
-    if (row.storage_path_thumb) paths.add(row.storage_path_thumb);
-    if (row.pre_generation_storage_path) paths.add(row.pre_generation_storage_path);
+  for (const path of collectGeneratedImageStoragePaths(
+    generatedResult.data ?? []
+  )) {
+    paths.add(path);
   }
 
   for (const row of stockResult.data ?? []) {

--- a/app/api/my-page/images/route.ts
+++ b/app/api/my-page/images/route.ts
@@ -5,6 +5,10 @@ import { jsonError } from "@/lib/api/json-error";
 import { getRouteLocale } from "@/lib/api/route-locale";
 import { getMyPageRouteCopy } from "@/features/my-page/lib/route-copy";
 import { createClient } from "@/lib/supabase/server";
+import {
+  collectGeneratedImageStoragePaths,
+  GENERATED_IMAGE_STORAGE_PATH_COLUMNS,
+} from "@/features/generation/lib/generated-image-storage-paths";
 
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -96,12 +100,10 @@ export async function DELETE(request: NextRequest) {
 
   // 対象画像をまとめて取得（RLS により本人レコードのみ返る前提で user_id も明示）。
   // is_posted=false の絞り込みは DB 側で行う（in-memory フィルタ削減）。
-  // storage_path_thumb も SELECT に含めて、後の Storage 削除で孤立サムネを残さない。
+  // Storage 実体の列は 1 箇所に集約している(列を並べると取りこぼす)。
   const { data: rows, error: fetchError } = await supabase
     .from("generated_images")
-    .select(
-      "id, storage_path, storage_path_thumb, pre_generation_storage_path",
-    )
+    .select(`id, ${GENERATED_IMAGE_STORAGE_PATH_COLUMNS}`)
     .eq("user_id", user.id)
     .eq("is_posted", false)
     .in("id", imageIds);
@@ -146,16 +148,8 @@ export async function DELETE(request: NextRequest) {
   }
 
   // Storage 削除（DB 成功後に実行。失敗しても孤立ファイルが残るのみなのでログだけ残して継続）
-  // 本体 / サムネ / 生成前画像のすべてを対象に集める。
-  const storagePaths = eligibleRows.flatMap((row) => {
-    const paths: string[] = [];
-    if (row.storage_path) paths.push(row.storage_path);
-    if (row.storage_path_thumb) paths.push(row.storage_path_thumb);
-    if (row.pre_generation_storage_path) {
-      paths.push(row.pre_generation_storage_path);
-    }
-    return paths;
-  });
+  // 原本 / 表示用 / サムネ / 生成前画像のすべてを対象に集める。
+  const storagePaths = collectGeneratedImageStoragePaths(eligibleRows);
 
   if (storagePaths.length > 0) {
     const { error: storageError } = await supabase.storage

--- a/app/api/my-page/images/route.ts
+++ b/app/api/my-page/images/route.ts
@@ -6,8 +6,8 @@ import { getRouteLocale } from "@/lib/api/route-locale";
 import { getMyPageRouteCopy } from "@/features/my-page/lib/route-copy";
 import { createClient } from "@/lib/supabase/server";
 import {
-  collectGeneratedImageStoragePaths,
   GENERATED_IMAGE_STORAGE_PATH_COLUMNS,
+  resolveGeneratedImageDeletablePaths,
 } from "@/features/generation/lib/generated-image-storage-paths";
 
 const UUID_PATTERN =
@@ -147,9 +147,16 @@ export async function DELETE(request: NextRequest) {
     );
   }
 
-  // Storage 削除（DB 成功後に実行。失敗しても孤立ファイルが残るのみなのでログだけ残して継続）
-  // 原本 / 表示用 / サムネ / 生成前画像のすべてを対象に集める。
-  const storagePaths = collectGeneratedImageStoragePaths(eligibleRows);
+  /*
+    Storage 削除（DB 成功後に実行。失敗しても孤立ファイルが残るのみなのでログだけ残して継続）
+    列に入っている実測値 + 決定的に導ける派生パスの両方を消す。
+    派生(WebP変換/Before)は「upload → 列 UPDATE」の順に非同期で作られるため、
+    上の SELECT より後に upload されたぶんは列に入っておらず、
+    実測値だけでは実体が残る。
+  */
+  const storagePaths = resolveGeneratedImageDeletablePaths(
+    eligibleRows.map((row) => ({ ...row, user_id: user.id })),
+  );
 
   if (storagePaths.length > 0) {
     const { error: storageError } = await supabase.storage

--- a/features/generation/lib/generated-image-storage-paths.ts
+++ b/features/generation/lib/generated-image-storage-paths.ts
@@ -45,3 +45,58 @@ export function collectGeneratedImageStoragePaths(
   }
   return [...paths];
 }
+
+/**
+ * 行の情報から**決定的に導ける**派生パスを返す。
+ *
+ * なぜ必要か: 派生ファイル(WebP変換 / Before画像)は生成成功後に
+ * fire-and-forget で「upload → 列を UPDATE」の順に作られる。
+ * 削除が「行を SELECT した後・列が UPDATE される前」に走ると、
+ * 削除側の列には派生パスが入っておらず、実体だけが残る。
+ * 命名は元の storage_path と id から一意に決まるので、列に無くても消せる。
+ *
+ * 実在しないパスを remove しても Supabase Storage はエラーにしない
+ * (存在しないキーは黙って無視される)ため、常に足して問題ない。
+ *
+ * 命名の正本:
+ *   webp        uploadWebPVariants        `<storage_path から拡張子を除いた部分>_thumb.webp` / `_display.webp`
+ *   before画像   uploadBeforeImageWebP     `{user_id}/pre-generation/{generated_image_id}_display.webp`
+ */
+export function deriveGeneratedImageStoragePaths(row: {
+  id?: string | null;
+  user_id?: string | null;
+  storage_path?: string | null;
+}): string[] {
+  const paths: string[] = [];
+
+  if (row.storage_path) {
+    const withoutExtension = row.storage_path.replace(/\.[^.]+$/, "");
+    paths.push(`${withoutExtension}_thumb.webp`);
+    paths.push(`${withoutExtension}_display.webp`);
+  }
+
+  if (row.user_id && row.id) {
+    paths.push(`${row.user_id}/pre-generation/${row.id}_display.webp`);
+  }
+
+  return paths;
+}
+
+/**
+ * 削除時に remove すべきパスの最終形。
+ * 列に入っている実測値と、決定的に導ける派生パスの和(重複なし)。
+ */
+export function resolveGeneratedImageDeletablePaths(
+  rows: readonly (GeneratedImageStoragePathRow & {
+    id?: string | null;
+    user_id?: string | null;
+  })[],
+): string[] {
+  const paths = new Set(collectGeneratedImageStoragePaths(rows));
+  for (const row of rows) {
+    for (const derived of deriveGeneratedImageStoragePaths(row)) {
+      paths.add(derived);
+    }
+  }
+  return [...paths];
+}

--- a/features/generation/lib/generated-image-storage-paths.ts
+++ b/features/generation/lib/generated-image-storage-paths.ts
@@ -1,0 +1,47 @@
+/**
+ * generated_images 1行が持つ Storage 実体のパスを集める。
+ *
+ * 1行に対して最大4ファイルが存在する:
+ *   storage_path                  原本(png 等)          平均 約1.9MB
+ *   storage_path_display          表示用 WebP           平均 約137kB
+ *   storage_path_thumb            サムネ WebP           平均 約76kB
+ *   pre_generation_storage_path   Before 画像(生成前)
+ *
+ * **削除経路が個別に列を並べていたため取りこぼしが起きていた**
+ * (一括削除は display を、単体削除は display と thumb を消していなかった)。
+ * 列が増えたときに1箇所直せば全経路に効くよう、SELECT する列名と
+ * パスの取り出しをここに集約する。
+ */
+
+/** 削除前の SELECT にそのまま渡す列リスト。 */
+export const GENERATED_IMAGE_STORAGE_PATH_COLUMNS =
+  "storage_path, storage_path_display, storage_path_thumb, pre_generation_storage_path";
+
+export interface GeneratedImageStoragePathRow {
+  storage_path?: string | null;
+  storage_path_display?: string | null;
+  storage_path_thumb?: string | null;
+  pre_generation_storage_path?: string | null;
+}
+
+/**
+ * 行から Storage パスを重複なしで取り出す。
+ *
+ * ゲストのワードローブ引き継ぎ(save-wardrobe-image)は3列すべてに**同じパス**を
+ * 入れるため、重複除去が必要(同じパスを複数回 remove しても実害はないが、
+ * 「消したファイル数」を数える側が実態とずれる)。
+ */
+export function collectGeneratedImageStoragePaths(
+  rows: readonly GeneratedImageStoragePathRow[],
+): string[] {
+  const paths = new Set<string>();
+  for (const row of rows) {
+    if (row.storage_path) paths.add(row.storage_path);
+    if (row.storage_path_display) paths.add(row.storage_path_display);
+    if (row.storage_path_thumb) paths.add(row.storage_path_thumb);
+    if (row.pre_generation_storage_path) {
+      paths.add(row.pre_generation_storage_path);
+    }
+  }
+  return [...paths];
+}

--- a/features/generation/lib/webp-storage.ts
+++ b/features/generation/lib/webp-storage.ts
@@ -28,7 +28,12 @@ export type EnsureWebPVariantsResult =
     }
   | {
       status: "skipped";
-      reason: "already-exists" | "image-not-found" | "missing-source";
+      reason:
+        | "already-exists"
+        | "image-not-found"
+        | "missing-source"
+        /** アップロード中に行が削除された。実体は片付け済み。 */
+        | "image-deleted";
     };
 
 type EnsureWebPVariantsDependencies = {
@@ -155,25 +160,51 @@ export async function uploadWebPVariants(
  * @param imageId 画像ID
  * @param thumbPath サムネイルWebPのストレージパス
  * @param displayPath 表示用WebPのストレージパス
+ * @returns 更新できたか。false = 対象行が既に無い（削除された）
+ *
+ * 対象行が消えていても error にはならない(UPDATE の 0 行は正常)。
+ * ここで区別できないと、アップロード済みの WebP が誰からも参照されない
+ * 実体として残る。呼び出し側が片付けられるよう真偽値で返す。
  */
 export async function updateWebPStoragePaths(
   imageId: string,
   thumbPath: string,
   displayPath: string
-): Promise<void> {
+): Promise<{ updated: boolean }> {
   const supabase = createAdminClient();
 
-  const { error } = await supabase
+  const { data, error } = await supabase
     .from("generated_images")
     .update({
       storage_path_thumb: thumbPath,
       storage_path_display: displayPath,
     })
-    .eq("id", imageId);
+    .eq("id", imageId)
+    .select("id");
 
   if (error) {
     console.error("WebPストレージパスの更新に失敗しました:", error);
     throw new Error(`WebPストレージパスの更新に失敗しました: ${error.message}`);
+  }
+
+  return { updated: (data ?? []).length > 0 };
+}
+
+/**
+ * 登録できなかった WebP の実体を消す。失敗してもログのみ(孤立ファイルが残るだけ)。
+ */
+async function removeUnregisteredWebPVariants(
+  paths: readonly string[],
+  supabase: ReturnType<typeof createAdminClient>
+): Promise<void> {
+  const { error } = await supabase.storage
+    .from(STORAGE_BUCKET)
+    .remove([...paths]);
+  if (error) {
+    console.warn(
+      "[webp-storage] failed to remove unregistered variants:",
+      { paths, error: error.message }
+    );
   }
 }
 
@@ -235,7 +266,24 @@ export async function ensureWebPVariants(
     3
   );
 
-  await updateStoragePaths(image.id, thumbPath, displayPath);
+  /*
+    生成成功後に fire-and-forget で走るため、この間にユーザーが画像を
+    削除していることがある。UPDATE の 0 行は error にならないので、
+    ここで検知してアップロード済みの実体を片付ける。
+    そうしないと「誰からも参照されない WebP」が残る。
+  */
+  const { updated } = await updateStoragePaths(image.id, thumbPath, displayPath);
+  if (!updated) {
+    await removeUnregisteredWebPVariants(
+      [thumbPath, displayPath],
+      deps.supabase ?? createAdminClient()
+    );
+    return {
+      status: "skipped",
+      reason: "image-deleted",
+    };
+  }
+
   revalidateGeneratedImageTags(image, revalidateTagFn);
 
   return {

--- a/features/my-page/lib/api.ts
+++ b/features/my-page/lib/api.ts
@@ -2,8 +2,8 @@ import { createClient } from "@/lib/supabase/client";
 import { resolveOwnVisiblePrompts } from "@/features/generation/lib/prompt-secrets-client";
 import type { GeneratedImageRecord } from "@/features/generation/lib/database";
 import {
-  collectGeneratedImageStoragePaths,
   GENERATED_IMAGE_STORAGE_PATH_COLUMNS,
+  resolveGeneratedImageDeletablePaths,
 } from "@/features/generation/lib/generated-image-storage-paths";
 import {
   redactSensitivePrompt,
@@ -335,8 +335,12 @@ export async function deleteMyImage(
   }
 
   // Storage から削除（原本 / 表示用 / サムネ / Before）。
+  // 列の実測値に加えて、決定的に導ける派生パスも消す(上の SELECT より後に
+  // 非同期で upload されたぶんは列に入っていない)。
   // 失敗しても孤立ファイルが残るだけなのでログに留める。
-  const pathsToRemove = collectGeneratedImageStoragePaths([image]);
+  const pathsToRemove = resolveGeneratedImageDeletablePaths([
+    { ...image, id: imageId },
+  ]);
   if (pathsToRemove.length > 0) {
     const { error: storageError } = await supabase.storage
       .from("generated-images")

--- a/features/my-page/lib/api.ts
+++ b/features/my-page/lib/api.ts
@@ -2,6 +2,10 @@ import { createClient } from "@/lib/supabase/client";
 import { resolveOwnVisiblePrompts } from "@/features/generation/lib/prompt-secrets-client";
 import type { GeneratedImageRecord } from "@/features/generation/lib/database";
 import {
+  collectGeneratedImageStoragePaths,
+  GENERATED_IMAGE_STORAGE_PATH_COLUMNS,
+} from "@/features/generation/lib/generated-image-storage-paths";
+import {
   redactSensitivePrompt,
   redactSensitivePrompts,
 } from "@/features/generation/lib/prompt-visibility";
@@ -298,7 +302,7 @@ export async function deleteMyImage(
   // 画像情報を取得してStorageパスを確認
   const { data: image, error: fetchError } = await supabase
     .from("generated_images")
-    .select("storage_path, user_id, pre_generation_storage_path")
+    .select(`user_id, ${GENERATED_IMAGE_STORAGE_PATH_COLUMNS}`)
     .eq("id", imageId)
     .single();
 
@@ -312,20 +316,12 @@ export async function deleteMyImage(
     );
   }
 
-  // Storage から削除（生成画像本体 + Before（あれば））
-  const pathsToRemove = [image.storage_path];
-  if (image.pre_generation_storage_path) {
-    pathsToRemove.push(image.pre_generation_storage_path);
-  }
-  const { error: storageError } = await supabase.storage
-    .from("generated-images")
-    .remove(pathsToRemove);
-
-  if (storageError) {
-    console.error("Storage delete error:", storageError);
-  }
-
-  // データベースから削除
+  /*
+    DB → Storage の順で消す(一括削除と同じ順序)。
+    Storage を先に消すと、DB 削除が失敗したときに「行はあるが実体が無い」
+    = 表示が壊れた画像が残る。DB を真実とし Storage を後追いにすれば、
+    最悪でも孤立ファイルが残るだけで、後から掃除できる。
+  */
   const { error: deleteError } = await supabase
     .from("generated_images")
     .delete()
@@ -336,6 +332,19 @@ export async function deleteMyImage(
     throw new Error(
       `${messages?.deleteImageFailed || "画像の削除に失敗しました"}: ${deleteError.message}`
     );
+  }
+
+  // Storage から削除（原本 / 表示用 / サムネ / Before）。
+  // 失敗しても孤立ファイルが残るだけなのでログに留める。
+  const pathsToRemove = collectGeneratedImageStoragePaths([image]);
+  if (pathsToRemove.length > 0) {
+    const { error: storageError } = await supabase.storage
+      .from("generated-images")
+      .remove(pathsToRemove);
+
+    if (storageError) {
+      console.error("Storage delete error:", storageError);
+    }
   }
 }
 

--- a/features/posts/lib/before-image-storage.ts
+++ b/features/posts/lib/before-image-storage.ts
@@ -175,6 +175,10 @@ export async function persistBeforeImageFromUrl(
 
 /**
  * generated_images.pre_generation_storage_path を更新する。
+ *
+ * 対象行が既に削除されていた場合、UPDATE は 0 行で成功する(error にならない)。
+ * そのままだとアップロード済みの Before 画像が誰からも参照されない実体として
+ * 残るため、その場で片付ける。
  */
 export async function updatePreGenerationStoragePath(
   generatedImageId: string,
@@ -183,15 +187,32 @@ export async function updatePreGenerationStoragePath(
 ): Promise<void> {
   const supabase = createAdminClient();
 
-  const { error } = await supabase
+  const { data, error } = await supabase
     .from("generated_images")
     .update({ pre_generation_storage_path: path })
     .eq("id", generatedImageId)
-    .eq("user_id", userId);
+    .eq("user_id", userId)
+    .select("id");
 
   if (error) {
     console.error("[BeforeImage] failed to update pre_generation_storage_path:", error);
     throw new Error(`pre_generation_storage_path update failed: ${error.message}`);
+  }
+
+  if ((data ?? []).length === 0) {
+    console.warn(
+      "[BeforeImage] target row is gone; removing unregistered before image:",
+      { generatedImageId, path }
+    );
+    const { error: removeError } = await supabase.storage
+      .from(STORAGE_BUCKET)
+      .remove([path]);
+    if (removeError) {
+      console.warn("[BeforeImage] failed to remove unregistered before image:", {
+        path,
+        error: removeError.message,
+      });
+    }
   }
 }
 

--- a/tests/integration/api/my-page-images-bulk-delete-route.test.ts
+++ b/tests/integration/api/my-page-images-bulk-delete-route.test.ts
@@ -23,6 +23,7 @@ interface FakeRow {
   // ルートに返却される rows は必ず is_posted=false の前提。
   is_posted?: boolean;
   storage_path: string | null;
+  storage_path_display?: string | null;
   storage_path_thumb?: string | null;
   pre_generation_storage_path: string | null;
 }
@@ -156,6 +157,34 @@ describe("DELETE /api/my-page/images (bulk delete)", () => {
     // DB 削除は eligible な ID のみで実行され、本人 user_id で絞られている
     expect(deleteIn).toHaveBeenCalledWith("id", [UUID_A, UUID_B]);
     expect(deleteEq).toHaveBeenCalledWith("user_id", "user-1");
+  });
+
+  test("表示用WebPとサムネも Storage から削除する", async () => {
+    // 修正前は storage_path_display を消しておらず、削除ごとに
+    // 平均137kB の表示用WebPが残り続けていた(孤児の供給源)。
+    const { supabase, storageRemove } = buildSupabase({
+      rows: [
+        {
+          id: UUID_A,
+          is_posted: false,
+          storage_path: "user-1/a.png",
+          storage_path_display: "user-1/a_display.webp",
+          storage_path_thumb: "user-1/a_thumb.webp",
+          pre_generation_storage_path: "user-1/a-before.png",
+        },
+      ],
+    });
+    mockCreateClient.mockResolvedValue(supabase as never);
+
+    const res = await DELETE(createRequest({ imageIds: [UUID_A] }));
+
+    expect(res.status).toBe(200);
+    expect(storageRemove).toHaveBeenCalledWith([
+      "user-1/a.png",
+      "user-1/a_display.webp",
+      "user-1/a_thumb.webp",
+      "user-1/a-before.png",
+    ]);
   });
 
   test("投稿済みが混在する場合_投稿済みは failed に、未投稿のみ削除される", async () => {

--- a/tests/integration/api/my-page-images-bulk-delete-route.test.ts
+++ b/tests/integration/api/my-page-images-bulk-delete-route.test.ts
@@ -147,11 +147,18 @@ describe("DELETE /api/my-page/images (bulk delete)", () => {
     // 削除順は DB → Storage（壊れた DB レコードを残さないため）
     expect(callOrder).toEqual(["db_delete", "storage_remove"]);
 
-    // Storage は本体 + Before を含めて remove される
+    // Storage は本体 + Before に加えて、決定的に導ける派生パスも remove される
+    // (SELECT より後に非同期で upload された派生を取りこぼさないため)
     expect(storageRemove).toHaveBeenCalledWith([
       "user-1/a.png",
       "user-1/a-before.png",
       "user-1/b.png",
+      "user-1/a_thumb.webp",
+      "user-1/a_display.webp",
+      `user-1/pre-generation/${UUID_A}_display.webp`,
+      "user-1/b_thumb.webp",
+      "user-1/b_display.webp",
+      `user-1/pre-generation/${UUID_B}_display.webp`,
     ]);
 
     // DB 削除は eligible な ID のみで実行され、本人 user_id で絞られている
@@ -184,6 +191,7 @@ describe("DELETE /api/my-page/images (bulk delete)", () => {
       "user-1/a_display.webp",
       "user-1/a_thumb.webp",
       "user-1/a-before.png",
+      `user-1/pre-generation/${UUID_A}_display.webp`,
     ]);
   });
 

--- a/tests/unit/features/generation/generated-image-storage-paths.test.ts
+++ b/tests/unit/features/generation/generated-image-storage-paths.test.ts
@@ -1,6 +1,8 @@
 import {
   collectGeneratedImageStoragePaths,
+  deriveGeneratedImageStoragePaths,
   GENERATED_IMAGE_STORAGE_PATH_COLUMNS,
+  resolveGeneratedImageDeletablePaths,
 } from "@/features/generation/lib/generated-image-storage-paths";
 
 describe("collectGeneratedImageStoragePaths", () => {
@@ -72,5 +74,72 @@ describe("collectGeneratedImageStoragePaths", () => {
     ]) {
       expect(GENERATED_IMAGE_STORAGE_PATH_COLUMNS).toContain(column);
     }
+  });
+});
+
+describe("deriveGeneratedImageStoragePaths", () => {
+  test("storage_path から _thumb / _display を導く", () => {
+    expect(
+      deriveGeneratedImageStoragePaths({ storage_path: "u/abc-0-xyz.png" }),
+    ).toEqual(["u/abc-0-xyz_thumb.webp", "u/abc-0-xyz_display.webp"]);
+  });
+
+  test("user_id と id から Before 画像のパスを導く", () => {
+    expect(
+      deriveGeneratedImageStoragePaths({ id: "img-1", user_id: "u1" }),
+    ).toEqual(["u1/pre-generation/img-1_display.webp"]);
+  });
+
+  test("拡張子が無い/複数ドットでも最後の拡張子だけを落とす", () => {
+    expect(
+      deriveGeneratedImageStoragePaths({ storage_path: "u/a.b.c.png" }),
+    ).toEqual(["u/a.b.c_thumb.webp", "u/a.b.c_display.webp"]);
+  });
+
+  test("材料が無ければ何も導かない", () => {
+    expect(deriveGeneratedImageStoragePaths({})).toEqual([]);
+    expect(
+      // id だけ / user_id だけでは Before 画像のパスは決まらない
+      deriveGeneratedImageStoragePaths({ id: "img-1" }),
+    ).toEqual([]);
+  });
+});
+
+describe("resolveGeneratedImageDeletablePaths", () => {
+  test("列が空でも導出したパスを消せる(SELECT後にuploadされた派生を拾う)", () => {
+    // 派生は「upload → 列 UPDATE」の順に非同期で作られるため、
+    // 削除側が行を読んだ時点では列が空のことがある。
+    expect(
+      resolveGeneratedImageDeletablePaths([
+        {
+          id: "img-1",
+          user_id: "u1",
+          storage_path: "u1/img-1.png",
+          storage_path_display: null,
+          storage_path_thumb: null,
+          pre_generation_storage_path: null,
+        },
+      ]),
+    ).toEqual([
+      "u1/img-1.png",
+      "u1/img-1_thumb.webp",
+      "u1/img-1_display.webp",
+      "u1/pre-generation/img-1_display.webp",
+    ]);
+  });
+
+  test("列が埋まっていれば導出ぶんは重複として畳まれる", () => {
+    expect(
+      resolveGeneratedImageDeletablePaths([
+        {
+          id: "img-1",
+          user_id: "u1",
+          storage_path: "u1/img-1.png",
+          storage_path_display: "u1/img-1_display.webp",
+          storage_path_thumb: "u1/img-1_thumb.webp",
+          pre_generation_storage_path: "u1/pre-generation/img-1_display.webp",
+        },
+      ]),
+    ).toHaveLength(4);
   });
 });

--- a/tests/unit/features/generation/generated-image-storage-paths.test.ts
+++ b/tests/unit/features/generation/generated-image-storage-paths.test.ts
@@ -1,0 +1,76 @@
+import {
+  collectGeneratedImageStoragePaths,
+  GENERATED_IMAGE_STORAGE_PATH_COLUMNS,
+} from "@/features/generation/lib/generated-image-storage-paths";
+
+describe("collectGeneratedImageStoragePaths", () => {
+  test("1行が持つ4種のパスをすべて集める", () => {
+    expect(
+      collectGeneratedImageStoragePaths([
+        {
+          storage_path: "u/a.png",
+          storage_path_display: "u/a_display.webp",
+          storage_path_thumb: "u/a_thumb.webp",
+          pre_generation_storage_path: "u/pre-generation/a.webp",
+        },
+      ]),
+    ).toEqual([
+      "u/a.png",
+      "u/a_display.webp",
+      "u/a_thumb.webp",
+      "u/pre-generation/a.webp",
+    ]);
+  });
+
+  test("null / undefined / 空文字は落とす", () => {
+    expect(
+      collectGeneratedImageStoragePaths([
+        {
+          storage_path: "u/a.png",
+          storage_path_display: null,
+          storage_path_thumb: undefined,
+          pre_generation_storage_path: "",
+        },
+      ]),
+    ).toEqual(["u/a.png"]);
+  });
+
+  test("同じパスは1回だけ返す(ワードローブ引き継ぎは3列が同一)", () => {
+    const shared = "u/wardrobe.webp";
+    expect(
+      collectGeneratedImageStoragePaths([
+        {
+          storage_path: shared,
+          storage_path_display: shared,
+          storage_path_thumb: shared,
+          pre_generation_storage_path: null,
+        },
+      ]),
+    ).toEqual([shared]);
+  });
+
+  test("複数行をまたいで重複を除く", () => {
+    expect(
+      collectGeneratedImageStoragePaths([
+        { storage_path: "u/a.png", storage_path_display: "u/shared.webp" },
+        { storage_path: "u/b.png", storage_path_display: "u/shared.webp" },
+      ]),
+    ).toEqual(["u/a.png", "u/shared.webp", "u/b.png"]);
+  });
+
+  test("空配列では空を返す", () => {
+    expect(collectGeneratedImageStoragePaths([])).toEqual([]);
+  });
+
+  test("SELECT 列リストに4列すべてが含まれる", () => {
+    // 列を足したときにここが落ちれば、取り出し側の追従漏れに気づける。
+    for (const column of [
+      "storage_path",
+      "storage_path_display",
+      "storage_path_thumb",
+      "pre_generation_storage_path",
+    ]) {
+      expect(GENERATED_IMAGE_STORAGE_PATH_COLUMNS).toContain(column);
+    }
+  });
+});

--- a/tests/unit/features/my-page/delete-my-image.test.ts
+++ b/tests/unit/features/my-page/delete-my-image.test.ts
@@ -81,6 +81,9 @@ describe("deleteMyImage", () => {
       expect(mock.select).toHaveBeenCalledWith(
         `user_id, ${GENERATED_IMAGE_STORAGE_PATH_COLUMNS}`,
       );
+      // 列の実測値 + 決定的に導ける派生パス。
+      // このケースは列がすべて埋まっているので導出ぶんは全部重複し、
+      // 4件に畳まれる(remove を無駄に膨らませない)。
       expect(mock.remove).toHaveBeenCalledWith([
         "user-1/img-1.png",
         "user-1/img-1_display.webp",
@@ -125,10 +128,19 @@ describe("deleteMyImage", () => {
 
     await deleteMyImage("img-1");
 
-    expect(mock.remove).toHaveBeenCalledWith([sharedPath]);
+    // 実測値は1つに畳まれる。導出ぶんは実在しなければ remove が無視するだけ。
+    expect(mock.remove).toHaveBeenCalledWith([
+      sharedPath,
+      "user-1/wardrobe-1_thumb.webp",
+      "user-1/wardrobe-1_display.webp",
+      "user-1/pre-generation/img-1_display.webp",
+    ]);
   });
 
-  test("Storage パスが無い行では remove を呼ばない", async () => {
+  test("列が空でも導出できる Before 画像のパスは remove する", async () => {
+    // Before 画像は upload → 列 UPDATE の順で作られる。列が空でも
+    // 実体が既にあることがあり、そのぶんを取りこぼさない。
+    // 実在しないパスの remove は Supabase 側でエラーにならない。
     const mock = buildDeleteClient({
       storage_path: null,
       storage_path_display: null,
@@ -140,6 +152,8 @@ describe("deleteMyImage", () => {
 
     await deleteMyImage("img-1");
 
-    expect(mock.remove).not.toHaveBeenCalled();
+    expect(mock.remove).toHaveBeenCalledWith([
+      "user-1/pre-generation/img-1_display.webp",
+    ]);
   });
 });

--- a/tests/unit/features/my-page/delete-my-image.test.ts
+++ b/tests/unit/features/my-page/delete-my-image.test.ts
@@ -2,6 +2,7 @@
 
 import { createClient } from "@/lib/supabase/client";
 import { deleteMyImage } from "@/features/my-page/lib/api";
+import { GENERATED_IMAGE_STORAGE_PATH_COLUMNS } from "@/features/generation/lib/generated-image-storage-paths";
 
 jest.mock("@/lib/supabase/client", () => ({
   createClient: jest.fn(),
@@ -14,13 +15,22 @@ jest.mock("@/features/generation/lib/prompt-visibility", () => ({
 
 const createClientMock = createClient as jest.MockedFunction<typeof createClient>;
 
-function buildDeleteClient(image: {
-  storage_path: string;
+interface DeleteTargetImage {
+  storage_path: string | null;
+  storage_path_display?: string | null;
+  storage_path_thumb?: string | null;
   pre_generation_storage_path: string | null;
   user_id: string;
-}) {
+}
+
+function buildDeleteClient(
+  image: DeleteTargetImage,
+  overrides: { deleteError?: { message: string } } = {},
+) {
   const remove = jest.fn().mockResolvedValue({ error: null });
-  const deleteEqUser = jest.fn().mockResolvedValue({ error: null });
+  const deleteEqUser = jest
+    .fn()
+    .mockResolvedValue({ error: overrides.deleteError ?? null });
   const deleteEqId = jest.fn(() => ({ eq: deleteEqUser }));
   const deleteFn = jest.fn(() => ({ eq: deleteEqId }));
   const single = jest.fn().mockResolvedValue({ data: image, error: null });
@@ -55,24 +65,81 @@ describe("deleteMyImage", () => {
     jest.clearAllMocks();
   });
 
-  test("生成画像本体とBefore画像のStorageパスをまとめて削除する", async () => {
+  test("原本・表示用・サムネ・Before の4ファイルをまとめて削除する", () => {
+    // 修正前は表示用(_display)とサムネ(_thumb)を消しておらず、
+    // 削除ごとに実体が残り続けていた(表示用は平均137kB)。
     const mock = buildDeleteClient({
-      storage_path: "user-1/generated/img-1.webp",
+      storage_path: "user-1/img-1.png",
+      storage_path_display: "user-1/img-1_display.webp",
+      storage_path_thumb: "user-1/img-1_thumb.webp",
       pre_generation_storage_path: "user-1/pre-generation/img-1_display.webp",
+      user_id: "user-1",
+    });
+    createClientMock.mockReturnValue(mock.client as never);
+
+    return deleteMyImage("img-1").then(() => {
+      expect(mock.select).toHaveBeenCalledWith(
+        `user_id, ${GENERATED_IMAGE_STORAGE_PATH_COLUMNS}`,
+      );
+      expect(mock.remove).toHaveBeenCalledWith([
+        "user-1/img-1.png",
+        "user-1/img-1_display.webp",
+        "user-1/img-1_thumb.webp",
+        "user-1/pre-generation/img-1_display.webp",
+      ]);
+      expect(mock.deleteEqId).toHaveBeenCalledWith("id", "img-1");
+      expect(mock.deleteEqUser).toHaveBeenCalledWith("user_id", "user-1");
+    });
+  });
+
+  test("DB 削除が失敗したら Storage は消さない(壊れた画像を作らない)", async () => {
+    // Storage を先に消すと「行はあるが実体が無い」= 表示が壊れた画像になる。
+    // DB を真実とし、Storage は後追いにする。
+    const mock = buildDeleteClient(
+      {
+        storage_path: "user-1/img-1.png",
+        storage_path_display: "user-1/img-1_display.webp",
+        storage_path_thumb: null,
+        pre_generation_storage_path: null,
+        user_id: "user-1",
+      },
+      { deleteError: { message: "permission denied" } },
+    );
+    createClientMock.mockReturnValue(mock.client as never);
+
+    await expect(deleteMyImage("img-1")).rejects.toThrow(/permission denied/);
+    expect(mock.remove).not.toHaveBeenCalled();
+  });
+
+  test("同じパスが複数列に入っていても1回だけ remove する", async () => {
+    // ゲストのワードローブ引き継ぎ(save-wardrobe-image)は3列すべてに同じパスを入れる。
+    const sharedPath = "user-1/wardrobe-1.webp";
+    const mock = buildDeleteClient({
+      storage_path: sharedPath,
+      storage_path_display: sharedPath,
+      storage_path_thumb: sharedPath,
+      pre_generation_storage_path: null,
       user_id: "user-1",
     });
     createClientMock.mockReturnValue(mock.client as never);
 
     await deleteMyImage("img-1");
 
-    expect(mock.select).toHaveBeenCalledWith(
-      "storage_path, user_id, pre_generation_storage_path"
-    );
-    expect(mock.remove).toHaveBeenCalledWith([
-      "user-1/generated/img-1.webp",
-      "user-1/pre-generation/img-1_display.webp",
-    ]);
-    expect(mock.deleteEqId).toHaveBeenCalledWith("id", "img-1");
-    expect(mock.deleteEqUser).toHaveBeenCalledWith("user_id", "user-1");
+    expect(mock.remove).toHaveBeenCalledWith([sharedPath]);
+  });
+
+  test("Storage パスが無い行では remove を呼ばない", async () => {
+    const mock = buildDeleteClient({
+      storage_path: null,
+      storage_path_display: null,
+      storage_path_thumb: null,
+      pre_generation_storage_path: null,
+      user_id: "user-1",
+    });
+    createClientMock.mockReturnValue(mock.client as never);
+
+    await deleteMyImage("img-1");
+
+    expect(mock.remove).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/features/posts/before-image-storage.test.ts
+++ b/tests/unit/features/posts/before-image-storage.test.ts
@@ -306,6 +306,46 @@ describe("updatePreGenerationStoragePath", () => {
     expect(consoleError).toHaveBeenCalled();
     consoleError.mockRestore();
   });
+
+  test("対象行が既に削除されていたらアップロード済みのBefore画像を消す", async () => {
+    // 生成成功後に fire-and-forget で走るため、この間にユーザーが削除できる。
+    // UPDATE の 0 行は error にならないので、行数で検知して実体を片付ける。
+    const consoleWarn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const mock = buildSupabaseMock({
+      generatedImageRow: null,
+      imageJobRow: null,
+      updateResult: { data: [], error: null },
+    });
+    createAdminClientMock.mockReturnValue(mock.client);
+
+    await updatePreGenerationStoragePath(
+      "img-1",
+      "u1",
+      "u1/pre-generation/img-1_display.webp"
+    );
+
+    expect(mock.removeFn).toHaveBeenCalledWith([
+      "u1/pre-generation/img-1_display.webp",
+    ]);
+    consoleWarn.mockRestore();
+  });
+
+  test("更新できた場合はBefore画像を消さない", async () => {
+    const mock = buildSupabaseMock({
+      generatedImageRow: null,
+      imageJobRow: null,
+      updateResult: { data: [{ id: "img-1" }], error: null },
+    });
+    createAdminClientMock.mockReturnValue(mock.client);
+
+    await updatePreGenerationStoragePath(
+      "img-1",
+      "u1",
+      "u1/pre-generation/img-1_display.webp"
+    );
+
+    expect(mock.removeFn).not.toHaveBeenCalled();
+  });
 });
 
 type SupabaseQueryResult<T> = {
@@ -320,11 +360,16 @@ function buildSupabaseMock(opts: {
   imageJobRow: { input_image_url: string | null } | null;
   uploadResult?: SupabaseQueryResult<{ path: string } | null>;
   removeResult?: SupabaseQueryResult<unknown>;
-  updateResult?: { error: { message: string } | null };
+  updateResult?: { data?: { id: string }[]; error: { message: string } | null };
 }) {
-  const updateEqEq = jest
-    .fn()
-    .mockResolvedValue(opts.updateResult ?? { error: null });
+  // update(...).eq(...).eq(...).select("id") まで繋ぐ。
+  // select が返す行数で「対象行がまだ在るか」を判定するため、
+  // 既定は 1 行(=更新できた)にしておく。
+  const updateSelect = jest.fn().mockResolvedValue({
+    data: opts.updateResult?.data ?? [{ id: "img-1" }],
+    error: opts.updateResult?.error ?? null,
+  });
+  const updateEqEq = jest.fn(() => ({ select: updateSelect }));
   const updateEq1 = jest.fn(() => ({ eq: updateEqEq }));
   const updateFn = jest.fn(() => ({ eq: updateEq1 }));
 

--- a/tests/unit/lib/webp-storage.test.ts
+++ b/tests/unit/lib/webp-storage.test.ts
@@ -7,13 +7,17 @@ function createSupabaseMock(image: Record<string, unknown> | null) {
   const eq = jest.fn(() => ({ maybeSingle }));
   const select = jest.fn(() => ({ eq }));
   const from = jest.fn(() => ({ select }));
+  // 登録できなかった variants を消す経路で使う
+  const remove = jest.fn().mockResolvedValue({ error: null });
+  const storageFrom = jest.fn(() => ({ remove }));
 
   return {
-    client: { from },
+    client: { from, storage: { from: storageFrom } },
     from,
     select,
     eq,
     maybeSingle,
+    remove,
   };
 }
 
@@ -64,7 +68,7 @@ describe("ensureWebPVariants", () => {
       thumbPath: "user-2/original_thumb.webp",
       displayPath: "user-2/original_display.webp",
     });
-    const updateStoragePaths = jest.fn().mockResolvedValue(undefined);
+    const updateStoragePaths = jest.fn().mockResolvedValue({ updated: true });
     const revalidateTagFn = jest.fn();
 
     const result = await ensureWebPVariants("image-2", {
@@ -118,7 +122,7 @@ describe("ensureWebPVariants", () => {
       thumbPath: "user-4/original_thumb.webp",
       displayPath: "user-4/original_display.webp",
     });
-    const updateStoragePaths = jest.fn().mockResolvedValue(undefined);
+    const updateStoragePaths = jest.fn().mockResolvedValue({ updated: true });
     const revalidateTagFn = jest.fn();
 
     await ensureWebPVariants("image-4", {
@@ -153,7 +157,7 @@ describe("ensureWebPVariants", () => {
       thumbPath: "user-5/original_thumb.webp",
       displayPath: "user-5/original_display.webp",
     });
-    const updateStoragePaths = jest.fn().mockResolvedValue(undefined);
+    const updateStoragePaths = jest.fn().mockResolvedValue({ updated: true });
     const revalidateTagFn = jest.fn();
 
     const result = await ensureWebPVariants("image-5", {
@@ -232,5 +236,43 @@ describe("ensureWebPVariants", () => {
     expect(uploadVariants).not.toHaveBeenCalled();
     expect(updateStoragePaths).not.toHaveBeenCalled();
     expect(revalidateTagFn).not.toHaveBeenCalled();
+  });
+
+  test("アップロード中に行が削除された場合_実体を消してskippedを返す", async () => {
+    // 生成成功後に fire-and-forget で走るため、この間に削除できる。
+    // UPDATE の 0 行は error にならないので、更新できたかで判定する。
+    const consoleWarn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const supabase = createSupabaseMock({
+      id: "image-9",
+      user_id: "user-9",
+      image_url: "https://example.com/original.png",
+      storage_path: "user-9/original.png",
+      storage_path_thumb: null,
+      storage_path_display: null,
+      is_posted: false,
+    });
+    const uploadVariants = jest.fn().mockResolvedValue({
+      thumbPath: "user-9/original_thumb.webp",
+      displayPath: "user-9/original_display.webp",
+    });
+    const updateStoragePaths = jest.fn().mockResolvedValue({ updated: false });
+    const revalidateTagFn = jest.fn();
+
+    const result = await ensureWebPVariants("image-9", {
+      supabase: supabase.client as never,
+      uploadVariants,
+      updateStoragePaths,
+      revalidateTagFn,
+    });
+
+    expect(result).toEqual({ status: "skipped", reason: "image-deleted" });
+    // 参照されない実体を残さない
+    expect(supabase.remove).toHaveBeenCalledWith([
+      "user-9/original_thumb.webp",
+      "user-9/original_display.webp",
+    ]);
+    // 行が無いのでキャッシュ再検証はしない
+    expect(revalidateTagFn).not.toHaveBeenCalled();
+    consoleWarn.mockRestore();
   });
 });


### PR DESCRIPTION
## なぜ

未投稿の生成物を削除しても、Storage の実体が残っていました。削除経路ごとに列名を並べて書いていたため、**取りこぼしが経路ごとに違う形で**存在していました。

| 経路 | 原本 | 表示用 | サムネ | Before |
|---|---|---|---|---|
| 一括削除（未投稿のまとめ削除） | ✅ | ❌ | ✅ | ✅ |
| 単体削除（投稿詳細から） | ✅ | ❌ | ❌ | ✅ |
| 退会時の purge | ✅ | ✅ | ✅ | ✅ |

1行あたり最大4ファイルあり、実測の平均サイズは **原本 1,902kB / 表示用 137kB / サムネ 76kB** です。表示用が残るぶん、削除しても約 6.5% が消えずに積み上がっていました。孤児ストレージの棚卸しで見つけた「派生の残骸 236件・28MB」の供給源がこれです。

単体削除にはもう1つ問題があり、**Storage → DB の順**で消していました。DB 削除が失敗すると「行はあるが実体が無い」＝表示が壊れた画像が残ります（PR #522 で対処したのと同じ種類の事故）。一括削除側には「DB を真実とし Storage は後追い」という理由がコメントで明記されていたのに、単体側だけ逆でした。

## 何をしたか

列名の羅列をやめ、**SELECT する列リストとパスの取り出しを1箇所に集約**して3経路で共用します。

```ts
// features/generation/lib/generated-image-storage-paths.ts
export const GENERATED_IMAGE_STORAGE_PATH_COLUMNS =
  "storage_path, storage_path_display, storage_path_thumb, pre_generation_storage_path";

export function collectGeneratedImageStoragePaths(rows): string[]
```

- 列が増えたときに1箇所直せば全経路に効きます
- 単体削除の順序を **DB → Storage** に揃えました（最悪でも孤立ファイルが残るだけ）
- ゲストのワードローブ引き継ぎ（`save-wardrobe-image`）は**3列すべてに同じパス**を入れるため、ヘルパー側で重複を除きます
- 退会時の purge は既に正しく動いていましたが、正本を1つにするため同じヘルパーへ寄せました

## ユーザーから見て何が変わるか

未投稿の生成物を削除したとき、実体が**残らず**消えます（これまでは表示用WebPが残っていました）。表示・投稿数・生成数への影響はありません。

補足として、マイページの**生成数は `image_jobs` から数えている**ため（`get_user_generated_count`）、画像を削除しても減りません。**投稿数**は `is_posted = true` の件数で、削除APIは `is_posted = false` の行しか対象にしないため、こちらも減りません。

## 検証

- `npm run test` — 3559 passed（新規テスト10件）
- `npm run lint` — 変更したファイルはクリーン（リポジトリ既存の赤は別途）
- `npm run build -- --webpack` — 成功

## 補足（本PRでは触っていません）

`features/generation/lib/deleteGeneratedImage()` は DB 行だけを消して Storage を一切掃除しませんが、**呼び出し元がありません**（デッドコード）。範囲外のため今回は残しています。使う場合は必ずこのヘルパーを通す必要があります。