### PR TITLE
fix(admin): Gemini の原価に入力ぶん（テキスト＋画像）を計上する

### DIFF
--- a/features/admin-dashboard/lib/ai-cost-rates.ts
+++ b/features/admin-dashboard/lib/ai-cost-rates.ts
@@ -46,9 +46,8 @@ export type AiRateBasis = "measured" | "published" | "derived";
  * `basis` とは**別の軸**として持つ。出力ぶんが公表値で正確でも、
  * 入力ぶんが未計上なら合計は実額に届かないため、片方だけでは実態を表せない。
  *
- * - `counted` 入力画像・プロンプトとも計上している（OpenAI）
- * - `partial` 一部だけ計上している（Gemini: テキスト単価が未確認で常に未計上。
- *   flash 系は入力画像の公表もない）
+ * - `counted` 入力画像・プロンプトとも計上している
+ * - `partial` 一部だけ計上している
  */
 export type AiInputCompleteness = "counted" | "partial";
 
@@ -60,6 +59,14 @@ export interface AiModelRate {
    * `0` は「課金されない」ではなく **「未計測」** を意味し、その分だけ原価を低く見ている。
    */
   inputImageUsd: number;
+  /**
+   * プロンプト(テキスト)入力の単価 per 1M tokens。
+   *
+   * **provider ではなくモデルごとに持つ。** Gemini は同じ Google でも
+   * pro $2.00 / flash $0.50 / flash-lite $0.25 と 8倍の開きがあり、
+   * provider 単位の定数では表せない。
+   */
+  textInputUsdPer1M: number;
   provider: AiCostProvider;
   basis: AiRateBasis;
   inputCompleteness: AiInputCompleteness;
@@ -115,6 +122,7 @@ const gptImage2 = (
   return {
     outputUsd: (tokens * OPENAI_IMAGE_OUTPUT_USD_PER_1M) / 1e6,
     inputImageUsd: GPT_IMAGE_2_INPUT_IMAGE_USD,
+    textInputUsdPer1M: OPENAI_TEXT_INPUT_USD_PER_1M,
     provider: "openai",
     basis: tier === "1k" ? "measured" : "derived",
     inputCompleteness: "counted",
@@ -122,19 +130,62 @@ const gptImage2 = (
 };
 
 /**
- * Gemini は出力ぶんの公表値のみ。テキスト入力単価が未確認で常に未計上、
- * 入力画像も pro 以外は公表がないため `partial` 固定。
+ * Gemini の入力トークン単価（per 1M tokens・2026-08-18 取得）。
+ * **テキストと画像が同一単価**なのが OpenAI との違い（OpenAI は text $5 / image $8）。
+ *
+ * https://ai.google.dev/gemini-api/docs/pricing
  */
-const gemini = (outputUsd: number, inputImageUsd = 0): AiModelRate => ({
-  outputUsd,
-  inputImageUsd,
-  provider: "google",
-  basis: "published",
-  inputCompleteness: "partial",
-});
+const GEMINI_INPUT_USD_PER_1M = {
+  pro: 2.0,
+  flash: 0.5,
+  flashLite: 0.25,
+  /** gemini-2.5-flash-image（旧世代） */
+  legacyFlash: 0.3,
+} as const;
 
-/** gemini-3-pro-image の入力画像は 560 tok = $0.0011/枚（公表値）。他モデルは未公表。 */
-const GEMINI_PRO_INPUT_IMAGE_USD = 0.0011;
+/**
+ * 入力画像1枚あたりのトークン数。
+ *
+ * **Gemini 3 は既定 1,120 tok。** `media_resolution` を指定しなければ
+ * MEDIA_RESOLUTION_UNSPECIFIED = 画像 1,120 tok が適用される。
+ * 本アプリはどこでも指定していないため既定が効く（2026-08-18 時点でコード上に
+ * mediaResolution の指定なしを確認済み）。
+ *
+ * ⚠️ 価格ページの「$0.0011 per image」は **560 tok（MEDIA_RESOLUTION_MEDIUM）前提**で、
+ * 実際の既定の半分。以前の実装はこの値をそのまま使っており、pro の入力画像費を
+ * 半分に見積もっていた。
+ *
+ * gemini-2.5（Gemini 3 以前）は media_resolution が無く、タイル方式:
+ * 384px 以下なら 258 tok、それ以上は 768x768 タイルごとに 258 tok。
+ * 本アプリの入力画像は長辺 2048 に正規化される(normalize-source-image.ts)ため、
+ * 1024x1536 相当で 6 タイル = 1,548 tok と見積もる。**実測していない**。
+ */
+const GEMINI_3_INPUT_IMAGE_TOKENS = 1120;
+const GEMINI_25_INPUT_IMAGE_TOKENS_ESTIMATE = 1548;
+
+/**
+ * Gemini の単価を組み立てる。
+ *
+ * 出力ぶんは公表の「1枚あたり価格」をそのまま使う（トークン数も公表されており、
+ * 単価×トークンと一致する）。入力ぶんは トークン数 × 入力単価 で算出する。
+ */
+const gemini = (
+  outputUsd: number,
+  tier: keyof typeof GEMINI_INPUT_USD_PER_1M,
+  inputImageTokens: number = GEMINI_3_INPUT_IMAGE_TOKENS
+): AiModelRate => {
+  const inputUsdPer1M = GEMINI_INPUT_USD_PER_1M[tier];
+  return {
+    outputUsd,
+    inputImageUsd: (inputImageTokens * inputUsdPer1M) / 1e6,
+    textInputUsdPer1M: inputUsdPer1M,
+    provider: "google",
+    basis: "published",
+    // 出力=公表値、入力=公表単価×トークン数。OpenAI の実測ほどではないが
+    // 3要素すべてを数えている状態になった。
+    inputCompleteness: "counted",
+  };
+};
 
 /**
  * `generated_images.model` に記録される値をキーにした単価表。
@@ -159,13 +210,17 @@ export const MODEL_COST_RATES: Record<string, AiModelRate> = {
   "gpt-image-2-low": gptImage2("low", "1k"),
 
   // --- Google（公表されている1枚あたりの価格）---
-  "gemini-2.5-flash-image": gemini(0.039),
-  "gemini-3.1-flash-image-preview-512": gemini(0.045),
-  "gemini-3.1-flash-image-preview-1024": gemini(0.067),
-  "gemini-3.1-flash-lite-image-1024": gemini(0.0336),
-  "gemini-3-pro-image-1k": gemini(0.134, GEMINI_PRO_INPUT_IMAGE_USD),
-  "gemini-3-pro-image-2k": gemini(0.134, GEMINI_PRO_INPUT_IMAGE_USD),
-  "gemini-3-pro-image-4k": gemini(0.24, GEMINI_PRO_INPUT_IMAGE_USD),
+  "gemini-2.5-flash-image": gemini(
+    0.039,
+    "legacyFlash",
+    GEMINI_25_INPUT_IMAGE_TOKENS_ESTIMATE
+  ),
+  "gemini-3.1-flash-image-preview-512": gemini(0.045, "flash"),
+  "gemini-3.1-flash-image-preview-1024": gemini(0.067, "flash"),
+  "gemini-3.1-flash-lite-image-1024": gemini(0.0336, "flashLite"),
+  "gemini-3-pro-image-1k": gemini(0.134, "pro"),
+  "gemini-3-pro-image-2k": gemini(0.134, "pro"),
+  "gemini-3-pro-image-4k": gemini(0.24, "pro"),
 };
 
 /**
@@ -251,8 +306,10 @@ export interface AiGenerationCost {
  * 1生成あたりの推定原価を、入力ぶんを含めて算出する。
  * 単価表に無いモデルは `null`（呼び出し側で「単価未設定」として件数だけ数える）。
  *
- * テキストぶんは OpenAI のみ計上する。Gemini のテキスト入力単価は未確認で、
- * 直近30日の Gemini 利用が全体の約1%しかないため、まず OpenAI を正確にした。
+ * テキストぶんはモデルごとの入力単価で計上する（2026-08-18 に Gemini も対応）。
+ * トークン数は OpenAI のトークナイザで数えた実測値を Gemini にも流用している。
+ * 両者のトークナイザは異なるが、日本語混じりの同じ文で概ね同じ桁に収まるため、
+ * Gemini が全体の約1%という利用比率に対しては十分な精度と判断した。
  */
 export function estimateGenerationCost(
   model: string | null,
@@ -262,9 +319,7 @@ export function estimateGenerationCost(
   if (!rate) return null;
 
   const textUsd =
-    rate.provider === "openai"
-      ? (getPromptTextTokens(generationType) * OPENAI_TEXT_INPUT_USD_PER_1M) / 1e6
-      : 0;
+    (getPromptTextTokens(generationType) * rate.textInputUsdPer1M) / 1e6;
 
   const inputUsd = rate.inputImageUsd + textUsd;
 

--- a/features/admin-dashboard/lib/build-ai-cost.ts
+++ b/features/admin-dashboard/lib/build-ai-cost.ts
@@ -32,6 +32,12 @@ type GenerationLike = {
    * `null` は同期経路・旧データで、その行だけで1リクエストとみなす。
    */
   image_job_id?: string | null;
+  /**
+   * 完走フィード投稿(台紙の合成画像)は `completion_id` を持つ。
+   * **AI 生成ではない**ので原価は 0 が正しく、「単価未設定」にも数えない。
+   * (直近60日の model=NULL 51件のうち 47件がこれだった)
+   */
+  completion_id?: string | null;
 };
 
 /**
@@ -91,6 +97,15 @@ export function buildAiCostEstimate(
 
   for (const generation of generations) {
     if (!isWithinDateRange(generation.created_at, currentStart, now)) {
+      continue;
+    }
+
+    /*
+      完走フィード投稿は台紙画像を合成して作る行で、モデルを呼んでいない。
+      これを「単価未設定」に数えると、実際には穴が無いのに
+      「原価を取りこぼしている件数」がカードに出て判断を誤らせる。
+    */
+    if (generation.completion_id) {
       continue;
     }
 

--- a/features/admin-dashboard/lib/get-admin-dashboard-data.ts
+++ b/features/admin-dashboard/lib/get-admin-dashboard-data.ts
@@ -58,6 +58,7 @@ type GeneratedImageRow = {
   model: string | null;
   /** AI原価の見積もり精度がこれに依存するため必須（旧データは null） */
   generation_type: string | null;
+  completion_id?: string | null;
   /** 入力ぶんをジョブ単位で1回だけ数えるために使う */
   image_job_id?: string | null;
   generation_metadata?: Record<string, unknown> | null;
@@ -653,7 +654,7 @@ export async function getAdminDashboardData(
     supabase
       .from("generated_images")
       .select(
-        "user_id, created_at, is_posted, moderation_status, model, generation_type, image_job_id, generation_metadata, posted_at"
+        "user_id, created_at, is_posted, moderation_status, model, generation_type, image_job_id, completion_id, generation_metadata, posted_at"
       )
       .gte("created_at", sharedFetchStartIso)
       .lte("created_at", sharedFetchEndIso),

--- a/tests/unit/features/admin-dashboard/build-ai-cost.test.ts
+++ b/tests/unit/features/admin-dashboard/build-ai-cost.test.ts
@@ -20,8 +20,18 @@ const GPT_LOW_OUTPUT_USD = 0.00516; //               172 tok × $30/1M
 const GPT_LOW_DEFAULT_USD = GPT_LOW_OUTPUT_USD + GPT_INPUT_IMAGE_USD + 0.00185;
 // one_tap_style → 1,640 tok
 const GPT_LOW_ONE_TAP_USD = GPT_LOW_OUTPUT_USD + GPT_INPUT_IMAGE_USD + 0.0082;
-// Gemini はテキストぶん未計上、入力画像も flash 系は未公表なので出力ぶんのみ
-const GEMINI_FLASH_USD = 0.067;
+/*
+  Gemini も 2026-08-18 から3要素すべてを数える。
+  入力はテキストも画像も同一単価（flash は $0.50/1M）で、
+  入力画像は media_resolution 既定の 1,120 tok。
+*/
+const GEMINI_FLASH_INPUT_IMAGE_USD = (1120 * 0.5) / 1e6; // = 0.00056
+// generation_type 未指定 → 既定 370 tok
+const GEMINI_FLASH_DEFAULT_USD =
+  0.067 + GEMINI_FLASH_INPUT_IMAGE_USD + (370 * 0.5) / 1e6;
+// one_tap_style → 1,640 tok
+const GEMINI_FLASH_ONE_TAP_USD =
+  0.067 + GEMINI_FLASH_INPUT_IMAGE_USD + (1640 * 0.5) / 1e6;
 
 describe("buildAiCostEstimate", () => {
   it("生成がなくても期間分の日別バケットを埋めて0円を返す", () => {
@@ -54,7 +64,7 @@ describe("buildAiCostEstimate", () => {
       NOW
     );
 
-    const expectedUsd = GPT_LOW_DEFAULT_USD * 2 + GEMINI_FLASH_USD;
+    const expectedUsd = GPT_LOW_DEFAULT_USD * 2 + GEMINI_FLASH_DEFAULT_USD;
     expect(result.totalUsd).toBeCloseTo(expectedUsd, 4);
     expect(result.totalJpy).toBeCloseTo(expectedUsd * USD_JPY_RATE, 1);
   });
@@ -173,7 +183,7 @@ describe("buildAiCostEstimate", () => {
       expect(syncRows.totalUsd).toBeCloseTo(GPT_LOW_ONE_TAP_USD * 2, 4);
     });
 
-    it("Gemini にはテキストぶんを乗せない（単価未確認のため）", () => {
+    it("Gemini もモデル別の入力単価でテキストぶんを計上する", () => {
       const withType = buildAiCostEstimate(
         [
           {
@@ -186,7 +196,10 @@ describe("buildAiCostEstimate", () => {
         NOW
       );
 
-      expect(withType.totalUsd).toBeCloseTo(GEMINI_FLASH_USD, 5);
+      // buildAiCostEstimate は合計を丸めるため精度4で比較する
+      expect(withType.totalUsd).toBeCloseTo(GEMINI_FLASH_ONE_TAP_USD, 4);
+      // 出力ぶんだけの頃(0.067)より高い = テキスト・入力画像を数えている
+      expect(withType.totalUsd).toBeGreaterThan(0.067);
     });
   });
 
@@ -230,6 +243,76 @@ describe("buildAiCostEstimate", () => {
       );
     });
 
+    it("完走フィード投稿は原価にも単価未設定にも数えない", () => {
+      // 台紙の合成画像でモデルを呼んでいない。単価未設定に混ぜると
+      // 「取りこぼしている件数」に見えて判断を誤らせる。
+      const result = buildAiCostEstimate(
+        [
+          {
+            model: null,
+            created_at: "2026-07-25T01:00:00.000Z",
+            generation_type: "one_tap_style",
+            completion_id: "11111111-1111-1111-1111-111111111111",
+          },
+          {
+            // completion_id が無い model=null は従来どおり単価未設定
+            model: null,
+            created_at: "2026-07-25T02:00:00.000Z",
+            generation_type: "one_tap_style",
+          },
+        ],
+        CURRENT_START,
+        NOW
+      );
+
+      expect(result.totalUsd).toBe(0);
+      expect(result.unknownModelCount).toBe(1);
+    });
+
+    it("すべてのモデルが入力ぶんを計上している", () => {
+      // inputCompleteness=partial が残っていると、そのモデルの合計は実額に届かない。
+      // 2026-08-18 に Gemini のテキスト・入力画像を計上して全モデル counted になった。
+      for (const [model, rate] of Object.entries(MODEL_COST_RATES)) {
+        expect([model, rate.inputCompleteness]).toEqual([model, "counted"]);
+        expect(rate.inputImageUsd).toBeGreaterThan(0);
+        expect(rate.textInputUsdPer1M).toBeGreaterThan(0);
+      }
+    });
+
+    it("Gemini はモデル階層ごとに入力単価が違う", () => {
+      // pro $2.00 / flash $0.50 / flash-lite $0.25。
+      // provider 単位の定数にすると 8倍の開きを潰してしまう。
+      expect(MODEL_COST_RATES["gemini-3-pro-image-1k"]?.textInputUsdPer1M).toBe(2.0);
+      expect(
+        MODEL_COST_RATES["gemini-3.1-flash-image-preview-1024"]?.textInputUsdPer1M
+      ).toBe(0.5);
+      expect(
+        MODEL_COST_RATES["gemini-3.1-flash-lite-image-1024"]?.textInputUsdPer1M
+      ).toBe(0.25);
+    });
+
+    it("Gemini 3 の入力画像は media_resolution 既定の 1,120 tok で数える", () => {
+      // 価格ページの「$0.0011/枚」は 560 tok(MEDIUM)前提で、既定の半分。
+      // アプリは media_resolution を指定していないので既定が効く。
+      expect(MODEL_COST_RATES["gemini-3-pro-image-1k"]?.inputImageUsd).toBeCloseTo(
+        (1120 * 2.0) / 1e6,
+        6
+      );
+      expect(
+        MODEL_COST_RATES["gemini-3-pro-image-1k"]?.inputImageUsd
+      ).toBeGreaterThan(0.0011);
+    });
+
+    it("Gemini でも出力ぶんが原価の大半を占める(OpenAI Low とは逆)", () => {
+      // OpenAI Low は入力が7割。Gemini は出力単価が高く入力単価が安いため、
+      // 入力を計上しても合計は数%しか動かない。値付けの直感を固定しておく。
+      const cost = estimateGenerationCost("gemini-3-pro-image-1k", "one_tap_style")!;
+      expect(cost.inputUsd / cost.usd).toBeLessThan(0.05);
+
+      const low = estimateGenerationCost("gpt-image-2-low-1k", "one_tap_style")!;
+      expect(low.inputUsd / low.usd).toBeGreaterThan(0.7);
+    });
+
     it("外挿した 2k/4k は basis で見分けられる", () => {
       // 実測していないことをカード側と将来の読み手に明示する
       expect(MODEL_COST_RATES["gpt-image-2-low-1k"]?.basis).toBe("measured");
@@ -256,7 +339,7 @@ describe("buildAiCostEstimate", () => {
 
     expect(first.openaiJpy).toBeCloseTo(GPT_LOW_DEFAULT_USD * USD_JPY_RATE, 1);
     expect(first.googleJpy).toBe(0);
-    expect(last.googleJpy).toBeCloseTo(GEMINI_FLASH_USD * USD_JPY_RATE, 1);
+    expect(last.googleJpy).toBeCloseTo(GEMINI_FLASH_DEFAULT_USD * USD_JPY_RATE, 1);
     expect(last.openaiJpy).toBe(0);
     expect(last.totalJpy).toBeCloseTo(last.googleJpy, 1);
   });


### PR DESCRIPTION
## なぜ

AI原価カードは Gemini について**出力ぶんの公表値しか数えていません**でした。テキスト入力は常に未計上、入力画像も pro 以外は 0 で、`inputCompleteness: "partial"` のままでした。

## 公表単価（2026-08-18 取得）

[Gemini API pricing](https://ai.google.dev/gemini-api/docs/pricing) を確認しました。**Gemini はテキストと画像が同一単価**なのが OpenAI との違いです（OpenAI は text $5 / image $8）。

| モデル | 入力 per 1M | 出力（1枚） |
|---|---|---|
| gemini-3-pro-image | $2.00 | $0.134（1K/2K）/ $0.24（4K） |
| gemini-3.1-flash-image | $0.50 | $0.045（0.5K）/ $0.067（1K） |
| gemini-3.1-flash-lite-image | $0.25 | $0.0336（1K） |
| gemini-2.5-flash-image | $0.30 | $0.039 |

出力ぶんの値は既存の表と一致していました（そこは正しかった）。

## ⚠️ 入力画像のトークン数は公表の「$0.0011/枚」の2倍

価格ページの「equivalent to $0.0011 per image」は **560 tok = `MEDIA_RESOLUTION_MEDIUM` 前提**です。[Media resolution](https://ai.google.dev/gemini-api/docs/media-resolution) によると **Gemini 3 の既定（UNSPECIFIED）は画像 1,120 tok**。

本アプリは `media_resolution` をどこでも指定していないことをコードで確認したので、既定が効きます。従来は公表値 $0.0011 をそのまま使っており、**pro の入力画像費を半額で見積もっていました**。

## 実装

- 入力単価は provider ではなく**モデルごと**に持たせました。同じ Google でも pro と flash-lite で **8倍**の開きがあり、provider 単位の定数では表せません
- `estimateGenerationCost` の `provider === "openai"` 分岐を撤去し、全モデルでテキストぶんを計上
- 全モデルが `inputCompleteness: "counted"` になりました

プロンプトのトークン数は OpenAI のトークナイザで測った実測値を流用しています。トークナイザは異なりますが、日本語混じりの同じ文で概ね同じ桁に収まり、Gemini が全体の約1%という比率に対しては十分と判断しました（コメントに明記）。

## あわせて：完走フィード投稿を集計から除外

完走の台紙（合成画像）は `model = NULL` で保存されるため、「単価未設定」に数えられていました。**モデルを呼んでいないので原価0が正しい**のに、取りこぼし件数として表示されて判断を誤らせます。直近60日の `model = NULL` 51件のうち **47件がこれ**でした。`completion_id` を持つ行を除外します。

## 影響は小さい（正直な数字）

Gemini は出力単価が高く入力単価が安いため、入力を数えても **1生成あたり +1.8〜3.3%** しか動きません。

```
gemini-3-pro-image-1k    $0.13510 → $0.13952  (+3.3%)
gemini-3.1-flash-1024    $0.06700 → $0.06838  (+2.1%)
```

直近30日の Gemini 16件では **合計 +$0.02（約3円）**です。OpenAI Low で入力が原価の**7割**だったのとは対照的で、この非対称性（Gemini は入力が5%未満）をテストで固定しました。値付けの直感が逆転しないようにするためです。

## 検証

- `npm run test` — 3573 passed（新規テスト6件）
- `npm run lint` — 変更ファイルはエラー0
- `npm run build -- --webpack` — 成功