### PR TITLE
fix(storage): temp 掃除が毎回 500 で落ちていたのを直す

### DIFF
--- a/supabase/functions/cleanup-temp-images/index.ts
+++ b/supabase/functions/cleanup-temp-images/index.ts
@@ -72,15 +72,20 @@ Deno.serve(async (req) => {
   ).toISOString();
 
   while (batches < SAFE_MAX_BATCHES) {
-    // storage.list は再帰非対応 + ページング困難なため、storage.objects テーブルを直接 SELECT
-    const { data: rows, error: selectError } = await supabase
-      .schema("storage")
-      .from("objects")
-      .select("name")
-      .eq("bucket_id", STORAGE_BUCKET)
-      .like("name", "temp/%")
-      .lt("created_at", cutoffIso)
-      .limit(BATCH_SIZE);
+    /*
+      storage.list は再帰非対応(temp/ は temp/<user_id>/<file> の3階層)なので
+      storage.objects を読む必要があるが、**PostgREST は storage スキーマを
+      公開していない**(public / graphql_public のみ)。
+      `supabase.schema("storage").from("objects")` は毎回 500 で落ちる。
+
+      storage スキーマ全体を公開するのは影響範囲が広いため、必要な読み取りだけを
+      public の SECURITY DEFINER 関数(service_role 限定)として出して呼ぶ。
+      migration: 20260818090000_add_list_stale_temp_image_objects_rpc.sql
+    */
+    const { data: rows, error: selectError } = await supabase.rpc(
+      "list_stale_temp_image_objects",
+      { p_cutoff: cutoffIso, p_limit: BATCH_SIZE },
+    );
 
     if (selectError) {
       console.error("[cleanup-temp-images] SELECT failed", selectError);

--- a/supabase/migrations/20260818090000_add_list_stale_temp_image_objects_rpc.sql
+++ b/supabase/migrations/20260818090000_add_list_stale_temp_image_objects_rpc.sql
@@ -1,0 +1,45 @@
+-- cleanup-temp-images が temp/ の古いオブジェクトを列挙するための RPC。
+--
+-- 背景: この Edge Function は `supabase.schema("storage").from("objects")` で
+-- storage.objects を直接 SELECT していたが、PostgREST が公開しているスキーマは
+-- public / graphql_public だけなので**毎回 500 で落ちていた**。
+--   {"error":"select_failed",
+--    "message":"The schema must be one of the following: public, graphql_public"}
+-- cron 自体は成功扱い(net.http_post はリクエストIDを返すだけ)のため気づけず、
+-- 2026年1月以降 temp/ に 1,082件・691MB が滞留していた。
+--
+-- storage スキーマ全体を PostgREST に公開するのは影響範囲が広すぎるため、
+-- **必要な読み取りだけ**を public の SECURITY DEFINER 関数として出す。
+--
+-- 対象は temp/ に固定する(引数で bucket/prefix を受けない)。
+-- 任意のバケットを列挙できる汎用関数にすると、この関数自体が情報漏洩経路になる。
+-- 削除は行わない(実体の削除は Storage API 経由で Edge Function が行う)。
+
+CREATE OR REPLACE FUNCTION public.list_stale_temp_image_objects(
+  p_cutoff timestamptz,
+  p_limit integer DEFAULT 1000
+)
+RETURNS TABLE (name text)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, storage
+AS $$
+  SELECT o.name
+  FROM storage.objects AS o
+  WHERE o.bucket_id = 'generated-images'
+    AND o.name LIKE 'temp/%'
+    AND o.created_at < p_cutoff
+  ORDER BY o.created_at
+  LIMIT least(greatest(coalesce(p_limit, 1000), 1), 1000);
+$$;
+
+COMMENT ON FUNCTION public.list_stale_temp_image_objects(timestamptz, integer) IS
+  'cleanup-temp-images 専用。generated-images バケットの temp/ 配下で p_cutoff より古いオブジェクト名を返す(読み取りのみ)。';
+
+-- service_role だけが実行できる。anon/authenticated に渡すと
+-- 他人のアップロード中ファイル名が読めてしまう。
+REVOKE ALL ON FUNCTION public.list_stale_temp_image_objects(timestamptz, integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.list_stale_temp_image_objects(timestamptz, integer) FROM anon;
+REVOKE ALL ON FUNCTION public.list_stale_temp_image_objects(timestamptz, integer) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.list_stale_temp_image_objects(timestamptz, integer) TO service_role;


### PR DESCRIPTION
## 何が起きていたか

`cleanup-temp-images`（24時間TTLで `temp/` を掃除する Edge Function）は、**一度も成功していませんでした**。

```json
{"error":"select_failed",
 "message":"The schema must be one of the following: public, graphql_public",
 "deleted_so_far":0,"batches":0}
```

`supabase.schema("storage").from("objects")` で `storage.objects` を直接 SELECT していますが、**PostgREST が公開しているスキーマは `public` / `graphql_public` だけ**です。この経路は最初から通りません。

結果、2026年1月以降 `temp/` に **1,082件・691MB** が滞留していました。

## なぜ気づけなかったか

cron 側は**成功に見えます**。

| 見えるもの | 実際 |
|---|---|
| `cron.job_run_details.status = succeeded` / `return_message = "1 row"` | `net.http_post` が**リクエストIDを返しただけ**。HTTP は非同期で投げっぱなし |
| — | 実際の応答は `net._http_response` に **500** で残っていた |

昨夜 18:00 UTC（03:00 JST）の実行でこれを確認しました。cron が「成功」でも Edge Function の成否は別、という読み違いです。

## 直し方

`storage` スキーマ全体を PostgREST に公開するのは影響範囲が広すぎるので、**必要な読み取りだけ**を `public` の SECURITY DEFINER 関数として出します。

```sql
CREATE OR REPLACE FUNCTION public.list_stale_temp_image_objects(
  p_cutoff timestamptz, p_limit integer DEFAULT 1000
) RETURNS TABLE (name text) ...
  WHERE o.bucket_id = 'generated-images'
    AND o.name LIKE 'temp/%'
    AND o.created_at < p_cutoff
```

- **対象を `temp/` に固定**（引数で bucket/prefix を受けない）。任意のバケットを列挙できる汎用関数にすると、それ自体が情報漏洩経路になります
- **service_role のみ実行可**。anon/authenticated に渡すと他人のアップロード中のファイル名が読めます
- **読み取りのみ**。実体の削除は従来どおり Storage API 経由

`storage.list` を使わないのは、`temp/` が `temp/<user_id>/<file>` の**3階層**で list が再帰非対応だからです（元実装が `storage.objects` を読んでいた理由もこれ）。

## 適用後に起きること

次回実行（03:00 JST）で **1,081件が削除**されます（24時間以上経過ぶん）。1,000件/バッチ・最大50バッチなので1回で消化できます。

⚠️ 副作用として、`temp/` を参照している **`image_jobs.input_image_url` 等 1,058件が 404 を指すようになります**。ユーザー表示用の Before 画像は `pre-generation/` に別途永続化されているので**表示は壊れません**が、admin のジョブ調査で入力画像が見えなくなります。これは本来 24 時間で消えるはずのものなので、仕様どおりの状態に戻るという整理です。

## 検証

- `npm run test` — 3149 passed
- `npm run build -- --webpack` — 成功
- `supabase/functions` は tsconfig 対象外のため typecheck の対象外（Deno）

## 残作業

**マイグレーション適用 → Edge Function デプロイ**が必要です。関数だけ先に出すと RPC が無くて 500 のままなので、**migration を先**にします。